### PR TITLE
Mon 12068 inherited downtime 21.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ the kpi were in critical state, the state appeared as OK.
 The cache in bam is lighter, metrics are no
 more loaded. And queries to load the cache are parallelized.
 
+Inherited downtimes were duplicated on cbd reload. This is fixed.
+
 *mysql_connection*
 
 * A timeout is added on mysql\_ping and this function is less called than

--- a/centreon-broker/bam/src/kpi_service.cc
+++ b/centreon-broker/bam/src/kpi_service.cc
@@ -259,7 +259,6 @@ void kpi_service::service_update(std::shared_ptr<neb::downtime> const& dt,
   _downtimed = dt->was_started && dt->actual_end_time.is_null();
   if (!_event || _event->in_downtime != _downtimed) {
     _last_check = _downtimed ? dt->actual_start_time : dt->actual_end_time;
-    assert(static_cast<time_t>(_last_check) > 10);
     log_v2::bam()->trace("kpi service {} update, last check set to {}", _id,
                          _last_check);
   }

--- a/centreon-broker/bam/src/monitoring_stream.cc
+++ b/centreon-broker/bam/src/monitoring_stream.cc
@@ -433,9 +433,11 @@ void monitoring_stream::_write_external_command(std::string& cmd) {
 void monitoring_stream::_read_cache() {
   log_v2::bam()->trace("BAM: monitoring stream _read_cache");
   if (_cache == nullptr)
-    return;
-
-  _applier.load_from_cache(*_cache);
+    log_v2::bam()->debug("BAM: no cache configured");
+  else {
+    log_v2::bam()->debug("BAM: loading cache");
+    _applier.load_from_cache(*_cache);
+  }
 }
 
 /**
@@ -443,12 +445,10 @@ void monitoring_stream::_read_cache() {
  */
 void monitoring_stream::_write_cache() {
   log_v2::bam()->trace("BAM: monitoring stream _write_cache");
-  if (_cache == nullptr) {
+  if (_cache == nullptr)
     log_v2::bam()->debug("BAM: no cache configured");
-    return;
+  else {
+    log_v2::bam()->debug("BAM: saving cache");
+    _applier.save_to_cache(*_cache);
   }
-
-  log_v2::bam()->debug("BAM: loading cache");
-
-  _applier.save_to_cache(*_cache);
 }

--- a/centreon-broker/bam/src/monitoring_stream.cc
+++ b/centreon-broker/bam/src/monitoring_stream.cc
@@ -74,11 +74,8 @@ monitoring_stream::monitoring_stream(std::string const& ext_cmd_file,
   // Prepare queries.
   _prepare();
 
-  // Simulate a configuration update.
-  // FIXME DBR: what for? This update() call is made juste after the stream
-  // construction. I keep that in case I'm doing an error but it looks like
-  // a nonsense.
-  // update();
+  // Let's update BAs then we will be able to load the cache with inherited downtimes.
+  update();
   // Read cache.
   _read_cache();
 }

--- a/centreon-broker/bam/test/ba/kpi_service.cc
+++ b/centreon-broker/bam/test/ba/kpi_service.cc
@@ -544,13 +544,10 @@ TEST_F(BamBA, KpiServiceDtInheritOneOK) {
     kpis.push_back(s);
   }
 
-  // Change KPI state as much time as needed to trigger a
-  // recomputation. Note that the loop must terminate on a odd number
-  // for the test to be correct.
-  time_t now(time(nullptr));
+  time_t now = time(nullptr);
 
-  std::shared_ptr<neb::service_status> ss(new neb::service_status);
-  std::shared_ptr<neb::downtime> dt(new neb::downtime);
+  auto ss = std::make_shared<neb::service_status>();
+  auto dt = std::make_shared<neb::downtime>();
   ss->service_id = 1;
 
   for (size_t j = 0; j < kpis.size(); j++) {


### PR DESCRIPTION
inherited downtimes were duplicated. Fixed now.

REFS: MON-12068