### PR TITLE
Mon 5803 cmake variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ else()
   message(WARNING "The file conanbuildinfo.cmake doesn't exist, you have to run conan install first")
 endif()
 
+############ CONSTANTS ###########
+set(USER_BROKER centreon-broker)
+set(USER_ENGINE centreon-engine)
+##################################
+
 add_subdirectory(src/10-neb)
 add_subdirectory(src/15-stats)
 add_subdirectory(src/20-bam)

--- a/config/central-broker-master.json.in
+++ b/config/central-broker-master.json.in
@@ -8,8 +8,8 @@
         "log_timestamp": true,
         "log_thread_id": false,
         "event_queue_max_size": 100000,
-        "command_file": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LOCALSTATEDIR@/lib/centreon-broker/command.sock",
-        "cache_directory": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LOCALSTATEDIR@/lib/centreon-broker",
+        "command_file": "@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/centreon-broker/command.sock",
+        "cache_directory": "@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/centreon-broker",
         "input": [
             {
                 "name": "central-broker-input",
@@ -26,7 +26,7 @@
         ],
         "logger": [
             {
-                "name": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LOCALSTATEDIR@/log/centreon-broker/central-broker.log",
+                "name": "@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/log/centreon-broker/central-broker.log",
                 "config": "yes",
                 "debug": "no",
                 "error": "yes",
@@ -83,7 +83,7 @@
             {
                 "type": "stats",
                 "name": "central-broker-stats",
-                "json_fifo": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LOCALSTATEDIR@/lib/centreon-broker/central-broker-stats.json"
+                "json_fifo": "@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/centreon-broker/central-broker-stats.json"
             }
         ]
     }

--- a/config/central-rrd-master.json.in
+++ b/config/central-rrd-master.json.in
@@ -8,8 +8,8 @@
         "log_timestamp": true,
         "log_thread_id": false,
         "event_queue_max_size": 100000,
-        "command_file": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LOCALSTATEDIR@/lib/centreon-broker/central-rrd.cmd",
-        "cache_directory": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LOCALSTATEDIR@/lib/centreon-broker",
+        "command_file": "@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/centreon-broker/central-rrd.cmd",
+        "cache_directory": "@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/centreon-broker",
         "input": [
             {
                 "name": "central-rrd-input",
@@ -26,7 +26,7 @@
         ],
         "logger": [
             {
-                "name": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LOCALSTATEDIR@/log/centreon-broker/central-rrd.log",
+                "name": "@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/log/centreon-broker/central-rrd.log",
                 "config": "yes",
                 "debug": "no",
                 "error": "yes",
@@ -38,8 +38,8 @@
         "output": [
             {
                 "name": "central-rrd-output",
-                "metrics_path": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LOCALSTATEDIR@/lib/centreon/metrics/",
-                "status_path": ""@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LOCALSTATEDIR@/lib/centreon/status/",
+                "metrics_path": "@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/centreon/metrics/",
+                "status_path": "@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/centreon/status/",
                 "retry_interval": "60",
                 "buffering_timeout": "0",
                 "write_metrics": "yes",
@@ -52,7 +52,7 @@
             {
                 "type": "stats",
                 "name": "central-rrd-stats",
-                "json_fifo": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LOCALSTATEDIR@/lib/centreon-broker/central-rrd-stats.json"
+                "json_fifo": "@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/centreon-broker/central-rrd-stats.json"
             }
         ]
     }

--- a/config/poller-module.json.in
+++ b/config/poller-module.json.in
@@ -9,11 +9,11 @@
         "log_timestamp": false,
         "log_thread_id": false,
         "event_queue_max_size": 100000,
-        "command_file": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LOCALSTATEDIR@/lib/centreon-broker/poller-module.cmd",
-        "cache_directory": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LOCALSTATEDIR@/lib/centreon-broker",
+        "command_file": "@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/centreon-broker/poller-module.cmd",
+        "cache_directory": "@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/centreon-broker",
         "logger": [
             {
-                "name": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LOCALSTATEDIR@/log/centreon-broker/poller-module.log",
+                "name": "@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/log/centreon-broker/poller-module.log",
                 "config": "yes",
                 "debug": "no",
                 "error": "yes",
@@ -41,7 +41,7 @@
             {
                 "type": "stats",
                 "name": "poller-module-stats",
-                "json_fifo": "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LOCALSTATEDIR@/lib/centreon-broker/poller-module-stats.json"
+                "json_fifo": "@CMAKE_INSTALL_FULL_LOCALSTATEDIR@/lib/centreon-broker/poller-module-stats.json"
             }
         ]
     }

--- a/config/watchdog.json.in
+++ b/config/watchdog.json.in
@@ -1,6 +1,6 @@
 {
     "centreonBroker": {
-        @DAEMONS_CONFIGURATION@
+@DAEMONS_CONFIGURATION@
         "log": "/var/log/centreon-broker/watchdog.log"
     }
 }

--- a/config/watchdog.json.in
+++ b/config/watchdog.json.in
@@ -1,6 +1,8 @@
 {
     "centreonBroker": {
+      "cbd": [
 @DAEMONS_CONFIGURATION@
-        "log": "/var/log/centreon-broker/watchdog.log"
+      ],
+      "log": "/var/log/centreon-broker/watchdog.log"
     }
 }

--- a/include/com/centreon/broker/vars.hh.in
+++ b/include/com/centreon/broker/vars.hh.in
@@ -24,7 +24,7 @@
 CCB_BEGIN()
 
 // Paths.
-#  define PREFIX_BIN "@PREFIX_BIN@"
+#  define PREFIX_BIN "@CMAKE_INSTALL_FULL_SBINDIR@"
 #  define PREFIX_VAR "@PREFIX_VAR@"
 
 CCB_END()

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+chown -R apache:apache /etc/centreon-broker /etc/centreon-engine
+
+chown -R centreon-broker:centreon-broker /var/log/centreon-broker
+chown -R centreon-broker:centreon-broker /var/lib/centreon-broker
+
+chown -R centreon-engine:centreon-engine /var/log/centreon-engine
+chown -R centreon-engine:centreon-engine /var/lib/centreon-engine
+
+if [ -f /tmp/central-broker.log ] ; then
+  rm -f /tmp/central-*
+fi

--- a/script/debian/cbd.default.in
+++ b/script/debian/cbd.default.in
@@ -4,4 +4,4 @@
 RUN_AT_STARTUP="YES"
 
 # Centreon Broker user : default centreon-broker
-USER="@USER@"
+USER="@USER_BROKER@"

--- a/script/other/cbd.init.d.in
+++ b/script/other/cbd.init.d.in
@@ -43,7 +43,7 @@ config_dir="@PREFIX_CONF@"
 cbwd="@PREFIX_BIN@/cbwd"
 pid_path="@PREFIX_VAR@/run"
 stop_timeout=10
-user="@USER@"
+user="@USER_BROKER@"
 debug=0
 pidfile="${pid_path}/cbwd.pid"
 

--- a/script/redhat/cbd.init.d.in
+++ b/script/redhat/cbd.init.d.in
@@ -38,7 +38,7 @@ cbwd="@PREFIX_BIN@/cbwd"
 pid_path=/var/run
 lockfile=/var/lock/subsys/cbd
 stop_timeout=10
-user="@USER@"
+user="@USER_BROKER@"
 pidfile="${pid_path}/cbwd.pid"
 debug=0
 

--- a/script/systemd/cbd.service.in
+++ b/script/systemd/cbd.service.in
@@ -1,5 +1,5 @@
 ##
-## Copyright 2015 Centreon
+## Copyright 2015-2020 Centreon
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ After=mariadb.service
 ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/cbwd @CMAKE_INSTALL_FULL_SYSCONFDIR@/centreon-broker/watchdog.json
 ExecReload=/bin/kill -HUP $MAINPID
 Type=simple
-User=centreon-broker
+User=@USER_BROKER@
 UMask=0002
 
 [Install]

--- a/script/systemd/centengine.service.in
+++ b/script/systemd/centengine.service.in
@@ -1,5 +1,5 @@
 ##
-## Copyright 2016 Centreon
+## Copyright 2015-2020 Centreon
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ After=cbd.service
 ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/centengine @CMAKE_INSTALL_FULL_SYSCONFDIR@/centreon-engine/centengine.cfg
 ExecReload=/bin/kill -HUP $MAINPID
 Type=simple
-User=@USER@
+User=@USER_ENGINE@
 
 [Install]
 WantedBy=centreon.service

--- a/src/cbd/CMakeLists.txt
+++ b/src/cbd/CMakeLists.txt
@@ -5,11 +5,11 @@ include_directories(${CMAKE_BINARY_DIR})
 configure_file(${CMAKE_SOURCE_DIR}/config/poller-module.json.in
   ${CMAKE_BINARY_DIR}/poller-module.json
   @ONLY)
-configure_file(${CMAKE_SOURCE_DIR}/config/central-broker.json.in
-  ${CMAKE_BINARY_DIR}/central-broker.json
+configure_file(${CMAKE_SOURCE_DIR}/config/central-broker-master.json.in
+  ${CMAKE_BINARY_DIR}/central-broker-master.json
   @ONLY)
-configure_file(${CMAKE_SOURCE_DIR}/config/central-rrd.json.in
-  ${CMAKE_BINARY_DIR}/central-rrd.json
+configure_file(${CMAKE_SOURCE_DIR}/config/central-rrd-master.json.in
+  ${CMAKE_BINARY_DIR}/central-rrd-master.json
   @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/script/systemd/cbd.service.in
   ${CMAKE_BINARY_DIR}/cbd.service
@@ -22,8 +22,8 @@ add_executable(cbd
   ${CMAKE_SOURCE_DIR}/src/cbd/config/applier/logger.cc
   ${CMAKE_SOURCE_DIR}/src/cbd/broker_impl.cc
   ${CMAKE_SOURCE_DIR}/src/cbd/brokerrpc.cc
-  ${CMAKE_BINARY_DIR}/central-broker.json
-  ${CMAKE_BINARY_DIR}/central-rrd.json
+  ${CMAKE_BINARY_DIR}/central-broker-master.json
+  ${CMAKE_BINARY_DIR}/central-rrd-master.json
   ${CMAKE_BINARY_DIR}/poller-module.json
   )
 
@@ -35,7 +35,7 @@ target_link_libraries(cbd
 set_target_properties(cbd PROPERTIES COMPILE_FLAGS "-fPIC")
 
 install(FILES ${CMAKE_BINARY_DIR}/cbd.service COMPONENT cbd DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/system)
-install(FILES ${CMAKE_BINARY_DIR}/central-broker.json COMPONENT cbd DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/centreon-broker)
-install(FILES ${CMAKE_BINARY_DIR}/central-rrd.json COMPONENT cbd DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/centreon-broker)
+install(FILES ${CMAKE_BINARY_DIR}/central-broker-master.json COMPONENT cbd DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/centreon-broker)
+install(FILES ${CMAKE_BINARY_DIR}/central-rrd-master.json COMPONENT cbd DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/centreon-broker)
 install(FILES ${CMAKE_BINARY_DIR}/poller-module.json DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/centreon-broker)
 install(TARGETS cbd COMPONENT cbd DESTINATION ${CMAKE_INSTALL_SBINDIR})

--- a/src/cbd/main.cc
+++ b/src/cbd/main.cc
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <exception>
+#include <iostream>
 #include <thread>
 
 #include "com/centreon/broker/brokerrpc.hh"
@@ -317,11 +318,13 @@ int main(int argc, char* argv[]) {
   // Standard exception.
   catch (std::exception const& e) {
     logging::error(logging::high) << e.what();
+    std::cout << "Error: " << e.what() << "\n";
     retval = EXIT_FAILURE;
   }
   // Unknown exception.
   catch (...) {
     logging::error(logging::high) << "main: unknown error, aborting execution";
+    std::cout << "Fatal error\n";
     retval = EXIT_FAILURE;
   }
 

--- a/src/cbwd/CMakeLists.txt
+++ b/src/cbwd/CMakeLists.txt
@@ -20,13 +20,16 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 include_directories(${CMAKE_BINARY_DIR}/)
 
 set(WITH_DAEMONS
-    central-broker
-    central-rrd
+    central-broker-master
+    central-rrd-master
 )
 
 foreach (DAEMON_NAME IN LISTS WITH_DAEMONS)
+  if (NOT ${DAEMONS_CONFIGURATION} STREQUAL "")
+    set(DAEMONS_CONFIGURATION "${DAEMONS_CONFIGURATION},\n")
+  endif ()
   set(DAEMONS_CONFIGURATION
-   "${DAEMONS_CONFIGURATION}        \"cbd\": [ \"name\": \"${DAEMON_NAME}\", \"configuration_file\": \"${CMAKE_INSTALL_FULL_SYSCONFDIR}/centreon-broker/${DAEMON_NAME}.json\", \"run\": true, \"reload\": true } ],\n")
+   "${DAEMONS_CONFIGURATION}        { \"name\": \"${DAEMON_NAME}\", \"configuration_file\": \"${CMAKE_INSTALL_FULL_SYSCONFDIR}/centreon-broker/${DAEMON_NAME}.json\", \"run\": true, \"reload\": true }")
 endforeach ()
 
 configure_file(${CMAKE_SOURCE_DIR}/config/watchdog.json.in

--- a/src/cbwd/CMakeLists.txt
+++ b/src/cbwd/CMakeLists.txt
@@ -19,6 +19,16 @@
 include_directories(${CMAKE_SOURCE_DIR}/include)
 include_directories(${CMAKE_BINARY_DIR}/)
 
+set(WITH_DAEMONS
+    central-broker
+    central-rrd
+)
+
+foreach (DAEMON_NAME IN LISTS WITH_DAEMONS)
+  set(DAEMONS_CONFIGURATION
+   "${DAEMONS_CONFIGURATION}        \"cbd\": [ \"name\": \"${DAEMON_NAME}\", \"configuration_file\": \"${CMAKE_INSTALL_FULL_SYSCONFDIR}/centreon-broker/${DAEMON_NAME}.json\", \"run\": true, \"reload\": true } ],\n")
+endforeach ()
+
 configure_file(${CMAKE_SOURCE_DIR}/config/watchdog.json.in
   ${CMAKE_BINARY_DIR}/watchdog.json
   @ONLY)

--- a/src/cbwd/instance_configuration.cc
+++ b/src/cbwd/instance_configuration.cc
@@ -116,7 +116,7 @@ bool instance_configuration::is_empty() const noexcept {
  *
  *  @return[in]  The name of this instance.
  */
-std::string const& instance_configuration::get_name() const throw() {
+std::string const& instance_configuration::get_name() const noexcept {
   return _name;
 }
 
@@ -125,7 +125,7 @@ std::string const& instance_configuration::get_name() const throw() {
  *
  *  @return[in]  The configuration file for this instance.
  */
-std::string const& instance_configuration::get_config_file() const throw() {
+std::string const& instance_configuration::get_config_file() const noexcept {
   return _config_file;
 }
 
@@ -134,7 +134,7 @@ std::string const& instance_configuration::get_config_file() const throw() {
  *
  *  @return[in]  The executable to launch for this instance.
  */
-std::string const& instance_configuration::get_executable() const throw() {
+std::string const& instance_configuration::get_executable() const noexcept {
   return _executable;
 }
 

--- a/tests/clib/handle_manager.cc
+++ b/tests/clib/handle_manager.cc
@@ -27,6 +27,7 @@ using namespace com::centreon;
 
 class     listener : public handle_listener {
  public:
+  listener() = delete;
   listener(
       handle& ref_h,
       bool want_read,


### PR DESCRIPTION
# Pull Request Template

## Description

Several improvements in centreon-collect in the 'make install' phase.
Now cbd starts.

How to work:
* mkdir build
* cd build
* cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug ..
* make -j4
* make install
* ../install.sh

The last line changes several files of owner.

The configuration should then be able to be started with
systemctl start cbd

And to see it:
ps ax | grep cbd

should show two running instances of cbd
