### PR TITLE
Mon 13301 bulk downtimes

### DIFF
--- a/broker/storage/inc/com/centreon/broker/storage/conflict_manager.hh
+++ b/broker/storage/inc/com/centreon/broker/storage/conflict_manager.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2019-2021 Centreon
+** Copyright 2019-2022 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -165,13 +165,15 @@ class conflict_manager {
   int32_t _max_pending_queries;
   mysql _mysql;
   uint32_t _instance_timeout;
-  bool _store_in_db;
-  uint32_t _rrd_len;
-  uint32_t _interval_length;
-  uint32_t _max_perfdata_queries;
-  uint32_t _max_metrics_queries;
-  uint32_t _max_cv_queries;
-  uint32_t _max_log_queries;
+  bool _store_in_db = true;
+  uint32_t _rrd_len = 0u;
+  uint32_t _interval_length = 0u;
+  uint32_t _max_perfdata_queries = 0u;
+  uint32_t _max_metrics_queries = 0u;
+  uint32_t _max_cv_queries = 0u;
+  uint32_t _max_log_queries = 0u;
+  uint32_t _max_downtime_queries = 0u;
+
   std::unique_ptr<rebuilder> _rebuilder;
 
   std::thread _thread;
@@ -179,10 +181,10 @@ class conflict_manager {
   /* Stats */
   ConflictManagerStats* _stats;
   std::mutex _stat_m;
-  int32_t _events_handled;
-  float _speed;
+  int32_t _events_handled = 0;
+  float _speed = 0;
   std::array<float, 20> _stats_count;
-  int32_t _stats_count_pos;
+  int32_t _stats_count_pos = 0;
 
   /* How many streams are using this conflict_manager? */
   std::atomic<uint32_t> _ref_count;
@@ -222,6 +224,7 @@ class conflict_manager {
   std::deque<std::pair<bool*, std::string> > _cv_queue;
   std::deque<std::pair<bool*, std::string> > _cvs_queue;
   std::deque<std::pair<bool*, std::string> > _log_queue;
+  std::deque<std::pair<bool*, std::string> > _downtimes_queue;
 
   timestamp _oldest_timestamp;
   std::unordered_map<uint32_t, stored_timestamp> _stored_timestamps;
@@ -230,7 +233,6 @@ class conflict_manager {
   database::mysql_stmt _comment_insupdate;
   database::mysql_stmt _custom_variable_delete;
   database::mysql_stmt _custom_variable_status_insupdate;
-  database::mysql_stmt _downtime_insupdate;
   database::mysql_stmt _event_handler_insupdate;
   database::mysql_stmt _flapping_status_insupdate;
   database::mysql_stmt _host_check_update;
@@ -275,6 +277,7 @@ class conflict_manager {
   void _update_hosts_and_services_of_unresponsive_instances();
   void _update_hosts_and_services_of_instance(uint32_t id, bool responsive);
   void _update_timestamp(uint32_t instance_id);
+  void _update_downtimes();
   bool _is_valid_poller(uint32_t instance_id);
   void _check_deleted_index();
 

--- a/broker/storage/src/conflict_manager_sql.cc
+++ b/broker/storage/src/conflict_manager_sql.cc
@@ -506,11 +506,6 @@ void conflict_manager::_process_custom_variable_status(
 void conflict_manager::_process_downtime(
     std::tuple<std::shared_ptr<io::data>, uint32_t, bool*>& t) {
   auto& d = std::get<0>(t);
-  int conn = special_conn::downtime % _mysql.connections_count();
-  _finish_action(-1, actions::hosts | actions::instances | actions::downtimes |
-                         actions::host_parents | actions::host_dependencies |
-                         actions::service_dependencies);
-
   // Cast object.
   neb::downtime const& dd = *static_cast<neb::downtime const*>(d.get());
 
@@ -528,36 +523,31 @@ void conflict_manager::_process_downtime(
 
   // Check if poller is valid.
   if (_is_valid_poller(dd.poller_id)) {
-    // Prepare queries.
-    if (!_downtime_insupdate.prepared()) {
-      _downtime_insupdate = mysql_stmt(
-          "INSERT INTO downtimes (actual_end_time,actual_start_time,author,"
-          "type,deletion_time,duration,end_time,entry_time,"
-          "fixed,host_id,instance_id,internal_id,service_id,"
-          "start_time,triggered_by,cancelled,started,comment_data) "
-          "VALUES(:actual_end_time,:actual_start_time,:author,:type,"
-          ":deletion_time,:duration,:end_time,:entry_time,:fixed,:host_id,"
-          ":instance_id,:internal_id,:service_id,:start_time,"
-          ":triggered_by,:cancelled,:started,:comment_data) "
-          "ON DUPLICATE KEY UPDATE "
-          "actual_end_time=GREATEST(COALESCE(actual_end_time,-1),"
-          ":actual_end_time),actual_start_time=COALESCE(actual_start_time,"
-          ":actual_start_time),author=:author,cancelled=:cancelled,"
-          "comment_data=:comment_data,deletion_time=:deletion_time,duration="
-          ":duration,end_time=:end_time,fixed=:fixed,host_id=:host_id,"
-          "service_id=:service_id,start_time=:start_time,started=:started,"
-          "triggered_by=:triggered_by, type=:type",
-          true);
-      _mysql.prepare_statement(_downtime_insupdate);
-    }
-
-    // Process object.
-    _downtime_insupdate << dd;
-    _mysql.run_statement(_downtime_insupdate,
-                         database::mysql_error::store_downtime, true, conn);
-    _add_action(conn, actions::downtimes);
+    _downtimes_queue.emplace_back(
+        std::get<2>(t),
+        fmt::format(
+            "({},{},'{}',{},{},{},{},{},{},{},{},{},{},{},{},{},{},'{}')",
+            dd.actual_end_time.is_null()
+                ? "NULL"
+                : fmt::format("{}", dd.actual_end_time),
+            dd.actual_start_time.is_null()
+                ? "NULL"
+                : fmt::format("{}", dd.actual_start_time),
+            misc::string::escape(dd.author,
+                                 get_downtimes_col_size(downtimes_author)),
+            dd.downtime_type,
+            dd.deletion_time.is_null() ? "NULL"
+                                       : fmt::format("{}", dd.deletion_time),
+            dd.duration,
+            dd.end_time.is_null() ? "NULL" : fmt::format("{}", dd.end_time),
+            dd.entry_time.is_null() ? "NULL" : fmt::format("{}", dd.entry_time),
+            dd.fixed, dd.host_id, dd.poller_id, dd.internal_id, dd.service_id,
+            dd.start_time.is_null() ? "NULL" : fmt::format("{}", dd.start_time),
+            dd.triggered_by == 0 ? "NULL" : fmt::format("{}", dd.triggered_by),
+            dd.was_cancelled, dd.was_started,
+            misc::string::escape(
+                dd.comment, get_downtimes_col_size(downtimes_comment_data))));
   }
-  *std::get<2>(t) = true;
 }
 
 /**
@@ -1836,7 +1826,6 @@ void conflict_manager::_update_customvariables() {
            "(name,host_id,service_id,default_value,modified,type,update_time,"
            "value) VALUES "
         << std::get<1>(*it);
-    *std::get<0>(*it) = true;
     for (++it; it != _cv_queue.end(); ++it)
       oss << "," << std::get<1>(*it);
 
@@ -1885,6 +1874,55 @@ void conflict_manager::_update_customvariables() {
       auto it = _cvs_queue.begin();
       *std::get<0>(*it) = true;
       _cvs_queue.pop_front();
+    }
+  }
+}
+
+/**
+ * @brief Send a big query to update/insert a bulk of downtimes. When
+ * the query is done, we set the corresponding boolean of each pair to true
+ * to ack each event.
+ *
+ * When we exit the function, the downtimes queue is empty.
+ */
+void conflict_manager::_update_downtimes() {
+  int32_t conn = special_conn::downtime % _mysql.connections_count();
+  _finish_action(-1, actions::hosts | actions::instances | actions::downtimes |
+                         actions::host_parents | actions::host_dependencies |
+                         actions::service_dependencies);
+  if (!_downtimes_queue.empty()) {
+    auto it = _downtimes_queue.begin();
+    std::ostringstream oss;
+    oss << "INSERT INTO downtimes (actual_end_time,actual_start_time,author,"
+           "type,deletion_time,duration,end_time,entry_time,"
+           "fixed,host_id,instance_id,internal_id,service_id,"
+           "start_time,triggered_by,cancelled,started,comment_data) "
+           "VALUES"
+        << std::get<1>(*it);
+    for (++it; it != _downtimes_queue.end(); ++it)
+      oss << "," << std::get<1>(*it);
+
+    /* The duplicate part */
+    oss << " ON DUPLICATE KEY UPDATE "
+           "actual_end_time=GREATEST(COALESCE(actual_end_time,-1),VALUES("
+           "actual_end_time)),actual_start_time=COALESCE(actual_start_time,"
+           "VALUES(actual_start_time)),author=VALUES(author),cancelled=VALUES("
+           "cancelled),comment_data=VALUES(comment_data),deletion_time=VALUES("
+           "deletion_time),duration=VALUES(duration),end_time=VALUES(end_time),"
+           "fixed=VALUES(fixed),start_time=VALUES(start_time),started=VALUES("
+           "started),triggered_by=VALUES(triggered_by), type=VALUES(type)";
+    std::string query{oss.str()};
+
+    _mysql.run_query(query, database::mysql_error::store_downtime, true, conn);
+    log_v2::sql()->debug("{} new downtimes inserted", _downtimes_queue.size());
+    log_v2::sql()->trace("sending query << {} >>", query);
+    _add_action(conn, actions::downtimes);
+
+    /* Acknowledgement and cleanup */
+    while (!_downtimes_queue.empty()) {
+      auto it = _downtimes_queue.begin();
+      *std::get<0>(*it) = true;
+      _downtimes_queue.pop_front();
     }
   }
 }

--- a/broker/unified_sql/inc/com/centreon/broker/unified_sql/stream.hh
+++ b/broker/unified_sql/inc/com/centreon/broker/unified_sql/stream.hh
@@ -183,21 +183,23 @@ class stream : public io::stream {
   mysql _mysql;
   uint32_t _instance_timeout;
   rebuilder _rebuilder;
-  bool _store_in_db;
+  bool _store_in_db = true;
   bool _store_in_resources;
   bool _store_in_hosts_services;
-  uint32_t _rrd_len;
-  uint32_t _interval_length;
-  uint32_t _max_perfdata_queries;
-  uint32_t _max_metrics_queries;
-  uint32_t _max_cv_queries;
-  uint32_t _max_log_queries;
+  uint32_t _rrd_len = 0u;
+  uint32_t _interval_length = 0u;
+  uint32_t _max_perfdata_queries = 0u;
+  uint32_t _max_metrics_queries = 0u;
+  uint32_t _max_cv_queries = 0u;
+  uint32_t _max_log_queries = 0u;
+  uint32_t _max_dt_queries = 0u;
 
   std::time_t _next_insert_perfdatas;
   std::time_t _next_update_metrics;
   std::time_t _next_update_cv;
   std::time_t _next_insert_logs;
   std::time_t _next_loop_timeout;
+  std::time_t _next_update_downtimes;
 
   asio::steady_timer _timer;
   asio::steady_timer _queues_timer;
@@ -250,6 +252,7 @@ class stream : public io::stream {
   std::deque<std::string> _cv_queue;
   std::deque<std::string> _cvs_queue;
   std::deque<std::string> _log_queue;
+  std::deque<std::string> _downtimes_queue;
 
   timestamp _oldest_timestamp;
   std::unordered_map<uint32_t, stored_timestamp> _stored_timestamps;
@@ -305,6 +308,7 @@ class stream : public io::stream {
   void _update_hosts_and_services_of_unresponsive_instances();
   void _update_hosts_and_services_of_instance(uint32_t id, bool responsive);
   void _update_timestamp(uint32_t instance_id);
+  void _update_downtimes();
   bool _is_valid_poller(uint32_t instance_id);
   void _check_queues(asio::error_code ec);
   void _check_deleted_index(asio::error_code ec);

--- a/broker/unified_sql/src/stream_sql.cc
+++ b/broker/unified_sql/src/stream_sql.cc
@@ -515,11 +515,6 @@ void stream::_process_custom_variable_status(
  * @return The number of events that can be acknowledged.
  */
 void stream::_process_downtime(const std::shared_ptr<io::data>& d) {
-  int conn = special_conn::downtime % _mysql.connections_count();
-  _finish_action(-1, actions::hosts | actions::instances | actions::downtimes |
-                         actions::host_parents | actions::host_dependencies |
-                         actions::service_dependencies);
-
   // Cast object.
   neb::downtime const& dd = *static_cast<neb::downtime const*>(d.get());
 
@@ -537,34 +532,27 @@ void stream::_process_downtime(const std::shared_ptr<io::data>& d) {
 
   // Check if poller is valid.
   if (_is_valid_poller(dd.poller_id)) {
-    // Prepare queries.
-    if (!_downtime_insupdate.prepared()) {
-      _downtime_insupdate = mysql_stmt(
-          "INSERT INTO downtimes (actual_end_time,actual_start_time,author,"
-          "type,deletion_time,duration,end_time,entry_time,"
-          "fixed,host_id,instance_id,internal_id,service_id,"
-          "start_time,triggered_by,cancelled,started,comment_data) "
-          "VALUES(:actual_end_time,:actual_start_time,:author,:type,"
-          ":deletion_time,:duration,:end_time,:entry_time,:fixed,:host_id,"
-          ":instance_id,:internal_id,:service_id,:start_time,"
-          ":triggered_by,:cancelled,:started,:comment_data) "
-          "ON DUPLICATE KEY UPDATE "
-          "actual_end_time=GREATEST(COALESCE(actual_end_time,-1),"
-          ":actual_end_time),actual_start_time=COALESCE(actual_start_time,"
-          ":actual_start_time),author=:author,cancelled=:cancelled,"
-          "comment_data=:comment_data,deletion_time=:deletion_time,duration="
-          ":duration,end_time=:end_time,fixed=:fixed,host_id=:host_id,"
-          "service_id=:service_id,start_time=:start_time,started=:started,"
-          "triggered_by=:triggered_by, type=:type",
-          true);
-      _mysql.prepare_statement(_downtime_insupdate);
-    }
-
-    // Process object.
-    _downtime_insupdate << dd;
-    _mysql.run_statement(_downtime_insupdate,
-                         database::mysql_error::store_downtime, true, conn);
-    _add_action(conn, actions::downtimes);
+    _downtimes_queue.emplace_back(fmt::format(
+        "({},{},'{}',{},{},{},{},{},{},{},{},{},{},{},{},{},{},'{}')",
+        dd.actual_end_time.is_null() ? "NULL"
+                                     : fmt::format("{}", dd.actual_end_time),
+        dd.actual_start_time.is_null()
+            ? "NULL"
+            : fmt::format("{}", dd.actual_start_time),
+        misc::string::escape(dd.author,
+                             get_downtimes_col_size(downtimes_author)),
+        dd.downtime_type,
+        dd.deletion_time.is_null() ? "NULL"
+                                   : fmt::format("{}", dd.deletion_time),
+        dd.duration,
+        dd.end_time.is_null() ? "NULL" : fmt::format("{}", dd.end_time),
+        dd.entry_time.is_null() ? "NULL" : fmt::format("{}", dd.entry_time),
+        dd.fixed, dd.host_id, dd.poller_id, dd.internal_id, dd.service_id,
+        dd.start_time.is_null() ? "NULL" : fmt::format("{}", dd.start_time),
+        dd.triggered_by == 0 ? "NULL" : fmt::format("{}", dd.triggered_by),
+        dd.was_cancelled, dd.was_started,
+        misc::string::escape(dd.comment,
+                             get_downtimes_col_size(downtimes_comment_data))));
   }
 }
 
@@ -3356,6 +3344,46 @@ void stream::_update_customvariables() {
                          cvs_queue.size());
     log_v2::sql()->trace("sending query << {} >>", query);
   }
+}
+
+/**
+ * @brief Send a big query to update/insert a bulk of downtimes. When
+ * the query is done, we set the corresponding boolean of each pair to true
+ * to ack each event.
+ *
+ * When we exit the function, the downtimes queue is empty.
+ */
+void stream::_update_downtimes() {
+  std::deque<std::string> dt_queue;
+  {
+    std::lock_guard<std::mutex> lck(_queues_m);
+    if (_downtimes_queue.empty())
+      return;
+    std::swap(_downtimes_queue, dt_queue);
+  }
+  int32_t conn = special_conn::downtime % _mysql.connections_count();
+  _finish_action(-1, actions::hosts | actions::instances | actions::downtimes |
+                         actions::host_parents | actions::host_dependencies |
+                         actions::service_dependencies);
+  std::string query{fmt::format(
+      "INSERT INTO downtimes (actual_end_time,actual_start_time,author,"
+      "type,deletion_time,duration,end_time,entry_time,"
+      "fixed,host_id,instance_id,internal_id,service_id,"
+      "start_time,triggered_by,cancelled,started,comment_data) VALUES {}"
+      " ON DUPLICATE KEY UPDATE "
+      "actual_end_time=GREATEST(COALESCE(actual_end_time,-1),VALUES("
+      "actual_end_time)),actual_start_time=COALESCE(actual_start_time,"
+      "VALUES(actual_start_time)),author=VALUES(author),cancelled=VALUES("
+      "cancelled),comment_data=VALUES(comment_data),deletion_time=VALUES("
+      "deletion_time),duration=VALUES(duration),end_time=VALUES(end_time),"
+      "fixed=VALUES(fixed),start_time=VALUES(start_time),started=VALUES("
+      "started),triggered_by=VALUES(triggered_by), type=VALUES(type)",
+      fmt::join(dt_queue, ","))};
+
+  _mysql.run_query(query, database::mysql_error::store_downtime, true, conn);
+  log_v2::sql()->debug("{} new downtimes inserted", dt_queue.size());
+  log_v2::sql()->trace("sending query << {} >>", query);
+  _add_action(conn, actions::downtimes);
 }
 
 /**

--- a/broker/unified_sql/src/stream_storage.cc
+++ b/broker/unified_sql/src/stream_storage.cc
@@ -43,6 +43,7 @@ using namespace com::centreon::broker;
 using namespace com::centreon::broker::unified_sql;
 
 constexpr int32_t queue_timer_duration = 10;
+constexpr int32_t dt_queue_timer_duration = 5;
 
 /**
  *  Check that the floating point values are the same number or are NaN or are
@@ -860,7 +861,7 @@ void stream::_check_queues(asio::error_code ec) {
 
     bool downtimes_done = false;
     if (now >= _next_update_downtimes || sz_dt >= _max_dt_queries) {
-      _next_update_downtimes = now + queue_timer_duration;
+      _next_update_downtimes = now + dt_queue_timer_duration;
       _update_downtimes();
       downtimes_done = true;
     }
@@ -940,7 +941,8 @@ void stream::_check_deleted_index(asio::error_code ec) {
           _index_cache.erase({res.value_as_u32(3), res.value_as_u32(4)});
         }
         std::promise<database::mysql_result> promise_metrics;
-        std::future<database::mysql_result> future_metrics = promise_metrics.get_future();
+        std::future<database::mysql_result> future_metrics =
+            promise_metrics.get_future();
         _mysql.run_query_and_get_result(
             "SELECT metric_id, metric_name FROM metrics WHERE to_delete=1",
             std::move(promise_metrics), conn);

--- a/cmake.sh
+++ b/cmake.sh
@@ -99,6 +99,7 @@ if [ -r /etc/centos-release ] ; then
   fi
 
   pkgs=(
+    gcc-c++
     ninja-build
     rrdtool-devel
     gnutls-devel

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,14 +1,14 @@
 [requires]
 gtest/cci.20210126
-asio/1.21.0
-fmt/8.0.1
-spdlog/1.9.2
-nlohmann_json/3.10.4
+asio/1.22.1
+fmt/8.1.1
+spdlog/1.10.0
+nlohmann_json/3.10.5
 openssl/1.1.1n
 grpc/1.43.0
 mariadb-connector-c/3.1.12
 zlib/1.2.12
-boost/1.78.0
+boost/1.79.0
 libssh2/1.10.0
 
 [generators]

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,67 +52,227 @@ robot broker/sql.robot
 
 Here is the list of the currently implemented tests:
 
-### broker
+### Bam
+- [x] **BEBAMIDT1**: A BA of type 'worst' with one service is configured. The BA is in critical state, because of its service. Then we set a downtime on this last one. An inherited downtime is set to the BA. The downtime is removed from the service, the inherited downtime is then deleted.
+- [x] **BEBAMIDT2**: A BA of type 'worst' with one service is configured. The BA is in critical state, because of its service. Then we set a downtime on this last one. An inherited downtime is set to the BA. Engine is restarted. Broker is restarted. The two downtimes are still there with no duplicates. The downtime is removed from the service, the inherited downtime is then deleted.
 
-- [x] BSS1: Start-Stop two instances of broker and no coredump
-- [x] BSS2: Start/Stop 10 times broker with 300ms interval and no coredump
-- [x] BSS3: Start-Stop one instance of broker and no coredump
-- [x] BSS4: Start/Stop 10 times broker with 1sec interval and no coredump
-- [x] BSS5: Start-Stop with reversed connection on TCP acceptor with only one instance and no deadlock
-- [x] BSS6: Start-Stop with unified\_sql two instances of broker and no coredump
-- [x] BSS7: Start/Stop with unified\_sql 10 times broker with 300ms interval and no coredump
-- [x] BSS8: Start-Stop with unified\_sql one instance of broker and no coredump
-- [x] BSS9: Start/Stop with unified\_sql 10 times broker with 1sec interval and no coredump
-- [x] BSS10: Start-Stop with unified\_sql with reversed connection on TCP acceptor with only one instance and no deadlock
-- [x] BDB1: Access denied when database name exists but is not the good one for sql output
-- [x] BDB2: Access denied when database name exists but is not the good one for storage output
-- [x] BDB3: Access denied when database name does not exist for sql output
-- [x] BDB4: Access denied when database name does not exist for storage output
-- [x] BDB5: cbd does not crash if the storage db\_host is wrong
-- [x] BDB6: cbd does not crash if the sql db\_host is wrong
-- [x] BDB7: access denied when database user password is wrong for perfdata/sql
-- [x] BDB8: access denied when database user password is wrong for perfdata
-- [x] BDB9: access denied when database user password is wrong for sql
-- [x] BDB10: connection should be established when user password is good for sql/perfdata
-- [x] BEDB2: start broker/engine and then start MariaDB => connection is established
-- [x] BDBM1: start broker/engine and then start MariaDB => connection is established
-- [x] BDBU1: Access denied when database name exists but is not the good one for unified sql output
-- [x] BDBU3: Access denied when database name does not exist for unified sql output
-- [x] BDBU5: cbd does not crash if the unified sql db\_host is wrong
-- [x] BDBU7: access denied when database user password is wrong for unified sql
-- [x] BDBU10: connection should be established when user password is good for unified sql
-- [x] BEDBU2: start broker/engine with unified sql and then start MariaDB => connection is established
-- [x] BDBMU1: start broker/engine with unified sql and then start MariaDB => connection is established
+### Broker
+- [x] **BFC1**: Start broker with invalid filters but one filter ok
+- [x] **BFC2**: Start broker with only invalid filters on an output
+- [x] **BLDIS1**: Start broker with core logs 'disabled'
+- [x] **BSS1**: Start-Stop two instances of broker and no coredump
+- [x] **BSS2**: Start/Stop 10 times broker with 300ms interval and no coredump
+- [x] **BSS3**: Start-Stop one instance of broker and no coredump
+- [x] **BSS4**: Start/Stop 10 times broker with 1sec interval and no coredump
+- [x] **BSS5**: Start-Stop with reversed connection on TCP acceptor with only one instance and no deadlock
+- [x] **BSSU1**: Start-Stop with unified_sql two instances of broker and no coredump
+- [x] **BSSU2**: Start/Stop with unified_sql 10 times broker with 300ms interval and no coredump
+- [x] **BSSU3**: Start-Stop with unified_sql one instance of broker and no coredump
+- [x] **BSSU4**: Start/Stop with unified_sql 10 times broker with 1sec interval and no coredump
+- [x] **BSSU5**: Start-Stop with unified_sql with reversed connection on TCP acceptor with only one instance and no deadlock
+- [x] **BDB1**: Access denied when database name exists but is not the good one for sql output
+- [x] **BDB2**: Access denied when database name exists but is not the good one for storage output
+- [x] **BDB3**: Access denied when database name does not exist for sql output
+- [x] **BDB4**: Access denied when database name does not exist for storage and sql outputs
+- [x] **BDB5**: cbd does not crash if the storage/sql db_host is wrong
+- [x] **BDB6**: cbd does not crash if the sql db_host is wrong
+- [x] **BDB7**: access denied when database user password is wrong for perfdata/sql
+- [x] **BDB8**: access denied when database user password is wrong for perfdata/sql
+- [x] **BDB9**: access denied when database user password is wrong for sql
+- [x] **BDB10**: connection should be established when user password is good for sql/perfdata
+- [x] **BEDB2**: start broker/engine and then start MariaDB => connection is established
+- [x] **BEDB3**: start broker/engine, then stop MariaDB and then start it again. The gRPC API should give informations about SQL connections.
+- [x] **BEDB4**: start broker/engine, then stop MariaDB and then start it again. The gRPC API should give informations about SQL connections.
+- [x] **BDBM1**: start broker/engine and then start MariaDB => connection is established
+- [x] **BDBU1**: Access denied when database name exists but is not the good one for unified sql output
+- [x] **BDBU3**: Access denied when database name does not exist for unified sql output
+- [x] **BDBU5**: cbd does not crash if the unified sql db_host is wrong
+- [x] **BDBU7**: Access denied when database user password is wrong for unified sql
+- [x] **BDBU10**: Connection should be established when user password is good for unified sql
+- [x] **BDBMU1**: start broker/engine with unified sql and then start MariaDB => connection is established
+- [x] **BGRPCSS1**: Start-Stop two instances of broker configured with grpc stream and no coredump
+- [x] **BGRPCSS2**: Start/Stop 10 times broker configured with grpc stream with 300ms interval and no coredump
+- [x] **BGRPCSS3**: Start-Stop one instance of broker configured with grpc stream and no coredump
+- [x] **BGRPCSS4**: Start/Stop 10 times broker configured with grpc stream with 1sec interval and no coredump
+- [x] **BGRPCSS5**: Start-Stop with reversed connection on grpc acceptor with only one instance and no deadlock
+- [x] **BGRPCSSU1**: Start-Stop with unified_sql two instances of broker with grpc stream and no coredump
+- [x] **BGRPCSSU2**: Start/Stop with unified_sql 10 times broker configured with grpc stream with 300ms interval and no coredump
+- [x] **BGRPCSSU3**: Start-Stop with unified_sql one instance of broker configured with grpc and no coredump
+- [x] **BGRPCSSU4**: Start/Stop with unified_sql 10 times broker configured with grpc stream with 1sec interval and no coredump
+- [x] **BGRPCSSU5**: Start-Stop with unified_sql with reversed connection on grpc acceptor with only one instance and no deadlock
 
-### broker/engine
+### Broker/database
+- [x] **NetworkDbFail1**: network failure test between broker and database (shutting down connection for 100ms)
+- [x] **NetworkDbFail2**: network failure test between broker and database (shutting down connection for 1s)
+- [x] **NetworkDbFail3**: network failure test between broker and database (shutting down connection for 10s)
+- [x] **NetworkDbFail4**: network failure test between broker and database (shutting down connection for 30s)
+- [x] **NetworkDbFail5**: network failure test between broker and database (shutting down connection for 60s)
+- [x] **NetworkDBFail6**: network failure test between broker and database: we wait for the connection to be established and then we shut down the connection for 60s
+- [x] **NetworkDBFailU6**: network failure test between broker and database: we wait for the connection to be established and then we shut down the connection for 60s (with unified_sql)
+- [x] **NetworkDBFail7**: network failure test between broker and database: we wait for the connection to be established and then we shut down the connection for 60s
+- [x] **NetworkDBFailU7**: network failure test between broker and database: we wait for the connection to be established and then we shut down the connection for 60s (with unified_sql)
 
-- [x] BECT1: Broker/Engine communication with anonymous TLS between central and poller
-- [x] BECT2: Broker/Engine communication with TLS between central and poller with key/cert
-- [x] BECT3: Broker/Engine communication with anonymous TLS and ca certificate
-- [x] BECT4: Broker/Engine communication with TLS between central and poller with key/cert and hostname forced
-- [x] BESS1: Start-Stop Broker/Engine - Broker started first - Broker stopped first
-- [x] BESS2: Start-Stop Broker/Engine - Broker started first - Engine stopped first
-- [x] BESS3: Start-Stop Broker/Engine - Engine started first - Engine stopped first
-- [x] BESS4: Start-Stop Broker/Engine - Engine started first - Broker stopped first
-- [x] BESS5: Start-Stop Broker/engine - Engine debug level is set to all, it should not hang
-- [x] BRRDDM1: RRD metric deletion
-- [x] Broker reverse connection good
-- [x] Broker reverse connection too slow
-- [x] Broker reverse connection stopped
-- [x] New host group
-- [x] BECC1: Broker/Engine communication with compression between central and poller
-- [x] New host group
-- [x] New host group
-- [x] BETUSEV2 Seven services are configured with a severity on two pollers. Then only severities no more used should be removed from the database.
-- [x] BETUSEV1 Services have severities provided by templates.
-- [x] BEUSEV4	Seven services are configured with a severity on two pollers. Then only severities no more used should be removed from the database.
-- [x] BEUSEV3	Four services have a severity added. Then we remove the severity from service 1. Then we change severity 11 to severity7 for service 3.
-- [x] BEUSEV2	Engine is configured with some severities.
-- [x] BEUSEV1	Engine is configured with some severities.
-- [x] BESEV2	Engine is configured with some severities.
-- [x] BESEV1	Engine is configured with some severities.
-### engine
+### Broker/engine
+- [x] **BEPBBEE1**: central-module configured with bbdo_version 3.0 but not others. Unable to establish connection.
+- [x] **BEPBBEE2**: bbdo_version 3 not compatible with sql/storage
+- [x] **BEPBBEE3**: bbdo_version 3 generates new bbdo protobuf service status messages.
+- [x] **BEPBBEE4**: bbdo_version 3 generates new bbdo protobuf host status messages.
+- [x] **BEPBBEE5**: bbdo_version 3 generates new bbdo protobuf service messages.
+- [x] **BECC1**: Broker/Engine communication with compression between central and poller
+- [x] **EBNHG1**: New host group with several pollers and connections to DB
+- [x] **EBNHGU1**: New host group with several pollers and connections to DB with broker configured with unified_sql
+- [x] **EBNHGU2**: New host group with several pollers and connections to DB with broker configured with unified_sql
+- [x] **EBNHGU3**: New host group with several pollers and connections to DB with broker configured with unified_sql
+- [x] **EBNHG4**: New host group with several pollers and connections to DB with broker and rename this hostgroup
+- [x] **EBNHGU4**: New host group with several pollers and connections to DB with broker and rename this hostgroup
+- [x] **LOGV2EB1**: log-v2 enabled  old log disabled check broker sink
+- [x] **LOGV2DB1**: log-v2 disabled old log enabled check broker sink
+- [x] **LOGV2DB2**: log-v2 disabled old log disabled check broker sink
+- [x] **LOGV2EB2**: log-v2 enabled old log enabled check broker sink
+- [x] **LOGV2EF1**: log-v2 enabled  old log disabled check logfile sink
+- [x] **LOGV2DF1**: log-v2 disabled old log enabled check logfile sink
+- [x] **LOGV2DF2**: log-v2 disabled old log disabled check logfile sink
+- [x] **LOGV2EF2**: log-v2 enabled old log enabled check logfile sink
+- [x] **LOGV2BE2**: log-v2 enabled old log enabled check broker sink is equal
+- [x] **LOGV2FE2**: log-v2 enabled old log enabled check logfile sink
+- [x] **BERES1**: store_in_resources is enabled and store_in_hosts_services is not. Only writes into resources should be done (except hosts/services events that continue to be written in hosts/services tables)
+- [x] **BEHS1**: store_in_resources is enabled and store_in_hosts_services is not. Only writes into resources should be done (except hosts/services events that continue to be written in hosts/services tables)
+- [x] **BRGC1**: Broker good reverse connection
+- [x] **BRCTS1**: Broker reverse connection too slow
+- [x] **BRCS1**: Broker reverse connection stopped
+- [x] **BRRDDM1**: RRD metrics deletion from metric ids.
+- [x] **BRRDDID1**: RRD metrics deletion from index ids.
+- [x] **BRRDDMID1**: RRD deletion of non existing metrics and indexes
+- [x] **BRRDDMU1**: RRD metric deletion on table metric with unified sql output
+- [x] **BRRDDIDU1**: RRD metrics deletion from index ids with unified sql output.
+- [x] **BRRDDMIDU1**: RRD deletion of non existing metrics and indexes
+- [x] **BRRDRM1**: RRD metric rebuild with gRPC API and unified sql
+- [x] **BRRDRMU1**: RRD metric rebuild with gRPC API and unified sql
+- [x] **ENRSCHE1**: check next check of reschedule is last_check+interval_check
+- [x] **EBNSG1**: New service group with several pollers and connections to DB
+- [x] **EBNSGU1**: New service group with several pollers and connections to DB with broker configured with unified_sql
+- [x] **EBNSGU2**: New service group with several pollers and connections to DB with broker configured with unified_sql
+- [x] **EBNSVC1**: New services with several pollers
+- [x] **BETAG1**: Engine is configured with some tags. When broker receives them, it stores them in the centreon_storage.tags table. Broker is started before.
+- [x] **BETAG2**: Engine is configured with some tags. When broker receives them, it stores them in the centreon_storage.tags table. Engine is started before.
+- [x] **BEUTAG1**: Engine is configured with some tags. When broker receives them, it stores them in the centreon_storage.tags table. Broker is started before.
+- [x] **BEUTAG2**: Engine is configured with some tags. A new service is added with a tag. Broker should make the relations.
+- [x] **BEUTAG3**: Engine is configured with some tags. When broker receives them, it stores them in the centreon_storage.tags table. Engine is started before.
+- [x] **BEUTAG4**: Engine is configured with some tags. Group tags tag9, tag13 are set to services 1 and 3. Category tags tag3 and tag11 are added to services 1, 3, 5 and 6. The centreon_storage.resources and resources_tags tables are well filled.
+- [x] **BEUTAG5**: Engine is configured with some tags. Group tags tag2, tag6 are set to hosts 1 and 2. Category tags tag4 and tag8 are added to hosts 2, 3, 4. The resources and resources_tags tables are well filled.
+- [x] **BEUTAG6**: Engine is configured with some tags. When broker receives them, it stores them in the centreon_storage.resources_tags table. Engine is started before.
+- [x] **BEUTAG7**: some services are configured and deleted with tags on two pollers.
+- [x] **BEUTAG8**: Services have tags provided by templates.
+- [x] **BEUTAG9**: hosts have tags provided by templates.
+- [x] **BERD1**: Starting/stopping Broker does not create duplicated events.
+- [x] **BERD2**: Starting/stopping Engine does not create duplicated events.
+- [x] **BERDUC1**: Starting/stopping Broker does not create duplicated events in usual cases
+- [x] **BERDUCU1**: Starting/stopping Broker does not create duplicated events in usual cases with unified_sql
+- [x] **BERDUC2**: Starting/stopping Engine does not create duplicated events in usual cases
+- [x] **BERDUCU2**: Starting/stopping Engine does not create duplicated events in usual cases with unified_sql
+- [x] **BERDUC3U1**: Starting/stopping Broker does not create duplicated events in usual cases with unified_sql and BBDO 3.0
+- [x] **BERDUC3U2**: Starting/stopping Engine does not create duplicated events in usual cases with unified_sql and BBDO 3.0
+- [x] **BEDTMASS1**: New services with several pollers
+- [x] **BEDTMASS2**: New services with several pollers
+- [x] **BEEXTCMD1**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo3.0
+- [x] **BEEXTCMD2**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo2.0
+- [x] **BEEXTCMD3**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo3.0
+- [x] **BEEXTCMD4**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo2.0
+- [x] **BEEXTCMD5**: external command CHANGE_RETRY_SVC_CHECK_INTERVAL on bbdo3.0
+- [x] **BEEXTCMD6**: external command CHANGE_RETRY_SVC_CHECK_INTERVAL on bbdo2.0
+- [x] **BEEXTCMD7**: external command CHANGE_RETRY_HOST_CHECK_INTERVAL on bbdo3.0
+- [x] **BEEXTCMD8**: external command CHANGE_RETRY_HOST_CHECK_INTERVAL on bbdo2.0
+- [x] **BEEXTCMD9**: external command CHANGE_MAX_SVC_CHECK_ATTEMPTS on bbdo3.0
+- [x] **BEEXTCMD10**: external command CHANGE_MAX_SVC_CHECK_ATTEMPTS on bbdo2.0
+- [x] **BEEXTCMD11**: external command CHANGE_MAX_HOST_CHECK_ATTEMPTS on bbdo3.0
+- [x] **BEEXTCMD12**: external command CHANGE_MAX_HOST_CHECK_ATTEMPTS on bbdo2.0
+- [x] **BEEXTCMD13**: external command CHANGE_HOST_CHECK_TIMEPERIOD on bbdo3.0
+- [x] **BEEXTCMD14**: external command CHANGE_HOST_CHECK_TIMEPERIOD on bbdo2.0
+- [x] **BEEXTCMD15**: external command CHANGE_HOST_NOTIFICATION_TIMEPERIOD on bbdo3.0
+- [x] **BEEXTCMD16**: external command CHANGE_HOST_NOTIFICATION_TIMEPERIOD on bbdo2.0
+- [x] **BEEXTCMD17**: external command CHANGE_SVC_CHECK_TIMEPERIOD on bbdo3.0
+- [x] **BEEXTCMD18**: external command CHANGE_SVC_CHECK_TIMEPERIOD on bbdo2.0
+- [x] **BEEXTCMD19**: external command CHANGE_SVC_NOTIFICATION_TIMEPERIOD on bbdo3.0
+- [x] **BEEXTCMD20**: external command CHANGE_SVC_NOTIFICATION_TIMEPERIOD on bbdo2.0
+- [x] **BEEXTCMD21**: external command DISABLE_HOST_AND_CHILD_NOTIFICATIONS and ENABLE_HOST_AND_CHILD_NOTIFICATIONS on bbdo3.0
+- [x] **BEEXTCMD22**: external command DISABLE_HOST_AND_CHILD_NOTIFICATIONS and ENABLE_HOST_AND_CHILD_NOTIFICATIONS on bbdo2.0
+- [x] **BEEXTCMD23**: external command DISABLE_HOST_CHECK and ENABLE_HOST_CHECK on bbdo3.0
+- [x] **BEEXTCMD24**: external command DISABLE_HOST_CHECK and ENABLE_HOST_CHECK on bbdo2.0
+- [x] **BEEXTCMD25**: external command DISABLE_HOST_EVENT_HANDLER and ENABLE_HOST_EVENT_HANDLER on bbdo3.0
+- [x] **BEEXTCMD26**: external command DISABLE_HOST_EVENT_HANDLER and ENABLE_HOST_EVENT_HANDLER on bbdo2.0
+- [x] **BEEXTCMD27**: external command DISABLE_HOST_FLAP_DETECTION and ENABLE_HOST_FLAP_DETECTION on bbdo3.0
+- [x] **BEEXTCMD28**: external command DISABLE_HOST_FLAP_DETECTION and ENABLE_HOST_FLAP_DETECTION on bbdo2.0
+- [x] **BEEXTCMD29**: external command DISABLE_HOST_NOTIFICATIONS and ENABLE_HOST_NOTIFICATIONS on bbdo3.0
+- [x] **BEEXTCMD30**: external command DISABLE_HOST_NOTIFICATIONS and ENABLE_HOST_NOTIFICATIONS on bbdo2.0
+- [x] **BEEXTCMD31**: external command DISABLE_HOST_SVC_CHECKS and ENABLE_HOST_SVC_CHECKS on bbdo3.0
+- [x] **BEEXTCMD32**: external command DISABLE_HOST_SVC_CHECKS and ENABLE_HOST_SVC_CHECKS on bbdo2.0
+- [x] **BEEXTCMD33**: external command DISABLE_HOST_SVC_NOTIFICATIONS and ENABLE_HOST_SVC_NOTIFICATIONS on bbdo3.0
+- [x] **BEEXTCMD34**: external command DISABLE_HOST_SVC_NOTIFICATIONS and ENABLE_HOST_SVC_NOTIFICATIONS on bbdo2.0
+- [x] **BEEXTCMD35**: external command DISABLE_PASSIVE_HOST_CHECKS and ENABLE_PASSIVE_HOST_CHECKS on bbdo3.0
+- [x] **BEEXTCMD36**: external command DISABLE_PASSIVE_HOST_CHECKS and ENABLE_PASSIVE_HOST_CHECKS on bbdo2.0
+- [x] **BEEXTCMD37**: external command DISABLE_PASSIVE_SVC_CHECKS and ENABLE_PASSIVE_SVC_CHECKS on bbdo3.0
+- [x] **BEEXTCMD38**: external command DISABLE_PASSIVE_SVC_CHECKS and ENABLE_PASSIVE_SVC_CHECKS on bbdo2.0
+- [x] **BEEXTCMD39**: external command START_OBSESSING_OVER_HOST and STOP_OBSESSING_OVER_HOST on bbdo3.0
+- [x] **BEEXTCMD40**: external command START_OBSESSING_OVER_HOST and STOP_OBSESSING_OVER_HOST on bbdo2.0
+- [x] **BEEXTCMD41**: external command START_OBSESSING_OVER_SVC and STOP_OBSESSING_OVER_SVC on bbdo3.0
+- [x] **BEEXTCMD42**: external command START_OBSESSING_OVER_SVC and STOP_OBSESSING_OVER_SVC on bbdo2.0
+- [x] **BEEXTCMD_GRPC1**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo3.0 and grpc
+- [x] **BEEXTCMD_GRPC2**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo2.0 and grpc
+- [x] **BEEXTCMD_GRPC3**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo3.0 and grpc
+- [x] **BEEXTCMD_GRPC4**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo2.0 and grpc
+- [x] **BESS1**: Start-Stop Broker/Engine - Broker started first - Broker stopped first
+- [x] **BESS2**: Start-Stop Broker/Engine - Broker started first - Engine stopped first
+- [x] **BESS3**: Start-Stop Broker/Engine - Engine started first - Engine stopped first
+- [x] **BESS4**: Start-Stop Broker/Engine - Engine started first - Broker stopped first
+- [x] **BESS5**: Start-Stop Broker/engine - Engine debug level is set to all, it should not hang
+- [x] **BESS_GRPC1**: Start-Stop grpc version Broker/Engine - Broker started first - Broker stopped first
+- [x] **BESS_GRPC2**: Start-Stop grpc version Broker/Engine - Broker started first - Engine stopped first
+- [x] **BESS_GRPC3**: Start-Stop grpc version Broker/Engine - Engine started first - Engine stopped first
+- [x] **BESS_GRPC4**: Start-Stop grpc version Broker/Engine - Engine started first - Broker stopped first
+- [x] **BESS_GRPC5**: Start-Stop grpc version Broker/engine - Engine debug level is set to all, it should not hang
+- [x] **BESS_GRPC_COMPRESS1**: Start-Stop grpc version Broker/Engine - Broker started first - Broker stopped first compression activated
+- [x] **BECT1**: Broker/Engine communication with anonymous TLS between central and poller
+- [x] **BECT2**: Broker/Engine communication with TLS between central and poller with key/cert
+- [x] **BECT3**: Broker/Engine communication with anonymous TLS and ca certificate
+- [x] **BECT4**: Broker/Engine communication with TLS between central and poller with key/cert and hostname forced
+- [x] **BECT_GRPC1**: Broker/Engine communication with anonymous TLS between central and poller
+- [x] **BECT_GRPC2**: Broker/Engine communication with TLS between central and poller with key/cert
+- [x] **BECT_GRPC3**: Broker/Engine communication with anonymous TLS and ca certificate
+- [x] **BECT_GRPC4**: Broker/Engine communication with TLS between central and poller with key/cert and hostname forced
 
-- [x] ESS1: Start-Stop one instance of engine and no coredump
-- [x] ESS2: Start-Stop many instances of engine and no coredump
-- [x] EPC1: Check with perl connector
+### Connector perl
+- [x] **test use connector perl exist script**: test exist script
+- [x] **test use connector perl unknown script**: test unknown script
+- [x] **test use connector perl multiple script**: test script multiple
+
+### Connector ssh
+- [x] **TestBadUser**: test unknown user
+- [x] **TestBadPwd**: test bad password
+- [x] **Test6Hosts**: as 127.0.0.x point to the localhost address we will simulate check on 6 hosts
+
+### Engine
+- [x] **EFHC1**: Engine is configured with hosts and we force checks on one 5 times on bbdo2
+- [x] **EFHC2**: Engine is configured with hosts and we force checks on one 5 times on bbdo2
+- [x] **EFHCU1**: Engine is configured with hosts and we force checks on one 5 times on bbdo3. Bbdo3 has no impact on this behavior. resources table is cleared before starting broker.
+- [x] **EFHCU2**: Engine is configured with hosts and we force checks on one 5 times on bbdo3. Bbdo3 has no impact on this behavior.
+- [x] **ESS1**: Start-Stop (0s between start/stop) 5 times one instance of engine and no coredump
+- [x] **ESS2**: Start-Stop (300ms between start/stop) 5 times one instance of engine and no coredump
+- [x] **ESS3**: Start-Stop (0s between start/stop) 5 times three instances of engine and no coredump
+- [x] **ESS4**: Start-Stop (300ms between start/stop) 5 times three instances of engine and no coredump
+- [x] **EPC1**: Check with perl connector
+
+### Migration
+- [x] **MIGRATION**: Migration bbdo2 => sql/storage => unified_sql => bbdo3
+
+### Severities
+- [x] **BEUHSEV1**: Four hosts have a severity added. Then we remove the severity from host 1. Then we change severity 10 to severity8 for host 3.
+- [x] **BEUHSEV2**: Seven hosts are configured with a severity on two pollers. Then we remove severities from the first and second hosts of the first poller but only the severity from the first host of the second poller.
+- [x] **BETUHSEV1**: Hosts have severities provided by templates.
+- [x] **BESEV1**: Engine is configured with some severities. When broker receives them, it stores them in the centreon_storage.severities table. Broker is started before.
+- [x] **BESEV2**: Engine is configured with some severities. When broker receives them, it stores them in the centreon_storage.severities table. Engine is started before.
+- [x] **BEUSEV1**: Engine is configured with some severities. When broker receives them, it stores them in the centreon_storage.severities table. Broker is started before.
+- [x] **BEUSEV2**: Engine is configured with some severities. When broker receives them, it stores them in the centreon_storage.severities table. Engine is started before.
+- [x] **BEUSEV3**: Four services have a severity added. Then we remove the severity from service 1. Then we change severity 11 to severity7 for service 3.
+- [x] **BEUSEV4**: Seven services are configured with a severity on two pollers. Then we remove severities from the first and second services of the first poller but only the severity from the first service of the second poller. Then only severities no more used should be removed from the database.
+- [x] **BETUSEV1**: Services have severities provided by templates.
+

--- a/tests/broker-engine/downtimes.robot
+++ b/tests/broker-engine/downtimes.robot
@@ -73,3 +73,57 @@ BEDTMASS1
 
 	Stop Engine
 	Kindly Stop Broker
+
+BEDTMASS2
+	[Documentation]	New services with several pollers
+	[Tags]	Broker	Engine	services	protobuf
+	Config Engine	${3}	${50}	${20}
+	Engine Config Set Value	${0}	log_level_functions	trace
+	Engine Config Set Value	${1}	log_level_functions	trace
+	Engine Config Set Value	${2}	log_level_functions	trace
+	Config Broker	rrd
+	Config Broker	central
+	Config Broker	module	${3}
+	Broker Config Log	central	sql	debug
+	Broker Config Log	module0	neb	debug
+	Broker Config Log	module1	neb	debug
+	Broker Config Log	module2	neb	debug
+
+	Broker Config Log	central	sql	debug
+	Clear Retention
+	${start}=	Get Current Date
+	Start Broker
+	Start Engine
+	# Let's wait for the initial service states.
+        ${content}=	Create List	INITIAL SERVICE STATE: host_50;service_1000;
+        ${result}=	Find In Log with Timeout	${logEngine2}	${start}	${content}	60
+        Should Be True	${result}	msg=An Initial service state on service (50, 1000) should be raised before we can start external commands.
+
+	# It's time to schedule downtimes
+	FOR	${i}	IN RANGE	${17}
+	 ${host0}=	Catenate	SEPARATOR=	host_	${i + 1}
+	 ${host1}=	Catenate	SEPARATOR=	host_	${i + 18}
+	 ${host2}=	Catenate	SEPARATOR=	host_	${i + 35}
+	 Schedule host downtime	${0}	${host0}	${3600}
+	 Schedule host downtime	${1}	${host1}	${3600}
+	 Schedule host downtime	${2}	${host2}	${3600}
+	END
+
+	${result}=	check number of downtimes	${1050}	${start}	${60}
+	Should be true	${result}	msg=We should have 1050 downtimes enabled.
+
+	# It's time to delete downtimes
+	FOR	${i}	IN RANGE	${17}
+	 ${host0}=	Catenate	SEPARATOR=	host_	${i + 1}
+	 ${host1}=	Catenate	SEPARATOR=	host_	${i + 18}
+	 ${host2}=	Catenate	SEPARATOR=	host_	${i + 35}
+	 Delete host downtimes	${0}	${host0}
+	 Delete host downtimes	${1}	${host1}
+	 Delete host downtimes	${2}	${host2}
+	END
+
+	${result}=	check number of downtimes	${0}	${start}	${60}
+	Should be true	${result}	msg=We should have no downtime enabled.
+
+	Stop Engine
+	Kindly Stop Broker

--- a/tests/summary.py
+++ b/tests/summary.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python3
-import math
+import datetime
 import os
 import re
-import sys
 from xml.etree import ElementTree as ET
+
 import matplotlib.pyplot as plt
-import datetime
 
 content = os.listdir('.')
 r = re.compile(r"\d+")
@@ -37,11 +36,11 @@ for f in content:
                     if s.attrib['status'] == 'PASS':
                         success += 1
                     count += 1
-            durations.sort(reverse = True)
+            durations.sort(reverse=True)
             durations = durations[:10]
             gl_durations.append(durations)
-            gl_avg_duration.append((int(f), total_duration / count))
-            tests.append((int(f), success, fail))
+            gl_avg_duration.append((f, total_duration / count))
+            tests.append((f, success, fail))
             print("%s: %d/%d passed tests" % (f, success, count))
 
 # Display the arrays of longest tests
@@ -68,12 +67,8 @@ for xx in gl_avg_duration:
     x1.append(xx[0])
     y1.append(xx[1])
 
-#plt.figure()
 fig, ax = plt.subplots(2)
-#plt.title("Centreon-Tests")
 fig.suptitle("Centreon-Tests")
-#plt.subplots_adjust(bottom=0.226)
-#plt.stackplot(x, ys, yf, labels=['Success', 'failure'])
 ax[0].set_ylabel('tests')
 ax[0].set_xlabel('date')
 ax[0].tick_params(labelrotation=45)

--- a/tests/update-doc.py
+++ b/tests/update-doc.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python3
+import os
+import re
+
+
+def complete_doc(dico, ff):
+    f = open(ff, 'r')
+    content = f.readlines()
+    f.close()
+    r = re.compile(r"\s+\[Documentation\]\s+([^\s].*)$")
+
+    in_test = False
+    test_name = ""
+    for l in content:
+        if in_test:
+            if l.startswith("***"):
+                break
+            if len(test_name) != 0 and "[Documentation]" in l:
+                m = r.match(l)
+                if m:
+                    dico[test_name] = m.group(1)
+                    test_name = ""
+            if not l.startswith('\t') and not l.startswith("  "):
+                test_name = l.strip()
+        elif l.startswith("*** Test Cases ***"):
+            in_test = True
+
+
+def parse_dir(d):
+    r = re.compile(r".*\.robot$")
+    retval = {}
+    content = os.listdir(d)
+    for f in content:
+        ff = d + '/' + f
+        if os.path.isdir(ff):
+            ret = parse_dir(ff)
+            if len(ret) > 0:
+                retval[ff] = ret
+        if r.match(ff) and os.path.isfile(ff):
+            complete_doc(retval, ff)
+    return retval
+
+
+dico = parse_dir('.')
+
+out = open('README.md', 'w')
+out.write("""# Centreon Tests
+
+This sub-project contains functional tests for Centreon Broker, Engine and Connectors.
+
+## Getting Started
+
+To get this project, you have to clone centreon-collect.
+
+These tests are executed from the `centreon-tests/robot` folder and uses the [Robot Framework](https://robotframework.org/).
+
+From a Centreon host, you need to install Robot Framework
+
+On CentOS 7, the following commands should work to initialize your robot tests:
+
+```
+pip3 install -U robotframework robotframework-databaselibrary pymysql
+
+yum install "Development Tools" python3-devel -y
+
+pip3 install grpcio==1.33.2 grpcio_tools==1.33.2
+
+./init-proto.sh
+./init-bam.sh
+```
+
+On other rpm based distributions, you can try the following commands to initialize your robot tests:
+
+```
+pip3 install -U robotframework robotframework-databaselibrary pymysql
+
+yum install python3-devel -y
+
+pip3 install grpcio grpcio_tools
+
+./init-proto.sh
+./init-bam.sh
+```
+
+Then to run tests, you can use the following commands
+
+```
+robot .
+```
+
+And it is also possible to execute a specific test, for example:
+
+```
+robot broker/sql.robot
+```
+
+## Implemented tests
+
+Here is the list of the currently implemented tests:
+
+""")
+
+keys = list(dico.keys())
+keys.sort()
+
+for k in keys:
+    name = k[2:]
+    name = name.replace('-', '/')
+    name = name.replace('_', ' ').capitalize()
+    out.write("### {}\n".format(name))
+    if isinstance(dico[k], str):
+        out.write("- [x] **{}**: {}\n".format(k, dico[k]))
+    else:
+        for kk in dico[k]:
+            if isinstance(dico[k][kk], str):
+                out.write("- [x] **{}**: {}\n".format(kk, dico[k][kk]))
+            else:
+                print("This tree is too deep")
+                exit(1)
+        out.write("\n")
+
+out.close()


### PR DESCRIPTION
Downtimes are inserted in bulk. A timer executes downtimes injection every 5s.
This is done with unified_sql and also with storage. The storage part also sends bulk injections each time the thread loop restarts, so this one can wait a little less.