### PR TITLE
MON-14166 add grpc compression and fix bbdo negotiate compression

### DIFF
--- a/bbdo/CMakeLists.txt
+++ b/bbdo/CMakeLists.txt
@@ -1,82 +1,82 @@
-##
-## Copyright 2021 Centreon
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##     http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-##
-## For more information : contact@centreon.com
-##
+# #
+# # Copyright 2021 Centreon
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+# #
+# # For more information : contact@centreon.com
+# #
 
 set(protobuf_files
-    rebuild_message
-    remove_graph_message
-    service
-    host
-    severity
-    tag
-    welcome
-   )
+  rebuild_message
+  remove_graph_message
+  service
+  host
+  severity
+  tag
+  welcome
+)
 
 foreach(name IN LISTS protobuf_files)
-    set(proto_file "${name}.proto")
-    set(full_proto_file "${CMAKE_SOURCE_DIR}/bbdo/${name}.proto")
-    add_custom_command(OUTPUT "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc" "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h"
-        DEPENDS ${full_proto_file}
-        COMMENT "Generating interface files of the bbdo file ${proto_file}"
-        COMMAND ${Protobuf_PROTOC_EXECUTABLE}
-        ARGS --cpp_out=${CMAKE_SOURCE_DIR}/bbdo --proto_path=${CMAKE_SOURCE_DIR}/bbdo ${proto_file}
-        VERBATIM
-        )
+  set(proto_file "${name}.proto")
+  set(full_proto_file "${CMAKE_SOURCE_DIR}/bbdo/${name}.proto")
+  add_custom_command(OUTPUT "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc" "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h"
+    DEPENDS ${full_proto_file}
+    COMMENT "Generating interface files of the bbdo file ${proto_file}"
+    COMMAND ${Protobuf_PROTOC_EXECUTABLE}
+    ARGS --cpp_out=${CMAKE_SOURCE_DIR}/bbdo --proto_path=${CMAKE_SOURCE_DIR}/bbdo ${proto_file}
+    VERBATIM
+  )
 
-    add_custom_target("target_${name}" DEPENDS "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc" "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h")
+  add_custom_target("target_${name}" DEPENDS "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc" "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h")
 endforeach()
 
 add_library(
-    pb_welcome_lib STATIC
-      welcome.pb.cc
-      welcome.pb.h
-    )
+  pb_welcome_lib STATIC
+  welcome.pb.cc
+  welcome.pb.h
+)
 add_dependencies(pb_welcome_lib target_welcome)
 set_target_properties(pb_welcome_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_library(
-    pb_service_lib STATIC
-      service.pb.cc
-      service.pb.h
-    )
-add_dependencies(pb_service_lib target_service)
+  pb_service_lib STATIC
+  service.pb.cc
+  service.pb.h
+)
+add_dependencies(pb_service_lib target_service pb_tag_lib)
 set_target_properties(pb_service_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_library(
-    pb_host_lib STATIC
-      host.pb.cc
-      host.pb.h
-    )
+  pb_host_lib STATIC
+  host.pb.cc
+  host.pb.h
+)
 add_dependencies(pb_host_lib target_host)
 set_target_properties(pb_host_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_library(
-    pb_severity_lib STATIC
-      severity.pb.cc
-      severity.pb.h
-    )
+  pb_severity_lib STATIC
+  severity.pb.cc
+  severity.pb.h
+)
 add_dependencies(pb_severity_lib target_host)
 set_target_properties(pb_severity_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_library(
-    pb_tag_lib STATIC
-      tag.pb.cc
-      tag.pb.h
-    )
+  pb_tag_lib STATIC
+  tag.pb.cc
+  tag.pb.h
+)
 add_dependencies(pb_tag_lib target_host)
 set_target_properties(pb_tag_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
@@ -84,87 +84,87 @@ macro(get_protobuf_files name)
   set_source_files_properties("${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc" PROPERTIES GENERATED TRUE)
   set_source_files_properties("${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h" PROPERTIES GENERATED TRUE)
   set(proto_${name}
-      "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc"
-      "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h")
+    "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc"
+    "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h")
 endmacro()
 
 macro(get_protobuf_accessor name)
