### PR TITLE
fix(broker/sc): perfdata must not be written perf_data

### DIFF
--- a/bbdo/host.proto
+++ b/bbdo/host.proto
@@ -77,7 +77,7 @@ message Host {
   string output = 35;
   bool passive_checks_enabled = 36;
   double percent_state_change = 37;
-  string perf_data = 38;
+  string perfdata = 38;
   double retry_interval = 39;
   bool should_be_scheduled = 40;
   bool obsess_over = 41;
@@ -163,7 +163,7 @@ message HostStatus {
 
   string output = 12;
   string long_output = 13;
-  string perf_data = 14;
+  string perfdata = 14;
 
   bool is_flapping = 15;
   double percent_state_change = 16;

--- a/bbdo/host.proto
+++ b/bbdo/host.proto
@@ -33,9 +33,9 @@ message Host {
   bool acknowledged = 2;
   int32 acknowledgement_type = 3;
 
-  bool active_checks_enabled = 4;
+  bool active_checks = 4;
   bool enabled = 5;
-  int32 downtime_depth = 6;
+  int32 scheduled_downtime_depth = 6;
   string check_command = 7;
   int32 check_interval = 8;
   string check_period = 9;
@@ -45,19 +45,19 @@ message Host {
     PASSIVE = 1;
   }
   CheckType check_type = 10;
-  int32 current_check_attempt = 11;
+  int32 check_attempt = 11;
   enum State {
     UP = 0;
     DOWN = 1;
     UNREACHABLE = 2;
   }
-  State current_state = 12;
+  State state = 12;
   bool event_handler_enabled = 13;
   string event_handler = 14;
   double execution_time = 15;
-  bool flap_detection_enabled = 16;
-  bool has_been_checked = 17;
-  bool is_flapping = 18;
+  bool flap_detection = 16;
+  bool checked = 17;
+  bool flapping = 18;
   int64 last_check = 19;
   State last_hard_state = 20;
   int64 last_hard_state_change = 21;
@@ -71,16 +71,16 @@ message Host {
   double latency = 29;
   int32 max_check_attempts = 30;
   int64 next_check = 31;
-  int64 next_notification = 32;
+  int64 next_host_notification = 32;
   bool no_more_notifications = 33;
-  bool notifications_enabled = 34;
+  bool notify = 34;
   string output = 35;
-  bool passive_checks_enabled = 36;
+  bool passive_checks = 36;
   double percent_state_change = 37;
   string perfdata = 38;
   double retry_interval = 39;
   bool should_be_scheduled = 40;
-  bool obsess_over = 41;
+  bool obsess_over_host = 41;
 
   enum StateType {
     SOFT = 0;
@@ -92,11 +92,11 @@ message Host {
   string address = 44;
   string alias = 45;
   bool check_freshness = 46;
-  bool default_active_checks_enabled = 47;
+  bool default_active_checks = 47;
   bool default_event_handler_enabled = 48;
-  bool default_flap_detection_enabled = 49;
-  bool default_notifications_enabled = 50;
-  bool default_passive_checks_enabled = 51;
+  bool default_flap_detection = 49;
+  bool default_notify = 50;
+  bool default_passive_checks = 51;
   string display_name = 52;
   double first_notification_delay = 53;
   bool flap_detection_on_down = 54;
@@ -104,10 +104,10 @@ message Host {
   bool flap_detection_on_up = 56;
   double freshness_threshold = 57;
   double high_flap_threshold = 58;
-  string host_name = 59;
+  string name = 59;
   string icon_image = 60;
   string icon_image_alt = 61;
-  int32 poller_id = 62;
+  int32 instance_id = 62;
   double low_flap_threshold = 63;
   string notes = 64;
   string notes_url = 65;
@@ -136,7 +136,7 @@ message Host {
 message HostStatus {
   uint64 host_id = 1;
 
-  bool has_been_checked = 2;
+  bool checked = 2;
   enum CheckType {
     ACTIVE = 0;
     PASSIVE = 1;
@@ -148,7 +148,7 @@ message HostStatus {
     DOWN = 1;
     UNREACHABLE = 2;
   }
-  State current_state = 4;
+  State state = 4;
   enum StateType {
     SOFT = 0;
     HARD = 1;
@@ -165,19 +165,19 @@ message HostStatus {
   string long_output = 13;
   string perfdata = 14;
 
-  bool is_flapping = 15;
+  bool flapping = 15;
   double percent_state_change = 16;
   double latency = 17;
   double execution_time = 18;
   int64 last_check = 19;
   int64 next_check = 20;
   bool should_be_scheduled = 21;
-  int32 current_check_attempt = 22;
+  int32 check_attempt = 22;
 
   int32 notification_number = 23;
   bool no_more_notifications = 24;
   int64 last_notification = 25;
-  int64 next_notification = 26;
+  int64 next_host_notification = 26;
 
   enum AckType {
     NONE = 0;
@@ -185,7 +185,7 @@ message HostStatus {
     STICKY = 2;
   }
   AckType acknowledgement_type = 27;
-  int32 downtime_depth = 28;
+  int32 scheduled_downtime_depth = 28;
 }
 
 /**
@@ -197,13 +197,13 @@ message HostStatus {
 message AdaptiveHost {
   uint64 host_id = 1;
 
-  optional bool notifications_enabled = 2;
-  optional bool active_checks_enabled = 3;
+  optional bool notify = 2;
+  optional bool active_checks = 3;
   optional bool should_be_scheduled = 4;
-  optional bool passive_checks_enabled = 5;
+  optional bool passive_checks = 5;
   optional bool event_handler_enabled = 6;
-  optional bool flap_detection_enabled  = 7;
-  optional bool obsess_over  = 8;
+  optional bool flap_detection = 7;
+  optional bool obsess_over_host = 8;
   optional string event_handler = 9;
   optional string check_command  = 10;
   optional uint32 check_interval  = 11;

--- a/bbdo/service.proto
+++ b/bbdo/service.proto
@@ -45,9 +45,9 @@ message Service {
   bool acknowledged = 3;
   AckType acknowledgement_type = 4;
 
-  bool active_checks_enabled = 5;
+  bool active_checks = 5;
   bool enabled = 6;
-  int32 downtime_depth = 7;
+  int32 scheduled_downtime_depth = 7;
   string check_command = 8;
   uint32 check_interval = 9;
   string check_period = 10;
@@ -57,7 +57,7 @@ message Service {
     PASSIVE = 1;
   }
   CheckType check_type = 11;
-  int32 current_check_attempt = 12;
+  int32 check_attempt = 12;
   enum State {
     OK = 0;
     WARNING = 1;
@@ -65,13 +65,13 @@ message Service {
     UNKNOWN = 3;
     PENDING = 4;
   }
-  State current_state = 13;
+  State state = 13;
   bool event_handler_enabled = 14;
   string event_handler = 15;
   double execution_time = 16;
-  bool flap_detection_enabled = 17;
-  bool has_been_checked = 18;
-  bool is_flapping = 19;
+  bool flap_detection = 17;
+  bool checked = 18;
+  bool flapping = 19;
   int64 last_check = 20;
   State last_hard_state = 21;
   int64 last_hard_state_change = 22;
@@ -88,17 +88,17 @@ message Service {
   int64 next_check = 33;
   int64 next_notification = 34;
   bool no_more_notifications = 35;
-  bool notifications_enabled = 36;
+  bool notify = 36;
   string output = 37;
   string long_output = 38;
-  bool passive_checks_enabled = 39;
+  bool passive_checks = 39;
   double percent_state_change = 40;
   string perfdata = 41;
   double retry_interval = 42;
   string host_name = 43;
-  string service_description = 44;
+  string description = 44;
   bool should_be_scheduled = 45;
-  bool obsess_over = 46;
+  bool obsess_over_service = 46;
 
   enum StateType {
     SOFT = 0;
@@ -108,11 +108,11 @@ message Service {
   StateType state_type = 47;
   string action_url = 48;
   bool check_freshness = 49;
-  bool default_active_checks_enabled = 50;
+  bool default_active_checks = 50;
   bool default_event_handler_enabled = 51;
-  bool default_flap_detection_enabled = 52;
-  bool default_notifications_enabled = 53;
-  bool default_passive_checks_enabled = 54;
+  bool default_flap_detection = 52;
+  bool default_notify = 53;
+  bool default_passive_checks = 54;
   string display_name = 55;
   double first_notification_delay = 56;
   bool flap_detection_on_critical = 57;
@@ -160,7 +160,7 @@ message ServiceStatus {
   uint64 host_id = 1;
   uint64 service_id = 2;
 
-  bool has_been_checked = 3;
+  bool checked = 3;
   enum CheckType {
     ACTIVE = 0;
     PASSIVE = 1;
@@ -174,7 +174,7 @@ message ServiceStatus {
     UNKNOWN = 3;
     PENDING = 4;
   }
-  State current_state = 5;
+  State state = 5;
   enum StateType {
     SOFT = 0;
     HARD = 1;
@@ -192,14 +192,14 @@ message ServiceStatus {
   string long_output = 15;
   string perfdata = 16;
 
-  bool is_flapping = 17;
+  bool flapping = 17;
   double percent_state_change = 18;
   double latency = 19;
   double execution_time = 20;
   int64 last_check = 21;
   int64 next_check = 22;
   bool should_be_scheduled = 23;
-  int32 current_check_attempt = 24;
+  int32 check_attempt = 24;
 
   int32 notification_number = 25;
   bool no_more_notifications = 26;
@@ -212,7 +212,7 @@ message ServiceStatus {
     STICKY = 2;
   }
   AckType acknowledgement_type = 29;
-  int32 downtime_depth = 30;
+  int32 scheduled_downtime_depth = 30;
 
   ServiceType type = 31;
 
@@ -231,13 +231,13 @@ message AdaptiveService {
   uint64 host_id = 1;
   uint64 service_id = 2;
 
-  optional bool notifications_enabled = 3;
-  optional bool active_checks_enabled = 4;
+  optional bool notify = 3;
+  optional bool active_checks = 4;
   optional bool should_be_scheduled = 5;
-  optional bool passive_checks_enabled = 6;
+  optional bool passive_checks = 6;
   optional bool event_handler_enabled = 7;
   optional bool flap_detection_enabled = 8;
-  optional bool obsess_over = 9;
+  optional bool obsess_over_service = 9;
   optional string event_handler = 10;
   optional string check_command = 11;
   optional uint32 check_interval = 12;

--- a/bbdo/service.proto
+++ b/bbdo/service.proto
@@ -93,7 +93,7 @@ message Service {
   string long_output = 38;
   bool passive_checks_enabled = 39;
   double percent_state_change = 40;
-  string perf_data = 41;
+  string perfdata = 41;
   double retry_interval = 42;
   string host_name = 43;
   string service_description = 44;
@@ -190,7 +190,7 @@ message ServiceStatus {
 
   string output = 14;
   string long_output = 15;
-  string perf_data = 16;
+  string perfdata = 16;
 
   bool is_flapping = 17;
   double percent_state_change = 18;

--- a/broker/bam/src/ba.cc
+++ b/broker/bam/src/ba.cc
@@ -617,7 +617,7 @@ void ba::visit(io::stream* visitor) {
         o.set_output(
             fmt::format("BA : Business Activity {} - current_level = {}%", _id,
                         static_cast<int>(normalize(_level_hard))));
-        o.set_perf_data(fmt::format("BA_Level={}%;{};{};0;100",
+        o.set_perfdata(fmt::format("BA_Level={}%;{};{};0;100",
                                     static_cast<int>(normalize(_level_hard)),
                                     static_cast<int>(_level_warning),
                                     static_cast<int>(_level_critical)));

--- a/broker/bam/src/ba.cc
+++ b/broker/bam/src/ba.cc
@@ -602,11 +602,11 @@ void ba::visit(io::stream* visitor) {
         auto status{std::make_shared<neb::pb_service_status>()};
         auto& o = status->mut_obj();
         o.set_check_type(ServiceStatus_CheckType_PASSIVE);  // Passive.
-        o.set_current_check_attempt(1);
-        o.set_current_state(ServiceStatus_State_OK);
-        o.set_has_been_checked(true);
+        o.set_check_attempt(1);
+        o.set_state(ServiceStatus_State_OK);
+        o.set_checked(true);
         o.set_host_id(_host_id);
-        o.set_downtime_depth(_in_downtime);
+        o.set_scheduled_downtime_depth(_in_downtime);
         if (_event)
           o.set_last_check(_event->start_time);
         else
@@ -618,9 +618,9 @@ void ba::visit(io::stream* visitor) {
             fmt::format("BA : Business Activity {} - current_level = {}%", _id,
                         static_cast<int>(normalize(_level_hard))));
         o.set_perfdata(fmt::format("BA_Level={}%;{};{};0;100",
-                                    static_cast<int>(normalize(_level_hard)),
-                                    static_cast<int>(_level_warning),
-                                    static_cast<int>(_level_critical)));
+                                   static_cast<int>(normalize(_level_hard)),
+                                   static_cast<int>(_level_warning),
+                                   static_cast<int>(_level_critical)));
         o.set_service_id(_service_id);
         o.set_state_type(ServiceStatus_StateType_HARD);
         visitor->write(status);

--- a/broker/bam/src/bool_service.cc
+++ b/broker/bam/src/bool_service.cc
@@ -107,9 +107,9 @@ void bool_service::service_update(
   auto& o = status->obj();
   if (status && o.host_id() == _host_id && o.service_id() == _service_id) {
     _state_hard = o.last_hard_state();
-    _state_soft = o.current_state();
+    _state_soft = o.state();
     _state_known = true;
-    _in_downtime = o.downtime_depth() > 0;
+    _in_downtime = o.scheduled_downtime_depth() > 0;
     propagate_update(visitor);
   }
 }

--- a/broker/bam/src/configuration/applier/ba.cc
+++ b/broker/bam/src/configuration/applier/ba.cc
@@ -235,10 +235,10 @@ std::shared_ptr<neb::host> applier::ba::_ba_host(uint32_t host_id) {
 std::shared_ptr<neb::pb_host> applier::ba::_ba_pb_host(uint32_t host_id) {
   auto h = std::make_shared<neb::pb_host>();
   auto& o = h->mut_obj();
-  o.set_poller_id(
+  o.set_instance_id(
       com::centreon::broker::config::applier::state::instance().poller_id());
   o.set_host_id(host_id);
-  o.set_host_name(fmt::format("_Module_BAM_{}", o.poller_id()));
+  o.set_name(fmt::format("_Module_BAM_{}", o.instance_id()));
   o.set_last_update(time(nullptr));
   o.set_enabled(true);
   return h;
@@ -289,12 +289,12 @@ std::shared_ptr<neb::pb_service> applier::ba::_ba_pb_service(
   auto& o = s->mut_obj();
   o.set_host_id(host_id);
   o.set_service_id(service_id);
-  o.set_service_description(fmt::format("ba_{}", ba_id));
+  o.set_description(fmt::format("ba_{}", ba_id));
   o.set_type(BA);
   o.set_internal_id(ba_id);
-  o.set_display_name(o.service_description());
+  o.set_display_name(o.description());
   o.set_last_update(time(nullptr));
-  o.set_downtime_depth(in_downtime ? 1 : 0);
+  o.set_scheduled_downtime_depth(in_downtime ? 1 : 0);
   o.set_max_check_attempts(1);
   o.set_enabled(true);
   return s;

--- a/broker/bam/src/kpi_service.cc
+++ b/broker/bam/src/kpi_service.cc
@@ -236,7 +236,7 @@ void kpi_service::service_update(
     log_v2::bam()->debug(
         "BAM: KPI {} is getting notified of service ({}, {}) update (state: "
         "{})",
-        _id, _host_id, _service_id, o.current_state());
+        _id, _host_id, _service_id, o.state());
 
     // Update information.
     if (o.last_check() == 0 || o.last_check() == -1) {
@@ -255,7 +255,7 @@ void kpi_service::service_update(
     _output = o.output();
     _perfdata = o.perfdata();
     _state_hard = static_cast<state>(o.last_hard_state());
-    _state_soft = static_cast<state>(o.current_state());
+    _state_soft = static_cast<state>(o.state());
     _state_type = o.state_type();
 
     // Generate status event.

--- a/broker/bam/src/kpi_service.cc
+++ b/broker/bam/src/kpi_service.cc
@@ -253,7 +253,7 @@ void kpi_service::service_update(
           o.last_check());
     }
     _output = o.output();
-    _perfdata = o.perf_data();
+    _perfdata = o.perfdata();
     _state_hard = static_cast<state>(o.last_hard_state());
     _state_soft = static_cast<state>(o.current_state());
     _state_type = o.state_type();

--- a/broker/bam/src/monitoring_stream.cc
+++ b/broker/bam/src/monitoring_stream.cc
@@ -210,7 +210,7 @@ int monitoring_stream::write(std::shared_ptr<io::data> const& data) {
       log_v2::bam()->trace(
           "BAM: processing pb service status (host: {}, service: {}, hard "
           "state {}, current state {})",
-          o.host_id(), o.service_id(), o.last_hard_state(), o.current_state());
+          o.host_id(), o.service_id(), o.last_hard_state(), o.state());
       multiplexing::publisher pblshr;
       event_cache_visitor ev_cache;
       _applier.book_service().update(ss, &ev_cache);
@@ -222,7 +222,7 @@ int monitoring_stream::write(std::shared_ptr<io::data> const& data) {
       log_v2::bam()->trace(
           "BAM: processing pb service status (host: {}, service: {}, hard "
           "state {}, current state {})",
-          o.host_id(), o.service_id(), o.last_hard_state(), o.current_state());
+          o.host_id(), o.service_id(), o.last_hard_state(), o.state());
       multiplexing::publisher pblshr;
       event_cache_visitor ev_cache;
       _applier.book_service().update(s, &ev_cache);

--- a/broker/graphite/src/macro_cache.cc
+++ b/broker/graphite/src/macro_cache.cc
@@ -101,7 +101,7 @@ std::string const& macro_cache::get_host_name(uint64_t host_id) const {
     return h->host_name;
   } else {
     auto const& h = std::static_pointer_cast<neb::pb_host>(found->second);
-    return h->obj().host_name();
+    return h->obj().name();
   }
 }
 
@@ -125,7 +125,7 @@ std::string const& macro_cache::get_service_description(
     return s->service_description;
   } else {
     auto const& s = std::static_pointer_cast<neb::pb_service>(found->second);
-    return s->obj().service_description();
+    return s->obj().description();
   }
 }
 

--- a/broker/graphite/test/query.cc
+++ b/broker/graphite/test/query.cc
@@ -123,11 +123,11 @@ TEST(graphiteQuery, ComplexPbMetric) {
 
   m.source_id = 3;
 
-  svc->mut_obj().set_service_description("svc.1");
+  svc->mut_obj().set_description("svc.1");
   svc->mut_obj().set_service_id(1);
   svc->mut_obj().set_host_id(1);
 
-  host->mut_obj().set_host_name("host1");
+  host->mut_obj().set_name("host1");
   host->mut_obj().set_host_id(1);
 
   instance->poller_id = 3;
@@ -168,11 +168,11 @@ TEST(graphiteQuery, ComplexPbStatus) {
       "$INDEXID$ $TEST$ TEST $$",
       "a", graphite::query::status, cache};
 
-  svc->mut_obj().set_service_description("svc1");
+  svc->mut_obj().set_description("svc1");
   svc->mut_obj().set_service_id(1);
   svc->mut_obj().set_host_id(1);
 
-  host->mut_obj().set_host_name("host1");
+  host->mut_obj().set_name("host1");
   host->mut_obj().set_host_id(1);
 
   instance->poller_id = 3;

--- a/broker/influxdb/src/macro_cache.cc
+++ b/broker/influxdb/src/macro_cache.cc
@@ -101,7 +101,7 @@ std::string const& macro_cache::get_host_name(uint64_t host_id) const {
     return h->host_name;
   } else {
     auto const& h = std::static_pointer_cast<neb::pb_host>(found->second);
-    return h->obj().host_name();
+    return h->obj().name();
   }
 }
 
@@ -125,7 +125,7 @@ std::string const& macro_cache::get_service_description(
     return s->service_description;
   } else {
     auto const& s = std::static_pointer_cast<neb::pb_service>(found->second);
-    return s->obj().service_description();
+    return s->obj().description();
   }
 }
 

--- a/broker/influxdb/test/line_protocol_query.cc
+++ b/broker/influxdb/test/line_protocol_query.cc
@@ -218,11 +218,11 @@ TEST(InfluxDBLineProtoQuery, ComplexPbMetric) {
 
   m.source_id = 3;
 
-  svc->mut_obj().set_service_description("svc.1");
+  svc->mut_obj().set_description("svc.1");
   svc->mut_obj().set_service_id(1);
   svc->mut_obj().set_host_id(1);
 
-  host->mut_obj().set_host_name("host1");
+  host->mut_obj().set_name("host1");
   host->mut_obj().set_host_id(1);
 
   instance->poller_id = 3;
@@ -271,11 +271,11 @@ TEST(InfluxDBLineProtoQuery, ComplexPBStatus) {
       "$INDEXID$ $TEST$ TEST $$ $VALUE$",
       columns, influxdb::line_protocol_query::status, cache};
 
-  svc->mut_obj().set_service_description("svc1");
+  svc->mut_obj().set_description("svc1");
   svc->mut_obj().set_service_id(1);
   svc->mut_obj().set_host_id(1);
 
-  host->mut_obj().set_host_name("host1");
+  host->mut_obj().set_name("host1");
   host->mut_obj().set_host_id(1);
 
   instance->poller_id = 3;

--- a/broker/lua/src/macro_cache.cc
+++ b/broker/lua/src/macro_cache.cc
@@ -140,7 +140,7 @@ std::string const& macro_cache::get_host_name(uint64_t host_id) const {
     return s->host_name;
   } else {
     auto const& s = std::static_pointer_cast<neb::pb_host>(found->second);
-    return s->obj().host_name();
+    return s->obj().name();
   }
 }
 
@@ -325,7 +325,7 @@ std::string const& macro_cache::get_service_description(
     return s->service_description;
   } else {
     auto const& s = std::static_pointer_cast<neb::pb_service>(found->second);
-    return s->obj().service_description();
+    return s->obj().description();
   }
 }
 
@@ -522,8 +522,8 @@ void macro_cache::_process_host(std::shared_ptr<io::data> const& data) {
 void macro_cache::_process_pb_host(std::shared_ptr<io::data> const& data) {
   std::shared_ptr<neb::pb_host> const& h =
       std::static_pointer_cast<neb::pb_host>(data);
-  log_v2::lua()->debug("lua: processing host '{}' of id {}",
-                       h->obj().host_name(), h->obj().host_id());
+  log_v2::lua()->debug("lua: processing host '{}' of id {}", h->obj().name(),
+                       h->obj().host_id());
   if (h->obj().enabled())
     _hosts[h->obj().host_id()] = data;
   else
@@ -544,20 +544,20 @@ void macro_cache::_process_pb_adaptive_host(
   if (it != _hosts.end()) {
     if (it->second->type() == make_type(io::neb, neb::de_host)) {
       auto& h = *std::static_pointer_cast<neb::host>(it->second);
-      if (ah.has_notifications_enabled())
-        h.notifications_enabled = ah.notifications_enabled();
-      if (ah.has_active_checks_enabled())
-        h.active_checks_enabled = ah.active_checks_enabled();
+      if (ah.has_notify())
+        h.notifications_enabled = ah.notify();
+      if (ah.has_active_checks())
+        h.active_checks_enabled = ah.active_checks();
       if (ah.has_should_be_scheduled())
         h.should_be_scheduled = ah.should_be_scheduled();
-      if (ah.has_passive_checks_enabled())
-        h.passive_checks_enabled = ah.passive_checks_enabled();
+      if (ah.has_passive_checks())
+        h.passive_checks_enabled = ah.passive_checks();
       if (ah.has_event_handler_enabled())
         h.event_handler_enabled = ah.event_handler_enabled();
-      if (ah.has_flap_detection_enabled())
-        h.flap_detection_enabled = ah.flap_detection_enabled();
-      if (ah.has_obsess_over())
-        h.obsess_over = ah.obsess_over();
+      if (ah.has_flap_detection())
+        h.flap_detection_enabled = ah.flap_detection();
+      if (ah.has_obsess_over_host())
+        h.obsess_over = ah.obsess_over_host();
       if (ah.has_event_handler())
         h.event_handler = ah.event_handler();
       if (ah.has_check_command())
@@ -576,20 +576,20 @@ void macro_cache::_process_pb_adaptive_host(
         h.notification_period = ah.notification_period();
     } else {
       auto& h = std::static_pointer_cast<neb::pb_host>(it->second)->mut_obj();
-      if (ah.has_notifications_enabled())
-        h.set_notifications_enabled(ah.notifications_enabled());
-      if (ah.has_active_checks_enabled())
-        h.set_active_checks_enabled(ah.active_checks_enabled());
+      if (ah.has_notify())
+        h.set_notify(ah.notify());
+      if (ah.has_active_checks())
+        h.set_active_checks(ah.active_checks());
       if (ah.has_should_be_scheduled())
         h.set_should_be_scheduled(ah.should_be_scheduled());
-      if (ah.has_passive_checks_enabled())
-        h.set_passive_checks_enabled(ah.passive_checks_enabled());
+      if (ah.has_passive_checks())
+        h.set_passive_checks(ah.passive_checks());
       if (ah.has_event_handler_enabled())
         h.set_event_handler_enabled(ah.event_handler_enabled());
-      if (ah.has_flap_detection_enabled())
-        h.set_flap_detection_enabled(ah.flap_detection_enabled());
-      if (ah.has_obsess_over())
-        h.set_obsess_over(ah.obsess_over());
+      if (ah.has_flap_detection())
+        h.set_flap_detection(ah.flap_detection());
+      if (ah.has_obsess_over_host())
+        h.set_obsess_over_host(ah.obsess_over_host());
       if (ah.has_event_handler())
         h.set_event_handler(ah.event_handler());
       if (ah.has_check_command())
@@ -671,7 +671,7 @@ void macro_cache::_process_pb_service(std::shared_ptr<io::data> const& data) {
   auto const& s = std::static_pointer_cast<neb::pb_service>(data);
   log_v2::lua()->debug("lua: processing service ({}, {}) (description:{})",
                        s->obj().host_id(), s->obj().service_id(),
-                       s->obj().service_description());
+                       s->obj().description());
   if (s->obj().enabled())
     _services[{s->obj().host_id(), s->obj().service_id()}] = data;
   else
@@ -693,20 +693,20 @@ void macro_cache::_process_pb_adaptive_service(
   if (it != _services.end()) {
     if (it->second->type() == make_type(io::neb, neb::de_service)) {
       auto& s = *std::static_pointer_cast<neb::service>(it->second);
-      if (as.has_notifications_enabled())
-        s.notifications_enabled = as.notifications_enabled();
-      if (as.has_active_checks_enabled())
-        s.active_checks_enabled = as.active_checks_enabled();
+      if (as.has_notify())
+        s.notifications_enabled = as.notify();
+      if (as.has_active_checks())
+        s.active_checks_enabled = as.active_checks();
       if (as.has_should_be_scheduled())
         s.should_be_scheduled = as.should_be_scheduled();
-      if (as.has_passive_checks_enabled())
-        s.passive_checks_enabled = as.passive_checks_enabled();
+      if (as.has_passive_checks())
+        s.passive_checks_enabled = as.passive_checks();
       if (as.has_event_handler_enabled())
         s.event_handler_enabled = as.event_handler_enabled();
       if (as.has_flap_detection_enabled())
         s.flap_detection_enabled = as.flap_detection_enabled();
-      if (as.has_obsess_over())
-        s.obsess_over = as.obsess_over();
+      if (as.has_obsess_over_service())
+        s.obsess_over = as.obsess_over_service();
       if (as.has_event_handler())
         s.event_handler = as.event_handler();
       if (as.has_check_command())
@@ -726,20 +726,20 @@ void macro_cache::_process_pb_adaptive_service(
     } else {
       auto& s =
           std::static_pointer_cast<neb::pb_service>(it->second)->mut_obj();
-      if (as.has_notifications_enabled())
-        s.set_notifications_enabled(as.notifications_enabled());
-      if (as.has_active_checks_enabled())
-        s.set_active_checks_enabled(as.active_checks_enabled());
+      if (as.has_notify())
+        s.set_notify(as.notify());
+      if (as.has_active_checks())
+        s.set_active_checks(as.active_checks());
       if (as.has_should_be_scheduled())
         s.set_should_be_scheduled(as.should_be_scheduled());
-      if (as.has_passive_checks_enabled())
-        s.set_passive_checks_enabled(as.passive_checks_enabled());
+      if (as.has_passive_checks())
+        s.set_passive_checks(as.passive_checks());
       if (as.has_event_handler_enabled())
         s.set_event_handler_enabled(as.event_handler_enabled());
       if (as.has_flap_detection_enabled())
-        s.set_flap_detection_enabled(as.flap_detection_enabled());
-      if (as.has_obsess_over())
-        s.set_obsess_over(as.obsess_over());
+        s.set_flap_detection(as.flap_detection_enabled());
+      if (as.has_obsess_over_service())
+        s.set_obsess_over_service(as.obsess_over_service());
       if (as.has_event_handler())
         s.set_event_handler(as.event_handler());
       if (as.has_check_command())

--- a/broker/lua/test/lua.cc
+++ b/broker/lua/test/lua.cc
@@ -19,11 +19,11 @@
 #include <fmt/format.h>
 #include <gtest/gtest.h>
 
+#include <absl/strings/str_split.h>
 #include <cstdio>
 #include <fstream>
 #include <list>
 #include <memory>
-#include <absl/strings/str_split.h>
 
 #include "../../core/test/test_server.hh"
 #include "bbdo/storage/status.hh"
@@ -668,7 +668,7 @@ TEST_F(LuaTest, PbHostCacheTest) {
   std::string filename("/tmp/cache_test.lua");
   auto hst{std::make_shared<neb::pb_host>()};
   hst->mut_obj().set_host_id(1);
-  hst->mut_obj().set_host_name("centreon");
+  hst->mut_obj().set_name("centreon");
   hst->mut_obj().set_display_name("centreon");
   hst->mut_obj().set_alias("alias-centreon");
   hst->mut_obj().set_address("4.3.2.1");
@@ -682,7 +682,7 @@ TEST_F(LuaTest, PbHostCacheTest) {
                "  broker_log:info(1, 'host is ' .. tostring(hstname))\n"
                "  local hst = broker_cache:get_host(1)\n"
                "  broker_log:info(1, 'alias ' .. hst.alias .. ' address ' .. "
-               "hst.address .. ' name ' .. hst.host_name)\n"
+               "hst.address .. ' name ' .. hst.name)\n"
                "end\n\n"
                "function write(d)\n"
                "end\n");
@@ -706,7 +706,7 @@ TEST_F(LuaTest, PbHostCacheTestAdaptive) {
   std::string filename("/tmp/cache_test.lua");
   auto hst{std::make_shared<neb::pb_host>()};
   hst->mut_obj().set_host_id(1);
-  hst->mut_obj().set_host_name("centreon");
+  hst->mut_obj().set_name("centreon");
   hst->mut_obj().set_display_name("centreon");
   hst->mut_obj().set_alias("alias-centreon");
   hst->mut_obj().set_address("4.3.2.1");
@@ -746,7 +746,7 @@ TEST_F(LuaTest, PbHostCacheV2TestAdaptive) {
   std::string filename("/tmp/cache_test.lua");
   auto hst{std::make_shared<neb::pb_host>()};
   hst->mut_obj().set_host_id(1);
-  hst->mut_obj().set_host_name("centreon");
+  hst->mut_obj().set_name("centreon");
   hst->mut_obj().set_display_name("centreon");
   hst->mut_obj().set_alias("alias-centreon");
   hst->mut_obj().set_address("4.3.2.1");
@@ -854,7 +854,7 @@ TEST_F(LuaTest, ServiceCacheTestPbAndAdaptive) {
   auto svc = std::make_shared<neb::pb_service>();
   svc->mut_obj().set_host_id(1);
   svc->mut_obj().set_service_id(14);
-  svc->mut_obj().set_service_description("description");
+  svc->mut_obj().set_description("description");
   svc->mut_obj().set_enabled(true);
   TagInfo* tag = svc->mut_obj().mutable_tags()->Add();
   tag->set_id(23);
@@ -943,7 +943,7 @@ TEST_F(LuaTest, ServiceCacheApi2TestPbAndAdaptive) {
   auto svc = std::make_shared<neb::pb_service>();
   svc->mut_obj().set_host_id(1);
   svc->mut_obj().set_service_id(14);
-  svc->mut_obj().set_service_description("description");
+  svc->mut_obj().set_description("description");
   svc->mut_obj().set_enabled(true);
   TagInfo* tag = svc->mut_obj().mutable_tags()->Add();
   tag->set_id(24);
@@ -990,7 +990,7 @@ TEST_F(LuaTest, PbServiceCacheTest) {
   std::map<std::string, misc::variant> conf;
   std::string filename("/tmp/cache_test.lua");
   auto svc{std::make_shared<neb::pb_service>()};
-  svc->mut_obj().set_service_description("description");
+  svc->mut_obj().set_description("description");
   svc->mut_obj().set_service_id(14);
   svc->mut_obj().set_host_id(1);
   svc->mut_obj().set_enabled(true);
@@ -1062,14 +1062,14 @@ TEST_F(LuaTest, PbIndexMetricCacheTest) {
   std::map<std::string, misc::variant> conf;
   std::string filename("/tmp/cache_test.lua");
   auto svc{std::make_shared<neb::pb_service>()};
-  svc->mut_obj().set_service_description("MyDescription");
+  svc->mut_obj().set_description("MyDescription");
   svc->mut_obj().set_service_id(14);
   svc->mut_obj().set_host_id(1);
   svc->mut_obj().set_enabled(true);
   _cache->write(svc);
   auto hst{std::make_shared<neb::pb_host>()};
   hst->mut_obj().set_host_id(1);
-  hst->mut_obj().set_host_name("host1");
+  hst->mut_obj().set_name("host1");
   _cache->write(hst);
   auto im{std::make_shared<storage::index_mapping>()};
   im->index_id = 7;
@@ -1333,7 +1333,7 @@ TEST_F(LuaTest, PbHostGroupCacheTest) {
   _cache->write(hg);
   auto hst{std::make_shared<neb::pb_host>()};
   hst->mut_obj().set_host_id(22);
-  hst->mut_obj().set_host_name("host_centreon");
+  hst->mut_obj().set_name("host_centreon");
   _cache->write(hst);
   auto member{std::make_shared<neb::host_group_member>()};
   member->host_id = 22;
@@ -1516,7 +1516,7 @@ TEST_F(LuaTest, PbServiceGroupCacheTest) {
   sg->name = "centreon2";
   _cache->write(sg);
   auto svc{std::make_shared<neb::pb_service>()};
-  svc->mut_obj().set_service_description("service_description");
+  svc->mut_obj().set_description("service_description");
   svc->mut_obj().set_service_id(17);
   svc->mut_obj().set_host_id(22);
   svc->mut_obj().set_host_name("host_centreon");
@@ -2428,7 +2428,7 @@ TEST_F(LuaTest, PbCacheGetNotesUrlTest) {
   hst->mut_obj().set_notes("host notes");
   hst->mut_obj().set_notes_url("host notes url");
   hst->mut_obj().set_action_url("host action url");
-  hst->mut_obj().set_host_name("centreon");
+  hst->mut_obj().set_name("centreon");
   hst->mut_obj().set_enabled(true);
   _cache->write(hst);
 
@@ -2680,7 +2680,7 @@ TEST_F(LuaTest, PbBrokerEventIndex) {
   obj.set_host_id(1);
   obj.set_service_id(2);
   obj.set_stalk_on_ok(false);
-  obj.set_service_description("foo bar");
+  obj.set_description("foo bar");
   obj.set_notes("svc notes");
   obj.set_notes_url("svc notes url");
   obj.set_action_url("svc action url");
@@ -2696,7 +2696,7 @@ TEST_F(LuaTest, PbBrokerEventIndex) {
       "end\n\n"
       "function write(d)\n"
       "  broker_log:info(0, 'service_description = ' .. "
-      "d.service_description)\n"
+      "d.description)\n"
       "  broker_log:info(0, 'stalk_on_ok = ' .. tostring(d.stalk_on_ok))\n"
       "  broker_log:info(0, 'check_interval = ' .. d.check_interval)\n"
       "  broker_log:info(0, 'check_type = ' .. d.check_type)\n"
@@ -2726,7 +2726,7 @@ TEST_F(LuaTest, PbBrokerEventPairs) {
   auto& obj = svc->mut_obj();
   obj.set_host_id(1);
   obj.set_service_id(2);
-  obj.set_service_description("foo bar");
+  obj.set_description("foo bar");
   obj.set_notes("svc notes");
   obj.set_notes_url("svc notes url");
   obj.set_action_url("svc action url");
@@ -2745,7 +2745,7 @@ TEST_F(LuaTest, PbBrokerEventPairs) {
   binding->write(svc);
   std::string lst(ReadFile("/tmp/event_log"));
   std::cout << lst << std::endl;
-  ASSERT_NE(lst.find("service_description = foo bar"), std::string::npos);
+  ASSERT_NE(lst.find("description = foo bar"), std::string::npos);
   ASSERT_NE(lst.find("notes = svc notes"), std::string::npos);
   ASSERT_NE(lst.find("notes_url = svc notes url"), std::string::npos);
   ASSERT_NE(lst.find("action_url = svc action url"), std::string::npos);
@@ -2881,7 +2881,7 @@ TEST_F(LuaTest, PbTestHostApiV1) {
   std::map<std::string, misc::variant> conf;
   auto hst{std::make_shared<neb::pb_host>()};
   hst->mut_obj().set_host_id(1);
-  hst->mut_obj().set_host_name("foo bar host cache");
+  hst->mut_obj().set_name("foo bar host cache");
   hst->mut_obj().set_enabled(true);
   std::string filename("/tmp/cache_test.lua");
   CreateScript(filename,
@@ -2909,7 +2909,7 @@ TEST_F(LuaTest, PbTestHostApiV2) {
   std::map<std::string, misc::variant> conf;
   auto hst{std::make_shared<neb::pb_host>()};
   hst->mut_obj().set_host_id(1);
-  hst->mut_obj().set_host_name("foo bar host cache");
+  hst->mut_obj().set_name("foo bar host cache");
   hst->mut_obj().set_enabled(true);
   std::string filename("/tmp/cache_test.lua");
   CreateScript(filename,
@@ -3029,7 +3029,7 @@ TEST_F(LuaTest, PbTestSvcApiV2) {
   auto& obj = svc->mut_obj();
   obj.set_host_id(1);
   obj.set_service_id(2);
-  obj.set_service_description("foo bar cache");
+  obj.set_description("foo bar cache");
   obj.set_notes("svc notes");
   obj.set_notes_url("svc notes url");
   obj.set_action_url("svc action url");
@@ -3063,7 +3063,7 @@ TEST_F(LuaTest, PbTestSvcApiV1) {
   auto& obj = svc->mut_obj();
   obj.set_host_id(1);
   obj.set_service_id(2);
-  obj.set_service_description("foo bar cache");
+  obj.set_description("foo bar cache");
   obj.set_notes("svc notes");
   obj.set_notes_url("svc notes url");
   obj.set_action_url("svc action url");
@@ -3097,7 +3097,7 @@ TEST_F(LuaTest, PbBrokerEventCache) {
   auto& obj = svc->mut_obj();
   obj.set_host_id(1);
   obj.set_service_id(2);
-  obj.set_service_description("foo bar cache");
+  obj.set_description("foo bar cache");
   obj.set_notes("svc notes");
   obj.set_notes_url("svc notes url");
   obj.set_action_url("svc action url");
@@ -3110,7 +3110,7 @@ TEST_F(LuaTest, PbBrokerEventCache) {
                "function write(d)\n"
                "  local svc = broker_cache:get_service(1, 2)\n"
                "  broker_log:info(0, 'service_description = ' .. "
-               "svc.service_description)\n"
+               "svc.description)\n"
                "end\n");
   auto binding{std::make_unique<luabinding>(filename, conf, *_cache)};
   binding->write(svc);
@@ -3173,10 +3173,10 @@ TEST_F(LuaTest, BrokerPbServiceStatus) {
   auto& obj = svc->mut_obj();
   obj.set_host_id(1899);
   obj.set_service_id(288);
-  obj.set_service_description("foo bar");
+  obj.set_description("foo bar");
   obj.set_check_command("super command");
   obj.set_output("cool");
-  obj.set_current_state(Service_State_CRITICAL);
+  obj.set_state(Service_State_CRITICAL);
   obj.set_check_interval(7);
   obj.set_check_type(Service_CheckType_ACTIVE);
   obj.set_last_check(123456);
@@ -3187,10 +3187,10 @@ TEST_F(LuaTest, BrokerPbServiceStatus) {
       "  broker_log:set_parameters(3, '/tmp/event_log')\n"
       "end\n\n"
       "function write(d)\n"
-      "  broker_log:info(0, 'description = ' .. d.service_description)\n"
+      "  broker_log:info(0, 'description = ' .. d.description)\n"
       "  broker_log:info(0, 'check_command = ' .. tostring(d.check_command))\n"
       "  broker_log:info(0, 'output = ' .. d.output)\n"
-      "  broker_log:info(0, 'state = ' .. d.current_state)\n"
+      "  broker_log:info(0, 'state = ' .. d.state)\n"
       "  broker_log:info(0, 'check_interval = ' .. d.check_interval)\n"
       "  broker_log:info(0, 'check_type = ' .. d.check_type)\n"
       "  broker_log:info(0, 'service_id = ' .. d.service_id)\n"
@@ -3222,10 +3222,10 @@ TEST_F(LuaTest, BrokerApi2PbServiceStatusWithIndex) {
   auto& obj = svc->mut_obj();
   obj.set_host_id(1899);
   obj.set_service_id(288);
-  obj.set_service_description("foo bar");
+  obj.set_description("foo bar");
   obj.set_check_command("super command");
   obj.set_output("cool");
-  obj.set_current_state(Service_State_CRITICAL);
+  obj.set_state(Service_State_CRITICAL);
   obj.set_check_interval(7);
   obj.set_check_type(Service_CheckType_ACTIVE);
   obj.set_last_check(123456);
@@ -3237,10 +3237,10 @@ TEST_F(LuaTest, BrokerApi2PbServiceStatusWithIndex) {
       "  broker_log:set_parameters(3, '/tmp/event_log')\n"
       "end\n\n"
       "function write(d)\n"
-      "  broker_log:info(0, 'description = ' .. d.service_description)\n"
+      "  broker_log:info(0, 'description = ' .. d.description)\n"
       "  broker_log:info(0, 'check_command = ' .. tostring(d.check_command))\n"
       "  broker_log:info(0, 'output = ' .. d.output)\n"
-      "  broker_log:info(0, 'state = ' .. d.current_state)\n"
+      "  broker_log:info(0, 'state = ' .. d.state)\n"
       "  broker_log:info(0, 'check_interval = ' .. d.check_interval)\n"
       "  broker_log:info(0, 'check_type = ' .. d.check_type)\n"
       "  broker_log:info(0, 'service_id = ' .. d.service_id)\n"
@@ -3272,10 +3272,10 @@ TEST_F(LuaTest, BrokerApi2PbServiceStatusWithNext) {
   auto& obj = svc->mut_obj();
   obj.set_host_id(1899);
   obj.set_service_id(288);
-  obj.set_service_description("foo bar");
+  obj.set_description("foo bar");
   obj.set_check_command("super command");
   obj.set_output("cool");
-  obj.set_current_state(Service_State_CRITICAL);
+  obj.set_state(Service_State_CRITICAL);
   obj.set_check_interval(7);
   obj.set_check_type(Service_CheckType_ACTIVE);
   obj.set_last_check(123459);
@@ -3323,10 +3323,10 @@ TEST_F(LuaTest, BrokerApi2PbServiceStatusJsonEncode) {
   auto& obj = svc->mut_obj();
   obj.set_host_id(1899);
   obj.set_service_id(288);
-  obj.set_service_description("foo bar");
+  obj.set_description("foo bar");
   obj.set_check_command("super command");
   obj.set_output("cool");
-  obj.set_current_state(Service_State_CRITICAL);
+  obj.set_state(Service_State_CRITICAL);
   obj.set_check_interval(7);
   obj.set_check_type(Service_CheckType_ACTIVE);
   obj.set_last_check(123459);
@@ -3355,12 +3355,11 @@ TEST_F(LuaTest, BrokerApi2PbServiceStatusJsonEncode) {
   ASSERT_NE(pos1, std::string::npos);
   ASSERT_NE(lst.find("\"host_id\":1899", pos1), std::string::npos);
   ASSERT_NE(lst.find("\"service_id\":288", pos1), std::string::npos);
-  ASSERT_NE(lst.find("\"service_description\":\"foo bar\"", pos1),
-            std::string::npos);
+  ASSERT_NE(lst.find("\"description\":\"foo bar\"", pos1), std::string::npos);
   ASSERT_NE(lst.find("\"check_command\":\"super command\"", pos1),
             std::string::npos);
   ASSERT_NE(lst.find("\"output\":\"cool\"", pos1), std::string::npos);
-  ASSERT_NE(lst.find("\"current_state\":2", pos1), std::string::npos);
+  ASSERT_NE(lst.find("\"state\":2", pos1), std::string::npos);
   ASSERT_NE(lst.find("\"check_interval\":7", pos1), std::string::npos);
   ASSERT_NE(lst.find("\"check_type\":0", pos1), std::string::npos);
   ASSERT_NE(lst.find("\"last_check\":123459", pos1), std::string::npos);
@@ -3380,10 +3379,10 @@ TEST_F(LuaTest, BrokerPbServiceStatusJsonEncode) {
   auto& obj = svc->mut_obj();
   obj.set_host_id(1899);
   obj.set_service_id(288);
-  obj.set_service_description("foo bar");
+  obj.set_description("foo bar");
   obj.set_check_command("super command");
   obj.set_output("cool");
-  obj.set_current_state(Service_State_CRITICAL);
+  obj.set_state(Service_State_CRITICAL);
   obj.set_check_interval(7);
   obj.set_check_type(Service_CheckType_ACTIVE);
   obj.set_last_check(123459);
@@ -3411,9 +3410,9 @@ TEST_F(LuaTest, BrokerPbServiceStatusJsonEncode) {
   ASSERT_NE(lst.find("\"host_id\":1899"), std::string::npos);
   ASSERT_NE(lst.find("\"service_id\":288"), std::string::npos);
   ASSERT_NE(lst.find("\"check_interval\":7"), std::string::npos);
-  ASSERT_NE(lst.find("\"current_state\":2"), std::string::npos);
+  ASSERT_NE(lst.find("\"state\":2"), std::string::npos);
   ASSERT_NE(lst.find("\"last_check\":123459"), std::string::npos);
-  ASSERT_NE(lst.find("\"service_description\":\"foo bar\""), std::string::npos);
+  ASSERT_NE(lst.find("\"description\":\"foo bar\""), std::string::npos);
   ASSERT_NE(lst.find("\"output\":\"cool\""), std::string::npos);
   size_t s1 = lst.find("\"tags\":[{\"id\":24,\"type\":2}");
   if (s1 == std::string::npos)
@@ -3435,10 +3434,10 @@ TEST_F(LuaTest, BrokerApi2PbServiceJsonEncode) {
   auto& obj = svc->mut_obj();
   obj.set_host_id(1899);
   obj.set_service_id(288);
-  obj.set_service_description("foo bar");
+  obj.set_description("foo bar");
   obj.set_check_command("super command");
   obj.set_output("cool");
-  obj.set_current_state(Service_State_CRITICAL);
+  obj.set_state(Service_State_CRITICAL);
   obj.set_check_interval(7);
   obj.set_check_type(Service_CheckType_ACTIVE);
   obj.set_last_check(123459);
@@ -3461,9 +3460,9 @@ TEST_F(LuaTest, BrokerApi2PbServiceJsonEncode) {
   ASSERT_NE(lst.find("\"host_id\":1899"), std::string::npos);
   ASSERT_NE(lst.find("\"service_id\":288"), std::string::npos);
   ASSERT_NE(lst.find("\"check_interval\":7"), std::string::npos);
-  ASSERT_NE(lst.find("\"current_state\":2"), std::string::npos);
+  ASSERT_NE(lst.find("\"state\":2"), std::string::npos);
   ASSERT_NE(lst.find("\"last_check\":123459"), std::string::npos);
-  ASSERT_NE(lst.find("\"service_description\":\"foo bar\""), std::string::npos);
+  ASSERT_NE(lst.find("\"description\":\"foo bar\""), std::string::npos);
   ASSERT_NE(lst.find("\"output\":\"cool\""), std::string::npos);
   RemoveFile(filename);
   RemoveFile("/tmp/event_log");
@@ -3477,10 +3476,10 @@ TEST_F(LuaTest, BrokerPbServiceJsonEncode) {
   auto& obj = svc->mut_obj();
   obj.set_host_id(1899);
   obj.set_service_id(288);
-  obj.set_service_description("foo bar");
+  obj.set_description("foo bar");
   obj.set_check_command("super command");
   obj.set_output("cool");
-  obj.set_current_state(Service_State_CRITICAL);
+  obj.set_state(Service_State_CRITICAL);
   obj.set_check_interval(7);
   obj.set_check_type(Service_CheckType_ACTIVE);
   obj.set_last_check(123459);
@@ -3502,9 +3501,9 @@ TEST_F(LuaTest, BrokerPbServiceJsonEncode) {
   ASSERT_NE(lst.find("\"host_id\":1899"), std::string::npos);
   ASSERT_NE(lst.find("\"service_id\":288"), std::string::npos);
   ASSERT_NE(lst.find("\"check_interval\":7"), std::string::npos);
-  ASSERT_NE(lst.find("\"current_state\":2"), std::string::npos);
+  ASSERT_NE(lst.find("\"state\":2"), std::string::npos);
   ASSERT_NE(lst.find("\"last_check\":123459"), std::string::npos);
-  ASSERT_NE(lst.find("\"service_description\":\"foo bar\""), std::string::npos);
+  ASSERT_NE(lst.find("\"description\":\"foo bar\""), std::string::npos);
   ASSERT_NE(lst.find("\"output\":\"cool\""), std::string::npos);
   RemoveFile(filename);
   RemoveFile("/tmp/event_log");
@@ -3519,7 +3518,7 @@ TEST_F(LuaTest, BrokerPbHostStatus) {
   obj.set_host_id(1899);
   obj.set_check_command("super command");
   obj.set_output("cool");
-  obj.set_current_state(Host_State_UP);
+  obj.set_state(Host_State_UP);
   obj.set_check_interval(7);
   obj.set_check_type(Host_CheckType_ACTIVE);
   obj.set_last_check(123456);
@@ -3532,7 +3531,7 @@ TEST_F(LuaTest, BrokerPbHostStatus) {
       "function write(d)\n"
       "  broker_log:info(0, 'check_command = ' .. tostring(d.check_command))\n"
       "  broker_log:info(0, 'output = ' .. d.output)\n"
-      "  broker_log:info(0, 'state = ' .. d.current_state)\n"
+      "  broker_log:info(0, 'state = ' .. d.state)\n"
       "  broker_log:info(0, 'check_interval = ' .. d.check_interval)\n"
       "  broker_log:info(0, 'check_type = ' .. d.check_type)\n"
       "  broker_log:info(0, 'host_id = ' .. d.host_id)\n"
@@ -3562,7 +3561,7 @@ TEST_F(LuaTest, BrokerApi2PbHostStatusWithIndex) {
   obj.set_host_id(1899);
   obj.set_check_command("super command");
   obj.set_output("cool");
-  obj.set_current_state(Host_State_UP);
+  obj.set_state(Host_State_UP);
   obj.set_check_interval(7);
   obj.set_check_type(Host_CheckType_ACTIVE);
   obj.set_last_check(123456);
@@ -3576,7 +3575,7 @@ TEST_F(LuaTest, BrokerApi2PbHostStatusWithIndex) {
       "function write(d)\n"
       "  broker_log:info(0, 'check_command = ' .. tostring(d.check_command))\n"
       "  broker_log:info(0, 'output = ' .. d.output)\n"
-      "  broker_log:info(0, 'state = ' .. d.current_state)\n"
+      "  broker_log:info(0, 'state = ' .. d.state)\n"
       "  broker_log:info(0, 'check_interval = ' .. d.check_interval)\n"
       "  broker_log:info(0, 'check_type = ' .. d.check_type)\n"
       "  broker_log:info(0, 'host_id = ' .. d.host_id)\n"
@@ -3606,7 +3605,7 @@ TEST_F(LuaTest, BrokerApi2PbHostStatusWithNext) {
   obj.set_host_id(1899);
   obj.set_check_command("super command");
   obj.set_output("cool");
-  obj.set_current_state(Host_State_UP);
+  obj.set_state(Host_State_UP);
   obj.set_check_interval(7);
   obj.set_check_type(Host_CheckType_ACTIVE);
   obj.set_last_check(123459);
@@ -3643,7 +3642,7 @@ TEST_F(LuaTest, BrokerApi2PbHostJsonEncode) {
   auto host = std::make_shared<neb::pb_host_status>();
   auto& obj = host->mut_obj();
   obj.set_host_id(1899);
-  obj.set_current_state(HostStatus_State_UP);
+  obj.set_state(HostStatus_State_UP);
   obj.set_output("cool");
   obj.set_perfdata("perfdata");
   std::string filename("/tmp/cache_test.lua");
@@ -3663,7 +3662,7 @@ TEST_F(LuaTest, BrokerApi2PbHostJsonEncode) {
   ASSERT_NE(lst.find("\"category\":1"), std::string::npos);
   ASSERT_NE(lst.find("\"element\":32"), std::string::npos);
   ASSERT_NE(lst.find("\"host_id\":1899"), std::string::npos);
-  ASSERT_NE(lst.find("\"current_state\":0"), std::string::npos);
+  ASSERT_NE(lst.find("\"state\":0"), std::string::npos);
   ASSERT_NE(lst.find("\"perfdata\":\"perfdata\""), std::string::npos);
   ASSERT_NE(lst.find("\"output\":\"cool\""), std::string::npos);
 
@@ -3680,7 +3679,7 @@ TEST_F(LuaTest, BrokerPbHostJsonEncode) {
   obj.set_host_id(1899);
   obj.set_check_command("super command");
   obj.set_output("cool");
-  obj.set_current_state(Host_State_UP);
+  obj.set_state(Host_State_UP);
   obj.set_check_interval(7);
   obj.set_check_type(Host_CheckType_ACTIVE);
   obj.set_last_check(123459);
@@ -3701,7 +3700,7 @@ TEST_F(LuaTest, BrokerPbHostJsonEncode) {
   ASSERT_NE(lst.find("\"element\":30"), std::string::npos);
   ASSERT_NE(lst.find("\"host_id\":1899"), std::string::npos);
   ASSERT_NE(lst.find("\"check_interval\":7"), std::string::npos);
-  ASSERT_NE(lst.find("\"current_state\":0"), std::string::npos);
+  ASSERT_NE(lst.find("\"state\":0"), std::string::npos);
   ASSERT_NE(lst.find("\"last_check\":123459"), std::string::npos);
   ASSERT_NE(lst.find("\"output\":\"cool\""), std::string::npos);
   RemoveFile(filename);
@@ -3711,14 +3710,15 @@ TEST_F(LuaTest, BrokerPbHostJsonEncode) {
 TEST_F(LuaTest, BrokerBbdoVersion) {
   std::map<std::string, misc::variant> conf;
   std::string filename("/tmp/cache_test.lua");
-  CreateScript(filename,
-               "function init(conf)\n"
-               "  broker_log:set_parameters(3, '/tmp/event_log')\n"
-               "  broker_log:info(0, 'BBDO version: ' .. broker.bbdo_version())\n"
-               "end\n"
-               "function write(d)\n"
-               "  return true\n"
-               "end");
+  CreateScript(
+      filename,
+      "function init(conf)\n"
+      "  broker_log:set_parameters(3, '/tmp/event_log')\n"
+      "  broker_log:info(0, 'BBDO version: ' .. broker.bbdo_version())\n"
+      "end\n"
+      "function write(d)\n"
+      "  return true\n"
+      "end");
   auto binding{std::make_unique<luabinding>(filename, conf, *_cache)};
   std::string lst(ReadFile("/tmp/event_log"));
   ASSERT_NE(lst.find("BBDO version: 2.0.0"), std::string::npos);
@@ -3734,7 +3734,7 @@ TEST_F(LuaTest, BrokerApi2PbHostStatusJsonEncode) {
   auto& obj = host->mut_obj();
   obj.set_host_id(1899);
   obj.set_output("cool");
-  obj.set_current_state(HostStatus_State_UP);
+  obj.set_state(HostStatus_State_UP);
   obj.set_check_type(HostStatus_CheckType_ACTIVE);
   obj.set_last_check(123459);
   std::string filename("/tmp/cache_test.lua");
@@ -3754,7 +3754,7 @@ TEST_F(LuaTest, BrokerApi2PbHostStatusJsonEncode) {
   ASSERT_NE(lst.find("\"category\":1"), std::string::npos);
   ASSERT_NE(lst.find("\"element\":32"), std::string::npos);
   ASSERT_NE(lst.find("\"host_id\":1899"), std::string::npos);
-  ASSERT_NE(lst.find("\"current_state\":0"), std::string::npos);
+  ASSERT_NE(lst.find("\"state\":0"), std::string::npos);
   ASSERT_NE(lst.find("\"last_check\":123459"), std::string::npos);
   ASSERT_NE(lst.find("\"output\":\"cool\""), std::string::npos);
   RemoveFile(filename);
@@ -3769,7 +3769,7 @@ TEST_F(LuaTest, BrokerPbHostStatusJsonEncode) {
   auto& obj = host->mut_obj();
   obj.set_host_id(1899);
   obj.set_output("cool");
-  obj.set_current_state(HostStatus_State_UP);
+  obj.set_state(HostStatus_State_UP);
   obj.set_check_type(HostStatus_CheckType_ACTIVE);
   obj.set_last_check(123459);
   std::string filename("/tmp/cache_test.lua");
@@ -3788,7 +3788,7 @@ TEST_F(LuaTest, BrokerPbHostStatusJsonEncode) {
   ASSERT_NE(lst.find("\"category\":1"), std::string::npos);
   ASSERT_NE(lst.find("\"element\":32"), std::string::npos);
   ASSERT_NE(lst.find("\"host_id\":1899"), std::string::npos);
-  ASSERT_NE(lst.find("\"current_state\":0"), std::string::npos);
+  ASSERT_NE(lst.find("\"state\":0"), std::string::npos);
   ASSERT_NE(lst.find("\"last_check\":123459"), std::string::npos);
   ASSERT_NE(lst.find("\"output\":\"cool\""), std::string::npos);
   RemoveFile(filename);
@@ -3875,30 +3875,41 @@ TEST_F(LuaTest, ServiceObjectMatchBetweenBbdoVersions) {
   svc->host_id = 1;
   svc->service_id = 14;
   svc->service_description = "description";
+  svc->host_name = "toto";
+  svc->last_hard_state_change = 12345;
+  svc->last_notification = 12345;
+  svc->last_state_change = 12345;
+  svc->last_time_ok = 12345;
+  svc->last_time_warning = 12345;
+  svc->last_time_critical = 12345;
+  svc->last_time_unknown = 12345;
+  svc->last_update = 12345;
+  svc->last_check = 12345;
+  svc->next_check = 12345;
+  svc->next_notification = 12345;
   auto svc1 = std::make_shared<neb::pb_service>();
   svc1->mut_obj().set_host_id(1);
   svc1->mut_obj().set_service_id(14);
-  svc1->mut_obj().set_service_description("description");
+  svc1->mut_obj().set_description("description");
 
-  CreateScript(
-      filename,
-      "function init(conf)\n"
-      "  broker_log:set_parameters(3, '/tmp/log')\n"
-      "end\n\n"
-      "local count = 1\n"
-      "function write(d)\n"
-      "  local puce = { '* ', '- ' }\n"
-      "  local keys = {}\n"
-      "  for k,_ in pairs(d) do\n"
-      "    keys[#keys + 1] = k\n"
-      "  end\n"
-      "  table.sort(keys)\n"
-      "  for i,k in ipairs(keys) do\n"
-      "    broker_log:info(1, puce[count] .. k)\n"
-      "  end\n"
-      "  count = count + 1\n"
-      "  return true\n"
-      "end\n");
+  CreateScript(filename,
+               "function init(conf)\n"
+               "  broker_log:set_parameters(3, '/tmp/log')\n"
+               "end\n\n"
+               "local count = 1\n"
+               "function write(d)\n"
+               "  local puce = { '* ', '- ' }\n"
+               "  local keys = {}\n"
+               "  for k,_ in pairs(d) do\n"
+               "    keys[#keys + 1] = k\n"
+               "  end\n"
+               "  table.sort(keys)\n"
+               "  for i,k in ipairs(keys) do\n"
+               "    broker_log:info(1, puce[count] .. k)\n"
+               "  end\n"
+               "  count = count + 1\n"
+               "  return true\n"
+               "end\n");
   auto binding{std::make_unique<luabinding>(filename, conf, *_cache)};
   binding->write(svc);
   binding->write(svc1);
@@ -3916,14 +3927,23 @@ TEST_F(LuaTest, ServiceObjectMatchBetweenBbdoVersions) {
   }
 
   auto it = l1.begin();
-  for (auto& s : l2) {
-    ASSERT_TRUE(it != l1.end() && s >= *it);
-    if (s == *it) {
+  for (auto it1 = l2.begin(); it1 != l2.end();) {
+    if (*it1 == "host_name" || *it1 == "icon_id" || *it1 == "internal_id" ||
+        *it1 == "is_volatile" || *it1 == "long_output" ||
+        *it1 == "severity_id" || *it1 == "tags" || *it1 == "type") {
+      ++it1;
+      continue;
+    }
+    std::cout << *it << " <=> " << *it1 << std::endl;
+    ASSERT_TRUE(it != l1.end() && *it1 >= *it);
+    if (*it1 == *it) {
+      ++it;
+      ++it1;
+      continue;
+    } else {
       ++it;
       continue;
     }
-    else
-      continue;
   }
   RemoveFile(filename);
   RemoveFile("/tmp/log");
@@ -3939,29 +3959,39 @@ TEST_F(LuaTest, HostObjectMatchBetweenBbdoVersions) {
   auto hst = std::make_shared<neb::host>();
   hst->host_id = 1;
   hst->host_name = "description";
+  hst->poller_id = 28;
+  hst->last_check = 12345;
+  hst->last_hard_state_change = 123456;
+  hst->last_notification = 123456;
+  hst->last_state_change = 123456;
+  hst->last_time_down = 123456;
+  hst->last_time_unreachable = 123456;
+  hst->last_time_up = 123456;
+  hst->last_update = 123456;
+  hst->next_check = 123456;
+  hst->next_notification = 123456;
   auto hst1 = std::make_shared<neb::pb_host>();
   hst1->mut_obj().set_host_id(1);
-  hst1->mut_obj().set_host_name("description");
+  hst1->mut_obj().set_name("description");
 
-  CreateScript(
-      filename,
-      "function init(conf)\n"
-      "  broker_log:set_parameters(3, '/tmp/log')\n"
-      "end\n\n"
-      "local count = 1\n"
-      "function write(d)\n"
-      "  local puce = { '* ', '- ' }\n"
-      "  local keys = {}\n"
-      "  for k,_ in pairs(d) do\n"
-      "    keys[#keys + 1] = k\n"
-      "  end\n"
-      "  table.sort(keys)\n"
-      "  for i,k in ipairs(keys) do\n"
-      "    broker_log:info(1, puce[count] .. k)\n"
-      "  end\n"
-      "  count = count + 1\n"
-      "  return true\n"
-      "end\n");
+  CreateScript(filename,
+               "function init(conf)\n"
+               "  broker_log:set_parameters(3, '/tmp/log')\n"
+               "end\n\n"
+               "local count = 1\n"
+               "function write(d)\n"
+               "  local puce = { '* ', '- ' }\n"
+               "  local keys = {}\n"
+               "  for k,_ in pairs(d) do\n"
+               "    keys[#keys + 1] = k\n"
+               "  end\n"
+               "  table.sort(keys)\n"
+               "  for i,k in ipairs(keys) do\n"
+               "    broker_log:info(1, puce[count] .. k)\n"
+               "  end\n"
+               "  count = count + 1\n"
+               "  return true\n"
+               "end\n");
   auto binding{std::make_unique<luabinding>(filename, conf, *_cache)};
   binding->write(hst);
   binding->write(hst1);
@@ -3979,14 +4009,21 @@ TEST_F(LuaTest, HostObjectMatchBetweenBbdoVersions) {
   }
 
   auto it = l1.begin();
-  for (auto& s : l2) {
-    ASSERT_TRUE(it != l1.end() && s >= *it);
-    if (s == *it) {
+  for (auto it1 = l2.begin(); it1 != l2.end();) {
+    if (*it1 == "icon_id" || *it1 == "severity_id" || *it1 == "tags") {
+      ++it1;
+      continue;
+    }
+    std::cout << *it << " <=> " << *it1 << std::endl;
+    ASSERT_TRUE(it != l1.end() && *it1 >= *it);
+    if (*it1 == *it) {
+      ++it;
+      ++it1;
+      continue;
+    } else {
       ++it;
       continue;
     }
-    else
-      continue;
   }
   RemoveFile(filename);
   RemoveFile("/tmp/log");
@@ -4002,29 +4039,38 @@ TEST_F(LuaTest, ServiceStatusObjectMatchBetweenBbdoVersions) {
   auto svc = std::make_shared<neb::service_status>();
   svc->host_id = 1;
   svc->service_id = 14;
+  svc->last_check = 12345;
+  svc->last_hard_state_change = 12345;
+  svc->last_notification = 12345;
+  svc->last_state_change = 12345;
+  svc->last_time_critical = 12345;
+  svc->last_time_ok = 12345;
+  svc->last_time_warning = 12345;
+  svc->last_time_unknown = 12345;
+  svc->next_check = 12345;
+  svc->next_notification = 12345;
   auto svc1 = std::make_shared<neb::pb_service_status>();
   svc1->mut_obj().set_host_id(1);
   svc1->mut_obj().set_service_id(14);
 
-  CreateScript(
-      filename,
-      "function init(conf)\n"
-      "  broker_log:set_parameters(3, '/tmp/log')\n"
-      "end\n\n"
-      "local count = 1\n"
-      "function write(d)\n"
-      "  local puce = { '* ', '- ' }\n"
-      "  local keys = {}\n"
-      "  for k,_ in pairs(d) do\n"
-      "    keys[#keys + 1] = k\n"
-      "  end\n"
-      "  table.sort(keys)\n"
-      "  for i,k in ipairs(keys) do\n"
-      "    broker_log:info(1, puce[count] .. k)\n"
-      "  end\n"
-      "  count = count + 1\n"
-      "  return true\n"
-      "end\n");
+  CreateScript(filename,
+               "function init(conf)\n"
+               "  broker_log:set_parameters(3, '/tmp/log')\n"
+               "end\n\n"
+               "local count = 1\n"
+               "function write(d)\n"
+               "  local puce = { '* ', '- ' }\n"
+               "  local keys = {}\n"
+               "  for k,_ in pairs(d) do\n"
+               "    keys[#keys + 1] = k\n"
+               "  end\n"
+               "  table.sort(keys)\n"
+               "  for i,k in ipairs(keys) do\n"
+               "    broker_log:info(1, puce[count] .. k)\n"
+               "  end\n"
+               "  count = count + 1\n"
+               "  return true\n"
+               "end\n");
   auto binding{std::make_unique<luabinding>(filename, conf, *_cache)};
   binding->write(svc);
   binding->write(svc1);
@@ -4042,14 +4088,21 @@ TEST_F(LuaTest, ServiceStatusObjectMatchBetweenBbdoVersions) {
   }
 
   auto it = l1.begin();
-  for (auto& s : l2) {
-    ASSERT_TRUE(it != l1.end() && s >= *it);
-    if (s == *it) {
+  for (auto it1 = l2.begin(); it1 != l2.end();) {
+    if (*it1 == "internal_id" || *it1 == "long_output" || *it1 == "type") {
+      ++it1;
+      continue;
+    }
+    std::cout << *it << " <=> " << *it1 << std::endl;
+    ASSERT_TRUE(it != l1.end() && *it1 >= *it);
+    if (*it1 == *it) {
+      ++it;
+      ++it1;
+      continue;
+    } else {
       ++it;
       continue;
     }
-    else
-      continue;
   }
   RemoveFile(filename);
   RemoveFile("/tmp/log");
@@ -4064,28 +4117,37 @@ TEST_F(LuaTest, HostStatusObjectMatchBetweenBbdoVersions) {
   std::string filename("/tmp/cache_test.lua");
   auto hst = std::make_shared<neb::host_status>();
   hst->host_id = 1;
+  hst->last_hard_state = 12345;
+  hst->last_check = 12345;
+  hst->last_hard_state_change = 12345;
+  hst->last_notification = 12345;
+  hst->last_state_change = 12345;
+  hst->last_time_down = 12345;
+  hst->last_time_up = 12345;
+  hst->last_time_unreachable = 12345;
+  hst->next_check = 12345;
+  hst->next_notification = 12345;
   auto hst1 = std::make_shared<neb::pb_host_status>();
   hst1->mut_obj().set_host_id(1);
 
-  CreateScript(
-      filename,
-      "function init(conf)\n"
-      "  broker_log:set_parameters(3, '/tmp/log')\n"
-      "end\n\n"
-      "local count = 1\n"
-      "function write(d)\n"
-      "  local puce = { '* ', '- ' }\n"
-      "  local keys = {}\n"
-      "  for k,_ in pairs(d) do\n"
-      "    keys[#keys + 1] = k\n"
-      "  end\n"
-      "  table.sort(keys)\n"
-      "  for i,k in ipairs(keys) do\n"
-      "    broker_log:info(1, puce[count] .. k)\n"
-      "  end\n"
-      "  count = count + 1\n"
-      "  return true\n"
-      "end\n");
+  CreateScript(filename,
+               "function init(conf)\n"
+               "  broker_log:set_parameters(3, '/tmp/log')\n"
+               "end\n\n"
+               "local count = 1\n"
+               "function write(d)\n"
+               "  local puce = { '* ', '- ' }\n"
+               "  local keys = {}\n"
+               "  for k,_ in pairs(d) do\n"
+               "    keys[#keys + 1] = k\n"
+               "  end\n"
+               "  table.sort(keys)\n"
+               "  for i,k in ipairs(keys) do\n"
+               "    broker_log:info(1, puce[count] .. k)\n"
+               "  end\n"
+               "  count = count + 1\n"
+               "  return true\n"
+               "end\n");
   auto binding{std::make_unique<luabinding>(filename, conf, *_cache)};
   binding->write(hst);
   binding->write(hst1);
@@ -4103,14 +4165,21 @@ TEST_F(LuaTest, HostStatusObjectMatchBetweenBbdoVersions) {
   }
 
   auto it = l1.begin();
-  for (auto& s : l2) {
-    ASSERT_TRUE(it != l1.end() && s >= *it);
-    if (s == *it) {
+  for (auto it1 = l2.begin(); it1 != l2.end();) {
+    if (*it1 == "long_output" || *it1 == "icon_id") {
+      ++it1;
+      continue;
+    }
+    std::cout << *it << " <=> " << *it1 << std::endl;
+    ASSERT_TRUE(it != l1.end() && *it1 >= *it);
+    if (*it1 == *it) {
+      ++it;
+      ++it1;
+      continue;
+    } else {
       ++it;
       continue;
     }
-    else
-      continue;
   }
   RemoveFile(filename);
   RemoveFile("/tmp/log");

--- a/broker/neb/src/callbacks.cc
+++ b/broker/neb/src/callbacks.cc
@@ -1429,7 +1429,7 @@ int neb::callback_pb_host(int callback_type, void* data) {
     host.set_passive_checks_enabled(eh->passive_checks_enabled());
     host.set_percent_state_change(eh->get_percent_state_change());
     if (!eh->get_perf_data().empty())
-      host.set_perf_data(misc::string::check_string_utf8(eh->get_perf_data()));
+      host.set_perfdata(misc::string::check_string_utf8(eh->get_perf_data()));
     host.set_poller_id(config::applier::state::instance().poller_id());
     host.set_retain_nonstatus_information(
         eh->get_retain_nonstatus_information());
@@ -1712,7 +1712,7 @@ int neb::callback_pb_host_status(int callback_type, void* data) noexcept {
 
   hscr.set_percent_state_change(eh->get_percent_state_change());
   if (!eh->get_perf_data().empty())
-    hscr.set_perf_data(misc::string::check_string_utf8(eh->get_perf_data()));
+    hscr.set_perfdata(misc::string::check_string_utf8(eh->get_perf_data()));
   hscr.set_should_be_scheduled(eh->get_should_be_scheduled());
   hscr.set_state_type(static_cast<HostStatus_StateType>(
       eh->has_been_checked() ? eh->get_state_type() : engine::notifier::hard));
@@ -2470,7 +2470,7 @@ int neb::callback_pb_service(int callback_type, void* data) {
     srv.set_passive_checks_enabled(es->passive_checks_enabled());
     srv.set_percent_state_change(es->get_percent_state_change());
     if (!es->get_perf_data().empty())
-      *srv.mutable_perf_data() =
+      *srv.mutable_perfdata() =
           misc::string::check_string_utf8(es->get_perf_data());
     srv.set_retain_nonstatus_information(
         es->get_retain_nonstatus_information());
@@ -2753,7 +2753,7 @@ int32_t neb::callback_pb_service_status(int callback_type
 
   sscr.set_percent_state_change(es->get_percent_state_change());
   if (!es->get_perf_data().empty()) {
-    sscr.set_perf_data(misc::string::check_string_utf8(es->get_perf_data()));
+    sscr.set_perfdata(misc::string::check_string_utf8(es->get_perf_data()));
     log_v2::neb()->trace("callbacks: service ({}, {}) has perfdata <<{}>>",
                          es->get_host_id(), es->get_service_id(),
                          es->get_perf_data());

--- a/broker/neb/src/callbacks.cc
+++ b/broker/neb/src/callbacks.cc
@@ -1276,18 +1276,18 @@ int neb::callback_pb_host(int callback_type, void* data) {
     auto h{std::make_shared<neb::pb_adaptive_host>()};
     AdaptiveHost& hst = h.get()->mut_obj();
     if (dh->modified_attribute & MODATTR_NOTIFICATIONS_ENABLED)
-      hst.set_notifications_enabled(eh->get_notifications_enabled());
+      hst.set_notify(eh->get_notifications_enabled());
     else if (dh->modified_attribute & MODATTR_ACTIVE_CHECKS_ENABLED) {
-      hst.set_active_checks_enabled(eh->active_checks_enabled());
+      hst.set_active_checks(eh->active_checks_enabled());
       hst.set_should_be_scheduled(eh->get_should_be_scheduled());
     } else if (dh->modified_attribute & MODATTR_PASSIVE_CHECKS_ENABLED)
-      hst.set_passive_checks_enabled(eh->passive_checks_enabled());
+      hst.set_passive_checks(eh->passive_checks_enabled());
     else if (dh->modified_attribute & MODATTR_EVENT_HANDLER_ENABLED)
       hst.set_event_handler_enabled(eh->event_handler_enabled());
     else if (dh->modified_attribute & MODATTR_FLAP_DETECTION_ENABLED)
-      hst.set_flap_detection_enabled(eh->flap_detection_enabled());
+      hst.set_flap_detection(eh->flap_detection_enabled());
     else if (dh->modified_attribute & MODATTR_OBSESSIVE_HANDLER_ENABLED)
-      hst.set_obsess_over(eh->obsess_over());
+      hst.set_obsess_over_host(eh->obsess_over());
     else if (dh->modified_attribute & MODATTR_EVENT_HANDLER_COMMAND)
       hst.set_event_handler(
           misc::string::check_string_utf8(eh->event_handler()));
@@ -1334,7 +1334,7 @@ int neb::callback_pb_host(int callback_type, void* data) {
     if (!eh->get_action_url().empty())
       host.set_action_url(
           misc::string::check_string_utf8(eh->get_action_url()));
-    host.set_active_checks_enabled(eh->active_checks_enabled());
+    host.set_active_checks(eh->active_checks_enabled());
     if (!eh->get_address().empty())
       host.set_address(misc::string::check_string_utf8(eh->get_address()));
     if (!eh->get_alias().empty())
@@ -1347,16 +1347,16 @@ int neb::callback_pb_host(int callback_type, void* data) {
     if (!eh->check_period().empty())
       host.set_check_period(eh->check_period());
     host.set_check_type(static_cast<Host_CheckType>(eh->get_check_type()));
-    host.set_current_check_attempt(eh->get_current_attempt());
-    host.set_current_state(static_cast<Host_State>(eh->has_been_checked()
-                                                       ? eh->get_current_state()
-                                                       : 4));  // Pending state.
-    host.set_default_active_checks_enabled(eh->active_checks_enabled());
+    host.set_check_attempt(eh->get_current_attempt());
+    host.set_state(static_cast<Host_State>(eh->has_been_checked()
+                                               ? eh->get_current_state()
+                                               : 4));  // Pending state.
+    host.set_default_active_checks(eh->active_checks_enabled());
     host.set_default_event_handler_enabled(eh->event_handler_enabled());
-    host.set_default_flap_detection_enabled(eh->flap_detection_enabled());
-    host.set_default_notifications_enabled(eh->get_notifications_enabled());
-    host.set_default_passive_checks_enabled(eh->passive_checks_enabled());
-    host.set_downtime_depth(eh->get_scheduled_downtime_depth());
+    host.set_default_flap_detection(eh->flap_detection_enabled());
+    host.set_default_notify(eh->get_notifications_enabled());
+    host.set_default_passive_checks(eh->passive_checks_enabled());
+    host.set_scheduled_downtime_depth(eh->get_scheduled_downtime_depth());
     if (!eh->get_display_name().empty())
       host.set_display_name(
           misc::string::check_string_utf8(eh->get_display_name()));
@@ -1369,7 +1369,7 @@ int neb::callback_pb_host(int callback_type, void* data) {
     host.set_execution_time(eh->get_execution_time());
     host.set_first_notification_delay(eh->get_first_notification_delay());
     host.set_notification_number(eh->get_notification_number());
-    host.set_flap_detection_enabled(eh->flap_detection_enabled());
+    host.set_flap_detection(eh->flap_detection_enabled());
     host.set_flap_detection_on_down(
         eh->get_flap_detection_on(engine::notifier::down));
     host.set_flap_detection_on_unreachable(
@@ -1377,17 +1377,17 @@ int neb::callback_pb_host(int callback_type, void* data) {
     host.set_flap_detection_on_up(
         eh->get_flap_detection_on(engine::notifier::up));
     host.set_freshness_threshold(eh->get_freshness_threshold());
-    host.set_has_been_checked(eh->has_been_checked());
+    host.set_checked(eh->has_been_checked());
     host.set_high_flap_threshold(eh->get_high_flap_threshold());
     if (!eh->get_name().empty())
-      host.set_host_name(misc::string::check_string_utf8(eh->get_name()));
+      host.set_name(misc::string::check_string_utf8(eh->get_name()));
     if (!eh->get_icon_image().empty())
       host.set_icon_image(
           misc::string::check_string_utf8(eh->get_icon_image()));
     if (!eh->get_icon_image_alt().empty())
       host.set_icon_image_alt(
           misc::string::check_string_utf8(eh->get_icon_image_alt()));
-    host.set_is_flapping(eh->get_is_flapping());
+    host.set_flapping(eh->get_is_flapping());
     host.set_last_check(eh->get_last_check());
     host.set_last_hard_state(
         static_cast<Host_State>(eh->get_last_hard_state()));
@@ -1402,13 +1402,13 @@ int neb::callback_pb_host(int callback_type, void* data) {
     host.set_low_flap_threshold(eh->get_low_flap_threshold());
     host.set_max_check_attempts(eh->max_check_attempts());
     host.set_next_check(eh->get_next_check());
-    host.set_next_notification(eh->get_next_notification());
+    host.set_next_host_notification(eh->get_next_notification());
     host.set_no_more_notifications(eh->get_no_more_notifications());
     if (!eh->get_notes().empty())
       host.set_notes(misc::string::check_string_utf8(eh->get_notes()));
     if (!eh->get_notes_url().empty())
       host.set_notes_url(misc::string::check_string_utf8(eh->get_notes_url()));
-    host.set_notifications_enabled(eh->get_notifications_enabled());
+    host.set_notify(eh->get_notifications_enabled());
     host.set_notification_interval(eh->get_notification_interval());
     if (!eh->notification_period().empty())
       host.set_notification_period(eh->notification_period());
@@ -1419,18 +1419,18 @@ int neb::callback_pb_host(int callback_type, void* data) {
     host.set_notify_on_recovery(eh->get_notify_on(engine::notifier::up));
     host.set_notify_on_unreachable(
         eh->get_notify_on(engine::notifier::unreachable));
-    host.set_obsess_over(eh->obsess_over());
+    host.set_obsess_over_host(eh->obsess_over());
     if (!eh->get_plugin_output().empty()) {
       host.set_output(misc::string::check_string_utf8(eh->get_plugin_output()));
     }
     if (!eh->get_long_plugin_output().empty())
       host.set_output(
           misc::string::check_string_utf8(eh->get_long_plugin_output()));
-    host.set_passive_checks_enabled(eh->passive_checks_enabled());
+    host.set_passive_checks(eh->passive_checks_enabled());
     host.set_percent_state_change(eh->get_percent_state_change());
     if (!eh->get_perf_data().empty())
       host.set_perfdata(misc::string::check_string_utf8(eh->get_perf_data()));
-    host.set_poller_id(config::applier::state::instance().poller_id());
+    host.set_instance_id(config::applier::state::instance().poller_id());
     host.set_retain_nonstatus_information(
         eh->get_retain_nonstatus_information());
     host.set_retain_status_information(eh->get_retain_status_information());
@@ -1456,13 +1456,13 @@ int neb::callback_pb_host(int callback_type, void* data) {
     }
 
     // Find host ID.
-    uint64_t host_id = engine::get_host_id(host.host_name());
+    uint64_t host_id = engine::get_host_id(host.name());
     if (host_id != 0) {
       host.set_host_id(host_id);
 
       // Send host event.
       log_v2::neb()->info("callbacks:  new host {} ('{}') on instance {}",
-                          host.host_id(), host.host_name(), host.poller_id());
+                          host.host_id(), host.name(), host.instance_id());
       neb::gl_publisher.write(h);
 
       /* No need to send this service custom variables changes, custom variables
@@ -1684,12 +1684,12 @@ int neb::callback_pb_host_status(int callback_type, void* data) noexcept {
     hscr.set_acknowledgement_type(HostStatus_AckType_NONE);
 
   hscr.set_check_type(static_cast<HostStatus_CheckType>(eh->get_check_type()));
-  hscr.set_current_check_attempt(eh->get_current_attempt());
-  hscr.set_current_state(static_cast<HostStatus_State>(
+  hscr.set_check_attempt(eh->get_current_attempt());
+  hscr.set_state(static_cast<HostStatus_State>(
       eh->has_been_checked() ? eh->get_current_state() : 4));  // Pending state.
   hscr.set_execution_time(eh->get_execution_time());
-  hscr.set_has_been_checked(eh->has_been_checked());
-  hscr.set_is_flapping(eh->get_is_flapping());
+  hscr.set_checked(eh->has_been_checked());
+  hscr.set_flapping(eh->get_is_flapping());
   hscr.set_last_check(eh->get_last_check());
   hscr.set_last_hard_state(
       static_cast<HostStatus_State>(eh->get_last_hard_state()));
@@ -1702,7 +1702,7 @@ int neb::callback_pb_host_status(int callback_type, void* data) noexcept {
   hscr.set_last_time_up(eh->get_last_time_up());
   hscr.set_latency(eh->get_latency());
   hscr.set_next_check(eh->get_next_check());
-  hscr.set_next_notification(eh->get_next_notification());
+  hscr.set_next_host_notification(eh->get_next_notification());
   hscr.set_no_more_notifications(eh->get_no_more_notifications());
   if (!eh->get_plugin_output().empty())
     hscr.set_output(misc::string::check_string_utf8(eh->get_plugin_output()));
@@ -1716,7 +1716,7 @@ int neb::callback_pb_host_status(int callback_type, void* data) noexcept {
   hscr.set_should_be_scheduled(eh->get_should_be_scheduled());
   hscr.set_state_type(static_cast<HostStatus_StateType>(
       eh->has_been_checked() ? eh->get_state_type() : engine::notifier::hard));
-  hscr.set_downtime_depth(eh->get_scheduled_downtime_depth());
+  hscr.set_scheduled_downtime_depth(eh->get_scheduled_downtime_depth());
 
   // Send event(s).
   gl_publisher.write(h);
@@ -1725,9 +1725,8 @@ int neb::callback_pb_host_status(int callback_type, void* data) noexcept {
   auto it = gl_acknowledgements.find(std::make_pair(hscr.host_id(), 0u));
   if (it != gl_acknowledgements.end() &&
       hscr.acknowledgement_type() == HostStatus_AckType_NONE) {
-    if (!(!hscr.current_state()  // !(OK or (normal ack and NOK))
-          || (!it->second.is_sticky &&
-              (hscr.current_state() != it->second.state)))) {
+    if (!(!hscr.state()  // !(OK or (normal ack and NOK))
+          || (!it->second.is_sticky && (hscr.state() != it->second.state)))) {
       auto ack = std::make_shared<neb::acknowledgement>(it->second);
       ack->deletion_time = time(nullptr);
       gl_publisher.write(ack);
@@ -2270,18 +2269,18 @@ int neb::callback_pb_service(int callback_type, void* data) {
     auto s{std::make_shared<neb::pb_adaptive_service>()};
     AdaptiveService& srv = s.get()->mut_obj();
     if (ds->modified_attribute & MODATTR_NOTIFICATIONS_ENABLED)
-      srv.set_notifications_enabled(es->get_notifications_enabled());
+      srv.set_notify(es->get_notifications_enabled());
     else if (ds->modified_attribute & MODATTR_ACTIVE_CHECKS_ENABLED) {
-      srv.set_active_checks_enabled(es->active_checks_enabled());
+      srv.set_active_checks(es->active_checks_enabled());
       srv.set_should_be_scheduled(es->get_should_be_scheduled());
     } else if (ds->modified_attribute & MODATTR_PASSIVE_CHECKS_ENABLED)
-      srv.set_passive_checks_enabled(es->passive_checks_enabled());
+      srv.set_passive_checks(es->passive_checks_enabled());
     else if (ds->modified_attribute & MODATTR_EVENT_HANDLER_ENABLED)
       srv.set_event_handler_enabled(es->event_handler_enabled());
     else if (ds->modified_attribute & MODATTR_FLAP_DETECTION_ENABLED)
       srv.set_flap_detection_enabled(es->flap_detection_enabled());
     else if (ds->modified_attribute & MODATTR_OBSESSIVE_HANDLER_ENABLED)
-      srv.set_obsess_over(es->obsess_over());
+      srv.set_obsess_over_service(es->obsess_over());
     else if (ds->modified_attribute & MODATTR_EVENT_HANDLER_COMMAND)
       srv.set_event_handler(
           misc::string::check_string_utf8(es->event_handler()));
@@ -2333,7 +2332,7 @@ int neb::callback_pb_service(int callback_type, void* data) {
         static_cast<Service_AckType>(es->get_acknowledgement_type()));
     if (!es->get_action_url().empty())
       srv.set_action_url(misc::string::check_string_utf8(es->get_action_url()));
-    srv.set_active_checks_enabled(es->active_checks_enabled());
+    srv.set_active_checks(es->active_checks_enabled());
     if (!es->check_command().empty())
       srv.set_check_command(
           misc::string::check_string_utf8(es->check_command()));
@@ -2342,16 +2341,16 @@ int neb::callback_pb_service(int callback_type, void* data) {
     if (!es->check_period().empty())
       srv.set_check_period(es->check_period());
     srv.set_check_type(static_cast<Service_CheckType>(es->get_check_type()));
-    srv.set_current_check_attempt(es->get_current_attempt());
-    srv.set_current_state(static_cast<Service_State>(
-        es->has_been_checked() ? es->get_current_state()
-                               : 4));  // Pending state.
-    srv.set_default_active_checks_enabled(es->active_checks_enabled());
+    srv.set_check_attempt(es->get_current_attempt());
+    srv.set_state(static_cast<Service_State>(es->has_been_checked()
+                                                 ? es->get_current_state()
+                                                 : 4));  // Pending state.
+    srv.set_default_active_checks(es->active_checks_enabled());
     srv.set_default_event_handler_enabled(es->event_handler_enabled());
-    srv.set_default_flap_detection_enabled(es->flap_detection_enabled());
-    srv.set_default_notifications_enabled(es->get_notifications_enabled());
-    srv.set_default_passive_checks_enabled(es->passive_checks_enabled());
-    srv.set_downtime_depth(es->get_scheduled_downtime_depth());
+    srv.set_default_flap_detection(es->flap_detection_enabled());
+    srv.set_default_notify(es->get_notifications_enabled());
+    srv.set_default_passive_checks(es->passive_checks_enabled());
+    srv.set_scheduled_downtime_depth(es->get_scheduled_downtime_depth());
     if (!es->get_display_name().empty())
       srv.set_display_name(
           misc::string::check_string_utf8(es->get_display_name()));
@@ -2364,7 +2363,7 @@ int neb::callback_pb_service(int callback_type, void* data) {
     srv.set_execution_time(es->get_execution_time());
     srv.set_first_notification_delay(es->get_first_notification_delay());
     srv.set_notification_number(es->get_notification_number());
-    srv.set_flap_detection_enabled(es->flap_detection_enabled());
+    srv.set_flap_detection(es->flap_detection_enabled());
     srv.set_flap_detection_on_critical(
         es->get_flap_detection_on(engine::notifier::critical));
     srv.set_flap_detection_on_ok(
@@ -2374,25 +2373,25 @@ int neb::callback_pb_service(int callback_type, void* data) {
     srv.set_flap_detection_on_warning(
         es->get_flap_detection_on(engine::notifier::warning));
     srv.set_freshness_threshold(es->get_freshness_threshold());
-    srv.set_has_been_checked(es->has_been_checked());
+    srv.set_checked(es->has_been_checked());
     srv.set_high_flap_threshold(es->get_high_flap_threshold());
     if (!es->get_description().empty())
-      *srv.mutable_service_description() =
-          misc::string::check_string_utf8(es->get_description());
+      srv.set_description(
+          misc::string::check_string_utf8(es->get_description()));
 
     if (!es->get_hostname().empty()) {
       std::string name{misc::string::check_string_utf8(es->get_hostname())};
       if (strncmp(name.c_str(), "_Module_Meta", 13) == 0) {
-        if (strncmp(srv.service_description().c_str(), "meta_", 5) == 0) {
+        if (strncmp(srv.description().c_str(), "meta_", 5) == 0) {
           srv.set_type(METASERVICE);
           uint64_t iid = 0;
-          for (auto c = srv.service_description().begin() + 5;
-               c != srv.service_description().end(); ++c) {
+          for (auto c = srv.description().begin() + 5;
+               c != srv.description().end(); ++c) {
             if (!isdigit(*c)) {
               log_v2::neb()->error(
                   "callbacks: service ('{}', '{}') looks like a meta-service "
                   "but its name is malformed",
-                  name, srv.service_description());
+                  name, srv.description());
               break;
             }
             iid = 10 * iid + (*c - '0');
@@ -2400,16 +2399,16 @@ int neb::callback_pb_service(int callback_type, void* data) {
           srv.set_internal_id(iid);
         }
       } else if (strncmp(name.c_str(), "_Module_BAM", 11) == 0) {
-        if (strncmp(srv.service_description().c_str(), "ba_", 3) == 0) {
+        if (strncmp(srv.description().c_str(), "ba_", 3) == 0) {
           srv.set_type(BA);
           uint64_t iid = 0;
-          for (auto c = srv.service_description().begin() + 3;
-               c != srv.service_description().end(); ++c) {
+          for (auto c = srv.description().begin() + 3;
+               c != srv.description().end(); ++c) {
             if (!isdigit(*c)) {
               log_v2::neb()->error(
                   "callbacks: service ('{}', '{}') looks like a "
                   "business-activity but its name is malformed",
-                  name, srv.service_description());
+                  name, srv.description());
               break;
             }
             iid = 10 * iid + (*c - '0');
@@ -2425,7 +2424,7 @@ int neb::callback_pb_service(int callback_type, void* data) {
     if (!es->get_icon_image_alt().empty())
       *srv.mutable_icon_image_alt() =
           misc::string::check_string_utf8(es->get_icon_image_alt());
-    srv.set_is_flapping(es->get_is_flapping());
+    srv.set_flapping(es->get_is_flapping());
     srv.set_is_volatile(es->get_is_volatile());
     srv.set_last_check(es->get_last_check());
     srv.set_last_hard_state(
@@ -2449,7 +2448,7 @@ int neb::callback_pb_service(int callback_type, void* data) {
     if (!es->get_notes_url().empty())
       *srv.mutable_notes_url() =
           misc::string::check_string_utf8(es->get_notes_url());
-    srv.set_notifications_enabled(es->get_notifications_enabled());
+    srv.set_notify(es->get_notifications_enabled());
     srv.set_notification_interval(es->get_notification_interval());
     if (!es->notification_period().empty())
       srv.set_notification_period(es->notification_period());
@@ -2460,14 +2459,14 @@ int neb::callback_pb_service(int callback_type, void* data) {
     srv.set_notify_on_recovery(es->get_notify_on(engine::notifier::ok));
     srv.set_notify_on_unknown(es->get_notify_on(engine::notifier::unknown));
     srv.set_notify_on_warning(es->get_notify_on(engine::notifier::warning));
-    srv.set_obsess_over(es->obsess_over());
+    srv.set_obsess_over_service(es->obsess_over());
     if (!es->get_plugin_output().empty())
       *srv.mutable_output() =
           misc::string::check_string_utf8(es->get_plugin_output());
     if (!es->get_long_plugin_output().empty())
       *srv.mutable_long_output() =
           misc::string::check_string_utf8(es->get_long_plugin_output());
-    srv.set_passive_checks_enabled(es->passive_checks_enabled());
+    srv.set_passive_checks(es->passive_checks_enabled());
     srv.set_percent_state_change(es->get_percent_state_change());
     if (!es->get_perf_data().empty())
       *srv.mutable_perfdata() =
@@ -2505,8 +2504,7 @@ int neb::callback_pb_service(int callback_type, void* data) {
     if (srv.host_id() && srv.service_id()) {
       // Send service event.
       log_v2::neb()->info("callbacks: new service {} ('{}') on host {}",
-                          srv.service_id(), srv.service_description(),
-                          srv.host_id());
+                          srv.service_id(), srv.description(), srv.host_id());
       neb::gl_publisher.write(s);
 
       /* No need to send this service custom variables changes, custom
@@ -2516,8 +2514,7 @@ int neb::callback_pb_service(int callback_type, void* data) {
           "callbacks: service has no host ID or no service ID (yet) (host "
           "'{}', service '{}')",
           (!es->get_hostname().empty() ? srv.host_name() : "(unknown)"),
-          (!es->get_description().empty() ? srv.service_description()
-                                          : "(unknown)"));
+          (!es->get_description().empty() ? srv.description() : "(unknown)"));
   }
   return 0;
 }
@@ -2723,12 +2720,12 @@ int32_t neb::callback_pb_service_status(int callback_type
 
   sscr.set_check_type(
       static_cast<ServiceStatus_CheckType>(es->get_check_type()));
-  sscr.set_current_check_attempt(es->get_current_attempt());
-  sscr.set_current_state(static_cast<ServiceStatus_State>(
+  sscr.set_check_attempt(es->get_current_attempt());
+  sscr.set_state(static_cast<ServiceStatus_State>(
       es->has_been_checked() ? es->get_current_state() : 4));  // Pending state.
   sscr.set_execution_time(es->get_execution_time());
-  sscr.set_has_been_checked(es->has_been_checked());
-  sscr.set_is_flapping(es->get_is_flapping());
+  sscr.set_checked(es->has_been_checked());
+  sscr.set_flapping(es->get_is_flapping());
   sscr.set_last_check(es->get_last_check());
   sscr.set_last_hard_state(
       static_cast<ServiceStatus_State>(es->get_last_hard_state()));
@@ -2764,7 +2761,7 @@ int32_t neb::callback_pb_service_status(int callback_type
   sscr.set_should_be_scheduled(es->get_should_be_scheduled());
   sscr.set_state_type(static_cast<ServiceStatus_StateType>(
       es->has_been_checked() ? es->get_state_type() : engine::notifier::hard));
-  sscr.set_downtime_depth(es->get_scheduled_downtime_depth());
+  sscr.set_scheduled_downtime_depth(es->get_scheduled_downtime_depth());
 
   if (!es->get_hostname().empty()) {
     if (strncmp(es->get_hostname().c_str(), "_Module_Meta", 13) == 0) {
@@ -2811,9 +2808,8 @@ int32_t neb::callback_pb_service_status(int callback_type
       std::make_pair(sscr.host_id(), sscr.service_id()));
   if (it != gl_acknowledgements.end() &&
       sscr.acknowledgement_type() == ServiceStatus_AckType_NONE) {
-    if (!(!sscr.current_state()  // !(OK or (normal ack and NOK))
-          || (!it->second.is_sticky &&
-              (sscr.current_state() != it->second.state)))) {
+    if (!(!sscr.state()  // !(OK or (normal ack and NOK))
+          || (!it->second.is_sticky && (sscr.state() != it->second.state)))) {
       auto ack = std::make_shared<neb::acknowledgement>(it->second);
       ack->deletion_time = time(nullptr);
       gl_publisher.write(ack);

--- a/broker/unified_sql/src/stream_sql.cc
+++ b/broker/unified_sql/src/stream_sql.cc
@@ -1568,7 +1568,7 @@ void stream::_process_pb_host_status(const std::shared_ptr<io::data>& d) {
   log_v2::sql()->debug("SQL: pb host status check result output: <<{}>>",
                        hscr.output());
   log_v2::sql()->debug("SQL: pb host status check result perfdata: <<{}>>",
-                       hscr.perf_data());
+                       hscr.perfdata());
 
   time_t now = time(nullptr);
   if (hscr.check_type() == HostStatus_CheckType_PASSIVE ||
@@ -1650,10 +1650,10 @@ void stream::_process_pb_host_status(const std::shared_ptr<io::data>& d) {
           full_output, get_hosts_col_size(hosts_output));
       _hscr_update.bind_value_as_str(
           10, fmt::string_view(full_output.data(), size));
-      size = misc::string::adjust_size_utf8(hscr.perf_data(),
+      size = misc::string::adjust_size_utf8(hscr.perfdata(),
                                             get_hosts_col_size(hosts_perfdata));
       _hscr_update.bind_value_as_str(
-          11, fmt::string_view(hscr.perf_data().data(), size));
+          11, fmt::string_view(hscr.perfdata().data(), size));
       _hscr_update.bind_value_as_bool(12, hscr.is_flapping());
       _hscr_update.bind_value_as_f64(13, hscr.percent_state_change());
       _hscr_update.bind_value_as_f64(14, hscr.latency());
@@ -1691,7 +1691,7 @@ void stream::_process_pb_host_status(const std::shared_ptr<io::data>& d) {
       _hscr_resources_update.bind_value_as_bool(
           5, hscr.state_type() == HostStatus_StateType_HARD);
       _hscr_resources_update.bind_value_as_u32(6, hscr.current_check_attempt());
-      _hscr_resources_update.bind_value_as_bool(7, hscr.perf_data() != "");
+      _hscr_resources_update.bind_value_as_bool(7, hscr.perfdata() != "");
       _hscr_resources_update.bind_value_as_u32(8, hscr.check_type());
       _hscr_resources_update.bind_value_as_u64(9, hscr.last_check(),
                                                is_not_zero);
@@ -2963,7 +2963,7 @@ void stream::_process_pb_service_status(const std::shared_ptr<io::data>& d) {
       sscr.host_id(), sscr.service_id(), sscr.output());
   log_v2::sql()->debug(
       "SQL: service ({}, {}) status check result perfdata: <<{}>>",
-      sscr.host_id(), sscr.service_id(), sscr.perf_data());
+      sscr.host_id(), sscr.service_id(), sscr.perfdata());
 
   time_t now = time(nullptr);
   if (sscr.check_type() == ServiceStatus_CheckType_PASSIVE ||
@@ -3048,9 +3048,9 @@ void stream::_process_pb_service_status(const std::shared_ptr<io::data>& d) {
       _sscr_update.bind_value_as_str(
           11, fmt::string_view(full_output.data(), size));
       size = misc::string::adjust_size_utf8(
-          sscr.perf_data(), get_services_col_size(services_perfdata));
+          sscr.perfdata(), get_services_col_size(services_perfdata));
       _sscr_update.bind_value_as_str(
-          12, fmt::string_view(sscr.perf_data().data(), size));
+          12, fmt::string_view(sscr.perfdata().data(), size));
       _sscr_update.bind_value_as_bool(13, sscr.is_flapping());
       _sscr_update.bind_value_as_f64(14, sscr.percent_state_change());
       _sscr_update.bind_value_as_f64(15, sscr.latency());
@@ -3090,7 +3090,7 @@ void stream::_process_pb_service_status(const std::shared_ptr<io::data>& d) {
       _sscr_resources_update.bind_value_as_bool(
           5, sscr.state_type() == ServiceStatus_StateType_HARD);
       _sscr_resources_update.bind_value_as_u32(6, sscr.current_check_attempt());
-      _sscr_resources_update.bind_value_as_bool(7, sscr.perf_data() != "");
+      _sscr_resources_update.bind_value_as_bool(7, sscr.perfdata() != "");
       _sscr_resources_update.bind_value_as_u32(8, sscr.check_type());
       _sscr_resources_update.bind_value_as_u64(9, sscr.last_check(),
                                                is_not_zero);

--- a/broker/unified_sql/src/stream_sql.cc
+++ b/broker/unified_sql/src/stream_sql.cc
@@ -1066,15 +1066,15 @@ void stream::_process_pb_host(const std::shared_ptr<io::data>& d) {
   // Log message.
   log_v2::sql()->info(
       "SQL: processing pb host event (poller: {}, host: {}, name: {})",
-      h.poller_id(), h.host_id(), h.host_name());
+      h.instance_id(), h.host_id(), h.name());
 
   // Processing
-  if (_is_valid_poller(h.poller_id())) {
+  if (_is_valid_poller(h.instance_id())) {
     // FixMe BAM Generate fake host, this host
     // does not contain a display_name
     // We should not store them in db
     if (h.host_id() && !h.alias().empty()) {
-      int32_t conn = _mysql.choose_connection_by_instance(h.poller_id());
+      int32_t conn = _mysql.choose_connection_by_instance(h.instance_id());
 
       // Prepare queries.
       if (!_pb_host_insupdate.prepared()) {
@@ -1207,7 +1207,7 @@ void stream::_process_pb_host(const std::shared_ptr<io::data>& d) {
 
       // Fill the cache...
       if (h.enabled())
-        _cache_host_instance[h.host_id()] = h.poller_id();
+        _cache_host_instance[h.host_id()] = h.instance_id();
       else
         _cache_host_instance.erase(h.host_id());
 
@@ -1218,13 +1218,13 @@ void stream::_process_pb_host(const std::shared_ptr<io::data>& d) {
         if (h.enabled()) {
           uint64_t sid = 0;
           fmt::string_view name{misc::string::truncate(
-              h.host_name(), get_resources_col_size(resources_name))};
+              h.name(), get_resources_col_size(resources_name))};
           fmt::string_view address{misc::string::truncate(
               h.address(), get_resources_col_size(resources_address))};
           fmt::string_view alias{misc::string::truncate(
               h.alias(), get_resources_col_size(resources_alias))};
           fmt::string_view parent_name{misc::string::truncate(
-              h.host_name(), get_resources_col_size(resources_parent_name))};
+              h.name(), get_resources_col_size(resources_parent_name))};
           fmt::string_view notes_url{misc::string::truncate(
               h.notes_url(), get_resources_col_size(resources_notes_url))};
           fmt::string_view notes{misc::string::truncate(
@@ -1235,18 +1235,17 @@ void stream::_process_pb_host(const std::shared_ptr<io::data>& d) {
           // INSERT
           if (found == _resource_cache.end()) {
             _resources_host_insert.bind_value_as_u64(0, h.host_id());
-            _resources_host_insert.bind_value_as_u32(1, h.current_state());
+            _resources_host_insert.bind_value_as_u32(1, h.state());
             _resources_host_insert.bind_value_as_u32(
-                2, hst_ordered_status[h.current_state()]);
+                2, hst_ordered_status[h.state()]);
             _resources_host_insert.bind_value_as_u64(3, h.last_state_change());
-            _resources_host_insert.bind_value_as_bool(4,
-                                                      h.downtime_depth() > 0);
+            _resources_host_insert.bind_value_as_bool(
+                4, h.scheduled_downtime_depth() > 0);
             _resources_host_insert.bind_value_as_bool(
                 5, h.acknowledgement_type() != Host_AckType_NONE);
             _resources_host_insert.bind_value_as_bool(
                 6, h.state_type() == Host_StateType_HARD);
-            _resources_host_insert.bind_value_as_u32(7,
-                                                     h.current_check_attempt());
+            _resources_host_insert.bind_value_as_u32(7, h.check_attempt());
             _resources_host_insert.bind_value_as_u32(8, h.max_check_attempts());
             _resources_host_insert.bind_value_as_u64(
                 9, _cache_host_instance[h.host_id()]);
@@ -1268,12 +1267,9 @@ void stream::_process_pb_host(const std::shared_ptr<io::data>& d) {
             _resources_host_insert.bind_value_as_str(15, notes_url);
             _resources_host_insert.bind_value_as_str(16, notes);
             _resources_host_insert.bind_value_as_str(17, action_url);
-            _resources_host_insert.bind_value_as_bool(
-                18, h.notifications_enabled());
-            _resources_host_insert.bind_value_as_bool(
-                19, h.passive_checks_enabled());
-            _resources_host_insert.bind_value_as_bool(
-                20, h.active_checks_enabled());
+            _resources_host_insert.bind_value_as_bool(18, h.notify());
+            _resources_host_insert.bind_value_as_bool(19, h.passive_checks());
+            _resources_host_insert.bind_value_as_bool(20, h.active_checks());
             _resources_host_insert.bind_value_as_u64(21, h.icon_id());
 
             std::promise<uint64_t> p;
@@ -1316,18 +1312,17 @@ void stream::_process_pb_host(const std::shared_ptr<io::data>& d) {
           if (res_id == 0) {
             res_id = found->second;
             // UPDATE
-            _resources_host_update.bind_value_as_u32(0, h.current_state());
+            _resources_host_update.bind_value_as_u32(0, h.state());
             _resources_host_update.bind_value_as_u32(
-                1, hst_ordered_status[h.current_state()]);
+                1, hst_ordered_status[h.state()]);
             _resources_host_update.bind_value_as_u64(2, h.last_state_change());
-            _resources_host_update.bind_value_as_bool(3,
-                                                      h.downtime_depth() > 0);
+            _resources_host_update.bind_value_as_bool(
+                3, h.scheduled_downtime_depth() > 0);
             _resources_host_update.bind_value_as_bool(
                 4, h.acknowledgement_type() != Host_AckType_NONE);
             _resources_host_update.bind_value_as_bool(
                 5, h.state_type() == Host_StateType_HARD);
-            _resources_host_update.bind_value_as_u32(6,
-                                                     h.current_check_attempt());
+            _resources_host_update.bind_value_as_u32(6, h.check_attempt());
             _resources_host_update.bind_value_as_u32(7, h.max_check_attempts());
             _resources_host_update.bind_value_as_u64(
                 8, _cache_host_instance[h.host_id()]);
@@ -1349,12 +1344,9 @@ void stream::_process_pb_host(const std::shared_ptr<io::data>& d) {
             _resources_host_update.bind_value_as_str(14, notes_url);
             _resources_host_update.bind_value_as_str(15, notes);
             _resources_host_update.bind_value_as_str(16, action_url);
-            _resources_host_update.bind_value_as_bool(
-                17, h.notifications_enabled());
-            _resources_host_update.bind_value_as_bool(
-                18, h.passive_checks_enabled());
-            _resources_host_update.bind_value_as_bool(
-                19, h.active_checks_enabled());
+            _resources_host_update.bind_value_as_bool(17, h.notify());
+            _resources_host_update.bind_value_as_bool(18, h.passive_checks());
+            _resources_host_update.bind_value_as_bool(19, h.active_checks());
             _resources_host_update.bind_value_as_u64(20, h.icon_id());
             _resources_host_update.bind_value_as_u64(21, res_id);
 
@@ -1434,7 +1426,7 @@ void stream::_process_pb_host(const std::shared_ptr<io::data>& d) {
       log_v2::sql()->trace(
           "SQL: host '{}' of poller {} has no ID nor alias, probably bam "
           "fake host",
-          h.host_name(), h.poller_id());
+          h.name(), h.instance_id());
   }
 }
 
@@ -1459,25 +1451,25 @@ void stream::_process_pb_adaptive_host(const std::shared_ptr<io::data>& d) {
     constexpr const char* buf = "UPDATE hosts SET";
     constexpr size_t size = strlen(buf);
     std::string query{buf};
-    if (ah.has_notifications_enabled())
-      query += fmt::format(" notify='{}',", ah.notifications_enabled() ? 1 : 0);
-    if (ah.has_active_checks_enabled())
-      query += fmt::format(" active_checks='{}',",
-                           ah.active_checks_enabled() ? 1 : 0);
+    if (ah.has_notify())
+      query += fmt::format(" notify='{}',", ah.notify() ? 1 : 0);
+    if (ah.has_active_checks())
+      query += fmt::format(" active_checks='{}',", ah.active_checks() ? 1 : 0);
     if (ah.has_should_be_scheduled())
       query += fmt::format(" should_be_scheduled='{}',",
                            ah.should_be_scheduled() ? 1 : 0);
-    if (ah.has_passive_checks_enabled())
-      query += fmt::format(" passive_checks='{}',",
-                           ah.passive_checks_enabled() ? 1 : 0);
+    if (ah.has_passive_checks())
+      query +=
+          fmt::format(" passive_checks='{}',", ah.passive_checks() ? 1 : 0);
     if (ah.has_event_handler_enabled())
       query += fmt::format(" event_handler_enabled='{}',",
                            ah.event_handler_enabled() ? 1 : 0);
-    if (ah.has_flap_detection_enabled())
+    if (ah.has_flap_detection())
       query += fmt::format(" flap_detection='{}',",
-                           ah.flap_detection_enabled() ? 1 : 0);
-    if (ah.has_obsess_over())
-      query += fmt::format(" obsess_over_host='{}',", ah.obsess_over() ? 1 : 0);
+                           ah.flap_detection() ? 1 : 0);
+    if (ah.has_obsess_over_host())
+      query +=
+          fmt::format(" obsess_over_host='{}',", ah.obsess_over_host() ? 1 : 0);
     if (ah.has_event_handler())
       query += fmt::format(
           " event_handler='{}',",
@@ -1521,15 +1513,15 @@ void stream::_process_pb_adaptive_host(const std::shared_ptr<io::data>& d) {
         constexpr const char* res_buf = "UPDATE resources SET";
         constexpr size_t res_size = strlen(res_buf);
         std::string res_query{res_buf};
-        if (ah.has_notifications_enabled())
-          res_query += fmt::format(" notifications_enabled='{}',",
-                                   ah.notifications_enabled() ? 1 : 0);
-        if (ah.has_active_checks_enabled())
+        if (ah.has_notify())
+          res_query +=
+              fmt::format(" notifications_enabled='{}',", ah.notify() ? 1 : 0);
+        if (ah.has_active_checks())
           res_query += fmt::format(" active_checks_enabled='{}',",
-                                   ah.active_checks_enabled() ? 1 : 0);
-        if (ah.has_passive_checks_enabled())
+                                   ah.active_checks() ? 1 : 0);
+        if (ah.has_passive_checks())
           res_query += fmt::format(" passive_checks_enabled='{}',",
-                                   ah.passive_checks_enabled() ? 1 : 0);
+                                   ah.passive_checks() ? 1 : 0);
         if (ah.has_max_check_attempts())
           res_query +=
               fmt::format(" max_check_attempts={},", ah.max_check_attempts());
@@ -1578,8 +1570,7 @@ void stream::_process_pb_host_status(const std::shared_ptr<io::data>& d) {
     log_v2::sql()->info(
         "SQL: processing host status check result event proto (host: {}, "
         "last check: {}, state ({}, {}))",
-        hscr.host_id(), hscr.last_check(), hscr.current_state(),
-        hscr.state_type());
+        hscr.host_id(), hscr.last_check(), hscr.state(), hscr.state_type());
 
     // Prepare queries.
     if (_store_in_hosts_services && !_hscr_update.prepared()) {
@@ -1634,9 +1625,9 @@ void stream::_process_pb_host_status(const std::shared_ptr<io::data>& d) {
     // Processing.
 
     if (_store_in_hosts_services) {
-      _hscr_update.bind_value_as_bool(0, hscr.has_been_checked());
+      _hscr_update.bind_value_as_bool(0, hscr.checked());
       _hscr_update.bind_value_as_i32(1, hscr.check_type());
-      _hscr_update.bind_value_as_i32(2, hscr.current_state());
+      _hscr_update.bind_value_as_i32(2, hscr.state());
       _hscr_update.bind_value_as_i32(3, hscr.state_type());
       _hscr_update.bind_value_as_i64(4, hscr.last_state_change());
       _hscr_update.bind_value_as_i32(5, hscr.last_hard_state());
@@ -1654,22 +1645,22 @@ void stream::_process_pb_host_status(const std::shared_ptr<io::data>& d) {
                                             get_hosts_col_size(hosts_perfdata));
       _hscr_update.bind_value_as_str(
           11, fmt::string_view(hscr.perfdata().data(), size));
-      _hscr_update.bind_value_as_bool(12, hscr.is_flapping());
+      _hscr_update.bind_value_as_bool(12, hscr.flapping());
       _hscr_update.bind_value_as_f64(13, hscr.percent_state_change());
       _hscr_update.bind_value_as_f64(14, hscr.latency());
       _hscr_update.bind_value_as_f64(15, hscr.execution_time());
       _hscr_update.bind_value_as_i64(16, hscr.last_check(), is_not_zero);
       _hscr_update.bind_value_as_i64(17, hscr.next_check());
       _hscr_update.bind_value_as_bool(18, hscr.should_be_scheduled());
-      _hscr_update.bind_value_as_i32(19, hscr.current_check_attempt());
+      _hscr_update.bind_value_as_i32(19, hscr.check_attempt());
       _hscr_update.bind_value_as_i32(20, hscr.notification_number());
       _hscr_update.bind_value_as_bool(21, hscr.no_more_notifications());
       _hscr_update.bind_value_as_i64(22, hscr.last_notification());
-      _hscr_update.bind_value_as_i64(23, hscr.next_notification());
+      _hscr_update.bind_value_as_i64(23, hscr.next_host_notification());
       _hscr_update.bind_value_as_bool(
           24, hscr.acknowledgement_type() != HostStatus_AckType_NONE);
       _hscr_update.bind_value_as_i32(25, hscr.acknowledgement_type());
-      _hscr_update.bind_value_as_i32(26, hscr.downtime_depth());
+      _hscr_update.bind_value_as_i32(26, hscr.scheduled_downtime_depth());
       _hscr_update.bind_value_as_i32(27, hscr.host_id());
 
       int32_t conn = _mysql.choose_connection_by_instance(
@@ -1681,16 +1672,17 @@ void stream::_process_pb_host_status(const std::shared_ptr<io::data>& d) {
     }
 
     if (_store_in_resources) {
-      _hscr_resources_update.bind_value_as_i32(0, hscr.current_state());
+      _hscr_resources_update.bind_value_as_i32(0, hscr.state());
       _hscr_resources_update.bind_value_as_i32(
-          1, hst_ordered_status[hscr.current_state()]);
+          1, hst_ordered_status[hscr.state()]);
       _hscr_resources_update.bind_value_as_u64(2, hscr.last_state_change());
-      _hscr_resources_update.bind_value_as_bool(3, hscr.downtime_depth() > 0);
+      _hscr_resources_update.bind_value_as_bool(
+          3, hscr.scheduled_downtime_depth() > 0);
       _hscr_resources_update.bind_value_as_bool(
           4, hscr.acknowledgement_type() != HostStatus_AckType_NONE);
       _hscr_resources_update.bind_value_as_bool(
           5, hscr.state_type() == HostStatus_StateType_HARD);
-      _hscr_resources_update.bind_value_as_u32(6, hscr.current_check_attempt());
+      _hscr_resources_update.bind_value_as_u32(6, hscr.check_attempt());
       _hscr_resources_update.bind_value_as_bool(7, hscr.perfdata() != "");
       _hscr_resources_update.bind_value_as_u32(8, hscr.check_type());
       _hscr_resources_update.bind_value_as_u64(9, hscr.last_check(),
@@ -1713,7 +1705,7 @@ void stream::_process_pb_host_status(const std::shared_ptr<io::data>& d) {
         "check type: {}, last check: {}, next check: {}, now: {}, state ({}, "
         "{}))",
         hscr.host_id(), hscr.check_type(), hscr.last_check(), hscr.next_check(),
-        now, hscr.current_state(), hscr.state_type());
+        now, hscr.state(), hscr.state_type());
 }
 
 /**
@@ -2223,7 +2215,7 @@ void stream::_process_pb_service(const std::shared_ptr<io::data>& d) {
     log_v2::sql()->info(
         "SQL: processing pb service event (host: {}, service: {}, "
         "description: {})",
-        ss.host_id(), ss.service_id(), ss.service_description());
+        ss.host_id(), ss.service_id(), ss.description());
 
     if (ss.host_id() && ss.service_id()) {
       // Prepare queries.
@@ -2396,19 +2388,18 @@ void stream::_process_pb_service(const std::shared_ptr<io::data>& d) {
               _resources_service_insert.bind_value_as_u64(3, ss.internal_id());
             else
               _resources_service_insert.bind_value_as_null(3);
-            _resources_service_insert.bind_value_as_u32(4, ss.current_state());
+            _resources_service_insert.bind_value_as_u32(4, ss.state());
             _resources_service_insert.bind_value_as_u32(
-                5, svc_ordered_status[ss.current_state()]);
+                5, svc_ordered_status[ss.state()]);
             _resources_service_insert.bind_value_as_u64(6,
                                                         ss.last_state_change());
             _resources_service_insert.bind_value_as_bool(
-                7, ss.downtime_depth() > 0);
+                7, ss.scheduled_downtime_depth() > 0);
             _resources_service_insert.bind_value_as_bool(
                 8, ss.acknowledgement_type() != Service_AckType_NONE);
             _resources_service_insert.bind_value_as_bool(
                 9, ss.state_type() == Service_StateType_HARD);
-            _resources_service_insert.bind_value_as_u32(
-                10, ss.current_check_attempt());
+            _resources_service_insert.bind_value_as_u32(10, ss.check_attempt());
             _resources_service_insert.bind_value_as_u32(
                 11, ss.max_check_attempts());
             _resources_service_insert.bind_value_as_u64(
@@ -2428,12 +2419,11 @@ void stream::_process_pb_service(const std::shared_ptr<io::data>& d) {
             _resources_service_insert.bind_value_as_str(16, notes_url);
             _resources_service_insert.bind_value_as_str(17, notes);
             _resources_service_insert.bind_value_as_str(18, action_url);
-            _resources_service_insert.bind_value_as_bool(
-                19, ss.notifications_enabled());
-            _resources_service_insert.bind_value_as_bool(
-                20, ss.passive_checks_enabled());
-            _resources_service_insert.bind_value_as_bool(
-                21, ss.active_checks_enabled());
+            _resources_service_insert.bind_value_as_bool(19, ss.notify());
+            _resources_service_insert.bind_value_as_bool(20,
+                                                         ss.passive_checks());
+            _resources_service_insert.bind_value_as_bool(21,
+                                                         ss.active_checks());
             _resources_service_insert.bind_value_as_u64(22, ss.icon_id());
 
             std::promise<uint64_t> p;
@@ -2481,19 +2471,18 @@ void stream::_process_pb_service(const std::shared_ptr<io::data>& d) {
               _resources_service_update.bind_value_as_u64(1, ss.internal_id());
             else
               _resources_service_update.bind_value_as_null(1);
-            _resources_service_update.bind_value_as_u32(2, ss.current_state());
+            _resources_service_update.bind_value_as_u32(2, ss.state());
             _resources_service_update.bind_value_as_u32(
-                3, svc_ordered_status[ss.current_state()]);
+                3, svc_ordered_status[ss.state()]);
             _resources_service_update.bind_value_as_u64(4,
                                                         ss.last_state_change());
             _resources_service_update.bind_value_as_bool(
-                5, ss.downtime_depth() > 0);
+                5, ss.scheduled_downtime_depth() > 0);
             _resources_service_update.bind_value_as_bool(
                 6, ss.acknowledgement_type() != Service_AckType_NONE);
             _resources_service_update.bind_value_as_bool(
                 7, ss.state_type() == Service_StateType_HARD);
-            _resources_service_update.bind_value_as_u32(
-                8, ss.current_check_attempt());
+            _resources_service_update.bind_value_as_u32(8, ss.check_attempt());
             _resources_service_update.bind_value_as_u32(
                 9, ss.max_check_attempts());
             _resources_service_update.bind_value_as_u64(
@@ -2513,12 +2502,11 @@ void stream::_process_pb_service(const std::shared_ptr<io::data>& d) {
             _resources_service_update.bind_value_as_str(14, notes_url);
             _resources_service_update.bind_value_as_str(15, notes);
             _resources_service_update.bind_value_as_str(16, action_url);
-            _resources_service_update.bind_value_as_bool(
-                17, ss.notifications_enabled());
-            _resources_service_update.bind_value_as_bool(
-                18, ss.passive_checks_enabled());
-            _resources_service_update.bind_value_as_bool(
-                19, ss.active_checks_enabled());
+            _resources_service_update.bind_value_as_bool(17, ss.notify());
+            _resources_service_update.bind_value_as_bool(18,
+                                                         ss.passive_checks());
+            _resources_service_update.bind_value_as_bool(19,
+                                                         ss.active_checks());
             _resources_service_update.bind_value_as_u64(20, ss.icon_id());
             _resources_service_update.bind_value_as_u64(21, res_id);
 
@@ -2601,7 +2589,7 @@ void stream::_process_pb_service(const std::shared_ptr<io::data>& d) {
       log_v2::sql()->trace(
           "SQL: service '{}' has no host ID, service ID nor hostname, probably "
           "bam fake service",
-          ss.service_description());
+          ss.description());
   } else
     log_v2::sql()->error(
         "SQL: host with host_id = {} does not exist - unable to store service "
@@ -2630,26 +2618,25 @@ void stream::_process_pb_adaptive_service(const std::shared_ptr<io::data>& d) {
     constexpr const char* buf = "UPDATE services SET";
     constexpr size_t size = strlen(buf);
     std::string query{buf};
-    if (as.has_notifications_enabled())
-      query += fmt::format(" notify='{}',", as.notifications_enabled() ? 1 : 0);
-    if (as.has_active_checks_enabled())
-      query += fmt::format(" active_checks='{}',",
-                           as.active_checks_enabled() ? 1 : 0);
+    if (as.has_notify())
+      query += fmt::format(" notify='{}',", as.notify() ? 1 : 0);
+    if (as.has_active_checks())
+      query += fmt::format(" active_checks='{}',", as.active_checks() ? 1 : 0);
     if (as.has_should_be_scheduled())
       query += fmt::format(" should_be_scheduled='{}',",
                            as.should_be_scheduled() ? 1 : 0);
-    if (as.has_passive_checks_enabled())
-      query += fmt::format(" passive_checks='{}',",
-                           as.passive_checks_enabled() ? 1 : 0);
+    if (as.has_passive_checks())
+      query +=
+          fmt::format(" passive_checks='{}',", as.passive_checks() ? 1 : 0);
     if (as.has_event_handler_enabled())
       query += fmt::format(" event_handler_enabled='{}',",
                            as.event_handler_enabled() ? 1 : 0);
     if (as.has_flap_detection_enabled())
       query += fmt::format(" flap_detection='{}',",
                            as.flap_detection_enabled() ? 1 : 0);
-    if (as.has_obsess_over())
-      query +=
-          fmt::format(" obsess_over_service='{}',", as.obsess_over() ? 1 : 0);
+    if (as.has_obsess_over_service())
+      query += fmt::format(" obsess_over_service='{}',",
+                           as.obsess_over_service() ? 1 : 0);
     if (as.has_event_handler())
       query += fmt::format(
           " event_handler='{}',",
@@ -2695,15 +2682,15 @@ void stream::_process_pb_adaptive_service(const std::shared_ptr<io::data>& d) {
         constexpr const char* res_buf = "UPDATE resources SET";
         constexpr size_t res_size = strlen(res_buf);
         std::string res_query{res_buf};
-        if (as.has_notifications_enabled())
-          res_query += fmt::format(" notifications_enabled='{}',",
-                                   as.notifications_enabled() ? 1 : 0);
-        if (as.has_active_checks_enabled())
+        if (as.has_notify())
+          res_query +=
+              fmt::format(" notifications_enabled='{}',", as.notify() ? 1 : 0);
+        if (as.has_active_checks())
           res_query += fmt::format(" active_checks_enabled='{}',",
-                                   as.active_checks_enabled() ? 1 : 0);
-        if (as.has_passive_checks_enabled())
+                                   as.active_checks() ? 1 : 0);
+        if (as.has_passive_checks())
           res_query += fmt::format(" passive_checks_enabled='{}',",
-                                   as.passive_checks_enabled() ? 1 : 0);
+                                   as.passive_checks() ? 1 : 0);
         if (as.has_max_check_attempts())
           res_query +=
               fmt::format(" max_check_attempts={},", as.max_check_attempts());
@@ -2739,7 +2726,7 @@ void stream::_check_and_update_index_cache(const Service& ss) {
   fmt::string_view hv(misc::string::truncate(
       ss.host_name(), get_index_data_col_size(index_data_host_name)));
   fmt::string_view sv(misc::string::truncate(
-      ss.service_description(),
+      ss.description(),
       get_index_data_col_size(index_data_service_description)));
   bool special = ss.type() == BA;
 
@@ -2777,7 +2764,7 @@ void stream::_check_and_update_index_cache(const Service& ss) {
       index_info info{
           .index_id = index_id,
           .host_name = ss.host_name(),
-          .service_description = ss.service_description(),
+          .service_description = ss.description(),
           .rrd_retention = _rrd_len,
           .interval = ss.check_interval(),
           .special = special,
@@ -2974,8 +2961,8 @@ void stream::_process_pb_service_status(const std::shared_ptr<io::data>& d) {
         "SQL: processing service status check result event proto (host: {}, "
         "service: {}, "
         "last check: {}, state ({}, {}))",
-        sscr.host_id(), sscr.service_id(), sscr.last_check(),
-        sscr.current_state(), sscr.state_type());
+        sscr.host_id(), sscr.service_id(), sscr.last_check(), sscr.state(),
+        sscr.state_type());
 
     // Prepare queries.
     if (_store_in_hosts_services && !_sscr_update.prepared()) {
@@ -3030,9 +3017,9 @@ void stream::_process_pb_service_status(const std::shared_ptr<io::data>& d) {
 
     // Processing.
     if (_store_in_hosts_services) {
-      _sscr_update.bind_value_as_bool(0, sscr.has_been_checked());
+      _sscr_update.bind_value_as_bool(0, sscr.checked());
       _sscr_update.bind_value_as_i32(1, sscr.check_type());
-      _sscr_update.bind_value_as_i32(2, sscr.current_state());
+      _sscr_update.bind_value_as_i32(2, sscr.state());
       _sscr_update.bind_value_as_i32(3, sscr.state_type());
       _sscr_update.bind_value_as_i64(4, sscr.last_state_change());
       _sscr_update.bind_value_as_i32(5, sscr.last_hard_state());
@@ -3051,14 +3038,14 @@ void stream::_process_pb_service_status(const std::shared_ptr<io::data>& d) {
           sscr.perfdata(), get_services_col_size(services_perfdata));
       _sscr_update.bind_value_as_str(
           12, fmt::string_view(sscr.perfdata().data(), size));
-      _sscr_update.bind_value_as_bool(13, sscr.is_flapping());
+      _sscr_update.bind_value_as_bool(13, sscr.flapping());
       _sscr_update.bind_value_as_f64(14, sscr.percent_state_change());
       _sscr_update.bind_value_as_f64(15, sscr.latency());
       _sscr_update.bind_value_as_f64(16, sscr.execution_time());
       _sscr_update.bind_value_as_i64(17, sscr.last_check(), is_not_zero);
       _sscr_update.bind_value_as_i64(18, sscr.next_check());
       _sscr_update.bind_value_as_bool(19, sscr.should_be_scheduled());
-      _sscr_update.bind_value_as_i32(20, sscr.current_check_attempt());
+      _sscr_update.bind_value_as_i32(20, sscr.check_attempt());
       _sscr_update.bind_value_as_i32(21, sscr.notification_number());
       _sscr_update.bind_value_as_bool(22, sscr.no_more_notifications());
       _sscr_update.bind_value_as_i64(23, sscr.last_notification());
@@ -3066,7 +3053,7 @@ void stream::_process_pb_service_status(const std::shared_ptr<io::data>& d) {
       _sscr_update.bind_value_as_bool(
           25, sscr.acknowledgement_type() != ServiceStatus_AckType_NONE);
       _sscr_update.bind_value_as_i32(26, sscr.acknowledgement_type());
-      _sscr_update.bind_value_as_i32(27, sscr.downtime_depth());
+      _sscr_update.bind_value_as_i32(27, sscr.scheduled_downtime_depth());
       _sscr_update.bind_value_as_i32(28, sscr.host_id());
       _sscr_update.bind_value_as_i32(29, sscr.service_id());
 
@@ -3080,16 +3067,17 @@ void stream::_process_pb_service_status(const std::shared_ptr<io::data>& d) {
     }
 
     if (_store_in_resources) {
-      _sscr_resources_update.bind_value_as_i32(0, sscr.current_state());
+      _sscr_resources_update.bind_value_as_i32(0, sscr.state());
       _sscr_resources_update.bind_value_as_i32(
-          1, svc_ordered_status[sscr.current_state()]);
+          1, svc_ordered_status[sscr.state()]);
       _sscr_resources_update.bind_value_as_u64(2, sscr.last_state_change());
-      _sscr_resources_update.bind_value_as_bool(3, sscr.downtime_depth() > 0);
+      _sscr_resources_update.bind_value_as_bool(
+          3, sscr.scheduled_downtime_depth() > 0);
       _sscr_resources_update.bind_value_as_bool(
           4, sscr.acknowledgement_type() != ServiceStatus_AckType_NONE);
       _sscr_resources_update.bind_value_as_bool(
           5, sscr.state_type() == ServiceStatus_StateType_HARD);
-      _sscr_resources_update.bind_value_as_u32(6, sscr.current_check_attempt());
+      _sscr_resources_update.bind_value_as_u32(6, sscr.check_attempt());
       _sscr_resources_update.bind_value_as_bool(7, sscr.perfdata() != "");
       _sscr_resources_update.bind_value_as_u32(8, sscr.check_type());
       _sscr_resources_update.bind_value_as_u64(9, sscr.last_check(),
@@ -3114,7 +3102,7 @@ void stream::_process_pb_service_status(const std::shared_ptr<io::data>& d) {
         "check type: {}, last check: {}, next check: {}, now: {}, state ({}, "
         "{}))",
         sscr.host_id(), sscr.service_id(), sscr.check_type(), sscr.last_check(),
-        sscr.next_check(), now, sscr.current_state(), sscr.state_type());
+        sscr.next_check(), now, sscr.state(), sscr.state_type());
 
   /* perfdata part */
   _unified_sql_process_pb_service_status(d);

--- a/broker/unified_sql/src/stream_storage.cc
+++ b/broker/unified_sql/src/stream_storage.cc
@@ -120,7 +120,7 @@ void stream::_unified_sql_process_pb_service_status(
       multiplexing::publisher().write(status);
     }
 
-    if (!ss.perf_data().empty()) {
+    if (!ss.perfdata().empty()) {
       /* Statements preparations */
       if (!_metrics_insert.prepared()) {
         _metrics_insert = _mysql.prepare_query(
@@ -134,7 +134,7 @@ void stream::_unified_sql_process_pb_service_status(
       /* Parse perfdata. */
       _finish_action(-1, actions::metrics);
       std::list<misc::perfdata> pds{misc::parse_perfdata(
-          ss.host_id(), ss.service_id(), ss.perf_data().c_str())};
+          ss.host_id(), ss.service_id(), ss.perfdata().c_str())};
 
       std::list<std::shared_ptr<io::data>> to_publish;
       for (auto& pd : pds) {

--- a/broker/unified_sql/src/stream_storage.cc
+++ b/broker/unified_sql/src/stream_storage.cc
@@ -113,7 +113,7 @@ void stream::_unified_sql_process_pb_service_status(
         "unified sql: host_id:{}, service_id:{} - generating status event "
         "with index_id {}, rrd_len: {}",
         host_id, service_id, index_id, rrd_len);
-    if (ss.has_been_checked()) {
+    if (ss.checked()) {
       auto status(std::make_shared<storage::status>(ss.last_check(), index_id,
                                                     interval, false, rrd_len,
                                                     ss.last_hard_state()));
@@ -280,7 +280,7 @@ void stream::_unified_sql_process_pb_service_status(
           metric_value val;
           val.c_time = ss.last_check();
           val.metric_id = metric_id;
-          val.status = ss.current_state();
+          val.status = ss.state();
           val.value = pd.value();
           {
             std::lock_guard<std::mutex> lck(_queues_m);
@@ -812,8 +812,7 @@ void stream::_insert_perfdatas() {
 void stream::_check_queues(asio::error_code ec) {
   if (ec)
     log_v2::sql()->error(
-        "unified_sql: the queues check encountered an error: {}",
-        ec.message());
+        "unified_sql: the queues check encountered an error: {}", ec.message());
   else {
     time_t now = time(nullptr);
     size_t sz_perfdatas;
@@ -828,21 +827,22 @@ void stream::_check_queues(asio::error_code ec) {
       sz_cvs = _cvs_queue.size();
       sz_logs = _log_queue.size();
     }
-  
+
     bool perfdata_done = false;
-    if (now >= _next_insert_perfdatas || sz_perfdatas >= _max_perfdata_queries) {
+    if (now >= _next_insert_perfdatas ||
+        sz_perfdatas >= _max_perfdata_queries) {
       _next_insert_perfdatas = now + queue_timer_duration;
       _insert_perfdatas();
       perfdata_done = true;
     }
-  
+
     bool metrics_done = false;
     if (now >= _next_update_metrics || sz_metrics >= _max_metrics_queries) {
       _next_update_metrics = now + queue_timer_duration;
       _update_metrics();
       metrics_done = true;
     }
-  
+
     bool customvar_done = false;
     if (now >= _next_update_cv || sz_cv >= _max_cv_queries ||
         sz_cvs >= _max_cv_queries) {
@@ -850,7 +850,7 @@ void stream::_check_queues(asio::error_code ec) {
       _update_customvariables();
       customvar_done = true;
     }
-  
+
     bool logs_done = false;
     if (now >= _next_insert_logs || sz_logs >= _max_log_queries) {
       _next_insert_logs = now + queue_timer_duration;
@@ -859,8 +859,10 @@ void stream::_check_queues(asio::error_code ec) {
     }
 
     // End.
-    log_v2::perfdata()->debug("unified_sql: end check_queue - perfdata: {}, metrics: {}, customvar: {}, logs: {}",
-                              perfdata_done, metrics_done, customvar_done, logs_done);
+    log_v2::perfdata()->debug(
+        "unified_sql: end check_queue - perfdata: {}, metrics: {}, customvar: "
+        "{}, logs: {}",
+        perfdata_done, metrics_done, customvar_done, logs_done);
 
     time_t duration = _next_insert_perfdatas;
     if (_next_update_metrics < duration)
@@ -878,8 +880,7 @@ void stream::_check_queues(asio::error_code ec) {
       _timer.expires_after(std::chrono::seconds(duration));
       _timer.async_wait(
           std::bind(&stream::_check_queues, this, std::placeholders::_1));
-    }
-    else {
+    } else {
       log_v2::sql()->info("SQL: check_queues correctly interrupted.");
       _check_queues_stopped = true;
       _queues_cond_var.notify_all();

--- a/engine/inc/com/centreon/engine/common.hh
+++ b/engine/inc/com/centreon/engine/common.hh
@@ -224,8 +224,8 @@
 /* Host/service check options. */
 #define CHECK_OPTION_NONE 0 /* No check options. */
 #define CHECK_OPTION_FORCE_EXECUTION 1
-    /* Force execution of a check (ignores disabled services/hosts, invalid \
-       timeperiods). */
+/* Force execution of a check (ignores disabled services/hosts, invalid \
+   timeperiods). */
 #define CHECK_OPTION_FRESHNESS_CHECK 2 /* This is a freshness check. */
 #define CHECK_OPTION_ORPHAN_CHECK 4    /* This is an orphan check. */
 
@@ -315,7 +315,7 @@ enum ret_val {
 #define MODATTR_CHECK_TIMEPERIOD (1 << 14)
 #define MODATTR_CUSTOM_VARIABLE (1 << 15)
 #define MODATTR_NOTIFICATION_TIMEPERIOD (1 << 16)
-#define MODATTR_ALL (~0)
+#define MODATTR_ALL (~0u)
 
 /* Default values. */
 #define DEFAULT_ORPHAN_CHECK_INTERVAL \


### PR DESCRIPTION
When the migration to protobuf of hosts and services has been done, the 'perfdata' field has been renamed 'perf_data'.
Bad idea for the retro-compatibility.
