### PR TITLE
fix(broker/bam): inherited downtimes finally work

### DIFF
--- a/centreon-broker/bam/CMakeLists.txt
+++ b/centreon-broker/bam/CMakeLists.txt
@@ -126,7 +126,7 @@ add_library("${BAM}" SHARED
   "${INC_DIR}/service_listener.hh"
   "${INC_DIR}/timeperiod_map.hh"
 )
-target_link_libraries("${BAM}" bbdo_storage bbdo_bam CONAN_PKG::spdlog)
+target_link_libraries("${BAM}" bbdo_storage bbdo_bam CONAN_PKG::spdlog CONAN_PKG::abseil)
 set_target_properties("${BAM}" PROPERTIES
     PREFIX "")
 

--- a/centreon-broker/bam/inc/com/centreon/broker/bam/configuration/applier/ba.hh
+++ b/centreon-broker/bam/inc/com/centreon/broker/bam/configuration/applier/ba.hh
@@ -67,7 +67,8 @@ class ba {
   std::shared_ptr<neb::host> _ba_host(uint32_t host_id);
   std::shared_ptr<neb::service> _ba_service(uint32_t ba_id,
                                             uint32_t host_id,
-                                            uint32_t service_id);
+                                            uint32_t service_id,
+                                            bool in_downtime = false);
   void _internal_copy(ba const& other);
   std::shared_ptr<bam::ba> _new_ba(configuration::ba const& cfg,
                                    service_book& book);

--- a/centreon-broker/bam/inc/com/centreon/broker/bam/hst_svc_mapping.hh
+++ b/centreon-broker/bam/inc/com/centreon/broker/bam/hst_svc_mapping.hh
@@ -19,10 +19,9 @@
 #ifndef CCB_BAM_HST_SVC_MAPPING_HH
 #define CCB_BAM_HST_SVC_MAPPING_HH
 
+#include <absl/container/flat_hash_map.h>
 #include <string>
-#include <unordered_map>
 #include <utility>
-#include "com/centreon/broker/misc/pair.hh"
 
 #include "com/centreon/broker/namespace.hh"
 