-    set(proto_file "${name}.proto")
-    set(full_proto_file "${CMAKE_SOURCE_DIR}/bbdo/${name}.proto")
-    add_custom_command(OUTPUT "${CMAKE_SOURCE_DIR}/bbdo/${name}_accessor.hh"
-        DEPENDS ${full_proto_file}
-        COMMENT "Generating accessor to protobuf message ${proto_file}"
-        COMMAND python3
-        ARGS ${full_proto_file}
-        VERBATIM
-        )
+  set(proto_file "${name}.proto")
+  set(full_proto_file "${CMAKE_SOURCE_DIR}/bbdo/${name}.proto")
+  add_custom_command(OUTPUT "${CMAKE_SOURCE_DIR}/bbdo/${name}_accessor.hh"
+    DEPENDS ${full_proto_file}
+    COMMENT "Generating accessor to protobuf message ${proto_file}"
+    COMMAND python3
+    ARGS ${full_proto_file}
+    VERBATIM
+  )
 endmacro()
 
 include_directories("${CMAKE_SOURCE_DIR}/broker/core/inc")
 
 add_library(
-    bbdo_bbdo STATIC
-      "bbdo/ack.cc"
-      "bbdo/version_response.cc"
-      "bbdo/stop.cc"
-      "bbdo/ack.hh"
-      "bbdo/version_response.hh"
-      "bbdo/stop.hh"
-    )
+  bbdo_bbdo STATIC
+  "bbdo/ack.cc"
+  "bbdo/version_response.cc"
+  "bbdo/stop.cc"
+  "bbdo/ack.hh"
+  "bbdo/version_response.hh"
+  "bbdo/stop.hh"
+)
 set_target_properties(bbdo_bbdo PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_precompile_headers(bbdo_bbdo PRIVATE precomp_inc/precomp.hpp)
 
 add_library(
-    bbdo_storage STATIC
-      "storage/index_mapping.cc"
-      "storage/metric_mapping.cc"
-      "storage/metric.cc"
-      "storage/rebuild.cc"
-      "storage/remove_graph.cc"
-      "storage/status.cc"
-      "storage/metric.hh"
-      "storage/rebuild.hh"
-      "storage/remove_graph.hh"
-      "storage/status.hh"
-    )
+  bbdo_storage STATIC
+  "storage/index_mapping.cc"
+  "storage/metric_mapping.cc"
+  "storage/metric.cc"
+  "storage/rebuild.cc"
+  "storage/remove_graph.cc"
+  "storage/status.cc"
+  "storage/metric.hh"
+  "storage/rebuild.hh"
+  "storage/remove_graph.hh"
+  "storage/status.hh"
+)
 set_target_properties(bbdo_storage PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_precompile_headers(bbdo_storage PRIVATE precomp_inc/precomp.hpp)
 add_dependencies(bbdo_storage table_max_size)
 add_library(
-    bbdo_bam STATIC
-      "bam/ba_duration_event.cc"
-      "bam/dimension_ba_bv_relation_event.hh"
-      "bam/dimension_kpi_event.cc"
-      "bam/dimension_timeperiod.hh"
-      "bam/kpi_status.cc"
-      "bam/ba_duration_event.hh"
-      "bam/dimension_ba_event.cc"
-      "bam/dimension_kpi_event.hh"
-      "bam/dimension_truncate_table_signal.cc"
-      "bam/kpi_status.hh"
-      "bam/ba_event.cc"
-      "bam/dimension_ba_event.hh"
-      "bam/dimension_timeperiod.cc"
-      "bam/dimension_truncate_table_signal.hh"
-      "bam/rebuild.cc"
-      "bam/ba_event.hh"
-      "bam/dimension_ba_timeperiod_relation.cc"
-      "bam/dimension_timeperiod_exception.cc"
-      "bam/inherited_downtime.cc"
-      "bam/rebuild.hh"
-      "bam/ba_status.cc"
-      "bam/dimension_ba_timeperiod_relation.hh"
-      "bam/dimension_timeperiod_exception.hh"
-      "bam/inherited_downtime.hh"
-      "bam/ba_status.hh"
-      "bam/dimension_bv_event.cc"
-      "bam/dimension_timeperiod_exclusion.cc"
-      "bam/kpi_event.cc"
-      "bam/dimension_ba_bv_relation_event.cc"
-      "bam/dimension_bv_event.hh"
-      "bam/dimension_timeperiod_exclusion.hh"
-      "bam/kpi_event.hh"
-    )
+  bbdo_bam STATIC
+  "bam/ba_duration_event.cc"
+  "bam/dimension_ba_bv_relation_event.hh"
+  "bam/dimension_kpi_event.cc"
+  "bam/dimension_timeperiod.hh"
+  "bam/kpi_status.cc"
+  "bam/ba_duration_event.hh"
+  "bam/dimension_ba_event.cc"
+  "bam/dimension_kpi_event.hh"
+  "bam/dimension_truncate_table_signal.cc"
+  "bam/kpi_status.hh"
+  "bam/ba_event.cc"
+  "bam/dimension_ba_event.hh"
+  "bam/dimension_timeperiod.cc"
+  "bam/dimension_truncate_table_signal.hh"
+  "bam/rebuild.cc"
+  "bam/ba_event.hh"
+  "bam/dimension_ba_timeperiod_relation.cc"
+  "bam/dimension_timeperiod_exception.cc"
+  "bam/inherited_downtime.cc"
+  "bam/rebuild.hh"
+  "bam/ba_status.cc"
+  "bam/dimension_ba_timeperiod_relation.hh"
+  "bam/dimension_timeperiod_exception.hh"
+  "bam/inherited_downtime.hh"
+  "bam/ba_status.hh"
+  "bam/dimension_bv_event.cc"
+  "bam/dimension_timeperiod_exclusion.cc"
+  "bam/kpi_event.cc"
+  "bam/dimension_ba_bv_relation_event.cc"
+  "bam/dimension_bv_event.hh"
+  "bam/dimension_timeperiod_exclusion.hh"
+  "bam/kpi_event.hh"
+)
 set_target_properties(bbdo_bam PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_precompile_headers(bbdo_bam PRIVATE precomp_inc/precomp.hpp)
 add_dependencies(bbdo_bam table_max_size)

--- a/broker/core/precomp_inc/precomp.hpp
+++ b/broker/core/precomp_inc/precomp.hpp
@@ -58,4 +58,6 @@
 
 #include <asio.hpp>
 
+#include <boost/algorithm/string.hpp>
+
 #endif

--- a/broker/core/src/bbdo/stream.cc
+++ b/broker/core/src/bbdo/stream.cc
@@ -909,14 +909,15 @@ void stream::negotiate(stream::negotiation_type neg) {
         for (std::map<std::string, io::protocols::protocol>::const_iterator
                  proto_it = io::protocols::instance().begin(),
                  proto_end = io::protocols::instance().end();
-             proto_it != proto_end; ++proto_it)
-          if (proto_it->first == ext->name()) {
+             proto_it != proto_end; ++proto_it) {
+          if (boost::iequals(proto_it->first, ext->name())) {
             std::shared_ptr<io::stream> s{
                 proto_it->second.endpntfactry->new_stream(
                     _substream, neg == negotiate_second, ext->options())};
             set_substream(s);
             break;
           }
+        }
       } else
         log_v2::bbdo()->info("BBDO: extension '{}' already configured",
                              ext->name());

--- a/broker/core/src/config/applier/endpoint.cc
+++ b/broker/core/src/config/applier/endpoint.cc
@@ -413,6 +413,8 @@ std::shared_ptr<io::endpoint> endpoint::_create_endpoint(config::endpoint& cfg,
       }
       endp = std::shared_ptr<io::endpoint>(
           it->second.endpntfactry->new_endpoint(cfg, is_acceptor, cache));
+      log_v2::config()->info(" create endpoint {} for endpoint '{}'", it->first,
+                             cfg.name);
       level = it->second.osi_to + 1;
       break;
     }
