### PR TITLE
Mon 12070 bam services cache too selective 21.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ A ba configured with best status was initialized in state OK. And when KPI were
 added, their status were always worst than OK (best case was OK). So even if all
 the kpi were in critical state, the state appeared as OK.
 
-The cache in bam is lighter, only needed services are loaded. Metrics are no
+The cache in bam is lighter, metrics are no
 more loaded. And queries to load the cache are parallelized.
 
 *mysql_connection*

--- a/centreon-broker/bam/src/configuration/reader_v2.cc
+++ b/centreon-broker/bam/src/configuration/reader_v2.cc
@@ -370,14 +370,11 @@ void reader_v2::_load(bam::hst_svc_mapping& mapping) {
     // XXX : expand hostgroups and servicegroups
     std::promise<database::mysql_result> promise;
     _mysql.run_query_and_get_result(
-        "SELECT DISTINCT h.host_id, s.service_id, h.host_name, "
+        "SELECT h.host_id, s.service_id, h.host_name, "
         "s.service_description,service_activate FROM "
-        "service s LEFT JOIN host_service_relation AS hsr ON "
+        "service s LEFT JOIN host_service_relation hsr ON "
         "s.service_id=hsr.service_service_id "
-        "LEFT JOIN host AS h ON hsr.host_host_id=h.host_id LEFT JOIN "
-        "mod_bam_kpi k ON "
-        "h.host_id=k.host_id AND k.service_id=s.service_id WHERE "
-        "k.kpi_type='0'",
+        "LEFT JOIN host h ON hsr.host_host_id=h.host_id",
         &promise, 0);
     database::mysql_result res(promise.get_future().get());
     while (_mysql.fetch_row(res))

--- a/centreon-broker/core/src/mysql_connection.cc
+++ b/centreon-broker/core/src/mysql_connection.cc
@@ -235,7 +235,8 @@ void mysql_connection::_commit(mysql_task* t) {
         fmt::format("Error during commit: {}", ::mysql_error(_conn)));
     log_v2::sql()->error("mysql_connection: {}", err_msg);
     set_error_message(err_msg);
-    if (--task->count == 0)
+    int c = atomic_fetch_sub(&task->count, 1) - 1;
+    if (c == 0)
       task->promise->set_value(true);
   } else {
     /* No more queries are waiting for a commit now. */
@@ -243,7 +244,8 @@ void mysql_connection::_commit(mysql_task* t) {
 
     /* Commit is done on each connection. If task->count is 0, then we are on
      * the last one. It's time to release the future boolean. */
-    if (--task->count == 0)
+    int c = atomic_fetch_sub(&task->count, 1) - 1;
+    if (c == 0)
       task->promise->set_value(true);
   }
 }


### PR DESCRIPTION
### Description

The services cache loading in bam was too restrictive.

REFS: MON-12070