### PR TITLE
MON-14166 fix bbdo compression nego

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ Default configuration files were not installed on a Debian fresh install.
 
 Don't coredump if connection fail on process start
 
+*Compression*
+In the bbdo negotiation, compression was never activated
+
 #### Enhancements
 
 *downtimes*

--- a/bbdo/CMakeLists.txt
+++ b/bbdo/CMakeLists.txt
@@ -1,73 +1,73 @@
-##
-## Copyright 2021 Centreon
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##     http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-##
-## For more information : contact@centreon.com
-##
+# #
+# # Copyright 2021 Centreon
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+# #
+# # For more information : contact@centreon.com
+# #
 
 set(protobuf_files
-    rebuild_message
-    remove_graph_message
-    service
-    host
-    severity
-    tag
-   )
+  rebuild_message
+  remove_graph_message
+  service
+  host
+  severity
+  tag
+)
 
 foreach(name IN LISTS protobuf_files)
-    set(proto_file "${name}.proto")
-    set(full_proto_file "${CMAKE_SOURCE_DIR}/bbdo/${name}.proto")
-    add_custom_command(OUTPUT "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc" "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h"
-        DEPENDS ${full_proto_file}
-        COMMENT "Generating interface files of the bbdo file ${proto_file}"
-        COMMAND ${Protobuf_PROTOC_EXECUTABLE}
-        ARGS --cpp_out=${CMAKE_SOURCE_DIR}/bbdo --proto_path=${CMAKE_SOURCE_DIR}/bbdo ${proto_file}
-        VERBATIM
-        )
+  set(proto_file "${name}.proto")
+  set(full_proto_file "${CMAKE_SOURCE_DIR}/bbdo/${name}.proto")
+  add_custom_command(OUTPUT "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc" "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h"
+    DEPENDS ${full_proto_file}
+    COMMENT "Generating interface files of the bbdo file ${proto_file}"
+    COMMAND ${Protobuf_PROTOC_EXECUTABLE}
+    ARGS --cpp_out=${CMAKE_SOURCE_DIR}/bbdo --proto_path=${CMAKE_SOURCE_DIR}/bbdo ${proto_file}
+    VERBATIM
+  )
 
-    add_custom_target("target_${name}" DEPENDS "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc" "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h")
+  add_custom_target("target_${name}" DEPENDS "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc" "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h")
 endforeach()
 
 add_library(
-    pb_service_lib STATIC
-      service.pb.cc
-      service.pb.h
-    )
-add_dependencies(pb_service_lib target_service)
+  pb_service_lib STATIC
+  service.pb.cc
+  service.pb.h
+)
+add_dependencies(pb_service_lib target_service pb_tag_lib)
 set_target_properties(pb_service_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_library(
-    pb_host_lib STATIC
-      host.pb.cc
-      host.pb.h
-    )
+  pb_host_lib STATIC
+  host.pb.cc
+  host.pb.h
+)
 add_dependencies(pb_host_lib target_host)
 set_target_properties(pb_host_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_library(
-    pb_severity_lib STATIC
-      severity.pb.cc
-      severity.pb.h
-    )
+  pb_severity_lib STATIC
+  severity.pb.cc
+  severity.pb.h
+)
 add_dependencies(pb_severity_lib target_host)
 set_target_properties(pb_severity_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 add_library(
-    pb_tag_lib STATIC
-      tag.pb.cc
-      tag.pb.h
-    )
+  pb_tag_lib STATIC
+  tag.pb.cc
+  tag.pb.h
+)
 add_dependencies(pb_tag_lib target_host)
 set_target_properties(pb_tag_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
@@ -75,87 +75,87 @@ macro(get_protobuf_files name)
   set_source_files_properties("${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc" PROPERTIES GENERATED TRUE)
   set_source_files_properties("${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h" PROPERTIES GENERATED TRUE)
   set(proto_${name}
-      "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc"
-      "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h")
+    "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc"
+    "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h")
 endmacro()
 
 macro(get_protobuf_accessor name)
