### PR TITLE
MON-13866 RemoveHold and no StartWrite after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ tags are well removed now.
 
 Default configuration files were not installed on a Debian fresh install.
 
+*GRPC stream*
+
+Don't coredump if connection fail on process start
 #### Enhancements
 
 *downtimes*

--- a/broker/grpc/inc/com/centreon/broker/grpc/client.hh
+++ b/broker/grpc/inc/com/centreon/broker/grpc/client.hh
@@ -36,7 +36,10 @@ class client : public channel,
   channel_ptr _channel;
   std::unique_ptr<com::centreon::broker::stream::centreon_bbdo::Stub> _stub;
   std::unique_ptr<::grpc::ClientContext> _context;
-  std::atomic_bool _hold_to_remove;
+  bool _hold_to_remove;
+  // recursive_mutex is mandatory as we don't know if grpc layers can do a
+  // direct call from StartWrite to OnWriteDone
+  std::recursive_mutex _hold_mutex;
 
  protected:
   client& operator=(const client&) = delete;


### PR DESCRIPTION
## Description
REFS: MON-13866

cbd with grpc configured core on start if rrd cbd is not started

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [X] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

start and stop cbd alone, it mustn't core.
## Checklist

#### Community contributors & Centreon team

- [X ] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
