### PR TITLE
enh(exceptions/error): This exception is based on msg_fmt now.

### DIFF
--- a/include/com/centreon/exceptions/error.hh
+++ b/include/com/centreon/exceptions/error.hh
@@ -1,0 +1,63 @@
+/*
+** Copyright 2020 Centreon
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+**
+** For more information : contact@centreon.com
+*/
+#ifndef CC_EXCEPTIONS_ERROR_HH
+#define CC_EXCEPTIONS_ERROR_HH
+
+#include "com/centreon/exceptions/msg_fmt.hh"
+#include "com/centreon/namespace.hh"
+
+CC_BEGIN()
+
+namespace exceptions {
+/**
+ *  @class error error.hh
+ *  @brief Base exception class.
+ *
+ *  Simple exception class containing an error message and a flag to
+ *  determine if the error that generated the exception was either fatal
+ *  or not.
+ */
+class error : public msg_fmt {
+ public:
+  template <typename... Args>
+  explicit error(std::string const& str, const Args&... args)
+      : msg_fmt(fmt::format(str, args...)) {}
+
+  ~error() noexcept {}
+  error() = delete;
+  error& operator=(const error&) = delete;
+};
+
+}  // namespace exceptions
+
+CC_END()
+
+#ifdef NDEBUG
+#define engine_error(format, ...) \
+  com::centreon::exceptions::error(format, __VA_ARGS__)
+#define engine_error_1(format) com::centreon::exceptions::error(format)
+#else
+#define engine_error(format, ...)                                            \
+  com::centreon::exceptions::error("[{}:{}:{}] " format, __FILE__, __func__, \
+                                   __LINE__, __VA_ARGS__)
+#define engine_error_1(format)                                          \
+  com::centreon::exceptions::error("[{}:{}:{}] {}", __FILE__, __func__, \
+                                   __LINE__, format)
+#endif  // !NDEBUG
+
+#endif  // !CC_EXCEPTIONS_ERROR_HH

--- a/script/ci/collect-build-deps.centos7.Dockerfile
+++ b/script/ci/collect-build-deps.centos7.Dockerfile
@@ -1,4 +1,4 @@
-FROM ci.int.centreon.com:5000/centos:7
+FROM registry.centreon.com/centos:7
 
 # Install Centreon repository.
 RUN yum install --nogpgcheck -y http://yum.centreon.com/standard/20.04/el7/stable/noarch/RPMS/centreon-release-20.04-1.el7.centos.noarch.rpm

--- a/src/cce_core/CMakeLists.txt
+++ b/src/cce_core/CMakeLists.txt
@@ -153,4 +153,4 @@ add_library(cce_core
 add_dependencies(cce_core engine_rpc)
 
 # Link target with required libraries.
-target_link_libraries(cce_core centreon_clib CONAN_PKG::json11)
+target_link_libraries(cce_core centreon_clib CONAN_PKG::fmt CONAN_PKG::json11)

--- a/src/cce_core/service.cc
+++ b/src/cce_core/service.cc
@@ -26,7 +26,6 @@
 #include "com/centreon/engine/deleter/listmember.hh"
 #include "com/centreon/engine/downtimes/downtime_manager.hh"
 #include "com/centreon/engine/events/loop.hh"
-#include "com/centreon/engine/exceptions/error.hh"
 #include "com/centreon/engine/flapping.hh"
 #include "com/centreon/engine/globals.hh"
 #include "com/centreon/engine/hostdependency.hh"
@@ -42,6 +41,7 @@
 #include "com/centreon/engine/shared.hh"
 #include "com/centreon/engine/string.hh"
 #include "com/centreon/engine/timezone_locker.hh"
+#include "com/centreon/exceptions/error.hh"
 #include "com/centreon/exceptions/interruption.hh"
 #include "compatibility/xpddefault.h"
 
@@ -815,8 +815,8 @@ com::centreon::engine::service& engine::find_service(uint64_t host_id,
   service_id_map::const_iterator it(
       service::services_by_id.find({host_id, service_id}));
   if (it == service::services_by_id.end())
-    throw(engine_error() << "Service '" << service_id << "' on host '"
-                         << host_id << "' was not found");
+    throw engine_error("Service '{}' on host '{}' was not found", service_id,
+                       host_id);
   return *it->second;
 }
 
@@ -3475,8 +3475,8 @@ void service::resolve(int& w, int& e) {
   e += errors;
 
   if (errors)
-    throw engine_error() << "Cannot resolve service '" << _description
-                         << "' of host '" << _hostname << "'";
+    throw engine_error("Cannot resolve service '{}' of host '{}'", _description,
+                       _hostname);
 }
 
 bool service::get_host_problem_at_last_check() const {


### PR DESCRIPTION
# Pull Request Template

## Description

A new version for the error exception based on the {fmt} library.
The file is moved from include/com/centreon/engine/exceptions to include/com/centreon/exceptions.

To have an idea on how to use it, look at the service.cc file.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)