@@ -433,6 +435,8 @@ std::shared_ptr<io::endpoint> endpoint::_create_endpoint(config::endpoint& cfg,
           (it->second.endpntfactry->has_endpoint(cfg, nullptr))) {
         std::shared_ptr<io::endpoint> current(
             it->second.endpntfactry->new_endpoint(cfg, is_acceptor));
+        log_v2::config()->info(" create endpoint {} for endpoint '{}'",
+                               it->first, cfg.name);
         current->from(endp);
         endp = current;
         level = it->second.osi_to;

--- a/broker/grpc/inc/com/centreon/broker/grpc/channel.hh
+++ b/broker/grpc/inc/com/centreon/broker/grpc/channel.hh
@@ -55,6 +55,15 @@ struct detail_centreon_event {
 
 const std::string authorization_header("authorization");
 
+constexpr uint32_t calc_accept_all_compression_mask() {
+  uint32_t ret = 0;
+  for (size_t algo_ind = 0; algo_ind < GRPC_COMPRESS_ALGORITHMS_COUNT;
+       algo_ind++) {
+    ret += (1u << algo_ind);
+  }
+  return ret;
+}
+
 /**
  * @brief base class of grpc communication final class server or client
  *

--- a/broker/grpc/inc/com/centreon/broker/grpc/grpc_config.hh
+++ b/broker/grpc/inc/com/centreon/broker/grpc/grpc_config.hh
@@ -26,31 +26,42 @@ class grpc_config {
   std::string _hostport;
   bool _crypted;
   std::string _certificate, _cert_key, _ca_cert, _authorization;
+  grpc_compression_level _compress_level;
 
  public:
   using pointer = std::shared_ptr<grpc_config>;
 
-  grpc_config() : _crypted(false) {}
-  grpc_config(const std::string& hostp) : _hostport(hostp), _crypted(false) {}
+  grpc_config() : _crypted(false), _compress_level(GRPC_COMPRESS_LEVEL_NONE) {}
+  grpc_config(const std::string& hostp)
+      : _hostport(hostp),
+        _crypted(false),
+        _compress_level(GRPC_COMPRESS_LEVEL_NONE) {}
   grpc_config(const std::string& hostp,
               bool crypted,
               const std::string& certificate,
               const std::string& cert_key,
               const std::string& ca_cert,
-              const std::string& authorization)
+              const std::string& authorization,
+              grpc_compression_level compress_level)
       : _hostport(hostp),
         _crypted(crypted),
         _certificate(certificate),
         _cert_key(cert_key),
         _ca_cert(ca_cert),
-        _authorization(authorization) {}
+        _authorization(authorization),
+        _compress_level(compress_level) {}
 
-  const std::string& get_hostport() const { return _hostport; }
-  bool is_crypted() const { return _crypted; }
-  const std::string& get_cert() const { return _certificate; }
-  const std::string& get_key() const { return _cert_key; }
-  const std::string& get_ca() const { return _ca_cert; }
-  const std::string& get_authorization() const { return _authorization; }
+  constexpr const std::string& get_hostport() const { return _hostport; }
+  constexpr bool is_crypted() const { return _crypted; }
+  constexpr const std::string& get_cert() const { return _certificate; }
+  constexpr const std::string& get_key() const { return _cert_key; }
+  constexpr const std::string& get_ca() const { return _ca_cert; }
+  constexpr const std::string& get_authorization() const {
+    return _authorization;
+  }
+  constexpr grpc_compression_level get_compress_level() const {
+    return _compress_level;
+  }
 
   friend class factory;
 };

--- a/broker/grpc/src/client.cc
+++ b/broker/grpc/src/client.cc
@@ -37,6 +37,21 @@ client::client(const grpc_config::pointer& conf)
   args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 30000);
   args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 10000);
   args.SetInt(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA, 0);
+  if (conf->get_compress_level() != GRPC_COMPRESS_LEVEL_NONE) {
+    grpc_compression_algorithm algo = grpc_compression_algorithm_for_level(
+        conf->get_compress_level(), calc_accept_all_compression_mask());
+    if (algo != GRPC_COMPRESS_NONE) {
+      const char* algo_name;
+      if (grpc_compression_algorithm_name(algo, &algo_name)) {
+        log_v2::grpc()->debug("client this={:p} activate compression {}",
+                              static_cast<void*>(this), algo_name);
+      } else {
+        log_v2::grpc()->debug("client this={:p} activate compression unknown",
+                              static_cast<void*>(this));
+      }
+      args.SetCompressionAlgorithm(algo);
+    }
+  }
   std::shared_ptr<::grpc::ChannelCredentials> creds;
 #ifdef USE_TLS
   if (conf->is_crypted()) {

--- a/broker/grpc/test/factory_test.cc
+++ b/broker/grpc/test/factory_test.cc
@@ -17,9 +17,7 @@
  *
  */
 
-#include <mutex>
-
-#include <gtest/gtest.h>
+#include "grpc_test_include.hh"
 
 using system_clock = std::chrono::system_clock;
 using time_point = system_clock::time_point;
@@ -34,7 +32,7 @@ using namespace com::centreon::exceptions;
 using namespace com::centreon::broker;
 
 TEST(grpc_factory, HasEndpoint) {
-  grpc::factory fact;
+  com::centreon::broker::grpc::factory fact;
   config::endpoint cfg(config::endpoint::io_type::output);
 
   cfg.type = "grpc";
@@ -44,7 +42,7 @@ TEST(grpc_factory, HasEndpoint) {
 }
 
 TEST(grpc_factory, Exception) {
-  grpc::factory fact;
+  com::centreon::broker::grpc::factory fact;
   config::endpoint cfg(config::endpoint::io_type::output);
   bool is_acceptor;
   std::shared_ptr<persistent_cache> cache;
@@ -53,7 +51,7 @@ TEST(grpc_factory, Exception) {
 }
 
 TEST(grpc_factory, Acceptor) {
-  grpc::factory fact;
+  com::centreon::broker::grpc::factory fact;
   config::endpoint cfg(config::endpoint::io_type::output);
   bool is_acceptor;
   std::shared_ptr<persistent_cache> cache;
@@ -69,7 +67,7 @@ TEST(grpc_factory, Acceptor) {
 }
 
 TEST(grpc_factory, BadPort) {
-  grpc::factory fact;
+  com::centreon::broker::grpc::factory fact;
   config::endpoint cfg(config::endpoint::io_type::output);
   bool is_acceptor;
   std::shared_ptr<persistent_cache> cache;
@@ -81,7 +79,7 @@ TEST(grpc_factory, BadPort) {
 }
 
 TEST(grpc_factory, BadHost) {
-  grpc::factory fact;
+  com::centreon::broker::grpc::factory fact;
   config::endpoint cfg(config::endpoint::io_type::output);
   bool is_acceptor;
   std::shared_ptr<persistent_cache> cache;
@@ -96,7 +94,7 @@ TEST(grpc_factory, BadHost) {
 }
 
 TEST(grpc_factory, Connector) {
-  grpc::factory fact;
+  com::centreon::broker::grpc::factory fact;
   config::endpoint cfg(config::endpoint::io_type::output);
   bool is_acceptor;
   std::shared_ptr<persistent_cache> cache;
@@ -104,7 +102,7 @@ TEST(grpc_factory, Connector) {
   cfg.type = "grpc";
   cfg.params["port"] = "4444";
   cfg.params["host"] = "127.0.0.1";
-  std::unique_ptr<io::factory> f{new grpc::factory};
+  std::unique_ptr<io::factory> f{new com::centreon::broker::grpc::factory};
   ASSERT_TRUE(f->has_endpoint(cfg, nullptr));
   std::unique_ptr<io::endpoint> endp{
       fact.new_endpoint(cfg, is_acceptor, cache)};

--- a/broker/grpc/test/grpc_test_include.hh
+++ b/broker/grpc/test/grpc_test_include.hh
@@ -34,6 +34,7 @@
 
 #include "../src/grpc_stream.pb.h"
 
+#include <grpc/impl/codegen/compression_types.h>
 #include <grpcpp/create_channel.h>
 
 using system_clock = std::chrono::system_clock;

--- a/broker/grpc/test/stream_test.cc
+++ b/broker/grpc/test/stream_test.cc
@@ -24,12 +24,14 @@ using namespace com::centreon::broker;
 using namespace com::centreon::exceptions;
 
 com::centreon::broker::grpc::grpc_config::pointer conf(
-    std::make_shared<com::centreon::broker::grpc::grpc_config>("127.0.0.1:4444",
-                                                               false,
-                                                               "",
-                                                               "",
-                                                               "",
-                                                               "my_aut"));
+    std::make_shared<com::centreon::broker::grpc::grpc_config>(
+        "127.0.0.1:4444",
+        false,
+        "",
+        "",
+        "",
+        "my_aut",
+        GRPC_COMPRESS_LEVEL_NONE));
 
 static constexpr unsigned relay_listen_port = 5123u;
 static constexpr unsigned server_listen_port = 5124u;
@@ -336,7 +338,8 @@ com::centreon::broker::grpc::grpc_config::pointer conf_crypted_server1234(
         read_file("tests/grpc_test_keys/server_1234.crt"),
         read_file("tests/grpc_test_keys/server_1234.key"),
         read_file("tests/grpc_test_keys/ca_1234.crt"),
-        "my_auth"));
+        "my_auth",
+        GRPC_COMPRESS_LEVEL_NONE));
 
 com::centreon::broker::grpc::grpc_config::pointer conf_crypted_client1234(
     std::make_shared<com::centreon::broker::grpc::grpc_config>(
@@ -345,7 +348,8 @@ com::centreon::broker::grpc::grpc_config::pointer conf_crypted_client1234(
         read_file("tests/grpc_test_keys/client_1234.crt"),
         read_file("tests/grpc_test_keys/client_1234.key"),
         read_file("tests/grpc_test_keys/ca_1234.crt"),
-        "my_auth"));
+        "my_auth",
+        GRPC_COMPRESS_LEVEL_NONE));
 
 class grpc_test_server_crypted : public ::testing::TestWithParam<test_param> {
  protected:
@@ -406,7 +410,8 @@ com::centreon::broker::grpc::grpc_config::pointer
             read_file("tests/grpc_test_keys/client_1234.crt"),
             read_file("tests/grpc_test_keys/client_1234.key"),
             read_file("tests/grpc_test_keys/ca_1234.crt"),
-            "my_auth_pasbon"));
+            "my_auth_pasbon",
+            GRPC_COMPRESS_LEVEL_NONE));
 
 TEST_P(grpc_test_server_crypted, ServerToClientWithKeyAndBadAuthorization) {
   com::centreon::broker::grpc::stream client(conf_crypted_client1234_bad_auth);

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -5,7 +5,7 @@ fmt/8.1.1
 spdlog/1.10.0
 nlohmann_json/3.10.5
 openssl/1.1.1n
-grpc/1.43.0
+grpc/1.46.3
 mariadb-connector-c/3.1.12
 zlib/1.2.12
 boost/1.79.0
@@ -16,6 +16,13 @@ cmake
 
 [options]
 grpc:secure=True
+grpc:csharp_ext=False
+grpc:csharp_plugin=False
+grpc:node_plugin=False
+grpc:objective_c_plugin=False
+grpc:php_plugin=False
+grpc:python_plugin=True
+grpc:ruby_plugin=False
 boost:header_only=True
 libssh2:shared=False
 

--- a/tests/broker-engine/external-commands.robot
+++ b/tests/broker-engine/external-commands.robot
@@ -2309,3 +2309,46 @@ BEEXTCMD_REVERSE_GRPC4
 		Stop Engine
 		Kindly Stop Broker
 	END
+
+
+BEEXTCMD_COMPRESS_GRPC1
+	[Documentation]	external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo3.0 and compressed grpc
+	[Tags]	Broker	Engine	services	extcmd
+	Config Engine	${1}	${50}	${20}
+	Config Broker	rrd
+	Config Broker	central
+	Config Broker	module	${1}
+	Change Broker tcp output to grpc	module0
+	Change Broker tcp input to grpc     central
+	Change Broker Compression Output  module0  central-module-master-output  yes
+	Change Broker Compression Input  central  centreon-broker-master-input  yes
+	Broker Config Add Item	module0	bbdo_version	3.0.0
+	Broker Config Add Item	central	bbdo_version	3.0.0
+	Broker Config Add Item	rrd	bbdo_version	3.0.0
+	Broker Config Log	central	sql	debug
+	Config Broker Sql Output	central	unified_sql
+	FOR  ${use_grpc}  IN RANGE  0  2
+		Log To Console	external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo3.0 use_grpc=${use_grpc}
+		Clear Retention
+		${start}=	Get Current Date
+		Start Broker
+		Start Engine
+			${content}=	Create List	INITIAL SERVICE STATE: host_50;service_1000;
+			${result}=	Find In Log with Timeout	${logEngine0}	${start}	${content}	60
+			Should Be True	${result}	msg=An Initial host state on host_1 should be raised before we can start our external commands.
+		Change Normal Svc Check Interval  ${use_grpc}  host_1	service_1	10
+
+		Connect To Database	pymysql	${DBName}	${DBUser}	${DBPass}	${DBHost}	${DBPort}
+
+		FOR	${index}	IN RANGE	300
+			Log To Console	SELECT s.check_interval FROM services s LEFT JOIN hosts h ON s.host_id=h.host_id WHERE s.description='service_1' AND h.name='host_1'
+			${output}=	Query	SELECT s.check_interval FROM services s LEFT JOIN hosts h ON s.host_id=h.host_id WHERE s.description='service_1' AND h.name='host_1'
+			Log To Console	${output}
+			Sleep	1s
+			EXIT FOR LOOP IF	"${output}" == "((10.0,),)"
+		END
+		Should Be Equal As Strings	${output}	((10.0,),)
+		Stop Engine
+		Kindly Stop Broker
+	END
+

--- a/tests/broker-engine/start-stop.robot
+++ b/tests/broker-engine/start-stop.robot
@@ -185,8 +185,8 @@ BESS_GRPC_COMPRESS1
 	Change Broker tcp output to grpc	module0
 	Change Broker tcp input to grpc     central
 	Change Broker tcp input to grpc     rrd
-	Change Broker Compression Output  module0  yes
-	Change Broker Compression Output  central  yes
+	Change Broker Compression Output  module0  central-module-master-output  yes
+	Change Broker Compression Input  central  centreon-broker-master-input  yes
 	Start Broker
 	Start Engine
 	${result}=	Check Connections


### PR DESCRIPTION
## Description

compression and compression_level are used by grpc stream
compression fields accept yes or no
compression_level must be lower or equal than 3

**Fixes** # (issue)
bbdo compression is inactive even if you configure it

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [X] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>
configure input broker and output broker without encryption, use compression and a tcpdump -i any -s 0 -A port 5669 mustn't return readable output

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