@@ -37,11 +36,11 @@ namespace bam {
  *  Allow to find an ID of a host or service by its name.
  */
 class hst_svc_mapping {
-  std::unordered_map<std::pair<std::string, std::string>,
-                     std::pair<uint32_t, uint32_t>>
+  absl::flat_hash_map<std::pair<std::string, std::string>,
+                      std::pair<uint32_t, uint32_t>>
       _mapping;
 
-  std::unordered_map<std::pair<uint32_t, uint32_t>, bool> _activated_mapping;
+  absl::flat_hash_map<std::pair<uint32_t, uint32_t>, bool> _activated_mapping;
 
  public:
   hst_svc_mapping() = default;

--- a/centreon-broker/bam/inc/com/centreon/broker/bam/kpi_service.hh
+++ b/centreon-broker/bam/inc/com/centreon/broker/bam/kpi_service.hh
@@ -20,6 +20,7 @@
 #define CCB_BAM_KPI_SERVICE_HH
 
 #include <array>
+#include <absl/container/flat_hash_set.h>
 #include "bbdo/bam/kpi_event.hh"
 #include "bbdo/bam/state.hh"
 #include "com/centreon/broker/bam/impact_values.hh"
@@ -49,6 +50,7 @@ class kpi_service : public service_listener, public kpi {
 
   bool _acknowledged;
   bool _downtimed;
+  absl::flat_hash_set<uint32_t> _downtime_ids;
   std::array<double, 5> _impacts;
   timestamp _last_check;
   std::string _output;

--- a/centreon-broker/bam/src/ba.cc
+++ b/centreon-broker/bam/src/ba.cc
@@ -508,6 +508,7 @@ void ba::visit(io::stream* visitor) {
     short hard_state(get_state_hard());
     bool state_changed(false);
     if (!_event) {
+      log_v2::bam()->trace("BAM: ba::visit no event => creation of one");
       if (_last_kpi_update.is_null())
         _last_kpi_update = time(nullptr);
       _open_new_event(visitor, hard_state);
@@ -515,6 +516,9 @@ void ba::visit(io::stream* visitor) {
     // If state changed, close event and open a new one.
     else if (_in_downtime != _event->in_downtime ||
              hard_state != _event->status) {
+      log_v2::bam()->trace(
+          "BAM: ba::visit event needs update downtime: {}, state: {}",
+          _in_downtime != _event->in_downtime, hard_state != _event->status);
       state_changed = true;
       _event->end_time = _last_kpi_update;
       visitor->write(std::static_pointer_cast<io::data>(_event));
@@ -546,7 +550,7 @@ void ba::visit(io::stream* visitor) {
 
     // Generate virtual service status event.
     if (_generate_virtual_status) {
-      std::shared_ptr<neb::service_status> status(new neb::service_status);
+      auto status{std::make_shared<neb::service_status>()};
       status->active_checks_enabled = false;
       status->check_interval = 0.0;
       status->check_type = 1;  // Passive.
@@ -558,6 +562,7 @@ void ba::visit(io::stream* visitor) {
       status->flap_detection_enabled = false;
       status->has_been_checked = true;
       status->host_id = _host_id;
+      status->downtime_depth = _in_downtime;
       // status->host_name = XXX;
       status->is_flapping = false;
       if (_event)
@@ -602,7 +607,7 @@ void ba::visit(io::stream* visitor) {
 void ba::service_update(const std::shared_ptr<neb::downtime>& dt,
                         io::stream* visitor) {
   (void)visitor;
-  if ((dt->host_id == _host_id) && (dt->service_id == _service_id)) {
+  if (dt->host_id == _host_id && dt->service_id == _service_id) {
     // Log message.
     log_v2::bam()->debug(
         "BAM: BA {} '{}' is getting notified of a downtime on its service ({}, "
@@ -645,8 +650,10 @@ void ba::save_inherited_downtime(persistent_cache& cache) const {
  *
  *  @param[in] dwn  The inherited downtime.
  */
-void ba::set_inherited_downtime(inherited_downtime const& dwn) {
+void ba::set_inherited_downtime(const inherited_downtime& dwn) {
   _inherited_downtime.reset(new inherited_downtime(dwn));
+  if (_inherited_downtime->in_downtime)
+    _in_downtime = true;
 }
 
 /**

--- a/centreon-broker/bam/src/configuration/applier/ba.cc
+++ b/centreon-broker/bam/src/configuration/applier/ba.cc
@@ -84,19 +84,15 @@ void applier::ba::apply(bam::configuration::state::bas const& my_bas,
   std::list<bam::configuration::ba> to_modify;
 
   // Iterate through configuration.
-  for (bam::configuration::state::bas::iterator it(to_create.begin()),
-       end(to_create.end());
-       it != end;) {
-    std::map<uint32_t, applied>::iterator cfg_it(to_delete.find(it->first));
+  for (auto it = to_create.begin(), end = to_create.end(); it != end;) {
+    auto cfg_it = to_delete.find(it->first);
     // Found = modify (or not).
     if (cfg_it != to_delete.end()) {
       // Configuration mismatch, modify object.
       if (cfg_it->second.cfg != it->second)
         to_modify.push_back(it->second);
       to_delete.erase(cfg_it);
-      bam::configuration::state::bas::iterator tmp = it;
-      ++it;
-      to_create.erase(tmp);
+      it = to_create.erase(it);
     }
     // Not found = create.
     else
@@ -220,13 +216,17 @@ std::shared_ptr<neb::host> applier::ba::_ba_host(uint32_t host_id) {
  */
 std::shared_ptr<neb::service> applier::ba::_ba_service(uint32_t ba_id,
                                                        uint32_t host_id,
-                                                       uint32_t service_id) {
-  std::shared_ptr<neb::service> s(new neb::service);
+                                                       uint32_t service_id,
+                                                       bool in_downtime) {
+  log_v2::bam()->trace("_ba_service ba {}, service {}:{} with downtime {}",
+                       ba_id, host_id, service_id, in_downtime);
+  auto s{std::make_shared<neb::service>()};
   s->host_id = host_id;
   s->service_id = service_id;
   s->service_description = fmt::format("ba_{}", ba_id);
   s->display_name = s->service_description;
   s->last_update = time(nullptr);
+  s->downtime_depth = in_downtime ? 1 : 0;
   return s;
 }
 
@@ -282,6 +282,7 @@ void applier::ba::save_to_cache(persistent_cache& cache) {
  *  @param[in] cache  The cache.
  */
 void applier::ba::load_from_cache(persistent_cache& cache) {
+  log_v2::bam()->trace("BAM: loading inherited downtimes from cache");
   std::shared_ptr<io::data> d;
   cache.get(d);
   while (d) {
@@ -294,6 +295,9 @@ void applier::ba::load_from_cache(persistent_cache& cache) {
       log_v2::bam()->debug("BAM: found an inherited downtime for BA {}",
                            found->first);
       found->second.obj->set_inherited_downtime(dwn);
+      auto s = _ba_service(found->first, found->second.cfg.get_host_id(),
+                           found->second.cfg.get_service_id(), dwn.in_downtime);
+      multiplexing::publisher().write(s);
     }
     cache.get(d);
   }

--- a/centreon-broker/bam/src/configuration/reader_v2.cc
+++ b/centreon-broker/bam/src/configuration/reader_v2.cc
@@ -272,7 +272,7 @@ void reader_v2::_load(state::bas& bas, bam::ba_svc_mapping& mapping) {
         "    ON s.service_id=hsr.service_service_id"
         "  INNER JOIN host AS h"
         "    ON hsr.host_host_id=h.host_id"
-        "  WHERE s.service_description LIKE 'ba_%'",
+        "  WHERE s.service_description LIKE 'ba\\_%'",
         &promise, 0);
     database::mysql_result res(promise.get_future().get());
     while (_mysql.fetch_row(res)) {

--- a/centreon-broker/bam/src/kpi_service.cc
+++ b/centreon-broker/bam/src/kpi_service.cc
@@ -257,6 +257,22 @@ void kpi_service::service_update(std::shared_ptr<neb::downtime> const& dt,
   assert(dt && dt->host_id == _host_id && dt->service_id == _service_id);
   // Update information.
   _downtimed = dt->was_started && dt->actual_end_time.is_null();
+  if (_downtime_ids.contains(dt->internal_id) && !dt->was_cancelled) {
+    log_v2::bam()->trace("Downtime {} already handled in this kpi service",
+                         dt->internal_id);
+    return;
+  }
+
+  if (_downtimed) {
+    log_v2::bam()->trace("adding in kpi service the impacting downtime {}",
+                         dt->internal_id);
+    _downtime_ids.insert(dt->internal_id);
+  } else {
+    log_v2::bam()->trace("removing from kpi service the impacting downtime {}",
+                         dt->internal_id);
+    _downtime_ids.erase(dt->internal_id);
+  }
+
   if (!_event || _event->in_downtime != _downtimed) {
     _last_check = _downtimed ? dt->actual_start_time : dt->actual_end_time;
     log_v2::bam()->trace("kpi service {} update, last check set to {}", _id,
@@ -265,10 +281,11 @@ void kpi_service::service_update(std::shared_ptr<neb::downtime> const& dt,
 
   // Log message.
   log_v2::bam()->debug(
-      "BAM: KPI {} is getting notified of a downtime on its service ({}, {}), "
+      "BAM: KPI {} is getting notified of a downtime ({}) on its service ({}, "
+      "{}), "
       "in "
       "downtime: {} at {}",
-      _id, _host_id, _service_id, _downtimed, _last_check);
+      _id, dt->internal_id, _host_id, _service_id, _downtimed, _last_check);
 
   // Generate status event.
   visit(visitor);
@@ -370,6 +387,8 @@ void kpi_service::visit(io::stream* visitor) {
       // If no event was cached, create one.
       if (!_event) {
         if (!_last_check.is_null()) {
+          log_v2::bam()->trace(
+              "BAM: kpi_service::visit no event => creation of one");
           _open_new_event(visitor, hard_values);
         }
       }
@@ -377,6 +396,10 @@ void kpi_service::visit(io::stream* visitor) {
       else if (_last_check >= _event->start_time &&
                (_downtimed != _event->in_downtime ||
                 _state_hard != _event->status)) {
+        log_v2::bam()->trace(
+            "BAM: kpi_service::visit event needs update downtime: {}, state: "
+            "{}",
+            _downtimed != _event->in_downtime, _state_hard != _event->status);
         _event->end_time = _last_check;
         visitor->write(std::static_pointer_cast<io::data>(_event));
         _open_new_event(visitor, hard_values);

--- a/centreon-broker/bam/src/monitoring_stream.cc
+++ b/centreon-broker/bam/src/monitoring_stream.cc
@@ -218,9 +218,8 @@ int monitoring_stream::write(std::shared_ptr<io::data> const& data) {
       std::shared_ptr<neb::downtime> dt(
           std::static_pointer_cast<neb::downtime>(data));
       log_v2::bam()->trace(
-          "BAM: processing downtime on service ({}, {}) started: {}, stopped: "
-          "{}",
-          dt->host_id, dt->service_id, dt->was_started, dt->was_cancelled);
+          "BAM: processing downtime ({}) on service ({}, {}) started: {}, stopped: {}",
+          dt->internal_id, dt->host_id, dt->service_id, dt->was_started, dt->was_cancelled);
       multiplexing::publisher pblshr;
       event_cache_visitor ev_cache;
       _applier.book_service().update(dt, &ev_cache);
@@ -307,11 +306,10 @@ int monitoring_stream::write(std::shared_ptr<io::data> const& data) {
             std::numeric_limits<int32_t>::max());
       else
         cmd = fmt::format(
-            "[{}] DEL_SVC_DOWNTIME_FULL;_Module_BAM_{};ba_{};;{};1;0;;Centreon "
+            "[{}] DEL_SVC_DOWNTIME_FULL;_Module_BAM_{};ba_{};;;1;0;;Centreon "
             "Broker BAM Module;Automatic downtime triggered by BA downtime "
             "inheritance",
-            now, config::applier::state::instance().poller_id(), dwn.ba_id,
-            std::numeric_limits<int32_t>::max());
+            now, config::applier::state::instance().poller_id(), dwn.ba_id);
       _write_external_command(cmd);
     } break;
     default:


### PR DESCRIPTION
Back port of MON-12068-inherited-downtime-next-step_21.04 made on centreon-broker