### PR TITLE
fix(broker/config): unknown filters do not hang broker anymore

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,6 +3,8 @@ sonar.projectKey={PROJECT_TITLE}
 sonar.projectName={PROJECT_NAME}
 sonar.projectVersion={PROJECT_VERSION}
 sonar.sources=.
+sonar.sourceEncoding=UTF-8
+sonar.cfamily.compile-commands=build/compile_commands.json
 sonar.cxx.xunit.reportPath=ut.xml
 
 sonar.tsql.file.suffixes=sql,tsql


### PR DESCRIPTION
Filters in broker output do not hang cbd anymore if they do not exist.
Two cases:
* an output is configured with only unknown filters: errors are raised and the 'all' filter is applied.
* an output is configured with existing filters and also unknown ones: errors are raised about wrong filters and only good ones are applied.

REFS: MON-11690