### PR TITLE
MON-13866 add a mutex to avoid StartWrite call after another thread h…

### DIFF
--- a/broker/grpc/inc/com/centreon/broker/grpc/client.hh
+++ b/broker/grpc/inc/com/centreon/broker/grpc/client.hh
@@ -36,7 +36,10 @@ class client : public channel,
   channel_ptr _channel;
   std::unique_ptr<com::centreon::broker::stream::centreon_bbdo::Stub> _stub;
   std::unique_ptr<::grpc::ClientContext> _context;
-  std::atomic_bool _hold_to_remove;
+  bool _hold_to_remove;
+  // recursive_mutex is mandatory as we don't know if grpc layers can do a
+  // direct call from StartWrite to OnWriteDone
+  std::recursive_mutex _hold_mutex;
 
  protected:
   client& operator=(const client&) = delete;


### PR DESCRIPTION
…ad remove hold

## Description
MON-13866

StartWrite mustn't be called after RemoveHold, so call to StartWrite and RemoveHold is protected by a mutex

To test
Start a central broker alone with grpc configured in both rrd output and centengine input, it mustn't core

**Fixes** # (issue)
If you start a broker alone without centengine or rrd with grpc configure, it may core

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [X] 22.04.x
- [X] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

described above
## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
