### PR TITLE
Mon 14091 ba downtime ignored

### DIFF
--- a/broker/bam/src/kpi_service.cc
+++ b/broker/bam/src/kpi_service.cc
@@ -302,14 +302,17 @@ void kpi_service::service_update(std::shared_ptr<neb::downtime> const& dt,
                                  io::stream* visitor) {
   assert(dt && dt->host_id == _host_id && dt->service_id == _service_id);
   // Update information.
-  _downtimed = dt->was_started && dt->actual_end_time.is_null();
+  bool downtimed = dt->was_started && dt->actual_end_time.is_null();
+  if (!_downtimed && downtimed)
+    _downtimed = true;
+
   if (_downtime_ids.contains(dt->internal_id) && !dt->was_cancelled) {
     log_v2::bam()->trace("Downtime {} already handled in this kpi service",
                          dt->internal_id);
     return;
   }
 
-  if (_downtimed) {
+  if (downtimed) {
     log_v2::bam()->trace("adding in kpi service the impacting downtime {}",
                          dt->internal_id);
     _downtime_ids.insert(dt->internal_id);
@@ -317,6 +320,7 @@ void kpi_service::service_update(std::shared_ptr<neb::downtime> const& dt,
     log_v2::bam()->trace("removing from kpi service the impacting downtime {}",
                          dt->internal_id);
     _downtime_ids.erase(dt->internal_id);
+    _downtimed = !_downtime_ids.empty();
   }
 
   if (!_event || _event->in_downtime != _downtimed) {

--- a/tests/README.md
+++ b/tests/README.md
@@ -55,6 +55,7 @@ Here is the list of the currently implemented tests:
 ### Bam
 - [x] **BEBAMIDT1**: A BA of type 'worst' with one service is configured. The BA is in critical state, because of its service. Then we set a downtime on this last one. An inherited downtime is set to the BA. The downtime is removed from the service, the inherited downtime is then deleted.
 - [x] **BEBAMIDT2**: A BA of type 'worst' with one service is configured. The BA is in critical state, because of its service. Then we set a downtime on this last one. An inherited downtime is set to the BA. Engine is restarted. Broker is restarted. The two downtimes are still there with no duplicates. The downtime is removed from the service, the inherited downtime is then deleted.
+- [x] **BEBAMIGNDT1**: A BA of type 'worst' with two services is configured. The downtime policy on this ba is "Ignore the indicator in the calculation". The BA is in critical state, because of the second critical service. Then we apply two downtimes on this last one. The BA state is ok because of the policy on indicators. A first downtime is cancelled, the BA is still OK, but when the second downtime is cancelled, the BA should be CRITICAL.
 
 ### Broker
 - [x] **BCL1**: Starting broker with option '-s foobar' should return an error
@@ -198,6 +199,12 @@ Here is the list of the currently implemented tests:
 - [x] **BESS3**: Start-Stop Broker/Engine - Engine started first - Engine stopped first
 - [x] **BESS4**: Start-Stop Broker/Engine - Engine started first - Broker stopped first
 - [x] **BESS5**: Start-Stop Broker/engine - Engine debug level is set to all, it should not hang
+- [x] **BESS_CRYPTED_GRPC1**: Start-Stop grpc version Broker/Engine - well configured
+- [x] **BESS_CRYPTED_GRPC2**: Start-Stop grpc version Broker/Engine only server crypted
+- [x] **BESS_CRYPTED_GRPC3**: Start-Stop grpc version Broker/Engine only engine crypted
+- [x] **BESS_CRYPTED_REVERSED_GRPC1**: Start-Stop grpc version Broker/Engine - well configured
+- [x] **BESS_CRYPTED_REVERSED_GRPC2**: Start-Stop grpc version Broker/Engine only engine server crypted
+- [x] **BESS_CRYPTED_REVERSED_GRPC3**: Start-Stop grpc version Broker/Engine only engine crypted
 - [x] **BESS_GRPC1**: Start-Stop grpc version Broker/Engine - Broker started first - Broker stopped first
 - [x] **BESS_GRPC2**: Start-Stop grpc version Broker/Engine - Broker started first - Engine stopped first
 - [x] **BESS_GRPC3**: Start-Stop grpc version Broker/Engine - Engine started first - Engine stopped first
@@ -233,6 +240,10 @@ Here is the list of the currently implemented tests:
 - [x] **EBDP2**: Three new pollers are started, then they are killed. After a simple restart of broker, it is still possible to remove Poller2 if removed from the configuration.
 - [x] **EBDP3**: Three new pollers are started, then they are killed. It is still possible to remove Poller2 if removed from the configuration.
 - [x] **EBDP4**: Four new pollers are started and then we remove Poller3 with its hosts and services. All service status/host status are then refused by broker.
+- [x] **EBDP5**: Four new pollers are started and then we remove Poller3.
+- [x] **EBDP6**: Three new pollers are started, then they are killed. After a simple restart of broker, it is still possible to remove Poller2 if removed from the configuration.
+- [x] **EBDP7**: Three new pollers are started, then they are killed. It is still possible to remove Poller2 if removed from the configuration.
+- [x] **EBDP8**: Four new pollers are started and then we remove Poller3 with its hosts and services. All service status/host status are then refused by broker.
 - [x] **EBNHG1**: New host group with several pollers and connections to DB
 - [x] **EBNHG4**: New host group with several pollers and connections to DB with broker and rename this hostgroup
 - [x] **EBNHGU1**: New host group with several pollers and connections to DB with broker configured with unified_sql

--- a/tests/bam/inherited_downtime.robot
+++ b/tests/bam/inherited_downtime.robot
@@ -127,3 +127,63 @@ BEBAMIDT2
 
 	Stop Engine
 	Stop Broker
+
+BEBAMIDT3
+	[Documentation]	A BA of type 'worst' with two services is configured. The downtime policy on this ba is "Ignore the indicator in the calculation". The BA is in critical state, because of the second critical service. Then we apply two downtimes on this last one. The BA state is ok because of the policy on indicators. A first downtime is cancelled, the BA is still OK, but when the second downtime is cancelled, the BA should be CRITICAL.
+	[Tags]	broker	downtime	engine	bam
+	Clear Commands Status
+	Config Broker	module
+	Config Broker	central
+	Broker Config Log	central	bam	trace
+	Config Broker	rrd
+	Config Engine	${1}
+
+	Clone Engine Config To DB
+	Add Bam Config To Engine
+
+	@{svc}=	Set Variable	${{ [("host_16", "service_313"), ("host_16", "service_314"] }}
+	Create BA With Services	test	worst	${svc}  ignore
+	Add Bam Config To Broker	central
+	# Command of service_314 is set to critical
+	${cmd_1}=	Get Command Id	313
+	Log To Console	service_314 has command id ${cmd_1}
+	Set Command Status	${cmd_1}	0
+	${cmd_2}=	Get Command Id	314
+	Log To Console	service_314 has command id ${cmd_2}
+	Set Command Status	${cmd_2}	2
+	Start Broker
+	Start Engine
+	Sleep	5s
+
+	# KPI set to ok
+	Repeat Keyword	3 times	Process Service Check Result	host_16	service_313	0	output critical for 313
+	${result}=	Check Service Status With Timeout	host_16	service_313	0	60
+	Should Be True	${result}	msg=The service (host_16,service_313) is not OK as expected
+
+	# KPI set to critical
+	Repeat Keyword	3 times	Process Service Check Result	host_16	service_314	2	output critical for 314
+	${result}=	Check Service Status With Timeout	host_16	service_314	2	60
+	Should Be True	${result}	msg=The service (host_16,service_314) is not CRITICAL as expected
+
+	# The BA should become critical
+	${result}=	Check Ba Status With Timeout	test	2	60
+	Should Be True	${result}	msg=The BA ba_1 is not CRITICAL as expected
+
+	# Two downtime are applied on service_314
+	Schedule Service Downtime	host_16	service_314	3600
+	${result}=	Check Service Downtime With Timeout	host_16	service_314	1	60
+	Should Be True	${result}	msg=The service (host_16, service_314) is not in downtime as it should be
+	Schedule Service Downtime	host_16	service_314	1800
+	${result}=	Check Service Downtime With Timeout	host_16	service_314	1	60
+	Should Be True	${result}	msg=The service (host_16, service_314) is not in downtime as it should be
+	${result}=	Check Service Downtime With Timeout	_Module_BAM_1	ba_1	1	60
+	Should Be True	${result}	msg=The BA ba_1 is not in downtime as it should
+
+	# The first downtime is deleted
+	Delete Service Downtime	host_16	service_314
+	${result}=	Check Service State With Timeout	_Module_BAM_1	ba_1	0
+	Should Be True	${result}	msg=The BA ba_1 is in downtime as it should not
+
+	Stop Engine
+	Stop Broker
+

--- a/tests/resources/Common.py
+++ b/tests/resources/Common.py
@@ -352,7 +352,7 @@ def check_service_status_with_timeout(hostname: str, service_desc: str, status: 
                 cursor.execute("SELECT s.state FROM services s LEFT JOIN hosts h ON s.host_id=h.host_id WHERE s.description=\"{}\" AND h.name=\"{}\"".format(
                     service_desc, hostname))
                 result = cursor.fetchall()
-                if result[0]['state'] and int(result[0]['state']) == status:
+                if result[0]['state'] is not None and int(result[0]['state']) == int(status):
                     return True
         time.sleep(5)
     return False
@@ -458,7 +458,7 @@ def check_ba_status_with_timeout(ba_name: str, status: int, timeout: int):
                 cursor.execute(
                     "SELECT current_status FROM mod_bam WHERE name='{}'".format(ba_name))
                 result = cursor.fetchall()
-                if result[0]['current_status'] and int(result[0]['current_status']) == status:
+                if result[0]['current_status'] is not None and int(result[0]['current_status']) == status:
                     return True
         time.sleep(5)
     return False
@@ -496,7 +496,7 @@ def delete_service_downtime(hst: str, svc: str):
 
     with connection:
         with connection.cursor() as cursor:
-            cursor.execute("select d.internal_id from downtimes d inner join hosts h on d.host_id=h.host_id inner join services s on d.service_id=s.service_id where d.cancelled='0' and s.scheduled_downtime_depth='1' and s.description='{}' and h.name='{}'".format(svc, hst))
+            cursor.execute("select d.internal_id from downtimes d inner join hosts h on d.host_id=h.host_id inner join services s on d.service_id=s.service_id where d.cancelled='0' and s.scheduled_downtime_depth<>'0' and s.description='{}' and h.name='{}' LIMIT 1".format(svc, hst))
             result = cursor.fetchall()
             did = int(result[0]['internal_id'])
 

--- a/tests/resources/Engine.py
+++ b/tests/resources/Engine.py
@@ -636,9 +636,9 @@ def add_bam_config_to_engine():
     dbconf.init_bam()
 
 
-def create_ba_with_services(name: str, typ: str, svc: list):
+def create_ba_with_services(name: str, typ: str, svc: list, dt_policy="inherit"):
     global dbconf
-    dbconf.create_ba_with_services(name, typ, svc)
+    dbconf.create_ba_with_services(name, typ, svc, dt_policy)
 
 
 def get_command_id(service: int):

--- a/tests/resources/db_conf.py
+++ b/tests/resources/db_conf.py
@@ -170,7 +170,7 @@ class DbConf:
                         hid += 1
                     connection.commit()
 
-    def create_ba_with_services(self, name:str, typ:str, svc:[(str,str)]):
+    def create_ba_with_services(self, name:str, typ:str, svc:[(str,str)], dt_policy):
         connection = pymysql.connect(host=DB_HOST,
                                      user=DB_USER,
                                      password=DB_PASS,
@@ -184,7 +184,14 @@ class DbConf:
             elif typ == 'worst':
                 t = 2
             with connection.cursor() as cursor:
-                cursor.execute("INSERT INTO mod_bam (name, state_source, activate,id_reporting_period,level_w,level_c,id_notification_period,notifications_enabled,event_handler_enabled, inherit_kpi_downtimes) VALUES ('{}',{},'1',1, 80, 70, 1,'0', '0','1')".format(name, t))
+                if dt_policy == "inherit":
+                    inherit_dt = 1
+                elif dt_policy == "ignore":
+                    inherit_dt = 2
+                else:
+                    inherit_dt = 0
+
+                cursor.execute("INSERT INTO mod_bam (name, state_source, activate,id_reporting_period,level_w,level_c,id_notification_period,notifications_enabled,event_handler_enabled, inherit_kpi_downtimes) VALUES ('{}',{},'1',1, 80, 70, 1,'0', '0','{}')".format(name, t, inherit_dt))
                 id_ba = cursor.lastrowid
                 sid = self.engine.create_bam_service("ba_{}".format(id_ba), name, "_Module_BAM_1", "centreon-bam-check!{}".format(id_ba))
                 cursor.execute("INSERT INTO service (service_id, service_description, display_name, service_active_checks_enabled, service_passive_checks_enabled,service_register) VALUES ({0}, \"ba_{1}\",\"{2}\",'2','2','2')".format(sid, id_ba, name))


### PR DESCRIPTION
## Description

When a service kpi has several downtimes, when the first one is cancelled, they are all cancelled.
This patch fixes this issue.

REFS: MON-14091

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