-    set(proto_file "${name}.proto")
-    set(full_proto_file "${CMAKE_SOURCE_DIR}/bbdo/${name}.proto")
-    add_custom_command(OUTPUT "${CMAKE_SOURCE_DIR}/bbdo/${name}_accessor.hh"
-        DEPENDS ${full_proto_file}
-        COMMENT "Generating accessor to protobuf message ${proto_file}"
-        COMMAND python3
-        ARGS ${full_proto_file}
-        VERBATIM
-        )
+  set(proto_file "${name}.proto")
+  set(full_proto_file "${CMAKE_SOURCE_DIR}/bbdo/${name}.proto")
+  add_custom_command(OUTPUT "${CMAKE_SOURCE_DIR}/bbdo/${name}_accessor.hh"
+    DEPENDS ${full_proto_file}
+    COMMENT "Generating accessor to protobuf message ${proto_file}"
+    COMMAND python3
+    ARGS ${full_proto_file}
+    VERBATIM
+  )
 endmacro()
 
 include_directories("${CMAKE_SOURCE_DIR}/broker/core/inc")
 
 add_library(
-    bbdo_bbdo STATIC
-      "bbdo/ack.cc"
-      "bbdo/version_response.cc"
-      "bbdo/stop.cc"
-      "bbdo/ack.hh"
-      "bbdo/version_response.hh"
-      "bbdo/stop.hh"
-    )
+  bbdo_bbdo STATIC
+  "bbdo/ack.cc"
+  "bbdo/version_response.cc"
+  "bbdo/stop.cc"
+  "bbdo/ack.hh"
+  "bbdo/version_response.hh"
+  "bbdo/stop.hh"
+)
 set_target_properties(bbdo_bbdo PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_precompile_headers(bbdo_bbdo PRIVATE precomp_inc/precomp.hpp)
 
 add_library(
-    bbdo_storage STATIC
-      "storage/index_mapping.cc"
-      "storage/metric_mapping.cc"
-      "storage/metric.cc"
-      "storage/rebuild.cc"
-      "storage/remove_graph.cc"
-      "storage/status.cc"
-      "storage/metric.hh"
-      "storage/rebuild.hh"
-      "storage/remove_graph.hh"
-      "storage/status.hh"
-    )
+  bbdo_storage STATIC
+  "storage/index_mapping.cc"
+  "storage/metric_mapping.cc"
+  "storage/metric.cc"
+  "storage/rebuild.cc"
+  "storage/remove_graph.cc"
+  "storage/status.cc"
+  "storage/metric.hh"
+  "storage/rebuild.hh"
+  "storage/remove_graph.hh"
+  "storage/status.hh"
+)
 set_target_properties(bbdo_storage PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_precompile_headers(bbdo_storage PRIVATE precomp_inc/precomp.hpp)
 add_dependencies(bbdo_storage table_max_size)
 add_library(
-    bbdo_bam STATIC
-      "bam/ba_duration_event.cc"
-      "bam/dimension_ba_bv_relation_event.hh"
-      "bam/dimension_kpi_event.cc"
-      "bam/dimension_timeperiod.hh"
-      "bam/kpi_status.cc"
-      "bam/ba_duration_event.hh"
-      "bam/dimension_ba_event.cc"
-      "bam/dimension_kpi_event.hh"
-      "bam/dimension_truncate_table_signal.cc"
-      "bam/kpi_status.hh"
-      "bam/ba_event.cc"
-      "bam/dimension_ba_event.hh"
-      "bam/dimension_timeperiod.cc"
-      "bam/dimension_truncate_table_signal.hh"
-      "bam/rebuild.cc"
-      "bam/ba_event.hh"
-      "bam/dimension_ba_timeperiod_relation.cc"
-      "bam/dimension_timeperiod_exception.cc"
-      "bam/inherited_downtime.cc"
-      "bam/rebuild.hh"
-      "bam/ba_status.cc"
-      "bam/dimension_ba_timeperiod_relation.hh"
-      "bam/dimension_timeperiod_exception.hh"
-      "bam/inherited_downtime.hh"
-      "bam/ba_status.hh"
-      "bam/dimension_bv_event.cc"
-      "bam/dimension_timeperiod_exclusion.cc"
-      "bam/kpi_event.cc"
-      "bam/dimension_ba_bv_relation_event.cc"
-      "bam/dimension_bv_event.hh"
-      "bam/dimension_timeperiod_exclusion.hh"
-      "bam/kpi_event.hh"
-    )
+  bbdo_bam STATIC
+  "bam/ba_duration_event.cc"
+  "bam/dimension_ba_bv_relation_event.hh"
+  "bam/dimension_kpi_event.cc"
+  "bam/dimension_timeperiod.hh"
+  "bam/kpi_status.cc"
+  "bam/ba_duration_event.hh"
+  "bam/dimension_ba_event.cc"
+  "bam/dimension_kpi_event.hh"
+  "bam/dimension_truncate_table_signal.cc"
+  "bam/kpi_status.hh"
+  "bam/ba_event.cc"
+  "bam/dimension_ba_event.hh"
+  "bam/dimension_timeperiod.cc"
+  "bam/dimension_truncate_table_signal.hh"
+  "bam/rebuild.cc"
+  "bam/ba_event.hh"
+  "bam/dimension_ba_timeperiod_relation.cc"
+  "bam/dimension_timeperiod_exception.cc"
+  "bam/inherited_downtime.cc"
+  "bam/rebuild.hh"
+  "bam/ba_status.cc"
+  "bam/dimension_ba_timeperiod_relation.hh"
+  "bam/dimension_timeperiod_exception.hh"
+  "bam/inherited_downtime.hh"
+  "bam/ba_status.hh"
+  "bam/dimension_bv_event.cc"
+  "bam/dimension_timeperiod_exclusion.cc"
+  "bam/kpi_event.cc"
+  "bam/dimension_ba_bv_relation_event.cc"
+  "bam/dimension_bv_event.hh"
+  "bam/dimension_timeperiod_exclusion.hh"
+  "bam/kpi_event.hh"
+)
 set_target_properties(bbdo_bam PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_precompile_headers(bbdo_bam PRIVATE precomp_inc/precomp.hpp)
 add_dependencies(bbdo_bam table_max_size)

--- a/broker/core/precomp_inc/precomp.hpp
+++ b/broker/core/precomp_inc/precomp.hpp
@@ -58,4 +58,6 @@
 
 #include <asio.hpp>
 
+#include <boost/algorithm/string.hpp>
+
 #endif

--- a/broker/core/src/bbdo/stream.cc
+++ b/broker/core/src/bbdo/stream.cc
@@ -809,7 +809,7 @@ void stream::negotiate(stream::negotiation_type neg) {
                  proto_it = io::protocols::instance().begin(),
                  proto_end = io::protocols::instance().end();
              proto_it != proto_end; ++proto_it)
-          if (proto_it->first == ext->name()) {
+          if (boost::iequals(proto_it->first, ext->name())) {
             std::shared_ptr<io::stream> s{
                 proto_it->second.endpntfactry->new_stream(
                     _substream, neg == negotiate_second, ext->options())};


### PR DESCRIPTION
## Description

fix compression bug

**Fixes** # (issue)
compression is never activated even if it's configured

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [X] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>
You start an engine and a cbd without compression nor encryption activated. You sniff network traffic with the command "tcpdump -i any -s 0 -A port 5669"
You will see commands executed by engine.
Then you activate compression on both sides, restart cbd and engine and tcpdump won't be readable.

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

