### PR TITLE
MON-14158-Enable-recheck-for-anomaly-detection-service-22.04 backport

### DIFF
--- a/bbdo/CMakeLists.txt
+++ b/bbdo/CMakeLists.txt
@@ -119,7 +119,7 @@ add_library(
   "storage/status.hh"
 )
 set_target_properties(bbdo_storage PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_precompile_headers(bbdo_storage PRIVATE precomp_inc/precomp.hpp)
+target_precompile_headers(bbdo_storage REUSE_FROM bbdo_bbdo)
 add_dependencies(bbdo_storage table_max_size)
 add_library(
   bbdo_bam STATIC
@@ -157,5 +157,5 @@ add_library(
   "bam/kpi_event.hh"
 )
 set_target_properties(bbdo_bam PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_precompile_headers(bbdo_bam PRIVATE precomp_inc/precomp.hpp)
+target_precompile_headers(bbdo_bam REUSE_FROM bbdo_bbdo)
 add_dependencies(bbdo_bam table_max_size)

--- a/broker/neb/CMakeLists.txt
+++ b/broker/neb/CMakeLists.txt
@@ -1,20 +1,20 @@
-##
-## Copyright 2009-2013,2015 Centreon
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##     http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-##
-## For more information : contact@centreon.com
-##
+# #
+# # Copyright 2009-2013,2015 Centreon
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+# #
+# # For more information : contact@centreon.com
+# #
 
 # Global options.
 set(INC_DIR "${PROJECT_SOURCE_DIR}/neb/inc")
@@ -24,6 +24,7 @@ include_directories("${INC_DIR}")
 
 # NEB sources.
 set(NEB_SOURCES
+
   # Sources.
   # Headers.
   ${SRC_DIR}/acknowledgement.cc
@@ -100,20 +101,21 @@ set(NEB_SOURCES
 add_library(nebbase STATIC ${NEB_SOURCES})
 add_dependencies(nebbase table_max_size target_service target_host target_severity target_tag)
 target_link_libraries(nebbase
-    CONAN_PKG::protobuf
-    pb_service_lib
-    pb_host_lib
-    pb_severity_lib
-    pb_tag_lib)
+  CONAN_PKG::protobuf
+  pb_service_lib
+  pb_host_lib
+  pb_severity_lib
+  pb_tag_lib)
 
 set(NEBBASE_CXXFLAGS "${NEBBASE_CXXFLAGS} -fPIC")
 set_property(TARGET nebbase PROPERTY COMPILE_FLAGS ${NEBBASE_CXXFLAGS})
-target_precompile_headers(nebbase PRIVATE precomp_inc/nebbase_precomp.hpp)
+target_precompile_headers(nebbase PRIVATE precomp_inc/precomp.hpp)
 
 # Centreon Broker module.
 set(NEB "10-neb")
 set(NEB "${NEB}" PARENT_SCOPE)
 add_library("${NEB}" SHARED
+
   # Main source.
   "${SRC_DIR}/broker.cc"
   "${SRC_DIR}/node_id.cc"
@@ -126,9 +128,10 @@ add_library("${NEB}" SHARED
 
 # Flags needed to include all symbols in binary.
 target_link_libraries(${NEB} nebbase CONAN_PKG::spdlog)
-#  "-Wl,--whole-archive" nebbase "-Wl,--no-whole-archive")
+
+# "-Wl,--whole-archive" nebbase "-Wl,--no-whole-archive")
 set_target_properties("${NEB}" PROPERTIES PREFIX "")
-target_precompile_headers(${NEB} PRIVATE precomp_inc/neb_precomp.hpp)
+target_precompile_headers(${NEB} REUSE_FROM nebbase)
 install(TARGETS "${NEB}"
   LIBRARY DESTINATION "${PREFIX_MODULES}"
 )
@@ -136,6 +139,7 @@ install(TARGETS "${NEB}"
 # Centreon Engine/Nagios module.
 set(CBMOD "cbmod")
 add_library("${CBMOD}" SHARED
+
   # Sources.
   "${PROJECT_SOURCE_DIR}/core/src/config/applier/init.cc"
   "${SRC_DIR}/callback.cc"
@@ -144,6 +148,7 @@ add_library("${CBMOD}" SHARED
   "${SRC_DIR}/internal.cc"
   "${SRC_DIR}/neb.cc"
   "${SRC_DIR}/set_log_data.cc"
+
   # Headers.
   "${INC_DIR}/com/centreon/broker/neb/callback.hh"
   "${INC_DIR}/com/centreon/broker/neb/callbacks.hh"
@@ -157,52 +162,54 @@ get_property(CBMOD_DEFINES
 list(APPEND CBMOD_DEFINES CBMOD)
 set_property(TARGET "${CBMOD}"
   PROPERTY COMPILE_DEFINITIONS "${CBMOD_DEFINES}")
-if (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # Flags needed to include all symbols in shared library.
   target_link_libraries("${CBMOD}"
     "-Wl,--whole-archive" "rokerbase" "-Wl,--no-whole-archive" CONAN_PKG::nlohmann_json CONAN_PKG::spdlog CONAN_PKG::asio)
-else ()
+else()
   target_link_libraries("${CBMOD}" "rokerbase" CONAN_PKG::nlohmann_json CONAN_PKG::spdlog CONAN_PKG::asio)
-endif ()
-set_target_properties("${CBMOD}" PROPERTIES PREFIX "")
-target_precompile_headers(${CBMOD} PRIVATE precomp_inc/precomp.hpp)
+endif()
 
+set_target_properties("${CBMOD}" PROPERTIES PREFIX "")
+target_precompile_headers(${CBMOD} REUSE_FROM nebbase)
 
 # Testing.
-if (WITH_TESTING)
+if(WITH_TESTING)
   set(
-      TESTS_SOURCES
-      ${TESTS_SOURCES}
-      ${SRC_DIR}/set_log_data.cc
-      #Actual tests
-      ${TEST_DIR}/custom_variable.cc
-      ${TEST_DIR}/custom_variable_status.cc
-      ${TEST_DIR}/event_handler.cc
-      ${TEST_DIR}/flapping_status.cc
-      ${TEST_DIR}/host.cc
-      ${TEST_DIR}/host_check.cc
-      ${TEST_DIR}/host_dependency.cc
-      ${TEST_DIR}/host_parent.cc
-      ${TEST_DIR}/host_status.cc
-      ${TEST_DIR}/instance.cc
-      ${TEST_DIR}/instance_status.cc
-      ${TEST_DIR}/log_entry.cc
-      ${TEST_DIR}/module.cc
-      ${TEST_DIR}/randomize.cc
-      ${TEST_DIR}/randomize.hh
-      ${TEST_DIR}/service.cc
-      ${TEST_DIR}/service_check.cc
-      ${TEST_DIR}/service_dependency.cc
-      ${TEST_DIR}/service_status.cc
-      ${TEST_DIR}/set_log_data.cc
-      PARENT_SCOPE
-     )
+    TESTS_SOURCES
+    ${TESTS_SOURCES}
+    ${SRC_DIR}/set_log_data.cc
+
+    # Actual tests
+    ${TEST_DIR}/custom_variable.cc
+    ${TEST_DIR}/custom_variable_status.cc
+    ${TEST_DIR}/event_handler.cc
+    ${TEST_DIR}/flapping_status.cc
+    ${TEST_DIR}/host.cc
+    ${TEST_DIR}/host_check.cc
+    ${TEST_DIR}/host_dependency.cc
+    ${TEST_DIR}/host_parent.cc
+    ${TEST_DIR}/host_status.cc
+    ${TEST_DIR}/instance.cc
+    ${TEST_DIR}/instance_status.cc
+    ${TEST_DIR}/log_entry.cc
+    ${TEST_DIR}/module.cc
+    ${TEST_DIR}/randomize.cc
+    ${TEST_DIR}/randomize.hh
+    ${TEST_DIR}/service.cc
+    ${TEST_DIR}/service_check.cc
+    ${TEST_DIR}/service_dependency.cc
+    ${TEST_DIR}/service_status.cc
+    ${TEST_DIR}/set_log_data.cc
+    PARENT_SCOPE
+  )
   set(
-      TESTS_LIBRARIES
-      ${TESTS_LIBRARIES}
-      ${NEB}
-      PARENT_SCOPE
-     )
+    TESTS_LIBRARIES
+    ${TESTS_LIBRARIES}
+    ${NEB}
+    PARENT_SCOPE
+  )
 endif()
 
 # Install rules.

--- a/broker/neb/precomp_inc/precomp.hpp
+++ b/broker/neb/precomp_inc/precomp.hpp
@@ -37,6 +37,7 @@
 #include <absl/strings/string_view.h>
 
 #include <boost/circular_buffer.hpp>
+#include <boost/container/flat_map.hpp>
 #include <boost/optional.hpp>
 
 #include <asio.hpp>

--- a/clib/inc/com/centreon/timestamp.hh
+++ b/clib/inc/com/centreon/timestamp.hh
@@ -21,6 +21,7 @@
 
 #include <cstdint>
 #include <ctime>
+#include <ostream>
 #include "com/centreon/namespace.hh"
 
 CC_BEGIN()
@@ -39,6 +40,8 @@ class timestamp {
  public:
   timestamp(time_t secs = 0, int32_t usecs = 0);
   timestamp(const timestamp& right);
+  timestamp(const struct timeval& right)
+      : _secs(right.tv_sec), _usecs(right.tv_usec) {}
   ~timestamp() noexcept = default;
   timestamp& operator=(const timestamp& right);
   bool operator==(const timestamp& right) const noexcept;
@@ -65,6 +68,8 @@ class timestamp {
   time_t to_seconds() const noexcept;
   int64_t to_useconds() const noexcept;
 };
+
+std::ostream& operator<<(std::ostream& s, const timestamp& to_dump);
 
 CC_END()
 

--- a/clib/src/timestamp.cc
+++ b/clib/src/timestamp.cc
@@ -319,3 +319,18 @@ time_t timestamp::to_seconds() const noexcept {
 int64_t timestamp::to_useconds() const noexcept {
   return _secs * 1000000ll + _usecs;
 }
+
+CC_BEGIN()
+
+std::ostream& operator<<(std::ostream& s, const timestamp& to_dump) {
+  struct tm tmp;
+  time_t seconds = to_dump.to_seconds();
+  localtime_r(&seconds, &tmp);
+  char buf[80];
+  strftime(buf, sizeof(buf), "%c: ", &tmp);
+  s << buf;
+
+  return s;
+}
+
+CC_END()

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1,21 +1,21 @@
-##
-## Copyright 2011-2021 Centreon
-##
-## This file is part of Centreon Engine.
-##
-## Centreon Engine is free software: you can redistribute it and/or
-## modify it under the terms of the GNU General Public License version 2
-## as published by the Free Software Foundation.
-##
-## Centreon Engine is distributed in the hope that it will be useful,
-## but WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-## General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with Centreon Engine. If not, see
-## <http://www.gnu.org/licenses/>.
-##
+# #
+# # Copyright 2011-2021 Centreon
+# #
+# # This file is part of Centreon Engine.
+# #
+# # Centreon Engine is free software: you can redistribute it and/or
+# # modify it under the terms of the GNU General Public License version 2
+# # as published by the Free Software Foundation.
+# #
+# # Centreon Engine is distributed in the hope that it will be useful,
+# # but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# # General Public License for more details.
+# #
+# # You should have received a copy of the GNU General Public License
+# # along with Centreon Engine. If not, see
+# # <http://www.gnu.org/licenses/>.
+# #
 
 #
 # Global settings.
@@ -25,18 +25,19 @@
 project("Centreon Engine" C CXX)
 
 # set -latomic if OS is Raspbian.
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
   set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
-endif ()
+endif()
 
 # With libasan
 option(WITH_ASAN "Add the libasan to check memory leaks and other memory issues." OFF)
-if (WITH_ASAN)
+
+if(WITH_ASAN)
   set(CMAKE_BUILD_TYPE Debug)
-  set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
-  set (CMAKE_LINKER_FLAGS_DEBUG
-       "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
-endif ()
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+  set(CMAKE_LINKER_FLAGS_DEBUG
+    "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+endif()
 
 set(INC_DIR "${PROJECT_SOURCE_DIR}/inc")
 set(SCRIPT_DIR "${PROJECT_SOURCE_DIR}/scripts")
@@ -51,11 +52,12 @@ include_directories("${INC_DIR}/compatibility")
 link_directories(${CMAKE_SOURCE_DIR}/build/centreon-clib/)
 
 # Version.
-if (CENTREON_ENGINE_PRERELEASE)
+if(CENTREON_ENGINE_PRERELEASE)
   set(CENTREON_ENGINE_VERSION "${COLLECT_MAJOR}.${COLLECT_MINOR}.${COLLECT_PATCH}-${CENTREON_ENGINE_PRERELEASE}")
-else ()
+else()
   set(CENTREON_ENGINE_VERSION "${COLLECT_MAJOR}.${COLLECT_MINOR}.${COLLECT_PATCH}")
 endif()
+
 message(STATUS "Generating version header (${CENTREON_ENGINE_VERSION}).")
 configure_file("${INC_DIR}/com/centreon/engine/version.hh.in"
   "${INC_DIR}/com/centreon/engine/version.hh")
@@ -68,73 +70,80 @@ configure_file("${INC_DIR}/com/centreon/engine/version.hh.in"
 include(CheckLibraryExists)
 message(STATUS "Checking for libm.")
 check_library_exists("m" "ceil" "${CMAKE_LIBRARY_PATH}" MATH_LIB_FOUND)
-if (MATH_LIB_FOUND)
+
+if(MATH_LIB_FOUND)
   set(MATH_LIBRARIES "m")
-endif ()
+endif()
+
 message(STATUS "Checking for libnsl.")
 check_library_exists("nsl" "getservbyname" "${CMAKE_LIBRARY_PATH}" NSL_LIB_FOUND)
-if (NSL_LIB_FOUND)
+
+if(NSL_LIB_FOUND)
   set(NSL_LIBRARIES "nsl")
-endif ()
+endif()
+
 message(STATUS "Checking for libsocket.")
 check_library_exists("socket" "connect" "${CMAKE_LIBRARY_PATH}" SOCKET_LIB_FOUND)
-if (SOCKET_LIB_FOUND)
+
+if(SOCKET_LIB_FOUND)
   set(SOCKET_LIBRARIES "socket")
-endif ()
+endif()
 
 # Find pthreads.
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 include(FindThreads)
-if (NOT CMAKE_USE_PTHREADS_INIT)
+
+if(NOT CMAKE_USE_PTHREADS_INIT)
   message(FATAL_ERROR "Could not find pthread's library.")
-endif ()
+endif()
+
 set(PTHREAD_LIBRARIES "${CMAKE_THREAD_LIBS_INIT}")
 
-## Find Centreon Clib's headers.
-#if (WITH_CENTREON_CLIB_INCLUDE_DIR)
-#  find_file(
-#    CLIB_HEADER_FOUND
-#    "com/centreon/clib/version.hh"
-#    PATHS "${WITH_CENTREON_CLIB_INCLUDE_DIR}"
-#    NO_DEFAULT_PATH)
-#  if (NOT CLIB_HEADER_FOUND)
-#    message(FATAL_ERROR "Could not find Centreon Clib's headers in ${WITH_CENTREON_CLIB_INCLUDE_DIR}.")
-#  endif ()
-#  set(CLIB_INCLUDE_DIR "${WITH_CENTREON_CLIB_INCLUDE_DIR}")
-#elseif (CLIB_FOUND) # Was Centreon Clib detected with pkg-config ?
-#  if (CMAKE_CXX_FLAGS)
-#    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLIB_CFLAGS}")
-#  else ()
-#    set(CMAKE_CXX_FLAGS "${CLIB_CFLAGS}")
-#  endif ()
-#else ()
-#  find_path(CLIB_INCLUDE_DIR "com/centreon/clib/version.hh" PATH_SUFFIXES "centreon-clib")
-#  if (NOT CLIB_INCLUDE_DIR)
-#    message(FATAL_ERROR "Could not find Centreon Clib's headers (try WITH_CENTREON_CLIB_INCLUDE_DIR).")
-#  endif ()
-#endif ()
+# # Find Centreon Clib's headers.
+# if (WITH_CENTREON_CLIB_INCLUDE_DIR)
+# find_file(
+# CLIB_HEADER_FOUND
+# "com/centreon/clib/version.hh"
+# PATHS "${WITH_CENTREON_CLIB_INCLUDE_DIR}"
+# NO_DEFAULT_PATH)
+# if (NOT CLIB_HEADER_FOUND)
+# message(FATAL_ERROR "Could not find Centreon Clib's headers in ${WITH_CENTREON_CLIB_INCLUDE_DIR}.")
+# endif ()
+# set(CLIB_INCLUDE_DIR "${WITH_CENTREON_CLIB_INCLUDE_DIR}")
+# elseif (CLIB_FOUND) # Was Centreon Clib detected with pkg-config ?
+# if (CMAKE_CXX_FLAGS)
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLIB_CFLAGS}")
+# else ()
+# set(CMAKE_CXX_FLAGS "${CLIB_CFLAGS}")
+# endif ()
+# else ()
+# find_path(CLIB_INCLUDE_DIR "com/centreon/clib/version.hh" PATH_SUFFIXES "centreon-clib")
+# if (NOT CLIB_INCLUDE_DIR)
+# message(FATAL_ERROR "Could not find Centreon Clib's headers (try WITH_CENTREON_CLIB_INCLUDE_DIR).")
+# endif ()
+# endif ()
 include_directories(${CMAKE_SOURCE_DIR}/clib/inc)
 
-## Find Centreon Clib's library.
-#if (WITH_CENTREON_CLIB_LIBRARIES)
-#  set(CLIB_LIBRARIES "${WITH_CENTREON_CLIB_LIBRARIES}")
-#elseif (WITH_CENTREON_CLIB_LIBRARY_DIR)
-#  find_library(
-#    CLIB_LIBRARIES
-#    "centreon_clib"
-#    PATHS "${WITH_CENTREON_CLIB_LIBRARY_DIR}"
-#    NO_DEFAULT_PATH)
-#  if (NOT CLIB_LIBRARIES)
-#    message(FATAL_ERROR "Could not find Centreon Clib's library in ${WITH_CENTREON_CLIB_LIBRARY_DIR}.")
-#  endif ()
-#elseif (CLIB_FOUND) # Was Centreon Clib detected with pkg-config ?
-#  set(CLIB_LIBRARIES "${CLIB_LDFLAGS}")
-#else ()
-#  find_library(CLIB_LIBRARIES "centreon_clib")
-#  if (NOT CLIB_LIBRARIES)
-#    message(FATAL_ERROR "Could not find Centreon Clib's library (try WITH_CENTREON_CLIB_LIBRARY_DIR or WITH_CENTREON_CLIB_LIBRARIES).")
-#  endif ()
-#endif ()
+# # Find Centreon Clib's library.
+# if (WITH_CENTREON_CLIB_LIBRARIES)
+# set(CLIB_LIBRARIES "${WITH_CENTREON_CLIB_LIBRARIES}")
+# elseif (WITH_CENTREON_CLIB_LIBRARY_DIR)
+# find_library(
+# CLIB_LIBRARIES
+# "centreon_clib"
+# PATHS "${WITH_CENTREON_CLIB_LIBRARY_DIR}"
+# NO_DEFAULT_PATH)
+# if (NOT CLIB_LIBRARIES)
+# message(FATAL_ERROR "Could not find Centreon Clib's library in ${WITH_CENTREON_CLIB_LIBRARY_DIR}.")
+# endif ()
+# elseif (CLIB_FOUND) # Was Centreon Clib detected with pkg-config ?
+# set(CLIB_LIBRARIES "${CLIB_LDFLAGS}")
+# else ()
+# find_library(CLIB_LIBRARIES "centreon_clib")
+# if (NOT CLIB_LIBRARIES)
+# message(FATAL_ERROR "Could not find Centreon Clib's library (try WITH_CENTREON_CLIB_LIBRARY_DIR or WITH_CENTREON_CLIB_LIBRARIES).")
+# endif ()
+# endif ()
 
 # Check functions.
 include(CheckIncludeFileCXX)
@@ -143,21 +152,26 @@ include(CheckStructHasMember)
 
 message(STATUS "Checking for tm_zone member in tm struct.")
 check_struct_has_member("tm" "tm_zone" "time.h" HAVE_TM_ZONE)
-if (HAVE_TM_ZONE)
+
+if(HAVE_TM_ZONE)
   add_definitions(-DHAVE_TM_ZONE)
-endif ()
+endif()
+
 include(CheckSymbolExists)
 message(STATUS "Checking for symbol tzname.")
 check_symbol_exists("tzname" "time.h" HAVE_TZNAME)
-if (HAVE_TZNAME)
+
+if(HAVE_TZNAME)
   add_definitions(-DHAVE_TZNAME)
-endif ()
+endif()
+
 message(STATUS "Checking for function getopt_long.")
 check_include_file_cxx("getopt.h" HAVE_GETOPT_H)
 check_function_exists("getopt_long" HAVE_GETOPT_LONG)
-if (HAVE_GETOPT_H AND HAVE_GETOPT_LONG)
+
+if(HAVE_GETOPT_H AND HAVE_GETOPT_LONG)
   add_definitions(-DHAVE_GETOPT_H)
-endif ()
+endif()
 
 #
 # Options.
@@ -172,60 +186,59 @@ set(CREATE_FILES "${WITH_CREATE_FILES}")
 
 set(PREFIX_ENGINE_CONF "${CMAKE_INSTALL_FULL_SYSCONFDIR}/centreon-engine")
 
-## Library directory.
-#if (WITH_PREFIX_LIB_ENGINE)
-#  set(PREFIX_LIB "${WITH_PREFIX_LIB_ENGINE}")
-#else ()
-#  set(PREFIX_LIB "${CMAKE_INSTALL_PREFIX}/lib/centreon-engine")
-#endif ()
+# # Library directory.
+# if (WITH_PREFIX_LIB_ENGINE)
+# set(PREFIX_LIB "${WITH_PREFIX_LIB_ENGINE}")
+# else ()
+# set(PREFIX_LIB "${CMAKE_INSTALL_PREFIX}/lib/centreon-engine")
+# endif ()
 #
 
-
 # User used to run Centreon Engine.
-if (WITH_USER_ENGINE)
+if(WITH_USER_ENGINE)
   set(USER "${WITH_USER_ENGINE}")
-else ()
+else()
   set(USER "root")
-endif ()
+endif()
 
 # Group used to run Centreon Engine.
-if (WITH_GROUP_ENGINE)
+if(WITH_GROUP_ENGINE)
   set(GROUP "${WITH_GROUP_ENGINE}")
-else ()
+else()
   set(GROUP "root")
-endif ()
+endif()
 
 # Set startup script to auto if not define.
-if (NOT WITH_STARTUP_SCRIPT)
+if(NOT WITH_STARTUP_SCRIPT)
   set(WITH_STARTUP_SCRIPT "auto")
-endif ()
+endif()
 
 # Check which startup script to use.
-if (WITH_STARTUP_SCRIPT STREQUAL "auto")
-  if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    if (OS_DISTRIBUTOR STREQUAL "Ubuntu")
+if(WITH_STARTUP_SCRIPT STREQUAL "auto")
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if(OS_DISTRIBUTOR STREQUAL "Ubuntu")
       set(WITH_STARTUP_SCRIPT "upstart")
-    else ()
+    else()
       set(WITH_STARTUP_SCRIPT "sysv")
-    endif ()
-  else ()
+    endif()
+  else()
     message(STATUS "Centreon Engine does not provide startup script for ${CMAKE_SYSTEM_NAME}.")
-  endif ()
-endif ()
+  endif()
+endif()
 
 # Create upstart file.
-if (WITH_STARTUP_SCRIPT STREQUAL "upstart")
+if(WITH_STARTUP_SCRIPT STREQUAL "upstart")
   # Generate Upstart script.
   message(STATUS "Generating upstart script.")
   configure_file("${SCRIPT_DIR}/upstart.conf.in"
     "${SCRIPT_DIR}/upstart.conf")
 
   # Startup dir.
-  if (WITH_STARTUP_DIR)
+  if(WITH_STARTUP_DIR)
     set(STARTUP_DIR "${WITH_STARTUP_DIR}")
-  else ()
+  else()
     set(STARTUP_DIR "/etc/init")
-  endif ()
+  endif()
 
   # Script install rule.
   install(FILES "${SCRIPT_DIR}/upstart.conf"
@@ -237,27 +250,29 @@ if (WITH_STARTUP_SCRIPT STREQUAL "upstart")
   set(STARTUP_SCRIPT "Upstart configuration file")
 
 # Create SysV start script.
-elseif (WITH_STARTUP_SCRIPT STREQUAL "sysv")
+elseif(WITH_STARTUP_SCRIPT STREQUAL "sysv")
   # Lock file.
-  if (WITH_LOCK_FILE)
+  if(WITH_LOCK_FILE)
     set(LOCK_FILE "${WITH_LOCK_FILE}")
-  else ()
-    if (OS_DISTRIBUTOR STREQUAL "Ubuntu"
-	OR OS_DISTRIBUTOR STREQUAL "Debian"
-	OR OS_DISTRIBUTOR STREQUAL "SUSE LINUX")
+  else()
+    if(OS_DISTRIBUTOR STREQUAL "Ubuntu"
+      OR OS_DISTRIBUTOR STREQUAL "Debian"
+      OR OS_DISTRIBUTOR STREQUAL "SUSE LINUX")
       set(LOCK_FILE "/var/lock/centengine.lock")
-    else ()
+    else()
       set(LOCK_FILE "/var/lock/subsys/centengine.lock")
-    endif ()
-  endif ()
+    endif()
+  endif()
+
   string(REGEX REPLACE "/[^/]*$" "" LOCK_DIR "${LOCK_FILE}")
 
   # PID file.
-  if (WITH_PID_FILE)
+  if(WITH_PID_FILE)
     set(PID_FILE "${WITH_PID_FILE}")
-  else ()
+  else()
     set(PID_FILE "/var/run/centengine.pid")
-  endif ()
+  endif()
+
   string(REGEX REPLACE "/[^/]*$" "" PID_DIR "${PID_FILE}")
 
   # Generate SysV script.
@@ -266,11 +281,11 @@ elseif (WITH_STARTUP_SCRIPT STREQUAL "sysv")
     "${SCRIPT_DIR}/centengine.sh")
 
   # Startup dir.
-  if (WITH_STARTUP_DIR)
+  if(WITH_STARTUP_DIR)
     set(STARTUP_DIR "${WITH_STARTUP_DIR}")
-  else ()
+  else()
     set(STARTUP_DIR "/etc/init.d")
-  endif ()
+  endif()
 
   # Script install rule.
   install(PROGRAMS "${SCRIPT_DIR}/centengine.sh"
@@ -282,18 +297,18 @@ elseif (WITH_STARTUP_SCRIPT STREQUAL "sysv")
   set(STARTUP_SCRIPT "SysV-style script")
 
 # Create Systemd start script.
-elseif (WITH_STARTUP_SCRIPT STREQUAL "systemd")
+elseif(WITH_STARTUP_SCRIPT STREQUAL "systemd")
   # Generate Systemd script.
   message(STATUS "Generating systemd startup script.")
   configure_file("${SCRIPT_DIR}/centengine.service.in"
     "${SCRIPT_DIR}/centengine.service")
 
   # Startup dir.
-  if (WITH_STARTUP_DIR)
+  if(WITH_STARTUP_DIR)
     set(STARTUP_DIR "${WITH_STARTUP_DIR}")
-  else ()
+  else()
     set(STARTUP_DIR "/etc/systemd/system")
-  endif ()
+  endif()
 
   # Script install rule.
   install(PROGRAMS "${SCRIPT_DIR}/centengine.service"
@@ -303,33 +318,35 @@ elseif (WITH_STARTUP_SCRIPT STREQUAL "systemd")
   # String printed in summary.
   set(STARTUP_SCRIPT "Systemd script")
 
-else ()
+else()
   # Default.
   message(STATUS "Invalid value for option WITH_STARTUP_SCRIPT (must be one of 'auto', 'sysv' or 'upstart').")
   set(STARTUP_SCRIPT "disabled")
-endif ()
+endif()
 
 # logrotate directory.
 option(WITH_ENGINE_LOGROTATE_SCRIPT "Generate and install logrotate script." OFF)
-if (WITH_ENGINE_LOGROTATE_SCRIPT)
+
+if(WITH_ENGINE_LOGROTATE_SCRIPT)
   # Generate logrotate file.
   message(STATUS "Generating logrorate file.")
-  if (WITH_STARTUP_SCRIPT STREQUAL "upstart")
+
+  if(WITH_STARTUP_SCRIPT STREQUAL "upstart")
     configure_file(
       "${SCRIPT_DIR}/logrotate_upstart.conf.in"
       "${SCRIPT_DIR}/logrotate.conf"
       @ONLY)
-  elseif (WITH_STARTUP_SCRIPT STREQUAL "systemd")
+  elseif(WITH_STARTUP_SCRIPT STREQUAL "systemd")
     configure_file(
       "${SCRIPT_DIR}/logrotate_systemd.conf.in"
       "${SCRIPT_DIR}/logrotate.conf"
       @ONLY)
-  else ()
+  else()
     configure_file(
       "${SCRIPT_DIR}/logrotate_sysv.conf.in"
       "${SCRIPT_DIR}/logrotate.conf"
       @ONLY)
-  endif ()
+  endif()
 
   # logrotate file install directory.
   set(LOGROTATE_DIR "${CMAKE_INSTALL_FULL_SYSCONFDIR}/logrotate.d")
@@ -340,30 +357,33 @@ if (WITH_ENGINE_LOGROTATE_SCRIPT)
     DESTINATION "${LOGROTATE_DIR}"
     COMPONENT "runtime"
     RENAME "centengine"
-    )
-endif ()
+  )
+endif()
 
 option(WITH_SHARED_LIB "Define if the core library is to be build as a shared object or a static library." OFF)
-if (WITH_SHARED_LIB)
+
+if(WITH_SHARED_LIB)
   set(LIBRARY_TYPE SHARED)
-else ()
+else()
   set(LIBRARY_TYPE STATIC)
-endif ()
+endif()
 
 # Simumod module to simulate cbmod and catch its output
 option(WITH_SIMU "Add a module only used for tests to see data that cbmod should receive" OFF)
-if (WITH_SIMU)
+
+if(WITH_SIMU)
   set(CMAKE_BUILD_TYPE "Debug")
   add_subdirectory(src/simumod)
-endif ()
+endif()
 
 # DEBUG_CONFIG enables checks on configuration. Those checks are not free and
 # may slow down engine reloads. But it provides a way to check bugs in
 # the configuration system.
 option(WITH_DEBUG_CONFIG "Enables checks on configuration. This is an option for developers." OFF)
-if (WITH_DEBUG_CONFIG)
+
+if(WITH_DEBUG_CONFIG)
   add_definitions(-DDEBUG_CONFIG)
-endif ()
+endif()
 
 # Configure files.
 configure_file("${INC_DIR}/compatibility/common.h.in"
@@ -379,14 +399,13 @@ add_definitions(-DDEFAULT_COMMAND_FILE="${ENGINE_VAR_LIB_DIR}/rw/centengine.cmd"
 add_definitions(-DDEFAULT_CONFIG_FILE="${PREFIX_ENGINE_CONF}/centengine.cfg")
 
 # Add specific linker flags for Mac OS to build correctly shared libraries.
-if (APPLE)
+if(APPLE)
   set(CMAKE_SHARED_LINKER_FLAGS "-Wl,-undefined -Wl,dynamic_lookup")
-endif ()
+endif()
 
 #
 # Targets.
 #
-
 set(
   FILES
 
@@ -496,9 +515,11 @@ set(
 # Subdirectories with core features.
 add_subdirectory(src/broker)
 add_subdirectory(src/checks)
-if (WITH_CONF)
+
+if(WITH_CONF)
   add_subdirectory(conf)
-endif ()
+endif()
+
 add_subdirectory(src/downtimes)
 add_subdirectory(src/configuration)
 add_subdirectory(src/commands)
@@ -519,7 +540,6 @@ add_dependencies(cce_core centreon_clib)
 
 target_precompile_headers(cce_core PRIVATE ${PRECOMP_HEADER})
 
-
 # Link target with required libraries.
 target_link_libraries(cce_core CONAN_PKG::nlohmann_json
   ${MATH_LIBRARIES}
@@ -536,7 +556,7 @@ set_property(TARGET "centengine" PROPERTY ENABLE_EXPORTS "1")
 add_dependencies(centengine centreon_clib)
 
 # Link centengine with required libraries.
-target_link_libraries(centengine "-export-dynamic" centreon_clib "-Wl,-whole-archive" enginerpc cce_core  "-Wl,-no-whole-archive" -L${CONAN_LIB_DIRS_GRPC} "-Wl,--whole-archive" grpc++ "-Wl,--no-whole-archive" CONAN_PKG::grpc ${absl_LIBS} CONAN_PKG::openssl ${c-ares_LIBS} CONAN_PKG::zlib dl)
+target_link_libraries(centengine "-export-dynamic" centreon_clib "-Wl,-whole-archive" enginerpc cce_core "-Wl,-no-whole-archive" -L${CONAN_LIB_DIRS_GRPC} "-Wl,--whole-archive" grpc++ "-Wl,--no-whole-archive" CONAN_PKG::grpc ${absl_LIBS} CONAN_PKG::openssl ${c-ares_LIBS} CONAN_PKG::zlib dl)
 
 # centenginestats target.
 add_executable("centenginestats" "${SRC_DIR}/centenginestats.cc")
@@ -556,8 +576,8 @@ install(TARGETS "centengine" "centenginestats"
   DESTINATION "${CMAKE_INSTALL_FULL_SBINDIR}"
   COMPONENT "runtime")
 
-## Create directories.
-if (CREATE_FILES)
+# # Create directories.
+if(CREATE_FILES)
   install(CODE "
   function(mkdir_chown user group path)
     if (APPLE OR (UNIX AND NOT CYGWIN))
@@ -598,7 +618,7 @@ if (CREATE_FILES)
   touch_chown(\"${USER}\" \"${GROUP}\" \"${ENGINE_VAR_LOG_DIR}/centengine.debug\")
   touch_chown(\"${USER}\" \"${GROUP}\" \"${ENGINE_VAR_LOG_DIR}/retention.dat\")
   ")
-endif ()
+endif()
 
 # Install header files for development.
 install(DIRECTORY "${INC_DIR}/"
@@ -611,13 +631,11 @@ install(DIRECTORY "${INC_DIR}/"
 #
 # Packaging.
 #
-
 include(cmake/package.cmake)
 
 #
 # Print summary.
 #
-
 message(STATUS "")
 message(STATUS "")
 message(STATUS "Configuration Summary")
@@ -635,47 +653,59 @@ message(STATUS "")
 message(STATUS "  Build")
 message(STATUS "    - Compiler                    ${CMAKE_CXX_COMPILER} (${CMAKE_CXX_COMPILER_ID})")
 message(STATUS "    - Extra compilation flags     ${CMAKE_CXX_FLAGS}")
-if (WITH_SHARED_LIB)
+
+if(WITH_SHARED_LIB)
   message(STATUS "    - Build static core library   no")
-else ()
+else()
   message(STATUS "    - Build static core library   yes")
-endif ()
+endif()
+
 message(STATUS "    - External commands module    enabled")
-if (WITH_TESTING)
+
+if(WITH_TESTING)
   message(STATUS "    - Unit tests                  enabled")
-  if (WITH_COVERAGE)
+
+  if(WITH_COVERAGE)
     message(STATUS "    - Code coverage               enabled")
-  else ()
+  else()
     message(STATUS "    - Code coverage               disabled")
-  endif ()
-else ()
+  endif()
+else()
   message(STATUS "    - Unit tests                  disabled")
-endif ()
-if (WITH_ENGINE_LOGROTATE_SCRIPT)
+endif()
+
+if(WITH_ENGINE_LOGROTATE_SCRIPT)
   message(STATUS "    - logrotate script            enabled")
-else ()
+else()
   message(STATUS "    - logrotate script            disabled")
-endif ()
+endif()
+
 message(STATUS "    - Startup script              ${STARTUP_SCRIPT}")
 message(STATUS "")
 message(STATUS "  Install")
-#message(STATUS "    - Prefix                      ${CMAKE_INSTALL_PREFIX}")
+
+# message(STATUS "    - Prefix                      ${CMAKE_INSTALL_PREFIX}")
 message(STATUS "    - Binary prefix               ${CMAKE_INSTALL_FULL_SBINDIR}")
 message(STATUS "    - Configuration prefix        ${PREFIX_ENGINE_CONF}")
-#message(STATUS "    - Library prefix              ${PREFIX_LIB}")
+
+# message(STATUS "    - Library prefix              ${PREFIX_LIB}")
 message(STATUS "    - Include prefix              ${CMAKE_INSTALL_FULL_INCLUDEDIR}/centreon-engine")
 message(STATUS "    - var directory               ${VAR_DIR}")
 message(STATUS "    - Log archive directory       ${ENGINE_VAR_LOG_ARCHIVE_DIR}")
 message(STATUS "    - RW directory                ${ENGINE_VAR_LIB_DIR}/rw")
-if (LOCK_FILE)
+
+if(LOCK_FILE)
   message(STATUS "    - Lock prefix                 ${LOCK_FILE}")
-endif ()
-if (WITH_ENGINE_LOGROTATE_SCRIPT)
+endif()
+
+if(WITH_ENGINE_LOGROTATE_SCRIPT)
   message(STATUS "    - logrotate directory         ${LOGROTATE_DIR}")
-endif ()
-if (STARTUP_DIR)
+endif()
+
+if(STARTUP_DIR)
   message(STATUS "    - Startup directory           ${STARTUP_DIR}")
-endif ()
+endif()
+
 message(STATUS "    - User                        ${USER}")
 message(STATUS "    - Group                       ${GROUP}")
 message(STATUS "    - Package                     ${PACKAGE_LIST}")

--- a/engine/enginerpc/engine_impl.cc
+++ b/engine/enginerpc/engine_impl.cc
@@ -2671,7 +2671,7 @@ grpc::Status engine_impl::ChangeHostObjectCharVar(
         break;
       case ChangeObjectChar_Mode_CHANGE_CHECK_COMMAND:
         temp_host->set_check_command(request->charval());
-        temp_host->set_check_command_ptr(cmd_found->second.get());
+        temp_host->set_check_command_ptr(cmd_found->second);
         attr = MODATTR_CHECK_COMMAND;
         /* send data to event broker */
         broker_adaptive_host_data(NEBTYPE_ADAPTIVEHOST_UPDATE, NEBFLAG_NONE,
@@ -2778,7 +2778,7 @@ grpc::Status engine_impl::ChangeServiceObjectCharVar(
       attr = MODATTR_EVENT_HANDLER_COMMAND;
     } else if (request->mode() == ChangeObjectChar_Mode_CHANGE_CHECK_COMMAND) {
       temp_service->set_check_command(request->charval());
-      temp_service->set_check_command_ptr(cmd_found->second.get());
+      temp_service->set_check_command_ptr(cmd_found->second);
       attr = MODATTR_CHECK_COMMAND;
     } else if (request->mode() ==
                ChangeObjectChar_Mode_CHANGE_CHECK_TIMEPERIOD) {

--- a/engine/enginerpc/precomp_inc/precomp.hh
+++ b/engine/enginerpc/precomp_inc/precomp.hh
@@ -28,6 +28,7 @@
 #include <absl/strings/string_view.h>
 
 #include <boost/circular_buffer.hpp>
+#include <boost/container/flat_map.hpp>
 #include <boost/optional.hpp>
 
 #endif  // CCE_PRECOMP_HH

--- a/engine/inc/com/centreon/engine/anomalydetection.hh
+++ b/engine/inc/com/centreon/engine/anomalydetection.hh
@@ -81,9 +81,12 @@ class anomalydetection : public service {
   void set_dependent_service(service* svc);
   void set_metric_name(std::string const& name);
   void set_thresholds_file(std::string const& file);
-  void set_thresholds(
-      const std::string& filename,
-      std::map<time_t, std::pair<double, double> >&& thresholds) noexcept;
+
+  void set_thresholds_lock(const std::string& filename,
+                           const nlohmann::json& thresholds);
+  void set_thresholds_no_lock(const std::string& filename,
+                              const nlohmann::json& thresholds);
+
   static int update_thresholds(const std::string& filename);
   virtual int run_async_check(int check_options,
                               double latency,
@@ -91,9 +94,11 @@ class anomalydetection : public service {
                               bool reschedule_check,
                               bool* time_is_valid,
                               time_t* preferred_time) noexcept override;
-  commands::command* get_check_command_ptr() const;
-  std::tuple<service::service_state, double, std::string, double, double>
-  parse_perfdata(std::string const& perfdata, time_t check_time);
+  int handle_async_check_result(
+      const check_result& queued_check_result) override;
+  bool parse_perfdata(std::string const& perfdata,
+                      time_t check_time,
+                      check_result& calculated_result);
   void init_thresholds();
   void set_status_change(bool status_change);
   const std::string& get_metric_name() const;

--- a/engine/inc/com/centreon/engine/check_result.hh
+++ b/engine/inc/com/centreon/engine/check_result.hh
@@ -31,11 +31,13 @@ CCE_BEGIN()
 class notifier;
 class check_result {
  public:
-  check_result() = delete;
+  using pointer = std::shared_ptr<check_result>;
+
+  check_result();
   check_result(enum check_source object_check_type,
                notifier* notifier,
                enum checkable::check_type check_type,
-               int check_options,
+               unsigned check_options,
                bool reschedule_check,
                double latency,
                struct timeval start_time,
@@ -44,41 +46,42 @@ class check_result {
                bool exited_ok,
                int return_code,
                std::string const& output);
-  check_result(check_result const&) = delete;
-  check_result(check_result&&) = delete;
-  check_result& operator=(check_result const&) = delete;
 
-  enum check_source get_object_check_type() const;
+  inline enum check_source get_object_check_type() const {
+    return _object_check_type;
+  }
   void set_object_check_type(enum check_source object_check_type);
-  notifier* get_notifier();
+  inline notifier* get_notifier() { return _notifier; }
   void set_notifier(notifier* notifier);
-  struct timeval get_finish_time() const;
+  inline struct timeval get_finish_time() const { return _finish_time; }
   void set_finish_time(struct timeval finish_time);
-  struct timeval get_start_time() const;
+  inline struct timeval get_start_time() const { return _start_time; }
   void set_start_time(struct timeval start_time);
-  int get_return_code() const;
+  inline int get_return_code() const { return _return_code; }
   void set_return_code(int return_code);
-  bool get_early_timeout() const;
+  inline bool get_early_timeout() const { return _early_timeout; }
   void set_early_timeout(bool early_timeout);
-  std::string const& get_output() const;
+  inline const std::string& get_output() const { return _output; }
   void set_output(std::string const& output);
-  bool get_exited_ok() const;
+  inline bool get_exited_ok() const { return _exited_ok; }
   void set_exited_ok(bool exited_ok);
-  bool get_reschedule_check() const;
+  inline bool get_reschedule_check() const { return _reschedule_check; }
   void set_reschedule_check(bool reschedule_check);
-  enum checkable::check_type get_check_type() const;
+  inline enum checkable::check_type get_check_type() const {
+    return _check_type;
+  };
   void set_check_type(enum checkable::check_type check_type);
-  double get_latency() const;
+  inline double get_latency() const { return _latency; };
   void set_latency(double latency);
-  int get_check_options() const;
-  void set_check_options(int check_options);
+  inline unsigned get_check_options() const { return _check_options; };
+  void set_check_options(unsigned check_options);
 
  private:
   enum check_source _object_check_type;  // is this a service or a host check?
   notifier* _notifier;
   // was this an active or passive service check?
   enum checkable::check_type _check_type;
-  int _check_options;
+  unsigned _check_options;
   bool _reschedule_check;  // should we reschedule the next check
   double _latency;
   struct timeval _start_time;   // time the service check was initiated

--- a/engine/inc/com/centreon/engine/checkable.hh
+++ b/engine/inc/com/centreon/engine/checkable.hh
@@ -158,8 +158,11 @@ class checkable {
   virtual bool is_in_downtime() const = 0;
   void set_event_handler_ptr(commands::command* cmd);
   commands::command* get_event_handler_ptr() const;
-  void set_check_command_ptr(commands::command* cmd);
-  commands::command* get_check_command_ptr() const;
+  void set_check_command_ptr(const std::shared_ptr<commands::command>& cmd);
+  inline const std::shared_ptr<commands::command>& get_check_command_ptr()
+      const {
+    return _check_command_ptr;
+  }
   bool get_is_executing() const;
   void set_is_executing(bool is_executing);
   void set_severity(std::shared_ptr<severity> sv);
@@ -214,7 +217,7 @@ class checkable {
   enum state_type _state_type;
   double _percent_state_change;
   commands::command* _event_handler_ptr;
-  commands::command* _check_command_ptr;
+  std::shared_ptr<commands::command> _check_command_ptr;
   bool _is_executing;
   std::shared_ptr<severity> _severity;
   uint64_t _icon_id;

--- a/engine/inc/com/centreon/engine/checks/checker.hh
+++ b/engine/inc/com/centreon/engine/checks/checker.hh
@@ -38,7 +38,7 @@ class checker : public commands::command_listener {
 
  public:
   static checker& instance();
-  static void init();
+  static void init(bool used_by_test = false);
   static void deinit();
 
   void clear() noexcept;
@@ -48,12 +48,15 @@ class checker : public commands::command_listener {
                 int check_options,
                 int use_cached_result,
                 unsigned long check_timestamp_horizon);
-  void add_check_result(uint64_t id, check_result* result) noexcept;
-  void add_check_result_to_reap(check_result* result) noexcept;
+  void add_check_result(uint64_t id,
+                        const check_result::pointer result) noexcept;
+  void add_check_result_to_reap(const check_result::pointer result) noexcept;
   static void forget(notifier* n) noexcept;
 
+  void wait_completion();
+
  private:
-  checker();
+  checker(bool used_by_test);
   checker(checker const& right);
   ~checker() noexcept override;
   checker& operator=(checker const& right);
@@ -66,19 +69,26 @@ class checker : public commands::command_listener {
    * Here is the list of prepared check results but with a command being
    * running. When the command will be finished, each check result is get back
    * updated and moved to _to_reap_partial list. */
-  std::unordered_map<uint64_t, check_result*> _waiting_check_result;
+  std::unordered_map<uint64_t, check_result::pointer> _waiting_check_result;
   /* This queue is filled during a cycle. When it is time to reap, its elements
    * are passed to _to_reap. It can then be filled in parallel during the
    * _to_reap treatment. */
-  std::deque<check_result*> _to_reap_partial;
+  std::deque<check_result::pointer> _to_reap_partial;
   /*
    * The list of check_results to reap: they contain data that have to be
    * translated to services/hosts. */
-  std::deque<check_result*> _to_reap;
+  std::deque<check_result::pointer> _to_reap;
 
   /* Due to reloads of centengine we have the following list with notifiers
    * that should be forgotten if notifiers are removed. */
   std::deque<notifier*> _to_forget;
+
+  /**
+   * used only for test in order to wait for completion
+   */
+  const bool _used_by_test;
+  std::condition_variable _finish_cond;
+  bool _finished;
 };
 }  // namespace checks
 

--- a/engine/inc/com/centreon/engine/commands/command.hh
+++ b/engine/inc/com/centreon/engine/commands/command.hh
@@ -49,11 +49,43 @@ class command {
  protected:
   static uint64_t get_uniq_id();
 
+  std::mutex _lock;
   std::string _command_line;
   command_listener* _listener;
   std::string _name;
 
+  /**
+   * @brief the goal of this structure is to ensure that checks shared by
+   * anomalydetection and service are not called to often
+   *
+   */
+  struct last_call {
+    using pointer = std::shared_ptr<last_call>;
+    time_t launch_time;
+    std::shared_ptr<result> res;
+
+    last_call() : launch_time(0) {}
+  };
+
+  /**
+   * @brief this map is used to group service and anomalydetection in order to
+   * insure that both don't call check too often
+   *
+   */
+  using caller_to_last_call_map = std::map<const void*, last_call::pointer>;
+  caller_to_last_call_map _result_cache;
+
+  using cmdid_to_last_call_map = std::map<uint64_t, last_call::pointer>;
+  cmdid_to_last_call_map _current;
+
+  bool gest_call_interval(uint64_t command_id,
+                          const check_result::pointer& to_push_to_checker,
+                          const void* caller);
+  void update_result_cache(uint64_t command_id, const result& res);
+
  public:
+  using pointer = std::shared_ptr<command>;
+
   command(const std::string& name,
           const std::string& command_line,
           command_listener* listener = nullptr);
@@ -67,15 +99,41 @@ class command {
   virtual std::string process_cmd(nagios_macros* macros) const;
   virtual uint64_t run(const std::string& processed_cmd,
                        nagios_macros& macors,
-                       uint32_t timeout) = 0;
+                       uint32_t timeout,
+                       const check_result::pointer& to_push_to_checker,
+                       const void* caller = nullptr) = 0;
   virtual void run(const std::string& process_cmd,
                    nagios_macros& macros,
                    uint32_t timeout,
                    result& res) = 0;
+
+  template <typename caller_iterator>
+  void add_caller_group(caller_iterator begin, caller_iterator end);
+  void remove_caller(void* caller);
+
   virtual void set_command_line(const std::string& command_line);
   void set_listener(command_listener* listener) noexcept;
   static command_map commands;
 };
+
+template <typename caller_iterator>
+void command::add_caller_group(caller_iterator begin, caller_iterator end) {
+  last_call::pointer obj{std::make_shared<last_call>()};
+
+  std::unique_lock<std::mutex> l(_lock);
+  for (; begin != end; ++begin) {
+    const void* caller = static_cast<const void*>(*begin);
+    _result_cache[caller] = obj;
+  }
+}
+
+std::ostream& operator<<(std::ostream& s, const command& cmd);
+
+inline std::ostream& operator<<(std::ostream& s, const command::pointer& cmd) {
+  s << *cmd;
+  return s;
+}
+
 }  // namespace commands
 
 CCE_END()

--- a/engine/inc/com/centreon/engine/commands/connector.hh
+++ b/engine/inc/com/centreon/engine/commands/connector.hh
@@ -127,7 +127,9 @@ class connector : public command, public process_listener {
   connector& operator=(const connector&) = delete;
   uint64_t run(std::string const& processed_cmd,
                nagios_macros& macros,
-               uint32_t timeout) override;
+               uint32_t timeout,
+               const check_result::pointer& to_push_to_checker,
+               const void* caller = nullptr) override;
   void run(std::string const& processed_cmd,
            nagios_macros& macros,
            uint32_t timeout,

--- a/engine/inc/com/centreon/engine/commands/forward.hh
+++ b/engine/inc/com/centreon/engine/commands/forward.hh
@@ -45,7 +45,9 @@ class forward : public command {
   forward& operator=(const forward&) = delete;
   uint64_t run(const std::string& processed_cmd,
                nagios_macros& macros,
-               uint32_t timeout) override;
+               uint32_t timeout,
+               const check_result::pointer& to_push_to_checker,
+               const void* caller = nullptr) override;
   void run(const std::string& processed_cmd,
            nagios_macros& macros,
            uint32_t timeout,

--- a/engine/inc/com/centreon/engine/commands/raw.hh
+++ b/engine/inc/com/centreon/engine/commands/raw.hh
@@ -36,7 +36,6 @@ class environment;
  *  Raw is a specific implementation of command.
  */
 class raw : public command, public process_listener {
-  std::mutex _lock;
   std::unordered_map<process*, uint64_t> _processes_busy;
   std::deque<process*> _processes_free;
 
@@ -68,7 +67,9 @@ class raw : public command, public process_listener {
   raw& operator=(const raw&) = delete;
   uint64_t run(const std::string& process_cmd,
                nagios_macros& macros,
-               uint32_t timeout) override;
+               uint32_t timeout,
+               const check_result::pointer& to_push_to_checker,
+               const void* caller = nullptr) override;
   void run(const std::string& process_cmd,
            nagios_macros& macros,
            uint32_t timeout,

--- a/engine/inc/com/centreon/engine/commands/result.hh
+++ b/engine/inc/com/centreon/engine/commands/result.hh
@@ -27,7 +27,10 @@
 
 CCE_BEGIN()
 
+class check_result;
+
 namespace commands {
+
 /**
  *  @class result result.hh
  *  @brief Result contain the result of execution process.
@@ -41,6 +44,7 @@ class result {
  public:
   result();
   result(result const& right);
+  result(const check_result& check_res);
   ~result() noexcept;
   result& operator=(result const& right);
   bool operator==(result const& right) const noexcept;
@@ -52,6 +56,9 @@ class result {
   timestamp start_time;
   std::string output;
 };
+
+std::ostream& operator<<(std::ostream& s, const result& to_dump);
+
 }  // namespace commands
 
 CCE_END()

--- a/engine/inc/com/centreon/engine/configuration/state.hh
+++ b/engine/inc/com/centreon/engine/configuration/state.hh
@@ -256,6 +256,8 @@ class state {
   void log_passive_checks(bool value);
   bool log_pid() const noexcept;
   void log_pid(bool value);
+  inline bool log_file_line() const { return _log_file_line; }
+  void log_file_line(bool value);
   bool log_service_retries() const noexcept;
   void log_service_retries(bool value);
   float low_host_flap_threshold() const noexcept;
@@ -578,6 +580,7 @@ class state {
   bool _log_notifications;
   bool _log_passive_checks;
   bool _log_pid;
+  bool _log_file_line;
   bool _log_service_retries;
   float _low_host_flap_threshold;
   float _low_service_flap_threshold;

--- a/engine/inc/com/centreon/engine/host.hh
+++ b/engine/inc/com/centreon/engine/host.hh
@@ -109,7 +109,7 @@ class host : public notifier {
   void add_child_host(host* child);
   void add_parent_host(std::string const& host_name);
   int log_event();
-  int handle_async_check_result_3x(check_result* queued_check_result);
+  int handle_async_check_result_3x(const check_result& queued_check_result);
   int run_scheduled_check(int check_options, double latency);
   int run_async_check(int check_options,
                       double latency,

--- a/engine/inc/com/centreon/engine/log_v2.hh
+++ b/engine/inc/com/centreon/engine/log_v2.hh
@@ -19,6 +19,7 @@
 #define CCE_LOG_V2_HH
 
 #include <spdlog/common.h>
+#include <spdlog/fmt/ostr.h>
 #include <spdlog/spdlog.h>
 
 #include "com/centreon/engine/configuration/state.hh"

--- a/engine/inc/com/centreon/engine/service.hh
+++ b/engine/inc/com/centreon/engine/service.hh
@@ -93,7 +93,7 @@ class service : public notifier {
           bool obsess_over,
           std::string const& timezone,
           uint64_t icon_id);
-  ~service() noexcept = default;
+  ~service() noexcept;
   void set_host_id(uint64_t host_id);
   uint64_t get_host_id() const;
   void set_service_id(uint64_t service_id);
@@ -130,7 +130,8 @@ class service : public notifier {
   int get_current_state_int() const override;
   std::string const& get_current_state_as_string() const override;
 
-  int handle_async_check_result(check_result* queued_check_result);
+  virtual int handle_async_check_result(
+      const check_result& queued_check_result);
   int log_event();
   void check_for_flapping(bool update, bool allow_flapstart_notification);
   int handle_service_event();

--- a/engine/inc/com/centreon/engine/utils.hh
+++ b/engine/inc/com/centreon/engine/utils.hh
@@ -50,6 +50,7 @@ int get_raw_command_line_r(nagios_macros* mac,
                            std::string const& cmd,
                            std::string& full_command,
                            int macro_options);
+
 // trap signals
 void setup_sighandler();
 // handles signals
@@ -79,5 +80,15 @@ void parse_check_output(std::string const& buffer,
 #ifdef __cplusplus
 }
 #endif  // C++
+
+inline int get_raw_command_line_r(
+    nagios_macros* mac,
+    const std::shared_ptr<com::centreon::engine::commands::command> cmd_ptr,
+    std::string const& cmd,
+    std::string& full_command,
+    int macro_options) {
+  return get_raw_command_line_r(mac, cmd_ptr.get(), cmd, full_command,
+                                macro_options);
+}
 
 #endif  // !CCE_UTILS_HH

--- a/engine/modules/external_commands/precomp_inc/precomp.hh
+++ b/engine/modules/external_commands/precomp_inc/precomp.hh
@@ -34,6 +34,7 @@
 #include <absl/strings/string_view.h>
 
 #include <boost/circular_buffer.hpp>
+#include <boost/container/flat_map.hpp>
 #include <boost/optional.hpp>
 
 #endif  // CCE_EXTERNAL_COMMANDS_PRECOMP_HH

--- a/engine/precomp_inc/precomp.hh
+++ b/engine/precomp_inc/precomp.hh
@@ -62,6 +62,7 @@
 #include <absl/strings/string_view.h>
 
 #include <boost/circular_buffer.hpp>
+#include <boost/container/flat_map.hpp>
 #include <boost/optional.hpp>
 
 #include "com/centreon/engine/namespace.hh"

--- a/engine/src/check_result.cc
+++ b/engine/src/check_result.cc
@@ -25,10 +25,23 @@
 
 using namespace com::centreon::engine;
 
+check_result::check_result()
+    : _object_check_type{check_source::service_check},
+      _notifier{nullptr},
+      _check_type(checkable::check_type::check_passive),
+      _check_options{0},
+      _reschedule_check{false},
+      _latency{0},
+      _start_time{0, 0},
+      _finish_time{0, 0},
+      _early_timeout{false},
+      _exited_ok{false},
+      _return_code{0} {}
+
 check_result::check_result(enum check_source object_check_type,
                            notifier* notifier,
                            enum checkable::check_type check_type,
-                           int check_options,
+                           unsigned check_options,
                            bool reschedule_check,
                            double latency,
                            struct timeval start_time,
@@ -50,56 +63,28 @@ check_result::check_result(enum check_source object_check_type,
       _return_code{return_code},
       _output{output} {}
 
-enum check_source check_result::get_object_check_type() const {
-  return _object_check_type;
-}
-
 void check_result::set_object_check_type(enum check_source object_check_type) {
   _object_check_type = object_check_type;
-}
-
-notifier* check_result::get_notifier() {
-  return _notifier;
 }
 
 void check_result::set_notifier(notifier* notifier) {
   _notifier = notifier;
 }
 
-struct timeval check_result::get_finish_time() const {
-  return _finish_time;
-}
-
 void check_result::set_finish_time(struct timeval finish_time) {
   _finish_time = finish_time;
-}
-
-struct timeval check_result::get_start_time() const {
-  return _start_time;
 }
 
 void check_result::set_start_time(struct timeval start_time) {
   _start_time = start_time;
 }
 
-int check_result::get_return_code() const {
-  return _return_code;
-}
-
 void check_result::set_return_code(int return_code) {
   _return_code = return_code;
 }
 
-bool check_result::get_early_timeout() const {
-  return _early_timeout;
-}
-
 void check_result::set_early_timeout(bool early_timeout) {
   _early_timeout = early_timeout;
-}
-
-std::string const& check_result::get_output() const {
-  return _output;
 }
 
 /**
@@ -114,42 +99,22 @@ void check_result::set_output(std::string const& output) {
   _output = output;
 }
 
-bool check_result::get_exited_ok() const {
-  return _exited_ok;
-}
-
 void check_result::set_exited_ok(bool exited_ok) {
   _exited_ok = exited_ok;
-}
-
-bool check_result::get_reschedule_check() const {
-  return _reschedule_check;
 }
 
 void check_result::set_reschedule_check(bool reschedule_check) {
   _reschedule_check = reschedule_check;
 }
 
-enum checkable::check_type check_result::get_check_type() const {
-  return _check_type;
-}
-
 void check_result::set_check_type(enum checkable::check_type check_type) {
   _check_type = check_type;
-}
-
-double check_result::get_latency() const {
-  return _latency;
 }
 
 void check_result::set_latency(double latency) {
   _latency = latency;
 }
 
-int check_result::get_check_options() const {
-  return _check_options;
-}
-
-void check_result::set_check_options(int check_options) {
+void check_result::set_check_options(unsigned check_options) {
   _check_options = check_options;
 }

--- a/engine/src/checkable.cc
+++ b/engine/src/checkable.cc
@@ -458,11 +458,8 @@ void checkable::set_event_handler_ptr(commands::command* cmd) {
   _event_handler_ptr = cmd;
 }
 
-commands::command* checkable::get_check_command_ptr() const {
-  return _check_command_ptr;
-}
-
-void checkable::set_check_command_ptr(commands::command* cmd) {
+void checkable::set_check_command_ptr(
+    const std::shared_ptr<commands::command>& cmd) {
   _check_command_ptr = cmd;
 }
 

--- a/engine/src/checks/checker.cc
+++ b/engine/src/checks/checker.cc
@@ -56,9 +56,9 @@ checker& checker::instance() {
   return *_instance;
 }
 
-void checker::init() {
+void checker::init(bool used_by_test) {
   if (!_instance)
-    _instance = new checker();
+    _instance = new checker(used_by_test);
 }
 
 void checker::deinit() {
@@ -71,21 +71,9 @@ void checker::deinit() {
 void checker::clear() noexcept {
   try {
     std::lock_guard<std::mutex> lock(_mut_reap);
-    while (!_to_reap_partial.empty()) {
-      check_result* result = _to_reap_partial.front();
-      _to_reap_partial.pop_front();
-      delete result;
-    }
-    while (!_to_reap.empty()) {
-      check_result* result = _to_reap.front();
-      _to_reap.pop_front();
-      delete result;
-    }
-    auto it = _waiting_check_result.begin();
-    while (it != _waiting_check_result.end()) {
-      delete it->second;
-      it = _waiting_check_result.erase(it);
-    }
+    _to_reap_partial.clear();
+    _to_reap.clear();
+    _waiting_check_result.clear();
     _to_forget.clear();
   } catch (...) {
   }
@@ -96,10 +84,10 @@ void checker::clear() noexcept {
  */
 void checker::reap() {
   engine_logger(dbg_functions, basic) << "checker::reap";
-  log_v2::functions()->trace("checker::reap()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "checker::reap()");
 
   engine_logger(dbg_checks, basic) << "Starting to reap check results.";
-  log_v2::checks()->trace("Starting to reap check results.");
+  SPDLOG_LOGGER_TRACE(log_v2::checks(), "Starting to reap check results.");
 
   // Time to start reaping.
   time_t reaper_start_time;
@@ -115,7 +103,6 @@ void checker::reap() {
           for (auto it = _waiting_check_result.begin();
                it != _waiting_check_result.end();) {
             if (it->second->get_notifier() == n) {
-              delete it->second;
               it = _waiting_check_result.erase(it);
             } else
               ++it;
@@ -123,7 +110,6 @@ void checker::reap() {
           for (auto it = _to_reap_partial.begin();
                it != _to_reap_partial.end();) {
             if ((*it)->get_notifier() == n) {
-              delete *it;
               it = _to_reap_partial.erase(it);
             } else
               ++it;
@@ -140,9 +126,10 @@ void checker::reap() {
       ++reaped_checks;
       engine_logger(dbg_checks, basic)
           << "Found a check result (#" << reaped_checks << ") to handle...";
-      log_v2::checks()->trace("Found a check result (#{}) to handle...",
-                              reaped_checks);
-      check_result* result = _to_reap.front();
+      SPDLOG_LOGGER_TRACE(log_v2::checks(),
+                          "Found a check result (#{}) to handle...",
+                          reaped_checks);
+      check_result::pointer result = _to_reap.front();
       _to_reap.pop_front();
 
       // Service check result->
@@ -153,16 +140,18 @@ void checker::reap() {
           engine_logger(dbg_checks, more)
               << "Handling check result for service " << svc->get_host_id()
               << "/" << svc->get_service_id() << "...";
-          log_v2::checks()->debug("Handling check result for service {}/{}...",
-                                  svc->get_host_id(), svc->get_service_id());
-          svc->handle_async_check_result(result);
+          SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                              "Handling check result for service {}/{}...",
+                              svc->get_host_id(), svc->get_service_id());
+          svc->handle_async_check_result(*result);
         } catch (std::exception const& e) {
           engine_logger(log_runtime_warning, basic)
               << "Check result queue errors for service " << svc->get_host_id()
               << "/" << svc->get_service_id() << " : " << e.what();
-          log_v2::runtime()->warn(
-              "Check result queue errors for service {}/{} : {}",
-              svc->get_host_id(), svc->get_service_id(), e.what());
+          SPDLOG_LOGGER_WARN(log_v2::runtime(),
+                             "Check result queue errors for service {}/{} : {}",
+                             svc->get_host_id(), svc->get_service_id(),
+                             e.what());
         }
       }
       // Host check result->
@@ -172,9 +161,10 @@ void checker::reap() {
           // Process the check result->
           engine_logger(dbg_checks, more) << "Handling check result for host "
                                           << hst->get_host_id() << "...";
-          log_v2::checks()->debug("Handling check result for host {}...",
-                                  hst->get_host_id());
-          hst->handle_async_check_result_3x(result);
+          SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                              "Handling check result for host {}...",
+                              hst->get_host_id());
+          hst->handle_async_check_result_3x(*result);
         } catch (std::exception const& e) {
           engine_logger(log_runtime_error, basic)
               << "Check result queue errors for "
@@ -184,8 +174,6 @@ void checker::reap() {
         }
       }
 
-      delete result;
-
       // Check if reaping has timed out.
       time_t current_time;
       time(&current_time);
@@ -194,7 +182,8 @@ void checker::reap() {
         engine_logger(dbg_checks, basic)
             << "Breaking out of check result reaper: "
             << "max reaper time exceeded";
-        log_v2::checks()->trace(
+        SPDLOG_LOGGER_TRACE(
+            log_v2::checks(),
             "Breaking out of check result reaper: max reaper time exceeded");
         break;
       }
@@ -203,7 +192,8 @@ void checker::reap() {
       if (sigshutdown) {
         engine_logger(dbg_checks, basic)
             << "Breaking out of check result reaper: signal encountered";
-        log_v2::checks()->trace(
+        SPDLOG_LOGGER_TRACE(
+            log_v2::checks(),
             "Breaking out of check result reaper: signal encountered");
         break;
       }
@@ -213,7 +203,8 @@ void checker::reap() {
   // Reaping finished.
   engine_logger(dbg_checks, basic)
       << "Finished reaping " << reaped_checks << " check results";
-  log_v2::checks()->trace("Finished reaping {} check results", reaped_checks);
+  SPDLOG_LOGGER_TRACE(log_v2::checks(), "Finished reaping {} check results",
+                      reaped_checks);
 }
 
 /**
@@ -234,11 +225,12 @@ void checker::run_sync(host* hst,
       << "checker::run: hst=" << hst << ", check_options=" << check_options
       << ", use_cached_result=" << use_cached_result
       << ", check_timestamp_horizon=" << check_timestamp_horizon;
-  log_v2::functions()->trace(
-      "checker::run: hst={:p}, check_options={}"
-      ", use_cached_result={}"
-      ", check_timestamp_horizon={}",
-      (void*)hst, check_options, use_cached_result, check_timestamp_horizon);
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "checker::run: hst={:p}, check_options={}"
+                      ", use_cached_result={}"
+                      ", check_timestamp_horizon={}",
+                      (void*)hst, check_options, use_cached_result,
+                      check_timestamp_horizon);
 
   // Preamble.
   if (!hst)
@@ -249,14 +241,16 @@ void checker::run_sync(host* hst,
 
   engine_logger(dbg_checks, basic)
       << "** Run sync check of host '" << hst->name() << "'...";
-  log_v2::checks()->trace("** Run sync check of host '{}'...", hst->name());
+  SPDLOG_LOGGER_TRACE(log_v2::checks(), "** Run sync check of host '{}'...",
+                      hst->name());
 
   // Check if the host is viable now.
   if (!hst->verify_check_viability(check_options, nullptr, nullptr)) {
     if (check_result_code)
       *check_result_code = hst->get_current_state();
     engine_logger(dbg_checks, basic) << "Host check is not viable at this time";
-    log_v2::checks()->trace("Host check is not viable at this time");
+    SPDLOG_LOGGER_TRACE(log_v2::checks(),
+                        "Host check is not viable at this time");
     return;
   }
 
@@ -275,8 +269,8 @@ void checker::run_sync(host* hst,
         *check_result_code = hst->get_current_state();
       engine_logger(dbg_checks, more)
           << "* Using cached host state: " << hst->get_current_state();
-      log_v2::checks()->debug("* Using cached host state: {}",
-                              hst->get_current_state());
+      SPDLOG_LOGGER_DEBUG(log_v2::checks(), "* Using cached host state: {}",
+                          hst->get_current_state());
 
       // Update statistics.
       update_check_stats(ACTIVE_ONDEMAND_HOST_CHECK_STATS, start_time.tv_sec);
@@ -288,8 +282,9 @@ void checker::run_sync(host* hst,
   // Checking starts.
   engine_logger(dbg_checks, more)
       << "* Running actual host check: old state=" << hst->get_current_state();
-  log_v2::checks()->debug("* Running actual host check: old state={}",
-                          hst->get_current_state());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "* Running actual host check: old state={}",
+                      hst->get_current_state());
 
   // Update statistics.
   update_check_stats(ACTIVE_ONDEMAND_HOST_CHECK_STATS, start_time.tv_sec);
@@ -343,8 +338,8 @@ void checker::run_sync(host* hst,
   // Synchronous check is done.
   engine_logger(dbg_checks, more)
       << "* Sync host check done: new state=" << hst->get_current_state();
-  log_v2::checks()->debug("* Sync host check done: new state={}",
-                          hst->get_current_state());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "* Sync host check done: new state={}",
+                      hst->get_current_state());
 
   // Get the end time of command.
   gettimeofday(&end_time, nullptr);
@@ -369,7 +364,10 @@ void checker::run_sync(host* hst,
 /**
  *  Default constructor.
  */
-checker::checker() : commands::command_listener() {}
+checker::checker(bool used_by_test)
+    : commands::command_listener(),
+      _used_by_test(used_by_test),
+      _finished(false) {}
 
 /**
  *  Default destructor.
@@ -386,19 +384,21 @@ checker::~checker() noexcept {
 void checker::finished(commands::result const& res) noexcept {
   // Debug message.
   engine_logger(dbg_functions, basic) << "checker::finished: res=" << &res;
-  log_v2::functions()->trace("checker::finished: res={:p}", (void*)&res);
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "checker::finished: res={:p}",
+                      (void*)&res);
 
   std::unique_lock<std::mutex> lock(_mut_reap);
   auto it_id = _waiting_check_result.find(res.command_id);
   if (it_id == _waiting_check_result.end()) {
     engine_logger(log_runtime_warning, basic)
         << "command ID '" << res.command_id << "' not found";
-    log_v2::runtime()->warn("command ID '{}' not found", res.command_id);
+    SPDLOG_LOGGER_WARN(log_v2::runtime(), "command ID '{}' not found",
+                       res.command_id);
     return;
   }
 
   // Find check result.
-  check_result* result = it_id->second;
+  check_result::pointer result = it_id->second;
   _waiting_check_result.erase(it_id);
   lock.unlock();
 
@@ -416,6 +416,20 @@ void checker::finished(commands::result const& res) noexcept {
   // Queue check result.
   lock.lock();
   _to_reap_partial.push_back(result);
+  if (_used_by_test) {
+    _finished = true;
+    lock.unlock();
+    _finish_cond.notify_one();
+  }
+}
+
+void checker::wait_completion() {
+  if (!_used_by_test) {
+    throw std::invalid_argument("checker not in test usage");
+  }
+  std::unique_lock<std::mutex> lock(_mut_reap);
+  _finished = false;
+  _finish_cond.wait(lock, [this]() { return _finished; });
 }
 
 /**
@@ -428,7 +442,8 @@ void checker::finished(commands::result const& res) noexcept {
  */
 com::centreon::engine::host::host_state checker::_execute_sync(host* hst) {
   engine_logger(dbg_functions, basic) << "checker::_execute_sync: hst=" << hst;
-  log_v2::functions()->trace("checker::_execute_sync: hst={:p}", (void*)hst);
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "checker::_execute_sync: hst={:p}",
+                      (void*)hst);
 
   // Preamble.
   if (!hst)
@@ -439,8 +454,8 @@ com::centreon::engine::host::host_state checker::_execute_sync(host* hst) {
 
   engine_logger(dbg_checks, basic)
       << "** Executing sync check of host '" << hst->name() << "'...";
-  log_v2::checks()->trace("** Executing sync check of host '{}'...",
-                          hst->name());
+  SPDLOG_LOGGER_TRACE(log_v2::checks(),
+                      "** Executing sync check of host '{}'...", hst->name());
 
   // Send broker event.
   timeval start_time;
@@ -472,7 +487,7 @@ com::centreon::engine::host::host_state checker::_execute_sync(host* hst) {
   hst->set_last_check(start_time.tv_sec);
 
   // Get command object.
-  commands::command* cmd = hst->get_check_command_ptr();
+  commands::command::pointer cmd = hst->get_check_command_ptr();
   std::string processed_cmd(cmd->process_cmd(macros));
   const char* tmp_processed_cmd = processed_cmd.c_str();
 
@@ -490,12 +505,13 @@ com::centreon::engine::host::host_state checker::_execute_sync(host* hst) {
   engine_logger(dbg_commands, more)
       << "Raw host check command: "
       << hst->get_check_command_ptr()->get_command_line();
-  log_v2::commands()->trace("Raw host check command: {}",
-                            hst->get_check_command_ptr()->get_command_line());
+  SPDLOG_LOGGER_TRACE(log_v2::commands(), "Raw host check command: {}",
+                      hst->get_check_command_ptr()->get_command_line());
 
   engine_logger(dbg_commands, more)
       << "Processed host check ommand: " << processed_cmd;
-  log_v2::commands()->trace("Processed host check ommand: {}", processed_cmd);
+  SPDLOG_LOGGER_TRACE(log_v2::commands(), "Processed host check ommand: {}",
+                      processed_cmd);
 
   // Cleanup.
   hst->set_plugin_output("");
@@ -528,7 +544,8 @@ com::centreon::engine::host::host_state checker::_execute_sync(host* hst) {
     engine_logger(log_runtime_warning, basic)
         << "Error: Synchronous host check command execution failed: "
         << e.what();
-    log_v2::runtime()->warn(
+    SPDLOG_LOGGER_WARN(
+        log_v2::runtime(),
         "Error: Synchronous host check command execution failed: {}", e.what());
   }
 
@@ -567,7 +584,8 @@ com::centreon::engine::host::host_state checker::_execute_sync(host* hst) {
         << "Warning: Host check command '" << processed_cmd << "' for host '"
         << hst->name() << "' timed out after " << config->host_check_timeout()
         << " seconds";
-    log_v2::runtime()->warn(
+    SPDLOG_LOGGER_WARN(
+        log_v2::runtime(),
         "Warning: Host check command '{}' for host '{}' timed out after {} "
         "seconds",
         processed_cmd, hst->name(), config->host_check_timeout());
@@ -628,7 +646,8 @@ com::centreon::engine::host::host_state checker::_execute_sync(host* hst) {
   // Termination.
   engine_logger(dbg_checks, basic)
       << "** Sync host check done: state=" << return_result;
-  log_v2::checks()->trace("** Sync host check done: state={}", return_result);
+  SPDLOG_LOGGER_TRACE(log_v2::checks(), "** Sync host check done: state={}",
+                      return_result);
   return return_result;
 }
 
@@ -641,8 +660,9 @@ com::centreon::engine::host::host_state checker::_execute_sync(host* hst) {
  * @param id A command id
  * @param check_result A check_result coming from a service or a host.
  */
-void checker::add_check_result(uint64_t id,
-                               check_result* check_result) noexcept {
+void checker::add_check_result(
+    uint64_t id,
+    const check_result::pointer check_result) noexcept {
   std::lock_guard<std::mutex> lock(_mut_reap);
   _waiting_check_result[id] = check_result;
 }
@@ -653,7 +673,8 @@ void checker::add_check_result(uint64_t id,
  *
  * @param check_result The check_result already finished.
  */
-void checker::add_check_result_to_reap(check_result* check_result) noexcept {
+void checker::add_check_result_to_reap(
+    const check_result::pointer check_result) noexcept {
   std::lock_guard<std::mutex> lock(_mut_reap);
   _to_reap_partial.push_back(check_result);
 }

--- a/engine/src/command_manager.cc
+++ b/engine/src/command_manager.cc
@@ -143,12 +143,12 @@ int command_manager::process_passive_service_check(
 
   timeval set_tv = {.tv_sec = check_time, .tv_usec = 0};
 
-  check_result* result =
-      new check_result(service_check, found->second.get(),
-                       checkable::check_passive, CHECK_OPTION_NONE, false,
-                       static_cast<double>(tv.tv_sec - check_time) +
-                           static_cast<double>(tv.tv_usec) / 1000000.0,
-                       set_tv, set_tv, false, true, return_code, output);
+  check_result::pointer result = std::make_shared<check_result>(
+      service_check, found->second.get(), checkable::check_passive,
+      CHECK_OPTION_NONE, false,
+      static_cast<double>(tv.tv_sec - check_time) +
+          static_cast<double>(tv.tv_usec) / 1000000.0,
+      set_tv, set_tv, false, true, return_code, output);
 
   /* make sure the return code is within bounds */
   if (result->get_return_code() < 0 || result->get_return_code() > 3)
@@ -213,12 +213,12 @@ int command_manager::process_passive_host_check(time_t check_time,
   tv_start.tv_sec = check_time;
   tv_start.tv_usec = 0;
 
-  check_result* result =
-      new check_result(host_check, it->second.get(), checkable::check_passive,
-                       CHECK_OPTION_NONE, false,
-                       static_cast<double>(tv.tv_sec - check_time) +
-                           static_cast<double>(tv.tv_usec) / 1000000.0,
-                       tv_start, tv_start, false, true, return_code, output);
+  check_result::pointer result = std::make_shared<check_result>(
+      host_check, it->second.get(), checkable::check_passive, CHECK_OPTION_NONE,
+      false,
+      static_cast<double>(tv.tv_sec - check_time) +
+          static_cast<double>(tv.tv_usec) / 1000000.0,
+      tv_start, tv_start, false, true, return_code, output);
 
   /* make sure the return code is within bounds */
   if (result->get_return_code() < 0 || result->get_return_code() > 3)

--- a/engine/src/commands/commands.cc
+++ b/engine/src/commands/commands.cc
@@ -165,7 +165,7 @@ int cmd_add_comment(int cmd, time_t entry_time, char* args) {
   char* comment_data(nullptr);
   bool persistent{false};
   uint64_t service_id = 0;
-  char* command_name;
+  const char* command_name;
 
   /* get the host name */
   if ((host_name = my_strtok(args, ";")) == nullptr)
@@ -605,12 +605,12 @@ int process_passive_service_check(time_t check_time,
 
   timeval set_tv = {.tv_sec = check_time, .tv_usec = 0};
 
-  check_result* result =
-      new check_result(service_check, found->second.get(),
-                       checkable::check_passive, CHECK_OPTION_NONE, false,
-                       static_cast<double>(tv.tv_sec - check_time) +
-                           static_cast<double>(tv.tv_usec / 1000000.0),
-                       set_tv, set_tv, false, true, return_code, output);
+  check_result::pointer result = std::make_shared<check_result>(
+      service_check, found->second.get(), checkable::check_passive,
+      CHECK_OPTION_NONE, false,
+      static_cast<double>(tv.tv_sec - check_time) +
+          static_cast<double>(tv.tv_usec / 1000000.0),
+      set_tv, set_tv, false, true, return_code, output);
 
   /* make sure the return code is within bounds */
   if (result->get_return_code() < 0 || result->get_return_code() > 3) {
@@ -719,12 +719,12 @@ int process_passive_host_check(time_t check_time,
   gettimeofday(&tv, nullptr);
   timeval tv_start = {.tv_sec = check_time, .tv_usec = 0};
 
-  check_result* result =
-      new check_result(host_check, it->second.get(), checkable::check_passive,
-                       CHECK_OPTION_NONE, false,
-                       static_cast<double>(tv.tv_sec - check_time) +
-                           static_cast<double>(tv.tv_usec / 1000000.0),
-                       tv_start, tv_start, false, true, return_code, output);
+  check_result::pointer result = std::make_shared<check_result>(
+      host_check, it->second.get(), checkable::check_passive, CHECK_OPTION_NONE,
+      false,
+      static_cast<double>(tv.tv_sec - check_time) +
+          static_cast<double>(tv.tv_usec / 1000000.0),
+      tv_start, tv_start, false, true, return_code, output);
 
   /* make sure the return code is within bounds */
   if (result->get_return_code() < 0 || result->get_return_code() > 3)
@@ -1860,7 +1860,7 @@ int cmd_change_object_char_var(int cmd, char* args) {
 
     case CMD_CHANGE_HOST_CHECK_COMMAND:
       temp_host->set_check_command(temp_ptr);
-      temp_host->set_check_command_ptr(cmd_found->second.get());
+      temp_host->set_check_command_ptr(cmd_found->second);
       attr = MODATTR_CHECK_COMMAND;
       break;
 
@@ -1884,7 +1884,7 @@ int cmd_change_object_char_var(int cmd, char* args) {
 
     case CMD_CHANGE_SVC_CHECK_COMMAND:
       found_svc->second->set_check_command(temp_ptr);
-      found_svc->second->set_check_command_ptr(cmd_found->second.get());
+      found_svc->second->set_check_command_ptr(cmd_found->second);
       attr = MODATTR_CHECK_COMMAND;
       break;
 

--- a/engine/src/commands/connector.cc
+++ b/engine/src/commands/connector.cc
@@ -118,10 +118,10 @@ connector::~connector() noexcept {
  *  @return The command id.
  */
 uint64_t connector::run(const std::string& processed_cmd,
-                        nagios_macros& macros,
-                        uint32_t timeout) {
-  (void)macros;
-
+                        nagios_macros&,
+                        uint32_t timeout,
+                        const check_result::pointer& to_push_to_checker,
+                        const void* caller) {
   engine_logger(dbg_commands, basic)
       << "connector::run: connector='" << _name << "', cmd='" << processed_cmd
       << "', timeout=" << timeout;
@@ -131,6 +131,11 @@ uint64_t connector::run(const std::string& processed_cmd,
 
   // Set query informations.
   uint64_t command_id(get_uniq_id());
+
+  if (!gest_call_interval(command_id, to_push_to_checker, caller)) {
+    return command_id;
+  }
+
   auto info = std::make_shared<query_info>();
   info->processed_cmd = processed_cmd;
   info->start_time = timestamp::now();
@@ -371,6 +376,7 @@ void connector::finished(process& p) noexcept {
   try {
     engine_logger(dbg_commands, basic) << "connector::finished: process=" << &p;
     log_v2::commands()->trace("connector::finished: process={}", (void*)&p);
+
     UNIQUE_LOCK(lock, _lock);
     _is_running = false;
     _data_available.clear();
@@ -661,14 +667,10 @@ void connector::_recv_query_execute(char const* data) {
                                        << res.output << "'";
     log_v2::commands()->trace(
         "connector::_recv_query_execute: "
-        "id={}, "
-        "start_time={}, "
-        "end_time={}, "
-        "exit_code={}, "
-        "exit_status={}, "
-        "output='{}'",
-        command_id, res.start_time.to_mseconds(), res.end_time.to_mseconds(),
-        res.exit_code, res.exit_status, res.output);
+        "id={}, {}",
+        command_id, res);
+
+    update_result_cache(command_id, res);
 
     if (!info->waiting_result) {
       // Forward result to the listener.

--- a/engine/src/commands/forward.cc
+++ b/engine/src/commands/forward.cc
@@ -52,13 +52,18 @@ forward::forward(std::string const& command_name,
  *  @param[in] args    The command arguments.
  *  @param[in] macros  The macros data struct.
  *  @param[in] timeout The command timeout.
+ *  @param[in] to_push_to_checker This check_result will be pushed to checher.
+ *  @param[in] caller  pointer to the caller
  *
  *  @return The command id.
  */
 uint64_t forward::run(std::string const& processed_cmd,
                       nagios_macros& macros,
-                      uint32_t timeout) {
-  return _command->run(processed_cmd, macros, timeout);
+                      uint32_t timeout,
+                      const check_result::pointer& to_push_to_checker,
+                      const void* caller) {
+  return _command->run(processed_cmd, macros, timeout, to_push_to_checker,
+                       caller);
 }
 
 /**

--- a/engine/src/commands/raw.cc
+++ b/engine/src/commands/raw.cc
@@ -64,8 +64,8 @@ raw::~raw() noexcept {
   } catch (std::exception const& e) {
     engine_logger(log_runtime_error, basic)
         << "Error: Raw command destructor failed: " << e.what();
-    log_v2::runtime()->error("Error: Raw command destructor failed: {}",
-                             e.what());
+    SPDLOG_LOGGER_ERROR(log_v2::runtime(),
+                        "Error: Raw command destructor failed: {}", e.what());
   }
 }
 
@@ -75,20 +75,28 @@ raw::~raw() noexcept {
  *  @param[in] args    The command arguments.
  *  @param[in] macros  The macros data struct.
  *  @param[in] timeout The command timeout.
+ *  @param[in] to_push_to_checker This check_result will be pushed to checher.
+ *  @param[in] caller  pointer to the caller
  *
  *  @return The command id.
  */
 uint64_t raw::run(std::string const& processed_cmd,
                   nagios_macros& macros,
-                  uint32_t timeout) {
+                  uint32_t timeout,
+                  const check_result::pointer& to_push_to_checker,
+                  const void* caller) {
   engine_logger(dbg_commands, basic)
       << "raw::run: cmd='" << processed_cmd << "', timeout=" << timeout;
-  log_v2::commands()->trace("raw::run: cmd='{}', timeout={}", processed_cmd,
-                            timeout);
+  SPDLOG_LOGGER_TRACE(log_v2::commands(), "raw::run: cmd='{}', timeout={}",
+                      processed_cmd, timeout);
 
   // Get process and put into the busy list.
   process* p;
   uint64_t command_id(get_uniq_id());
+
+  if (!gest_call_interval(command_id, to_push_to_checker, caller)) {
+    return command_id;
+  }
   {
     std::lock_guard<std::mutex> lock(_lock);
     p = _get_free_process();
@@ -97,8 +105,8 @@ uint64_t raw::run(std::string const& processed_cmd,
 
   engine_logger(dbg_commands, basic)
       << "raw::run: id=" << command_id << ", process=" << p;
-  log_v2::commands()->trace("raw::run: id={} , process={}", command_id,
-                            (void*)p);
+  SPDLOG_LOGGER_TRACE(log_v2::commands(), "raw::run: id={} , process={}",
+                      command_id, (void*)p);
 
   // Setup environnement macros if is necessary.
   environment env;
@@ -109,13 +117,13 @@ uint64_t raw::run(std::string const& processed_cmd,
     p->exec(processed_cmd.c_str(), env.data(), timeout);
     engine_logger(dbg_commands, basic)
         << "raw::run: start process success: id=" << command_id;
-    log_v2::commands()->trace("raw::run: start process success: id={}",
-                              command_id);
+    SPDLOG_LOGGER_TRACE(log_v2::commands(),
+                        "raw::run: start process success: id={}", command_id);
   } catch (...) {
     engine_logger(dbg_commands, basic)
         << "raw::run: start process failed: id=" << command_id;
-    log_v2::commands()->trace("raw::run: start process failed: id={}",
-                              command_id);
+    SPDLOG_LOGGER_TRACE(log_v2::commands(),
+                        "raw::run: start process failed: id={}", command_id);
 
     std::lock_guard<std::mutex> lock(_lock);
     _processes_busy.erase(p);
@@ -139,8 +147,8 @@ void raw::run(std::string const& processed_cmd,
               result& res) {
   engine_logger(dbg_commands, basic)
       << "raw::run: cmd='" << processed_cmd << "', timeout=" << timeout;
-  log_v2::commands()->trace("raw::run: cmd='{}', timeout={}", processed_cmd,
-                            timeout);
+  SPDLOG_LOGGER_TRACE(log_v2::commands(), "raw::run: cmd='{}', timeout={}",
+                      processed_cmd, timeout);
 
   // Get process.
   process p;
@@ -148,8 +156,8 @@ void raw::run(std::string const& processed_cmd,
 
   engine_logger(dbg_commands, basic)
       << "raw::run: id=" << command_id << ", process=" << &p;
-  log_v2::commands()->trace("raw::run: id={}, process={}", command_id,
-                            (void*)&p);
+  SPDLOG_LOGGER_TRACE(log_v2::commands(), "raw::run: id={}, process={}",
+                      command_id, (void*)&p);
 
   // Setup environement macros if is necessary.
   environment env;
@@ -160,13 +168,13 @@ void raw::run(std::string const& processed_cmd,
     p.exec(processed_cmd.c_str(), env.data(), timeout);
     engine_logger(dbg_commands, basic)
         << "raw::run: start process success: id=" << command_id;
-    log_v2::commands()->trace("raw::run: start process success: id={}",
-                              command_id);
+    SPDLOG_LOGGER_TRACE(log_v2::commands(),
+                        "raw::run: start process success: id={}", command_id);
   } catch (...) {
     engine_logger(dbg_commands, basic)
         << "raw::run: start process failed: id=" << command_id;
-    log_v2::commands()->trace("raw::run: start process failed: id={}",
-                              command_id);
+    SPDLOG_LOGGER_TRACE(log_v2::commands(),
+                        "raw::run: start process failed: id={}", command_id);
     throw;
   }
 
@@ -208,16 +216,10 @@ void raw::run(std::string const& processed_cmd,
                                      << ", "
                                         "output='"
                                      << res.output << "'";
-  log_v2::commands()->trace(
-      "raw::run: end process: "
-      "id={}, "
-      "start_time={}, "
-      "end_time={}, "
-      "exit_code={}, "
-      "exit_status={}, "
-      "output='{}'",
-      command_id, res.start_time.to_mseconds(), res.end_time.to_mseconds(),
-      res.exit_code, res.exit_status, res.output);
+  SPDLOG_LOGGER_TRACE(log_v2::commands(),
+                      "raw::run: end process: "
+                      "id={}, {}",
+                      command_id, res);
 }
 
 /**************************************
@@ -253,7 +255,8 @@ void raw::data_is_available_err(process& p) noexcept {
 void raw::finished(process& p) noexcept {
   try {
     engine_logger(dbg_commands, basic) << "raw::finished: process=" << &p;
-    log_v2::commands()->trace("raw::finished: process={}", (void*)&p);
+    SPDLOG_LOGGER_TRACE(log_v2::commands(), "raw::finished: process={}",
+                        (void*)&p);
 
     uint64_t command_id(0);
     {
@@ -269,9 +272,9 @@ void raw::finished(process& p) noexcept {
         engine_logger(log_runtime_warning, basic)
             << "Warning: Invalid process pointer: "
                "process not found into process busy list";
-        log_v2::runtime()->warn(
-            "Warning: Invalid process pointer: "
-            "process not found into process busy list");
+        SPDLOG_LOGGER_WARN(log_v2::runtime(),
+                           "Warning: Invalid process pointer: "
+                           "process not found into process busy list");
         return;
       }
       // Get command_id and remove the process from the busy list.
@@ -280,7 +283,7 @@ void raw::finished(process& p) noexcept {
     }
 
     engine_logger(dbg_commands, basic) << "raw::finished: id=" << command_id;
-    log_v2::commands()->trace("raw::finished: id={}", command_id);
+    SPDLOG_LOGGER_TRACE(log_v2::commands(), "raw::finished: id={}", command_id);
 
     // Build check result.
     result res;
@@ -315,11 +318,10 @@ void raw::finished(process& p) noexcept {
         << ", exit_code=" << res.exit_code
         << ", exit_status=" << res.exit_status << ", output='" << res.output
         << "'";
-    log_v2::commands()->trace(
-        "raw::finished: id={}, start_time={}, end_time={}, exit_code={}, "
-        "exit_status={}, output='{}'",
-        command_id, res.start_time.to_mseconds(), res.end_time.to_mseconds(),
-        res.exit_code, res.exit_status, res.output);
+    SPDLOG_LOGGER_TRACE(log_v2::commands(), "raw::finished: id={}, {}",
+                        command_id, res);
+
+    update_result_cache(command_id, res);
 
     // Forward result to the listener.
     if (_listener)
@@ -327,8 +329,9 @@ void raw::finished(process& p) noexcept {
   } catch (std::exception const& e) {
     engine_logger(log_runtime_warning, basic)
         << "Warning: Raw process termination routine failed: " << e.what();
-    log_v2::runtime()->warn(
-        "Warning: Raw process termination routine failed: {}", e.what());
+    SPDLOG_LOGGER_WARN(log_v2::runtime(),
+                       "Warning: Raw process termination routine failed: {}",
+                       e.what());
 
     // Release process, put into the free list.
     std::lock_guard<std::mutex> lock(_lock);

--- a/engine/src/commands/result.cc
+++ b/engine/src/commands/result.cc
@@ -17,6 +17,7 @@
  *
  */
 #include "com/centreon/engine/commands/result.hh"
+#include "com/centreon/engine/check_result.hh"
 
 #include "com/centreon/timestamp.hh"
 
@@ -42,6 +43,14 @@ result::result() : command_id(0), exit_code(0), exit_status(process::normal) {}
 result::result(result const& right) {
   _internal_copy(right);
 }
+
+result::result(const check_result& check_res)
+    : command_id(0),
+      end_time(check_res.get_finish_time()),
+      exit_code(check_res.get_return_code()),
+      start_time(check_res.get_start_time()),
+      exit_status(check_res.get_exited_ok() ? process::normal : process::crash),
+      output(check_res.get_output()) {}
 
 /**
  *  Destructor.
@@ -104,3 +113,17 @@ void result::_internal_copy(result const& right) {
   start_time = right.start_time;
   output = right.output;
 }
+
+CCE_BEGIN()
+namespace commands {
+std::ostream& operator<<(std::ostream& s, const result& to_dump) {
+  s << "start_time=" << to_dump.start_time << ", end_time=" << to_dump.end_time
+    << ", exit_code=" << to_dump.exit_code
+    << ", exit_status=" << to_dump.exit_status << ", output='" << to_dump.output
+    << '\'';
+  return s;
+}
+
+}  // namespace commands
+
+CCE_END()

--- a/engine/src/configuration/applier/anomalydetection.cc
+++ b/engine/src/configuration/applier/anomalydetection.cc
@@ -100,8 +100,9 @@ void applier::anomalydetection::add_object(
   engine_logger(logging::dbg_config, logging::more)
       << "Creating new anomalydetection '" << obj.service_description()
       << "' of host '" << obj.host_name() << "'.";
-  log_v2::config()->debug("Creating new anomalydetection '{}' of host '{}'.",
-                          obj.service_description(), obj.host_name());
+  SPDLOG_LOGGER_DEBUG(log_v2::config(),
+                      "Creating new anomalydetection '{}' of host '{}'.",
+                      obj.service_description(), obj.host_name());
 
   // Add anomalydetection to the global configuration set.
   config->anomalydetections().insert(obj);
@@ -238,8 +239,9 @@ void applier::anomalydetection::modify_object(
   engine_logger(logging::dbg_config, logging::more)
       << "Modifying new anomalydetection '" << service_description
       << "' of host '" << host_name << "'.";
-  log_v2::config()->debug("Modifying new anomalydetection '{}' of host '{}'.",
-                          service_description, host_name);
+  SPDLOG_LOGGER_DEBUG(log_v2::config(),
+                      "Modifying new anomalydetection '{}' of host '{}'.",
+                      service_description, host_name);
 
   // Find the configuration object.
   set_anomalydetection::iterator it_cfg(
@@ -447,8 +449,9 @@ void applier::anomalydetection::remove_object(
   engine_logger(logging::dbg_config, logging::more)
       << "Removing anomalydetection '" << service_description << "' of host '"
       << host_name << "'.";
-  log_v2::config()->debug("Removing anomalydetection '{}' of host '{}'.",
-                          service_description, host_name);
+  SPDLOG_LOGGER_DEBUG(log_v2::config(),
+                      "Removing anomalydetection '{}' of host '{}'.",
+                      service_description, host_name);
 
   // Find anomalydetection.
   service_id_map::iterator it(engine::service::services_by_id.find(obj.key()));
@@ -498,8 +501,9 @@ void applier::anomalydetection::resolve_object(
   engine_logger(logging::dbg_config, logging::more)
       << "Resolving anomalydetection '" << obj.service_description()
       << "' of host '" << obj.host_name() << "'.";
-  log_v2::config()->debug("Resolving anomalydetection '{}' of host '{}'.",
-                          obj.service_description(), obj.host_name());
+  SPDLOG_LOGGER_DEBUG(log_v2::config(),
+                      "Resolving anomalydetection '{}' of host '{}'.",
+                      obj.service_description(), obj.host_name());
 
   // Find anomalydetection.
   service_id_map::iterator it(

--- a/engine/src/configuration/state.cc
+++ b/engine/src/configuration/state.cc
@@ -140,6 +140,7 @@ std::unordered_map<std::string, state::setter_func> const state::_setters{
     {"log_notifications", SETTER(bool, log_notifications)},
     {"log_passive_checks", SETTER(bool, log_passive_checks)},
     {"log_pid", SETTER(bool, log_pid)},
+    {"log_file_line", SETTER(bool, log_file_line)},
     {"log_rotation_method",
      SETTER(std::string const&, _set_log_rotation_method)},
     {"log_service_retries", SETTER(bool, log_service_retries)},
@@ -457,6 +458,7 @@ state::state()
       _log_notifications(default_log_notifications),
       _log_passive_checks(default_log_passive_checks),
       _log_pid(default_log_pid),
+      _log_file_line(false),
       _log_service_retries(default_log_service_retries),
       _low_host_flap_threshold(default_low_host_flap_threshold),
       _low_service_flap_threshold(default_low_service_flap_threshold),
@@ -629,6 +631,7 @@ state& state::operator=(state const& right) {
     _log_notifications = right._log_notifications;
     _log_passive_checks = right._log_passive_checks;
     _log_pid = right._log_pid;
+    _log_file_line = right._log_file_line;
     _log_service_retries = right._log_service_retries;
     _low_host_flap_threshold = right._low_host_flap_threshold;
     _low_service_flap_threshold = right._low_service_flap_threshold;
@@ -792,7 +795,7 @@ bool state::operator==(state const& right) const noexcept {
       _log_host_retries == right._log_host_retries &&
       _log_notifications == right._log_notifications &&
       _log_passive_checks == right._log_passive_checks &&
-      _log_pid == right._log_pid &&
+      _log_pid == right._log_pid && _log_file_line == right._log_file_line &&
       _log_service_retries == right._log_service_retries &&
       _low_host_flap_threshold == right._low_host_flap_threshold &&
       _low_service_flap_threshold == right._low_service_flap_threshold &&
@@ -2460,6 +2463,15 @@ bool state::log_pid() const noexcept {
  */
 void state::log_pid(bool value) {
   _log_pid = value;
+}
+
+/**
+ *  Set the log file line value.
+ *
+ *  @param[in] value  The new log file line value.
+ */
+void state::log_file_line(bool value) {
+  _log_file_line = value;
 }
 
 /**

--- a/engine/src/host.cc
+++ b/engine/src/host.cc
@@ -1182,15 +1182,16 @@ int host::log_event() {
   engine_logger(log_options, basic)
       << "HOST ALERT: " << name() << ";" << state << ";" << state_type << ";"
       << get_current_attempt() << ";" << get_plugin_output();
-  log_v2::events()->info("HOST ALERT: {};{};{};{};{}", name(), state,
-                         state_type, get_current_attempt(),
-                         get_plugin_output());
+  SPDLOG_LOGGER_INFO(log_v2::events(), "HOST ALERT: {};{};{};{};{}", name(),
+                     state, state_type, get_current_attempt(),
+                     get_plugin_output());
 
   return OK;
 }
 
 /* process results of an asynchronous host check */
-int host::handle_async_check_result_3x(check_result* queued_check_result) {
+int host::handle_async_check_result_3x(
+    const check_result& queued_check_result) {
   enum service::service_state svc_res{service::state_ok};
   enum host::host_state hst_res{host::state_up};
   int reschedule_check{false};
@@ -1199,83 +1200,83 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
   struct timeval end_time_hires;
 
   engine_logger(dbg_functions, basic) << "handle_async_host_check_result_3x()";
-  log_v2::functions()->trace("handle_async_host_check_result_3x()");
-
-  /* make sure we have what we need */
-  if (!queued_check_result)
-    return ERROR;
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "handle_async_host_check_result_3x()");
 
   /* get the current time */
   time_t current_time = std::time(nullptr);
 
   double execution_time =
-      static_cast<double>(queued_check_result->get_finish_time().tv_sec -
-                          queued_check_result->get_start_time().tv_sec) +
-      static_cast<double>(queued_check_result->get_finish_time().tv_usec -
-                          queued_check_result->get_start_time().tv_usec) /
+      static_cast<double>(queued_check_result.get_finish_time().tv_sec -
+                          queued_check_result.get_start_time().tv_sec) +
+      static_cast<double>(queued_check_result.get_finish_time().tv_usec -
+                          queued_check_result.get_start_time().tv_usec) /
           1000000.0;
   if (execution_time < 0.0)
     execution_time = 0.0;
 
   engine_logger(dbg_checks, more)
       << "** Handling async check result for host '" << name() << "'...";
-  log_v2::checks()->debug("** Handling async check result for host '{}'...",
-                          name());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "** Handling async check result for host '{}'...",
+                      name());
 
   engine_logger(dbg_checks, most)
       << "\tCheck Type:         "
-      << (queued_check_result->get_check_type() == check_active ? "Active"
-                                                                : "Passive")
+      << (queued_check_result.get_check_type() == check_active ? "Active"
+                                                               : "Passive")
       << "\n"
-      << "\tCheck Options:      " << queued_check_result->get_check_options()
+      << "\tCheck Options:      " << queued_check_result.get_check_options()
       << "\n"
       << "\tReschedule Check?:  "
-      << (queued_check_result->get_reschedule_check() ? "Yes" : "No") << "\n"
+      << (queued_check_result.get_reschedule_check() ? "Yes" : "No") << "\n"
       << "\tShould Reschedule Current Host Check?:"
       << get_should_reschedule_current_check() << "\tExited OK?:         "
-      << (queued_check_result->get_exited_ok() ? "Yes" : "No") << "\n"
+      << (queued_check_result.get_exited_ok() ? "Yes" : "No") << "\n"
       << com::centreon::logging::setprecision(3)
       << "\tExec Time:          " << execution_time << "\n"
-      << "\tLatency:            " << queued_check_result->get_latency() << "\n"
-      << "\treturn Status:      " << queued_check_result->get_return_code()
+      << "\tLatency:            " << queued_check_result.get_latency() << "\n"
+      << "\treturn Status:      " << queued_check_result.get_return_code()
       << "\n"
-      << "\tOutput:             " << queued_check_result->get_output();
+      << "\tOutput:             " << queued_check_result.get_output();
 
-  log_v2::checks()->debug("Check Type: {}",
-                          queued_check_result->get_check_type() == check_active
-                              ? "Active"
-                              : "Passive");
-  log_v2::checks()->debug("Check Options: {}",
-                          queued_check_result->get_check_options());
-  log_v2::checks()->debug(
-      "Reschedule Check?:  {}",
-      queued_check_result->get_reschedule_check() ? "Yes" : "No");
-  log_v2::checks()->debug(
-      "Should Reschedule Current Host Check?: {}",
-      queued_check_result->get_reschedule_check() ? "Yes" : "No");
-  log_v2::checks()->debug("Exited OK?:         {}",
-                          queued_check_result->get_exited_ok() ? "Yes" : "No");
-  log_v2::checks()->debug("Exec Time:          {:.3f}", execution_time);
-  log_v2::checks()->debug("Latency:            {}",
-                          queued_check_result->get_latency());
-  log_v2::checks()->debug("return Status:      {}",
-                          queued_check_result->get_return_code());
-  log_v2::checks()->debug("Output:             {}",
-                          queued_check_result->get_output());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Check Type: {}",
+                      queued_check_result.get_check_type() == check_active
+                          ? "Active"
+                          : "Passive");
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Check Options: {}",
+                      queued_check_result.get_check_options());
+  SPDLOG_LOGGER_DEBUG(
+      log_v2::checks(), "Reschedule Check?:  {}",
+      queued_check_result.get_reschedule_check() ? "Yes" : "No");
+  SPDLOG_LOGGER_DEBUG(
+      log_v2::checks(), "Should Reschedule Current Host Check?: {}",
+      queued_check_result.get_reschedule_check() ? "Yes" : "No");
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Exited OK?:         {}",
+                      queued_check_result.get_exited_ok() ? "Yes" : "No");
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Exec Time:          {:.3f}",
+                      execution_time);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Latency:            {}",
+                      queued_check_result.get_latency());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "return Status:      {}",
+                      queued_check_result.get_return_code());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Output:             {}",
+                      queued_check_result.get_output());
   /* decrement the number of host checks still out there... */
-  if (queued_check_result->get_check_type() == check_active &&
+  if (queued_check_result.get_check_type() == check_active &&
       currently_running_host_checks > 0)
     currently_running_host_checks--;
 
   /*
    * skip this host check results if its passive and we aren't accepting passive
    * check results */
-  if (queued_check_result->get_check_type() == check_passive) {
+  if (queued_check_result.get_check_type() == check_passive) {
     if (!config->accept_passive_host_checks()) {
       engine_logger(dbg_checks, basic)
           << "Discarding passive host check result because passive host "
              "checks are disabled globally.";
-      log_v2::checks()->trace(
+      SPDLOG_LOGGER_TRACE(
+          log_v2::checks(),
           "Discarding passive host check result because passive host "
           "checks are disabled globally.");
 
@@ -1285,7 +1286,8 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
       engine_logger(dbg_checks, basic)
           << "Discarding passive host check result because passive checks "
              "are disabled for this host.";
-      log_v2::checks()->trace(
+      SPDLOG_LOGGER_TRACE(
+          log_v2::checks(),
           "Discarding passive host check result because passive checks "
           "are disabled for this host.");
       return ERROR;
@@ -1295,7 +1297,7 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
   /*
    * clear the freshening flag (it would have been set if this host was
    * determined to be stale) */
-  if (queued_check_result->get_check_options() & CHECK_OPTION_FRESHNESS_CHECK)
+  if (queued_check_result.get_check_options() & CHECK_OPTION_FRESHNESS_CHECK)
     set_is_being_freshened(false);
 
   /* DISCARD INVALID FRESHNESS CHECK RESULTS */
@@ -1306,13 +1308,14 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
   ** make the host fresh again, so we do a quick check to make sure the
   ** host is still stale before we accept the check result.
   */
-  if ((queued_check_result->get_check_options() &
+  if ((queued_check_result.get_check_options() &
        CHECK_OPTION_FRESHNESS_CHECK) &&
       is_result_fresh(current_time, false)) {
     engine_logger(dbg_checks, basic)
         << "Discarding host freshness check result because the host is "
            "currently fresh (race condition avoided).";
-    log_v2::checks()->trace(
+    SPDLOG_LOGGER_TRACE(
+        log_v2::checks(),
         "Discarding host freshness check result because the host is "
         "currently fresh (race condition avoided).");
     return OK;
@@ -1325,18 +1328,18 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
     set_last_hard_state_change(get_last_check());
 
   /* was this check passive or active? */
-  set_check_type((queued_check_result->get_check_type() == check_active)
+  set_check_type((queued_check_result.get_check_type() == check_active)
                      ? check_active
                      : check_passive);
 
   /* update check statistics for passive results */
-  if (queued_check_result->get_check_type() == check_passive)
+  if (queued_check_result.get_check_type() == check_passive)
     update_check_stats(PASSIVE_HOST_CHECK_STATS,
-                       queued_check_result->get_start_time().tv_sec);
+                       queued_check_result.get_start_time().tv_sec);
 
   /* should we reschedule the next check of the host? NOTE: this might be
    * overridden later... */
-  reschedule_check = queued_check_result->get_reschedule_check();
+  reschedule_check = queued_check_result.get_reschedule_check();
 
   // Inherit the should reschedule flag from the host. It is used when
   // rescheduled checks were discarded because only one check can be executed
@@ -1344,14 +1347,14 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
   // and this check should be rescheduled regardless of what it was meant
   // to initially.
   if (get_should_reschedule_current_check() &&
-      !queued_check_result->get_reschedule_check())
+      !queued_check_result.get_reschedule_check())
     reschedule_check = true;
 
   // Clear the should reschedule flag.
   set_should_reschedule_current_check(false);
 
   /* check latency is passed to us for both active and passive checks */
-  set_latency(queued_check_result->get_latency());
+  set_latency(queued_check_result.get_latency());
 
   /* update the execution time for this check (millisecond resolution) */
   set_execution_time(execution_time);
@@ -1360,14 +1363,14 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
   set_has_been_checked(true);
 
   /* clear the execution flag if this was an active check */
-  if (queued_check_result->get_check_type() == check_active)
+  if (queued_check_result.get_check_type() == check_active)
     set_is_executing(false);
 
   /* get the last check time */
-  set_last_check(queued_check_result->get_start_time().tv_sec);
+  set_last_check(queued_check_result.get_start_time().tv_sec);
 
   /* was this check passive or active? */
-  set_check_type((queued_check_result->get_check_type() == check_active)
+  set_check_type((queued_check_result.get_check_type() == check_active)
                      ? check_active
                      : check_passive);
 
@@ -1383,7 +1386,7 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
   /* parse check output to get: (1) short output, (2) long output, (3) perf data
    */
 
-  std::string output{queued_check_result->get_output()};
+  std::string output{queued_check_result.get_output()};
   std::string plugin_output;
   std::string long_plugin_output;
   std::string perf_data;
@@ -1413,7 +1416,8 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
       << "\n"
       << "Perf Data:\n"
       << (get_perf_data().empty() ? "NULL" : get_perf_data());
-  log_v2::checks()->debug(
+  SPDLOG_LOGGER_DEBUG(
+      log_v2::checks(),
       "Parsing check output... Short Output: {}  Long Output: {} "
       "Perf Data: {}",
       get_plugin_output().empty() ? "NULL" : get_plugin_output(),
@@ -1422,20 +1426,21 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
   /* get the unprocessed return code */
   /* NOTE: for passive checks, this is the final/processed state */
   svc_res = static_cast<enum service::service_state>(
-      queued_check_result->get_return_code());
-  hst_res = static_cast<enum host::host_state>(
-      queued_check_result->get_return_code());
+      queued_check_result.get_return_code());
+  hst_res =
+      static_cast<enum host::host_state>(queued_check_result.get_return_code());
 
   /* adjust return code (active checks only) */
-  if (queued_check_result->get_check_type() == check_active) {
+  if (queued_check_result.get_check_type() == check_active) {
     /* if there was some error running the command, just skip it (this shouldn't
      * be happening) */
-    if (!queued_check_result->get_exited_ok()) {
+    if (!queued_check_result.get_exited_ok()) {
       engine_logger(log_runtime_warning, basic)
           << "Warning:  Check of host '" << name()
           << "' did not exit properly!";
-      log_v2::runtime()->warn(
-          "Warning:  Check of host '{}' did not exit properly!", name());
+      SPDLOG_LOGGER_WARN(log_v2::runtime(),
+                         "Warning:  Check of host '{}' did not exit properly!",
+                         name());
 
       set_plugin_output("(Host check did not exit properly)");
       set_long_plugin_output("");
@@ -1445,31 +1450,32 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
     }
 
     /* make sure the return code is within bounds */
-    else if (queued_check_result->get_return_code() < 0 ||
-             queued_check_result->get_return_code() > 3) {
+    else if (queued_check_result.get_return_code() < 0 ||
+             queued_check_result.get_return_code() > 3) {
       engine_logger(log_runtime_warning, basic)
           << "Warning: return (code of "
-          << queued_check_result->get_return_code() << " for check of host '"
+          << queued_check_result.get_return_code() << " for check of host '"
           << name() << "' was out of bounds."
-          << ((queued_check_result->get_return_code() == 126 ||
-               queued_check_result->get_return_code() == 127)
+          << ((queued_check_result.get_return_code() == 126 ||
+               queued_check_result.get_return_code() == 127)
                   ? " Make sure the plugin you're trying to run actually "
                     "exists."
                   : "");
-      log_v2::runtime()->warn(
+      SPDLOG_LOGGER_WARN(
+          log_v2::runtime(),
           "Warning: return (code of {} for check of host '{}' was out of "
           "bounds.",
-          queued_check_result->get_return_code(), name(),
-          (queued_check_result->get_return_code() == 126 ||
-           queued_check_result->get_return_code() == 127)
+          queued_check_result.get_return_code(), name(),
+          (queued_check_result.get_return_code() == 126 ||
+           queued_check_result.get_return_code() == 127)
               ? " Make sure the plugin you're trying to run actually exists."
               : "");
 
       std::ostringstream oss;
-      oss << "(Return code of " << queued_check_result->get_return_code()
+      oss << "(Return code of " << queued_check_result.get_return_code()
           << " is out of bounds"
-          << ((queued_check_result->get_return_code() == 126 ||
-               queued_check_result->get_return_code() == 127)
+          << ((queued_check_result.get_return_code() == 126 ||
+               queued_check_result.get_return_code() == 127)
                   ? " - plugin may be missing"
                   : "")
           << ")";
@@ -1492,7 +1498,7 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
    * determination is made later */
   /* NOTE: only do this for active checks - passive check results already have
    * the final state */
-  if (queued_check_result->get_check_type() == check_active) {
+  if (queued_check_result.get_check_type() == check_active) {
     /* Let WARNING states indicate the host is up
      * (fake the result to be state_ok) */
     if (svc_res == service::state_warning)
@@ -1517,12 +1523,13 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
   engine_logger(dbg_checks, more)
       << "** Async check result for host '" << name()
       << "' handled: new state=" << get_current_state();
-  log_v2::checks()->debug(
+  SPDLOG_LOGGER_DEBUG(
+      log_v2::checks(),
       "** Async check result for host '{}' handled: new state={}", name(),
       get_current_state());
 
   /* high resolution start time for event broker */
-  start_time_hires = queued_check_result->get_start_time();
+  start_time_hires = queued_check_result.get_start_time();
 
   /* high resolution end time for event broker */
   gettimeofday(&end_time_hires, nullptr);
@@ -1532,8 +1539,8 @@ int host::handle_async_check_result_3x(check_result* queued_check_result) {
       NEBTYPE_HOSTCHECK_PROCESSED, NEBFLAG_NONE, NEBATTR_NONE, this,
       get_check_type(), get_current_state(), get_state_type(), start_time_hires,
       end_time_hires, get_latency(), get_execution_time(),
-      config->host_check_timeout(), queued_check_result->get_early_timeout(),
-      queued_check_result->get_return_code(), nullptr,
+      config->host_check_timeout(), queued_check_result.get_early_timeout(),
+      queued_check_result.get_return_code(), nullptr,
       const_cast<char*>(get_plugin_output().c_str()),
       const_cast<char*>(get_long_plugin_output().c_str()),
       const_cast<char*>(get_perf_data().c_str()), nullptr);
@@ -1549,12 +1556,13 @@ int host::run_scheduled_check(int check_options, double latency) {
   bool time_is_valid = true;
 
   engine_logger(dbg_functions, basic) << "run_scheduled_host_check_3x()";
-  log_v2::functions()->trace("run_scheduled_host_check_3x()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "run_scheduled_host_check_3x()");
 
   engine_logger(dbg_checks, basic)
       << "Attempting to run scheduled check of host '" << name()
       << "': check options=" << check_options << ", latency=" << latency;
-  log_v2::checks()->trace(
+  SPDLOG_LOGGER_TRACE(
+      log_v2::checks(),
       "Attempting to run scheduled check of host '{}': check options={}, "
       "latency={}",
       name(), check_options, latency);
@@ -1567,7 +1575,8 @@ int host::run_scheduled_check(int check_options, double latency) {
   if (result == ERROR) {
     engine_logger(dbg_checks, more)
         << "Unable to run scheduled host check at this time";
-    log_v2::checks()->debug("Unable to run scheduled host check at this time");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                        "Unable to run scheduled host check at this time");
 
     /* only attempt to (re)schedule checks that should get checked... */
     if (get_should_be_scheduled()) {
@@ -1602,7 +1611,8 @@ int host::run_scheduled_check(int check_options, double latency) {
             << "' could not be "
                "rescheduled properly.  Scheduling check for next week... "
             << " next_check  " << get_next_check();
-        log_v2::runtime()->warn(
+        SPDLOG_LOGGER_WARN(
+            log_v2::runtime(),
             "Warning: Check of host '{}' could not be rescheduled properly.  "
             "Scheduling check for next week... next_check  {}",
             name(), get_next_check());
@@ -1610,7 +1620,8 @@ int host::run_scheduled_check(int check_options, double latency) {
         engine_logger(dbg_checks, more)
             << "Unable to find any valid times to reschedule the next"
                " host check!";
-        log_v2::checks()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::checks(),
             "Unable to find any valid times to reschedule the next host "
             "check!");
       }
@@ -1621,8 +1632,9 @@ int host::run_scheduled_check(int check_options, double latency) {
 
         engine_logger(dbg_checks, more)
             << "Rescheduled next host check for " << my_ctime(&next_valid_time);
-        log_v2::checks()->debug("Rescheduled next host check for {}",
-                                my_ctime(&next_valid_time));
+        SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                            "Rescheduled next host check for {}",
+                            my_ctime(&next_valid_time));
       }
     }
 
@@ -1653,10 +1665,11 @@ int host::run_async_check(int check_options,
       << "host::run_async_check, check_options=" << check_options
       << ", latency=" << latency << ", scheduled_check=" << scheduled_check
       << ", reschedule_check=" << reschedule_check;
-  log_v2::functions()->trace(
-      "host::run_async_check, check_options={}, latency={}, "
-      "scheduled_check={}, reschedule_check={}",
-      check_options, latency, scheduled_check, reschedule_check);
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "host::run_async_check, check_options={}, latency={}, "
+                      "scheduled_check={}, reschedule_check={}",
+                      check_options, latency, scheduled_check,
+                      reschedule_check);
 
   // Preamble.
   if (!get_check_command_ptr()) {
@@ -1671,7 +1684,8 @@ int host::run_async_check(int check_options,
 
   engine_logger(dbg_checks, basic)
       << "** Running async check of host '" << name() << "'...";
-  log_v2::checks()->trace("** Running async check of host '{}'...", name());
+  SPDLOG_LOGGER_TRACE(log_v2::checks(),
+                      "** Running async check of host '{}'...", name());
 
   // Check if the host is viable now.
   if (!verify_check_viability(check_options, time_is_valid, preferred_time))
@@ -1689,7 +1703,8 @@ int host::run_async_check(int check_options,
     engine_logger(dbg_checks, basic)
         << "A check of this host (" << name()
         << ") is already being executed, so we'll pass for the moment...";
-    log_v2::checks()->trace(
+    SPDLOG_LOGGER_TRACE(
+        log_v2::checks(),
         "A check of this host ({}) is already being executed, so we'll pass "
         "for the moment...",
         name());
@@ -1721,7 +1736,8 @@ int host::run_async_check(int check_options,
     engine_logger(dbg_functions, basic)
         << "Some broker module overrode check of host '" << name()
         << "' so we'll bail out";
-    log_v2::functions()->trace(
+    SPDLOG_LOGGER_TRACE(
+        log_v2::functions(),
         "Some broker module overrode check of host '{}' so we'll bail out",
         name());
     return OK;
@@ -1729,7 +1745,7 @@ int host::run_async_check(int check_options,
 
   // Checking starts.
   engine_logger(dbg_functions, basic) << "Checking host '" << name() << "'...";
-  log_v2::functions()->trace("Checking host '{}'...", name());
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "Checking host '{}'...", name());
 
   // Clear check options.
   if (scheduled_check)
@@ -1764,7 +1780,7 @@ int host::run_async_check(int check_options,
   set_is_executing(true);
 
   // Get command object.
-  commands::command* cmd = get_check_command_ptr();
+  commands::command* cmd = get_check_command_ptr().get();
   std::string processed_cmd(cmd->process_cmd(macros));
 
   // Send event broker.
@@ -1785,10 +1801,10 @@ int host::run_async_check(int check_options,
 
   // Run command.
   bool retry;
-  std::unique_ptr<check_result> check_result_info;
+  check_result::pointer check_result_info;
   do {
     // Init check result info.
-    check_result_info = std::make_unique<check_result>(
+    check_result_info = std::make_shared<check_result>(
         host_check, this, checkable::check_active, check_options,
         reschedule_check, latency, start_time, start_time, false, true,
         service::state_ok, "");
@@ -1796,11 +1812,8 @@ int host::run_async_check(int check_options,
     retry = false;
     try {
       // Run command.
-      uint64_t id =
-          cmd->run(processed_cmd, *macros, config->host_check_timeout());
-      if (id != 0)
-        checks::checker::instance().add_check_result(
-            id, check_result_info.release());
+      uint64_t id = cmd->run(processed_cmd, *macros,
+                             config->host_check_timeout(), check_result_info);
     } catch (com::centreon::exceptions::interruption const& e) {
       retry = true;
     } catch (std::exception const& e) {
@@ -1814,13 +1827,13 @@ int host::run_async_check(int check_options,
       check_result_info->set_output("(Execute command failed)");
 
       // Queue check result.
-      checks::checker::instance().add_check_result_to_reap(
-          check_result_info.release());
+      checks::checker::instance().add_check_result_to_reap(check_result_info);
 
       engine_logger(log_runtime_warning, basic)
           << "Error: Host check command execution failed: " << e.what();
-      log_v2::runtime()->warn("Error: Host check command execution failed: {}",
-                              e.what());
+      SPDLOG_LOGGER_WARN(log_v2::runtime(),
+                         "Error: Host check command execution failed: {}",
+                         e.what());
     }
   } while (retry);
 
@@ -1844,15 +1857,15 @@ bool host::schedule_check(time_t check_time,
   int use_original_event = true;
 
   engine_logger(dbg_functions, basic) << "schedule_host_check()";
-  log_v2::functions()->trace("schedule_host_check()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "schedule_host_check()");
 
   engine_logger(dbg_checks, basic)
       << "Scheduling a "
       << (options & CHECK_OPTION_FORCE_EXECUTION ? "forced" : "non-forced")
       << ", active check of host '" << name() << "' @ "
       << my_ctime(&check_time);
-  log_v2::checks()->trace(
-      "Scheduling a {}, active check of host '{}' @ {}",
+  SPDLOG_LOGGER_TRACE(
+      log_v2::checks(), "Scheduling a {}, active check of host '{}' @ {}",
       options & CHECK_OPTION_FORCE_EXECUTION ? "forced" : "non-forced", name(),
       my_ctime(&check_time));
 
@@ -1860,7 +1873,8 @@ bool host::schedule_check(time_t check_time,
   if (!active_checks_enabled() && !(options & CHECK_OPTION_FORCE_EXECUTION)) {
     engine_logger(dbg_checks, basic)
         << "Active checks are disabled for this host.";
-    log_v2::checks()->trace("Active checks are disabled for this host.");
+    SPDLOG_LOGGER_TRACE(log_v2::checks(),
+                        "Active checks are disabled for this host.");
     return false;
   }
 
@@ -1884,8 +1898,9 @@ bool host::schedule_check(time_t check_time,
     engine_logger(dbg_checks, most)
         << "Found another host check event for this host @ "
         << my_ctime(&temp_event->run_time);
-    log_v2::checks()->debug("Found another host check event for this host @ {}",
-                            my_ctime(&temp_event->run_time));
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                        "Found another host check event for this host @ {}",
+                        my_ctime(&temp_event->run_time));
     /* use the originally scheduled check unless we decide otherwise */
     use_original_event = true;
 
@@ -1898,7 +1913,8 @@ bool host::schedule_check(time_t check_time,
         engine_logger(dbg_checks, most)
             << "New host check event is forced and occurs before the "
                "existing event, so the new event be used instead.";
-        log_v2::checks()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::checks(),
             "New host check event is forced and occurs before the "
             "existing event, so the new event be used instead.");
         use_original_event = false;
@@ -1913,7 +1929,8 @@ bool host::schedule_check(time_t check_time,
         engine_logger(dbg_checks, most)
             << "New host check event is forced, so it will be used "
                "instead of the existing event.";
-        log_v2::checks()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::checks(),
             "New host check event is forced, so it will be used "
             "instead of the existing event.");
       }
@@ -1925,7 +1942,8 @@ bool host::schedule_check(time_t check_time,
         engine_logger(dbg_checks, most)
             << "New host check event occurs before the existing (older) "
                "event, so it will be used instead.";
-        log_v2::checks()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::checks(),
             "New host check event occurs before the existing (older) "
             "event, so it will be used instead.");
       }
@@ -1935,7 +1953,8 @@ bool host::schedule_check(time_t check_time,
         engine_logger(dbg_checks, most)
             << "New host check event occurs after the existing event, "
                "so we'll ignore it.";
-        log_v2::checks()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::checks(),
             "New host check event occurs after the existing event, "
             "so we'll ignore it.");
       }
@@ -1951,7 +1970,7 @@ bool host::schedule_check(time_t check_time,
   /* use the new event */
   if (!use_original_event) {
     engine_logger(dbg_checks, most) << "Scheduling new host check event.";
-    log_v2::checks()->debug("Scheduling new host check event.");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Scheduling new host check event.");
 
     /* set the next host check time */
     set_next_check(check_time);
@@ -1969,7 +1988,8 @@ bool host::schedule_check(time_t check_time,
 
     engine_logger(dbg_checks, most)
         << "Keeping original host check event (ignoring the new one).";
-    log_v2::checks()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::checks(),
         "Keeping original host check event at {:%Y-%m-%dT%H:%M:%S} (ignoring "
         "the new one at {:%Y-%m-%dT%H:%M:%S}).",
         fmt::localtime(get_next_check()), fmt::localtime(check_time));
@@ -2002,11 +2022,12 @@ void host::check_for_flapping(bool update,
   double high_curve_value = 1.25;
 
   engine_logger(dbg_functions, basic) << "host::check_for_flapping()";
-  log_v2::functions()->trace("host::check_for_flapping()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "host::check_for_flapping()");
 
   engine_logger(dbg_flapping, more)
       << "Checking host '" << name() << "' for flapping...";
-  log_v2::checks()->debug("Checking host '{}' for flapping...", name());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Checking host '{}' for flapping...",
+                      name());
 
   time(&current_time);
 
@@ -2095,9 +2116,9 @@ void host::check_for_flapping(bool update,
       << com::centreon::logging::setprecision(2) << "LFT=" << low_threshold
       << ", HFT=" << high_threshold << ", CPC=" << curved_percent_change
       << ", PSC=" << curved_percent_change << "%";
-  log_v2::checks()->debug("LFT={:.2f}, HFT={}, CPC={}, PSC={}%", low_threshold,
-                          high_threshold, curved_percent_change,
-                          curved_percent_change);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "LFT={:.2f}, HFT={}, CPC={}, PSC={}%",
+                      low_threshold, high_threshold, curved_percent_change,
+                      curved_percent_change);
 
   /* don't do anything if we don't have flap detection enabled on a program-wide
    * basis */
@@ -2126,8 +2147,8 @@ void host::check_for_flapping(bool update,
   engine_logger(dbg_flapping, more)
       << "Host " << (is_flapping ? "is" : "is not") << " flapping ("
       << curved_percent_change << "% state change).";
-  log_v2::checks()->debug("Host {} flapping ({}% state change).",
-                          is_flapping ? "is" : "is not", curved_percent_change);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Host {} flapping ({}% state change).",
+                      is_flapping ? "is" : "is not", curved_percent_change);
 
   /* did the host just start flapping? */
   if (is_flapping && !get_is_flapping())
@@ -2144,11 +2165,11 @@ void host::set_flap(double percent_change,
                     double low_threshold,
                     bool allow_flapstart_notification) {
   engine_logger(dbg_functions, basic) << "set_host_flap()";
-  log_v2::functions()->trace("set_host_flap()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "set_host_flap()");
 
   engine_logger(dbg_flapping, more)
       << "Host '" << name() << "' started flapping!";
-  log_v2::checks()->debug("Host '{}' started flapping!", name());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Host '{}' started flapping!", name());
 
   /* log a notice - this one is parsed by the history CGI */
   engine_logger(log_runtime_warning, basic)
@@ -2156,7 +2177,8 @@ void host::set_flap(double percent_change,
       << "HOST FLAPPING ALERT: " << name()
       << ";STARTED; Host appears to have started flapping (" << percent_change
       << "% change > " << high_threshold << "% threshold)";
-  log_v2::runtime()->warn(
+  SPDLOG_LOGGER_WARN(
+      log_v2::runtime(),
       "HOST FLAPPING ALERT: {};STARTED; Host appears to have started flapping "
       "({:.1f}% change > {:.1f}% threshold)",
       name(), percent_change, high_threshold);
@@ -2200,11 +2222,11 @@ void host::clear_flap(double percent_change,
                       double high_threshold,
                       double low_threshold) {
   engine_logger(dbg_functions, basic) << "host::clear_flap()";
-  log_v2::functions()->trace("host::clear_flap()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "host::clear_flap()");
 
   engine_logger(dbg_flapping, basic)
       << "Host '" << name() << "' stopped flapping.";
-  log_v2::checks()->debug("Host '{}' stopped flapping.", name());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Host '{}' stopped flapping.", name());
 
   /* log a notice - this one is parsed by the history CGI */
   engine_logger(log_info_message, basic)
@@ -2212,7 +2234,8 @@ void host::clear_flap(double percent_change,
       << "HOST FLAPPING ALERT: " << name()
       << ";STOPPED; Host appears to have stopped flapping (" << percent_change
       << "% change < " << low_threshold << "% threshold)";
-  log_v2::events()->info(
+  SPDLOG_LOGGER_INFO(
+      log_v2::events(),
       "HOST FLAPPING ALERT: {};STOPPED; Host appears to have stopped flapping "
       "({:.1f}% change < {:.1f}% threshold)",
       name(), percent_change, low_threshold);
@@ -2256,8 +2279,8 @@ void host::check_for_expired_acknowledgement() {
       if (last_acknowledgement() + acknowledgement_timeout() >= now) {
         engine_logger(log_info_message, basic)
             << "Acknowledgement of host '" << name() << "' just expired";
-        log_v2::events()->info("Acknowledgement of host '{}' just expired",
-                               name());
+        SPDLOG_LOGGER_INFO(log_v2::events(),
+                           "Acknowledgement of host '{}' just expired", name());
         set_problem_has_been_acknowledged(false);
         set_acknowledgement_type(ACKNOWLEDGEMENT_NONE);
         // FIXME DBO: could be improved with something smaller.
@@ -2274,7 +2297,7 @@ int host::handle_state() {
   time_t current_time;
 
   engine_logger(dbg_functions, basic) << "handle_host_state()";
-  log_v2::functions()->trace("handle_host_state()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "handle_host_state()");
 
   /* get current time */
   time(&current_time);
@@ -2439,7 +2462,7 @@ bool host::verify_check_viability(int check_options,
   int check_interval = 0;
 
   engine_logger(dbg_functions, basic) << "check_host_check_viability_3x()";
-  log_v2::functions()->trace("check_host_check_viability_3x()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "check_host_check_viability_3x()");
 
   /* get the check interval to use if we need to reschedule the check */
   if (this->get_state_type() == soft &&
@@ -2518,7 +2541,7 @@ int host::notify_contact(nagios_macros* mac,
   int neb_result;
 
   engine_logger(dbg_functions, basic) << "notify_contact_of_host()";
-  log_v2::functions()->trace("notify_contact_of_host()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "notify_contact_of_host()");
   engine_logger(dbg_notifications, most)
       << "** Notifying contact '" << cntct->get_name() << "'";
   log_v2::notifications()->info("** Notifying contact '{}'", cntct->get_name());
@@ -2558,7 +2581,7 @@ int host::notify_contact(nagios_macros* mac,
       continue;
 
     /* get the raw command line */
-    get_raw_command_line_r(mac, cmd.get(), cmd->get_command_line().c_str(),
+    get_raw_command_line_r(mac, cmd, cmd->get_command_line().c_str(),
                            raw_command, macro_options);
     if (raw_command.empty())
       continue;
@@ -2681,7 +2704,7 @@ void host::disable_flap_detection() {
   unsigned long attr = MODATTR_FLAP_DETECTION_ENABLED;
 
   engine_logger(dbg_functions, basic) << "disable_host_flap_detection()";
-  log_v2::functions()->trace("disable_host_flap_detection()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "disable_host_flap_detection()");
 
   engine_logger(dbg_functions, more)
       << "Disabling flap detection for host '" << name() << "'.";
@@ -2711,11 +2734,12 @@ void host::enable_flap_detection() {
   unsigned long attr = MODATTR_FLAP_DETECTION_ENABLED;
 
   engine_logger(dbg_functions, basic) << "host::enable_flap_detection()";
-  log_v2::functions()->trace("host::enable_flap_detection()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "host::enable_flap_detection()");
 
   engine_logger(dbg_flapping, more)
       << "Enabling flap detection for host '" << name() << "'.";
-  log_v2::checks()->debug("Enabling flap detection for host '{}'.", name());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Enabling flap detection for host '{}'.", name());
 
   /* nothing to do... */
   if (flap_detection_enabled())
@@ -2750,7 +2774,8 @@ bool host::is_valid_escalation_for_notification(escalation const* e,
 
   engine_logger(dbg_functions, basic)
       << "host::is_valid_escalation_for_notification()";
-  log_v2::functions()->trace("host::is_valid_escalation_for_notification()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "host::is_valid_escalation_for_notification()");
 
   /* get the current time */
   time(&current_time);
@@ -2817,7 +2842,8 @@ bool host::is_result_fresh(time_t current_time, int log_this) {
 
   engine_logger(dbg_checks, most)
       << "Checking freshness of host '" << name() << "'...";
-  log_v2::checks()->debug("Checking freshness of host '{}'...", name());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Checking freshness of host '{}'...",
+                      name());
 
   /* use user-supplied freshness threshold or auto-calculate a freshness
    * threshold to use? */
@@ -2836,8 +2862,8 @@ bool host::is_result_fresh(time_t current_time, int log_this) {
   engine_logger(dbg_checks, most)
       << "Freshness thresholds: host=" << get_freshness_threshold()
       << ", use=" << freshness_threshold;
-  log_v2::checks()->debug("Freshness thresholds: host={}, use={}",
-                          get_freshness_threshold(), freshness_threshold);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Freshness thresholds: host={}, use={}",
+                      get_freshness_threshold(), freshness_threshold);
 
   /* calculate expiration time */
   /* CHANGED 11/10/05 EG - program start is only used in expiration time
@@ -2863,9 +2889,10 @@ bool host::is_result_fresh(time_t current_time, int log_this) {
       << "HBC: " << has_been_checked() << ", PS: " << program_start
       << ", ES: " << event_start << ", LC: " << get_last_check()
       << ", CT: " << current_time << ", ET: " << expiration_time;
-  log_v2::checks()->debug("HBC: {}, PS: {}, ES: {}, LC: {}, CT: {}, ET: {}",
-                          has_been_checked(), program_start, event_start,
-                          get_last_check(), current_time, expiration_time);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "HBC: {}, PS: {}, ES: {}, LC: {}, CT: {}, ET: {}",
+                      has_been_checked(), program_start, event_start,
+                      get_last_check(), current_time, expiration_time);
 
   /* the results for the last check of this host are stale */
   if (expiration_time < current_time) {
@@ -2883,7 +2910,8 @@ bool host::is_result_fresh(time_t current_time, int log_this) {
           << "m " << tseconds
           << "s).  I'm forcing an immediate check of"
              " the host.";
-    log_v2::runtime()->warn(
+    SPDLOG_LOGGER_WARN(
+        log_v2::runtime(),
         "Warning: The results of host '{}' are stale by {}d {}h {}m {}s "
         "(threshold={}d {}h {}m {}s).  I'm forcing an immediate check of the "
         "host.",
@@ -2897,7 +2925,8 @@ bool host::is_result_fresh(time_t current_time, int log_this) {
         << "m " << tseconds
         << "s).  "
            "Forcing an immediate check of the host...";
-    log_v2::checks()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::checks(),
         "Check results for host '{}' are stale by {}d {}h {}m {}s "
         "(threshold={}d {}h {}m {}s). Forcing an immediate check of the "
         "host...",
@@ -2908,8 +2937,8 @@ bool host::is_result_fresh(time_t current_time, int log_this) {
   } else
     engine_logger(dbg_checks, more)
         << "Check results for host '" << this->name() << "' are fresh.";
-  log_v2::checks()->debug("Check results for host '{}' are fresh.",
-                          this->name());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Check results for host '{}' are fresh.", this->name());
 
   return true;
 }
@@ -2919,7 +2948,8 @@ bool host::is_result_fresh(time_t current_time, int log_this) {
 void host::handle_flap_detection_disabled() {
   engine_logger(dbg_functions, basic)
       << "handle_host_flap_detection_disabled()";
-  log_v2::functions()->trace("handle_host_flap_detection_disabled()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "handle_host_flap_detection_disabled()");
   /* if the host was flapping, remove the flapping indicator */
   if (get_is_flapping()) {
     this->set_is_flapping(false);
@@ -2933,7 +2963,8 @@ void host::handle_flap_detection_disabled() {
     engine_logger(log_info_message, basic)
         << "HOST FLAPPING ALERT: " << this->name()
         << ";DISABLED; Flap detection has been disabled";
-    log_v2::events()->info(
+    SPDLOG_LOGGER_INFO(
+        log_v2::events(),
         "HOST FLAPPING ALERT: {};DISABLED; Flap detection has been disabled",
         this->name());
 
@@ -2958,7 +2989,7 @@ int host::perform_on_demand_check(enum host::host_state* check_return_code,
                                   int use_cached_result,
                                   unsigned long check_timestamp_horizon) {
   engine_logger(dbg_functions, basic) << "perform_on_demand_host_check()";
-  log_v2::functions()->trace("perform_on_demand_host_check()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "perform_on_demand_host_check()");
 
   perform_on_demand_check_3x(check_return_code, check_options,
                              use_cached_result, check_timestamp_horizon);
@@ -2973,11 +3004,12 @@ int host::perform_on_demand_check_3x(host::host_state* check_result_code,
   int result = OK;
 
   engine_logger(dbg_functions, basic) << "perform_on_demand_host_check_3x()";
-  log_v2::functions()->trace("perform_on_demand_host_check_3x()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "perform_on_demand_host_check_3x()");
 
   engine_logger(dbg_checks, basic)
       << "** On-demand check for host '" << name() << "'...";
-  log_v2::checks()->trace("** On-demand check for host '{}'...", name());
+  SPDLOG_LOGGER_TRACE(log_v2::checks(), "** On-demand check for host '{}'...",
+                      name());
 
   /* check the status of the host */
   result = this->run_sync_check_3x(check_result_code, check_options,
@@ -2996,7 +3028,8 @@ int host::run_sync_check_3x(enum host::host_state* check_result_code,
       << ", check_options=" << check_options
       << ", use_cached_result=" << use_cached_result
       << ", check_timestamp_horizon=" << check_timestamp_horizon;
-  log_v2::functions()->trace(
+  SPDLOG_LOGGER_TRACE(
+      log_v2::functions(),
       "run_sync_host_check_3x: hst={}, check_options={}, use_cached_result={}, "
       "check_timestamp_horizon={}",
       (void*)this, check_options, use_cached_result, check_timestamp_horizon);
@@ -3033,7 +3066,7 @@ int host::process_check_result_3x(enum host::host_state new_state,
   bool has_parent;
 
   engine_logger(dbg_functions, basic) << "process_host_check_result_3x()";
-  log_v2::functions()->trace("process_host_check_result_3x()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "process_host_check_result_3x()");
 
   engine_logger(dbg_checks, more)
       << "HOST: " << name() << ", ATTEMPT=" << get_current_attempt() << "/"
@@ -3041,7 +3074,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
       << (get_check_type() == check_active ? "ACTIVE" : "PASSIVE")
       << ", STATE TYPE=" << (get_state_type() == hard ? "HARD" : "SOFT")
       << ", OLD STATE=" << get_current_state() << ", NEW STATE=" << new_state;
-  log_v2::checks()->debug(
+  SPDLOG_LOGGER_DEBUG(
+      log_v2::checks(),
       "HOST: {}, ATTEMPT={}/{}, CHECK TYPE={}, STATE TYPE={}, OLD STATE={}, "
       "NEW STATE={}",
       name(), get_current_attempt(), max_check_attempts(),
@@ -3061,14 +3095,14 @@ int host::process_check_result_3x(enum host::host_state new_state,
       engine_logger(log_passive_check, basic)
           << "PASSIVE HOST CHECK: " << name() << ";" << new_state << ";"
           << get_plugin_output();
-    log_v2::checks()->debug("PASSIVE HOST CHECK: {};{};{}", name(), new_state,
-                            get_plugin_output());
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(), "PASSIVE HOST CHECK: {};{};{}",
+                        name(), new_state, get_plugin_output());
   }
 
   /******* HOST WAS DOWN/UNREACHABLE INITIALLY *******/
   if (_current_state != host::state_up) {
     engine_logger(dbg_checks, more) << "Host was DOWN/UNREACHABLE.";
-    log_v2::checks()->debug("Host was DOWN/UNREACHABLE.");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Host was DOWN/UNREACHABLE.");
 
     /***** HOST IS NOW UP *****/
     /* the host just recovered! */
@@ -3088,8 +3122,9 @@ int host::process_check_result_3x(enum host::host_state new_state,
           << "Host experienced a "
           << (get_state_type() == hard ? "HARD" : "SOFT")
           << " recovery (it's now UP).";
-      log_v2::checks()->debug("Host experienced a {} recovery (it's now UP).",
-                              get_state_type() == hard ? "HARD" : "SOFT");
+      SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                          "Host experienced a {} recovery (it's now UP).",
+                          get_state_type() == hard ? "HARD" : "SOFT");
 
       /* reschedule the next check of the host at the normal interval */
       reschedule_check = true;
@@ -3099,7 +3134,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
        * somewhere and we should catch the recovery as soon as possible */
       engine_logger(dbg_checks, more)
           << "Propagating checks to parent host(s)...";
-      log_v2::checks()->debug("Propagating checks to parent host(s)...");
+      SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                          "Propagating checks to parent host(s)...");
 
       for (host_map_unsafe::iterator it{parent_hosts.begin()},
            end{parent_hosts.end()};
@@ -3109,8 +3145,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
         if (it->second->get_current_state() != host::state_up) {
           engine_logger(dbg_checks, more)
               << "Check of parent host '" << it->first << "' queued.";
-          log_v2::checks()->debug("Check of parent host '{}' queued.",
-                                  it->first);
+          SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                              "Check of parent host '{}' queued.", it->first);
           check_hostlist.push_back(it->second);
         }
       }
@@ -3120,7 +3156,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
        * result of this recovery) switch to UP or DOWN states */
       engine_logger(dbg_checks, more)
           << "Propagating checks to child host(s)...";
-      log_v2::checks()->debug("Propagating checks to child host(s)...");
+      SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                          "Propagating checks to child host(s)...");
 
       for (host_map_unsafe::iterator it{child_hosts.begin()},
            end{child_hosts.end()};
@@ -3130,8 +3167,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
         if (it->second->get_current_state() != host::state_up) {
           engine_logger(dbg_checks, more)
               << "Check of child host '" << it->first << "' queued.";
-          log_v2::checks()->debug("Check of child host '{}' queued.",
-                                  it->first);
+          SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                              "Check of child host '{}' queued.", it->first);
           check_hostlist.push_back(it->second);
         }
       }
@@ -3141,7 +3178,7 @@ int host::process_check_result_3x(enum host::host_state new_state,
     /* we're still in a problem state... */
     else {
       engine_logger(dbg_checks, more) << "Host is still DOWN/UNREACHABLE.";
-      log_v2::checks()->debug("Host is still DOWN/UNREACHABLE.");
+      SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Host is still DOWN/UNREACHABLE.");
 
       /* set the state type */
       /* we've maxed out on the retries */
@@ -3173,13 +3210,13 @@ int host::process_check_result_3x(enum host::host_state new_state,
   /******* HOST WAS UP INITIALLY *******/
   else {
     engine_logger(dbg_checks, more) << "Host was UP.";
-    log_v2::checks()->debug("Host was UP.");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Host was UP.");
 
     /***** HOST IS STILL UP *****/
     /* either the host never went down since last check */
     if (new_state == host::state_up) {
       engine_logger(dbg_checks, more) << "Host is still UP.";
-      log_v2::checks()->debug("Host is still UP.");
+      SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Host is still UP.");
 
       /* set the current state */
       _current_state = host::state_up;
@@ -3191,12 +3228,12 @@ int host::process_check_result_3x(enum host::host_state new_state,
     /***** HOST IS NOW DOWN/UNREACHABLE *****/
     else {
       engine_logger(dbg_checks, more) << "Host is now DOWN/UNREACHABLE.";
-      log_v2::checks()->debug("Host is now DOWN/UNREACHABLE.");
+      SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Host is now DOWN/UNREACHABLE.");
 
       /***** SPECIAL CASE FOR HOSTS WITH MAX_ATTEMPTS==1 *****/
       if (max_check_attempts() == 1) {
         engine_logger(dbg_checks, more) << "Max attempts = 1!.";
-        log_v2::checks()->debug("Max attempts = 1!.");
+        SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Max attempts = 1!.");
 
         /* set the state type */
         set_state_type(hard);
@@ -3218,7 +3255,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
           engine_logger(dbg_checks, more)
               << "** WARNING: Max attempts = 1, so we have to run serial "
                  "checks of all parent hosts!";
-          log_v2::checks()->debug(
+          SPDLOG_LOGGER_DEBUG(
+              log_v2::checks(),
               "** WARNING: Max attempts = 1, so we have to run serial "
               "checks of all parent hosts!");
 
@@ -3232,8 +3270,9 @@ int host::process_check_result_3x(enum host::host_state new_state,
 
             engine_logger(dbg_checks, more)
                 << "Running serial check parent host '" << it->first << "'...";
-            log_v2::checks()->debug("Running serial check parent host '{}'...",
-                                    it->first);
+            SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                                "Running serial check parent host '{}'...",
+                                it->first);
 
             /* run an immediate check of the parent host */
             it->second->run_sync_check_3x(&parent_state, check_options,
@@ -3244,8 +3283,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
             if (parent_state == host::state_up) {
               engine_logger(dbg_checks, more)
                   << "Parent host is UP, so this one is DOWN.";
-              log_v2::checks()->debug(
-                  "Parent host is UP, so this one is DOWN.");
+              SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                                  "Parent host is UP, so this one is DOWN.");
 
               /* set the current state */
               _current_state = host::state_down;
@@ -3258,13 +3297,15 @@ int host::process_check_result_3x(enum host::host_state new_state,
             if (parent_hosts.empty()) {
               engine_logger(dbg_checks, more)
                   << "Host has no parents, so it's DOWN.";
-              log_v2::checks()->debug("Host has no parents, so it's DOWN.");
+              SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                                  "Host has no parents, so it's DOWN.");
               _current_state = host::state_down;
             } else {
               /* no parents were up, so this host is UNREACHABLE */
               engine_logger(dbg_checks, more)
                   << "No parents were UP, so this host is UNREACHABLE.";
-              log_v2::checks()->debug(
+              SPDLOG_LOGGER_DEBUG(
+                  log_v2::checks(),
                   "No parents were UP, so this host is UNREACHABLE.");
               _current_state = host::state_unreachable;
             }
@@ -3282,7 +3323,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
         /* we do this because we may now be blocking the route to child hosts */
         engine_logger(dbg_checks, more)
             << "Propagating check to immediate non-UNREACHABLE child hosts...";
-        log_v2::checks()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::checks(),
             "Propagating check to immediate non-UNREACHABLE child hosts...");
 
         for (host_map_unsafe::iterator it{child_hosts.begin()},
@@ -3293,8 +3335,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
           if (it->second->get_current_state() != host::state_unreachable) {
             engine_logger(dbg_checks, more)
                 << "Check of child host '" << it->first << "' queued.";
-            log_v2::checks()->debug("Check of child host '{}' queued.",
-                                    it->first);
+            SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                                "Check of child host '{}' queued.", it->first);
             check_hostlist.push_back(it->second);
           }
         }
@@ -3326,9 +3368,9 @@ int host::process_check_result_3x(enum host::host_state new_state,
         engine_logger(dbg_checks, more)
             << "Propagating checks to immediate parent hosts that "
                "are UP...";
-        log_v2::checks()->debug(
-            "Propagating checks to immediate parent hosts that "
-            "are UP...");
+        SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                            "Propagating checks to immediate parent hosts that "
+                            "are UP...");
 
         for (host_map_unsafe::iterator it{parent_hosts.begin()},
              end{parent_hosts.end()};
@@ -3339,7 +3381,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
             check_hostlist.push_back(it->second);
             engine_logger(dbg_checks, more)
                 << "Check of host '" << it->first << "' queued.";
-            log_v2::checks()->debug("Check of host '{}' queued.", it->first);
+            SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Check of host '{}' queued.",
+                                it->first);
           }
         }
 
@@ -3348,9 +3391,9 @@ int host::process_check_result_3x(enum host::host_state new_state,
         engine_logger(dbg_checks, more)
             << "Propagating checks to immediate non-UNREACHABLE "
                "child hosts...";
-        log_v2::checks()->debug(
-            "Propagating checks to immediate non-UNREACHABLE "
-            "child hosts...");
+        SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                            "Propagating checks to immediate non-UNREACHABLE "
+                            "child hosts...");
 
         for (host_map_unsafe::iterator it{child_hosts.begin()},
              end{child_hosts.end()};
@@ -3360,8 +3403,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
           if (it->second->get_current_state() != host::state_unreachable) {
             engine_logger(dbg_checks, more)
                 << "Check of child host '" << it->first << "' queued.";
-            log_v2::checks()->debug("Check of child host '{}' queued.",
-                                    it->first);
+            SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                                "Check of child host '{}' queued.", it->first);
             check_hostlist.push_back(it->second);
           }
         }
@@ -3376,7 +3419,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
           engine_logger(dbg_checks, more)
               << "Propagating predictive dependency checks to hosts this "
                  "one depends on...";
-          log_v2::checks()->debug(
+          SPDLOG_LOGGER_DEBUG(
+              log_v2::checks(),
               "Propagating predictive dependency checks to hosts this "
               "one depends on...");
 
@@ -3390,8 +3434,9 @@ int host::process_check_result_3x(enum host::host_state new_state,
               master_host = (host*)temp_dependency->master_host_ptr;
               engine_logger(dbg_checks, more)
                   << "Check of host '" << master_host->name() << "' queued.";
-              log_v2::checks()->debug("Check of host '{}' queued.",
-                                      master_host->name());
+              SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                                  "Check of host '{}' queued.",
+                                  master_host->name());
               check_hostlist.push_back(master_host);
             }
           }
@@ -3405,7 +3450,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
       << ", Attempt=" << get_current_attempt() << "/" << max_check_attempts()
       << ", Type=" << (get_state_type() == hard ? "HARD" : "SOFT")
       << ", Final State=" << _current_state;
-  log_v2::checks()->debug(
+  SPDLOG_LOGGER_DEBUG(
+      log_v2::checks(),
       "Pre-handle_host_state() Host: {}, Attempt={}/{}, Type={}, Final "
       "State={}",
       name(), get_current_attempt(), max_check_attempts(),
@@ -3419,7 +3465,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
       << ", Attempt=" << get_current_attempt() << "/" << max_check_attempts()
       << ", Type=" << (get_state_type() == hard ? "HARD" : "SOFT")
       << ", Final State=" << _current_state;
-  log_v2::checks()->debug(
+  SPDLOG_LOGGER_DEBUG(
+      log_v2::checks(),
       "Post-handle_host_state() Host: {}, Attempt={}/{}, Type={}, Final "
       "State={}",
       name(), get_current_attempt(), max_check_attempts(),
@@ -3451,11 +3498,12 @@ int host::process_check_result_3x(enum host::host_state new_state,
   if (reschedule_check) {
     engine_logger(dbg_checks, more)
         << "Rescheduling next check of host at " << my_ctime(&next_check);
-    log_v2::checks()->debug(
-        "Rescheduling next check of host: {} of last check at "
-        "{:%Y-%m-%dT%H:%M:%S} and next "
-        "check at {:%Y-%m-%dT%H:%M:%S}",
-        name(), fmt::localtime(get_last_check()), fmt::localtime(next_check));
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                        "Rescheduling next check of host: {} of last check at "
+                        "{:%Y-%m-%dT%H:%M:%S} and next "
+                        "check at {:%Y-%m-%dT%H:%M:%S}",
+                        name(), fmt::localtime(get_last_check()),
+                        fmt::localtime(next_check));
 
     /* default is to reschedule host check unless a test below fails... */
     set_should_be_scheduled(true);
@@ -3514,7 +3562,8 @@ int host::process_check_result_3x(enum host::host_state new_state,
         << ", CACHEDTIMEHORIZON: " << check_timestamp_horizon
         << ", USECACHEDRESULT: " << use_cached_result
         << ", ISEXECUTING: " << temp_host->get_is_executing();
-    log_v2::checks()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::checks(),
         "ASYNC CHECK OF HOST: {}, CURRENTTIME: {}, LASTHOSTCHECK: {}, "
         "CACHEDTIMEHORIZON: {}, USECACHEDRESULT: {}, ISEXECUTING: {}",
         temp_host->name(), current_time, temp_host->get_last_check(),
@@ -3548,26 +3597,29 @@ enum host::host_state host::determine_host_reachability(
   bool is_host_present = false;
 
   engine_logger(dbg_functions, basic) << "determine_host_reachability()";
-  log_v2::functions()->trace("determine_host_reachability()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "determine_host_reachability()");
 
   engine_logger(dbg_checks, most) << "Determining state of host '" << name()
                                   << "': current state=" << new_state;
-  log_v2::checks()->debug("Determining state of host '{}': current state= {}",
-                          name(), new_state);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Determining state of host '{}': current state= {}",
+                      name(), new_state);
 
   /* host is UP - no translation needed */
   if (new_state == host::state_up) {
     state = host::state_up;
     engine_logger(dbg_checks, most)
         << "Host is UP, no state translation needed.";
-    log_v2::checks()->debug("Host is UP, no state translation needed.");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                        "Host is UP, no state translation needed.");
   }
 
   /* host has no parents, so it is DOWN */
   else if (parent_hosts.size() == 0) {
     state = host::state_down;
     engine_logger(dbg_checks, most) << "Host has no parents, so it is DOWN.";
-    log_v2::checks()->debug("Host has no parents, so it is DOWN.");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                        "Host has no parents, so it is DOWN.");
   }
 
   /* check all parent hosts to see if we're DOWN or UNREACHABLE */
@@ -3585,8 +3637,9 @@ enum host::host_state host::determine_host_reachability(
         state = host::state_down;
         engine_logger(dbg_checks, most) << "At least one parent (" << it->first
                                         << ") is up, so host is DOWN.";
-        log_v2::checks()->debug(
-            "At least one parent ({}) is up, so host is DOWN.", it->first);
+        SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                            "At least one parent ({}) is up, so host is DOWN.",
+                            it->first);
         break;
       }
     }
@@ -3595,7 +3648,8 @@ enum host::host_state host::determine_host_reachability(
       state = host::state_unreachable;
       engine_logger(dbg_checks, most)
           << "No parents were up, so host is UNREACHABLE.";
-      log_v2::checks()->debug("No parents were up, so host is UNREACHABLE.");
+      SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                          "No parents were up, so host is UNREACHABLE.");
     }
   }
 
@@ -3620,7 +3674,8 @@ std::list<hostgroup*>& host::get_parent_groups() {
  */
 bool host::authorized_by_dependencies(dependency::types dependency_type) const {
   engine_logger(dbg_functions, basic) << "host::authorized_by_dependencies()";
-  log_v2::functions()->trace("host::authorized_by_dependencies()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "host::authorized_by_dependencies()");
 
   auto p(hostdependency::hostdependencies.equal_range(name()));
   for (hostdependency_mmap::const_iterator it{p.first}, end{p.second};
@@ -3673,16 +3728,18 @@ void host::check_result_freshness() {
   time_t current_time = 0L;
 
   engine_logger(dbg_functions, basic) << "check_host_result_freshness()";
-  log_v2::functions()->trace("check_host_result_freshness()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "check_host_result_freshness()");
   engine_logger(dbg_checks, most)
       << "Attempting to check the freshness of host check results...";
-  log_v2::checks()->debug(
+  SPDLOG_LOGGER_DEBUG(
+      log_v2::checks(),
       "Attempting to check the freshness of host check results...");
 
   /* bail out if we're not supposed to be checking freshness */
   if (!config->check_host_freshness()) {
     engine_logger(dbg_checks, most) << "Host freshness checking is disabled.";
-    log_v2::checks()->debug("Host freshness checking is disabled.");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                        "Host freshness checking is disabled.");
     return;
   }
 
@@ -3739,14 +3796,15 @@ void host::check_result_freshness() {
  */
 void host::adjust_check_attempt(bool is_active) {
   engine_logger(dbg_functions, basic) << "adjust_host_check_attempt_3x()";
-  log_v2::functions()->trace("adjust_host_check_attempt_3x()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "adjust_host_check_attempt_3x()");
 
   engine_logger(dbg_checks, most)
       << "Adjusting check attempt number for host '" << name()
       << "': current attempt=" << get_current_attempt() << "/"
       << max_check_attempts() << ", state=" << _current_state
       << ", state type=" << get_state_type();
-  log_v2::checks()->debug(
+  SPDLOG_LOGGER_DEBUG(
+      log_v2::checks(),
       "Adjusting check attempt number for host '{}': current attempt= {}/{}, "
       "state= {}, state type= {}",
       name(), get_current_attempt(), max_check_attempts(), _current_state,
@@ -3767,8 +3825,8 @@ void host::adjust_check_attempt(bool is_active) {
 
   engine_logger(dbg_checks, most)
       << "New check attempt number = " << get_current_attempt();
-  log_v2::checks()->debug("New check attempt number = {}",
-                          get_current_attempt());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(), "New check attempt number = {}",
+                      get_current_attempt());
 }
 
 /* check for hosts that never returned from a check... */
@@ -3777,7 +3835,7 @@ void host::check_for_orphaned() {
   time_t expected_time = 0L;
 
   engine_logger(dbg_functions, basic) << "check_for_orphaned_hosts()";
-  log_v2::functions()->trace("check_for_orphaned_hosts()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "check_for_orphaned_hosts()");
 
   /* get the current time */
   time(&current_time);
@@ -3796,10 +3854,9 @@ void host::check_for_orphaned() {
 
     /* determine the time at which the check results should have come in (allow
      * 10 minutes slack time) */
-    expected_time =
-        (time_t)(it->second->get_next_check() + it->second->get_latency() +
-                 config->host_check_timeout() +
-                 config->check_reaper_interval() + 600);
+    expected_time = (time_t)(
+        it->second->get_next_check() + it->second->get_latency() +
+        config->host_check_timeout() + config->check_reaper_interval() + 600);
 
     /* this host was supposed to have executed a while ago, but for some reason
      * the results haven't come back in... */
@@ -3809,7 +3866,8 @@ void host::check_for_orphaned() {
           << "Warning: The check of host '" << it->second->name()
           << "' looks like it was orphaned (results never came back).  "
              "I'm scheduling an immediate check of the host...";
-      log_v2::runtime()->warn(
+      SPDLOG_LOGGER_WARN(
+          log_v2::runtime(),
           "Warning: The check of host '{}' looks like it was orphaned (results "
           "never came back).  "
           "I'm scheduling an immediate check of the host...",
@@ -3818,7 +3876,8 @@ void host::check_for_orphaned() {
       engine_logger(dbg_checks, more)
           << "Host '" << it->second->name()
           << "' was orphaned, so we're scheduling an immediate check...";
-      log_v2::checks()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::checks(),
           "Host '{}' was orphaned, so we're scheduling an immediate check...",
           it->second->name());
 

--- a/engine/src/log_v2.cc
+++ b/engine/src/log_v2.cc
@@ -103,6 +103,7 @@ void log_v2::apply(const configuration::state& config) {
     sinks.push_back(std::make_shared<sinks::null_sink_mt>());
 
   auto create_logger = [&sinks, log_pid = config.log_pid(),
+                        log_file_line = config.log_file_line(),
                         log_flush_period = config.log_flush_period()](
                            const std::string& name, level::level_enum lvl) {
     spdlog::drop(name);
@@ -113,10 +114,19 @@ void log_v2::apply(const configuration::state& config) {
     else
       log->flush_on(lvl);
 
-    if (log_pid)
-      log->set_pattern("[%Y-%m-%dT%H:%M:%S.%e%z] [%n] [%l] [%P] %v");
-    else
-      log->set_pattern("[%Y-%m-%dT%H:%M:%S.%e%z] [%n] [%l] %v");
+    if (log_pid) {
+      if (log_file_line) {
+        log->set_pattern("[%Y-%m-%dT%H:%M:%S.%e%z] [%s:%#] [%n] [%l] [%P] %v");
+      } else {
+        log->set_pattern("[%Y-%m-%dT%H:%M:%S.%e%z] [%n] [%l] [%P] %v");
+      }
+    } else {
+      if (log_file_line) {
+        log->set_pattern("[%Y-%m-%dT%H:%M:%S.%e%z] [%s:%#] [%n] [%l] %v");
+      } else {
+        log->set_pattern("[%Y-%m-%dT%H:%M:%S.%e%z] [%n] [%l] %v");
+      }
+    }
     spdlog::register_logger(log);
     return log;
   };

--- a/engine/src/main.cc
+++ b/engine/src/main.cc
@@ -23,10 +23,12 @@
 #include <getopt.h>
 #endif  // HAVE_GETOPT_H
 #include <unistd.h>
-#include <boost/circular_buffer.hpp>
-#include <boost/optional.hpp>
 #include <random>
 #include <string>
+
+#include <boost/circular_buffer.hpp>
+#include <boost/container/flat_map.hpp>
+#include <boost/optional.hpp>
 
 #include "com/centreon/engine/broker.hh"
 #include "com/centreon/engine/broker/loader.hh"

--- a/engine/src/notifier.cc
+++ b/engine/src/notifier.cc
@@ -162,7 +162,8 @@ notifier::notifier(notifier::notifier_type notifier_type,
     engine_logger(log_config_error, basic)
         << "Error: Invalid notification_interval value for notifier '"
         << display_name << "'";
-    log_v2::config()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::config(),
         "Error: Invalid notification_interval value for notifier '{}'",
         display_name);
     throw engine_error() << "Could not register notifier '" << display_name
@@ -213,9 +214,9 @@ void notifier::set_last_problem_id(unsigned long last_problem_id) noexcept {
  * @param num The notification number.
  */
 void notifier::set_notification_number(int num) {
-  log_v2::notifications()->trace(
-      "_notification_number set_notification_number: {} => {}",
-      _notification_number, num);
+  SPDLOG_LOGGER_TRACE(log_v2::notifications(),
+                      "_notification_number set_notification_number: {} => {}",
+                      _notification_number, num);
   /* set the notification number */
   _notification_number = num;
 
@@ -228,7 +229,8 @@ bool notifier::_is_notification_viable_normal(reason_type type
                                               notification_option options) {
   engine_logger(dbg_functions, basic)
       << "notifier::is_notification_viable_normal()";
-  log_v2::functions()->trace("notifier::is_notification_viable_normal()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "notifier::is_notification_viable_normal()");
 
   /* forced notifications bust through everything */
   uint32_t notification_interval =
@@ -239,8 +241,8 @@ bool notifier::_is_notification_viable_normal(reason_type type
   if (options & notification_option_forced) {
     engine_logger(dbg_notifications, more)
         << "This is a forced notification, so we'll send it out.";
-    log_v2::notifications()->debug(
-        "This is a forced notification, so we'll send it out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "This is a forced notification, so we'll send it out.");
     return true;
   }
 
@@ -249,9 +251,9 @@ bool notifier::_is_notification_viable_normal(reason_type type
     engine_logger(dbg_notifications, more)
         << "Notifications are disabled, so notifications will "
            "not be sent out.";
-    log_v2::notifications()->debug(
-        "Notifications are disabled, so notifications will "
-        "not be sent out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "Notifications are disabled, so notifications will "
+                        "not be sent out.");
     return false;
   }
 
@@ -260,9 +262,9 @@ bool notifier::_is_notification_viable_normal(reason_type type
     engine_logger(dbg_notifications, more)
         << "Notifications are temporarily disabled for "
            "this notifier, so we won't send one out.";
-    log_v2::notifications()->debug(
-        "Notifications are temporarily disabled for "
-        "this notifier, so we won't send one out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "Notifications are temporarily disabled for "
+                        "this notifier, so we won't send one out.");
     return false;
   }
 
@@ -272,7 +274,8 @@ bool notifier::_is_notification_viable_normal(reason_type type
     engine_logger(dbg_notifications, more)
         << "This notifier is currently in a scheduled downtime, so "
            "we won't send notifications.";
-    log_v2::notifications()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::notifications(),
         "This notifier is currently in a scheduled downtime, so "
         "we won't send notifications.");
     return false;
@@ -287,9 +290,9 @@ bool notifier::_is_notification_viable_normal(reason_type type
     engine_logger(dbg_notifications, more)
         << "This notifier shouldn't have notifications sent out "
            "at this time.";
-    log_v2::notifications()->debug(
-        "This notifier shouldn't have notifications sent out "
-        "at this time.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "This notifier shouldn't have notifications sent out "
+                        "at this time.");
     return false;
   }
 
@@ -297,7 +300,8 @@ bool notifier::_is_notification_viable_normal(reason_type type
   if (get_is_flapping()) {
     engine_logger(dbg_notifications, more)
         << "This notifier is flapping, so we won't send notifications.";
-    log_v2::notifications()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::notifications(),
         "This notifier is flapping, so we won't send notifications.");
     return false;
   }
@@ -306,7 +310,8 @@ bool notifier::_is_notification_viable_normal(reason_type type
   if (get_is_volatile()) {
     engine_logger(dbg_notifications, more)
         << "This is a volatile service notification, so it is sent.";
-    log_v2::notifications()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::notifications(),
         "This is a volatile service notification, so it is sent.");
     return true;
   }
@@ -314,7 +319,8 @@ bool notifier::_is_notification_viable_normal(reason_type type
   if (get_state_type() != hard) {
     engine_logger(dbg_notifications, more)
         << "This notifier is in soft state, so we won't send notifications.";
-    log_v2::notifications()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::notifications(),
         "This notifier is in soft state, so we won't send notifications.");
     return false;
   }
@@ -323,7 +329,8 @@ bool notifier::_is_notification_viable_normal(reason_type type
     engine_logger(dbg_notifications, more)
         << "This notifier problem has been acknowledged, so we won't send "
            "notifications.";
-    log_v2::notifications()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::notifications(),
         "This notifier problem has been acknowledged, so we won't send "
         "notifications.");
     return false;
@@ -332,7 +339,8 @@ bool notifier::_is_notification_viable_normal(reason_type type
   if (get_current_state_int() == 0) {
     engine_logger(dbg_notifications, more)
         << "We don't send a normal notification when the state is ok/up";
-    log_v2::notifications()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::notifications(),
         "We don't send a normal notification when the state is ok/up");
     return false;
   }
@@ -342,7 +350,8 @@ bool notifier::_is_notification_viable_normal(reason_type type
         << "This notifier is unable to notify the state "
         << get_current_state_as_string()
         << ": not configured for that or, for a service, its host may be down";
-    log_v2::notifications()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::notifications(),
         "This notifier is unable to notify the state {}: not configured for "
         "that or, for a service, its host may be down",
         get_current_state_as_string());
@@ -357,7 +366,8 @@ bool notifier::_is_notification_viable_normal(reason_type type
         << "This notifier is configured with a first notification delay, we "
            "won't send notification until timestamp "
         << (_first_notification_delay * config->interval_length());
-    log_v2::notifications()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::notifications(),
         "This notifier is configured with a first notification delay, we "
         "won't send notification until timestamp {}",
         _first_notification_delay * config->interval_length());
@@ -368,7 +378,8 @@ bool notifier::_is_notification_viable_normal(reason_type type
     engine_logger(dbg_notifications, more)
         << "This notifier won't send any notification since it depends on"
            " another notifier that has already sent one";
-    log_v2::notifications()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::notifications(),
         "This notifier won't send any notification since it depends on"
         " another notifier that has already sent one");
     return false;
@@ -384,7 +395,8 @@ bool notifier::_is_notification_viable_normal(reason_type type
             << _last_notification
             << " so, since the notification interval is 0, it won't be sent"
             << " anymore";
-        log_v2::notifications()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::notifications(),
             "This notifier problem has already been sent at {} so, since the "
             "notification interval is 0, it won't be sent anymore",
             _last_notification);
@@ -397,7 +409,8 @@ bool notifier::_is_notification_viable_normal(reason_type type
               << "This notifier problem has been sent at " << _last_notification
               << " so it won't be sent until "
               << (notification_interval * config->interval_length());
-          log_v2::notifications()->debug(
+          SPDLOG_LOGGER_DEBUG(
+              log_v2::notifications(),
               "This notifier problem has been sent at {} so it won't be sent "
               "until {}",
               _last_notification,
@@ -416,7 +429,8 @@ bool notifier::_is_notification_viable_recovery(reason_type type
                                                 __attribute__((unused))) {
   engine_logger(dbg_functions, basic)
       << "notifier::is_notification_viable_recovery()";
-  log_v2::functions()->trace("notifier::is_notification_viable_recovery()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "notifier::is_notification_viable_recovery()");
   bool retval{true};
   bool send_later{false};
 
@@ -425,9 +439,9 @@ bool notifier::_is_notification_viable_recovery(reason_type type
     engine_logger(dbg_notifications, more)
         << "Notifications are disabled, so notifications will "
            "not be sent out.";
-    log_v2::notifications()->debug(
-        "Notifications are disabled, so notifications will "
-        "not be sent out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "Notifications are disabled, so notifications will "
+                        "not be sent out.");
     retval = false;
   }
   /* are notifications temporarily disabled for this notifier? */
@@ -435,9 +449,9 @@ bool notifier::_is_notification_viable_recovery(reason_type type
     engine_logger(dbg_notifications, more)
         << "Notifications are temporarily disabled for "
            "this notifier, so we won't send one out.";
-    log_v2::notifications()->debug(
-        "Notifications are temporarily disabled for "
-        "this notifier, so we won't send one out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "Notifications are temporarily disabled for "
+                        "this notifier, so we won't send one out.");
     retval = false;
   } else {
     timeperiod* tp{get_notification_timeperiod()};
@@ -449,9 +463,9 @@ bool notifier::_is_notification_viable_recovery(reason_type type
       engine_logger(dbg_notifications, more)
           << "This notifier shouldn't have notifications sent out "
              "at this time.";
-      log_v2::notifications()->debug(
-          "This notifier shouldn't have notifications sent out "
-          "at this time.");
+      SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                          "This notifier shouldn't have notifications sent out "
+                          "at this time.");
       retval = false;
       send_later = true;
     }
@@ -461,7 +475,8 @@ bool notifier::_is_notification_viable_recovery(reason_type type
       engine_logger(dbg_notifications, more)
           << "This notifier is currently in a scheduled downtime, so "
              "we won't send notifications.";
-      log_v2::notifications()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::notifications(),
           "This notifier is currently in a scheduled downtime, so "
           "we won't send notifications.");
       retval = false;
@@ -471,14 +486,16 @@ bool notifier::_is_notification_viable_recovery(reason_type type
     else if (get_is_flapping()) {
       engine_logger(dbg_notifications, more)
           << "This notifier is flapping, so we won't send notifications.";
-      log_v2::notifications()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::notifications(),
           "This notifier is flapping, so we won't send notifications.");
       retval = false;
       send_later = true;
     } else if (get_state_type() != hard) {
       engine_logger(dbg_notifications, more)
           << "This notifier is in soft state, so we won't send notifications.";
-      log_v2::notifications()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::notifications(),
           "This notifier is in soft state, so we won't send notifications.");
       retval = false;
       send_later = true;
@@ -487,14 +504,16 @@ bool notifier::_is_notification_viable_recovery(reason_type type
     else if (get_current_state_int() != 0) {
       engine_logger(dbg_notifications, more)
           << "This notifier state is not UP/OK to send a recovery notification";
-      log_v2::notifications()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::notifications(),
           "This notifier state is not UP/OK to send a recovery notification");
       retval = false;
       send_later = true;
     } else if (!(get_notify_on(up) || get_notify_on(ok))) {
       engine_logger(dbg_notifications, more)
           << "This notifier is not configured to send a recovery notification";
-      log_v2::notifications()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::notifications(),
           "This notifier is not configured to send a recovery notification");
       retval = false;
       send_later = false;
@@ -506,7 +525,8 @@ bool notifier::_is_notification_viable_recovery(reason_type type
           << "It won't send any recovery notification until timestamp "
           << " so it won't be sent until "
           << (get_last_hard_state_change() + _recovery_notification_delay);
-      log_v2::notifications()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::notifications(),
           "This notifier is configured with a recovery notification delay. "
           "It won't send any recovery notification until timestamp "
           "so it won't be sent until {}",
@@ -518,7 +538,8 @@ bool notifier::_is_notification_viable_recovery(reason_type type
           << "No notification has been sent to "
              "announce a problem. So no recovery"
           << " notification will be sent";
-      log_v2::notifications()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::notifications(),
           "No notification has been sent to "
           "announce a problem. So no recovery notification will be sent");
       retval = false;
@@ -527,10 +548,10 @@ bool notifier::_is_notification_viable_recovery(reason_type type
           << "We should not send a notification "
              "since no normal notification has"
              " been sent before";
-      log_v2::notifications()->debug(
-          "We should not send a notification "
-          "since no normal notification has"
-          " been sent before");
+      SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                          "We should not send a notification "
+                          "since no normal notification has"
+                          " been sent before");
       retval = false;
     }
   }
@@ -538,7 +559,8 @@ bool notifier::_is_notification_viable_recovery(reason_type type
   if (!retval) {
     if (!send_later) {
       _notification[cat_normal].reset();
-      log_v2::notifications()->trace(
+      SPDLOG_LOGGER_TRACE(
+          log_v2::notifications(),
           " _notification_number _is_notification_viable_recovery: {} => 0",
           _notification_number);
       _notification_number = 0;
@@ -553,14 +575,14 @@ bool notifier::_is_notification_viable_acknowledgement(
     notification_option options) {
   engine_logger(dbg_functions, basic)
       << "notifier::is_notification_viable_acknowledgement()";
-  log_v2::functions()->trace(
-      "notifier::is_notification_viable_acknowledgement()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "notifier::is_notification_viable_acknowledgement()");
   /* forced notifications bust through everything */
   if (options & notification_option_forced) {
     engine_logger(dbg_notifications, more)
         << "This is a forced notification, so we'll send it out.";
-    log_v2::notifications()->debug(
-        "This is a forced notification, so we'll send it out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "This is a forced notification, so we'll send it out.");
     return true;
   }
 
@@ -569,9 +591,9 @@ bool notifier::_is_notification_viable_acknowledgement(
     engine_logger(dbg_notifications, more)
         << "Notifications are disabled, so notifications will "
            "not be sent out.";
-    log_v2::notifications()->debug(
-        "Notifications are disabled, so notifications will "
-        "not be sent out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "Notifications are disabled, so notifications will "
+                        "not be sent out.");
     return false;
   }
 
@@ -580,9 +602,9 @@ bool notifier::_is_notification_viable_acknowledgement(
     engine_logger(dbg_notifications, more)
         << "Notifications are temporarily disabled for "
            "this notifier, so we won't send one out.";
-    log_v2::notifications()->debug(
-        "Notifications are temporarily disabled for "
-        "this notifier, so we won't send one out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "Notifications are temporarily disabled for "
+                        "this notifier, so we won't send one out.");
     return false;
   }
 
@@ -590,9 +612,9 @@ bool notifier::_is_notification_viable_acknowledgement(
     engine_logger(dbg_notifications, more)
         << "The notifier is currently OK/UP, so we "
            "won't send an acknowledgement.";
-    log_v2::notifications()->debug(
-        "The notifier is currently OK/UP, so we "
-        "won't send an acknowledgement.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "The notifier is currently OK/UP, so we "
+                        "won't send an acknowledgement.");
     return false;
   }
   return true;
@@ -602,13 +624,14 @@ bool notifier::_is_notification_viable_flapping(reason_type type,
                                                 notification_option options) {
   engine_logger(dbg_functions, basic)
       << "notifier::is_notification_viable_flapping()";
-  log_v2::functions()->trace("notifier::is_notification_viable_flapping()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "notifier::is_notification_viable_flapping()");
   /* forced notifications bust through everything */
   if (options & notification_option_forced) {
     engine_logger(dbg_notifications, more)
         << "This is a forced notification, so we'll send it out.";
-    log_v2::notifications()->debug(
-        "This is a forced notification, so we'll send it out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "This is a forced notification, so we'll send it out.");
     return true;
   }
 
@@ -617,9 +640,9 @@ bool notifier::_is_notification_viable_flapping(reason_type type,
     engine_logger(dbg_notifications, more)
         << "Notifications are disabled, so notifications will "
            "not be sent out.";
-    log_v2::notifications()->debug(
-        "Notifications are disabled, so notifications will "
-        "not be sent out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "Notifications are disabled, so notifications will "
+                        "not be sent out.");
     return false;
   }
 
@@ -628,9 +651,9 @@ bool notifier::_is_notification_viable_flapping(reason_type type,
     engine_logger(dbg_notifications, more)
         << "Notifications are temporarily disabled for "
            "this notifier, so we won't send one out.";
-    log_v2::notifications()->debug(
-        "Notifications are temporarily disabled for "
-        "this notifier, so we won't send one out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "Notifications are temporarily disabled for "
+                        "this notifier, so we won't send one out.");
     return false;
   }
 
@@ -647,7 +670,8 @@ bool notifier::_is_notification_viable_flapping(reason_type type,
     engine_logger(dbg_notifications, more)
         << "We shouldn't notify about " << tab_notification_str[type]
         << " events for this notifier.";
-    log_v2::notifications()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::notifications(),
         "We shouldn't notify about {} events for this notifier.",
         tab_notification_str[type]);
     return false;
@@ -659,7 +683,8 @@ bool notifier::_is_notification_viable_flapping(reason_type type,
     engine_logger(dbg_notifications, more)
         << "A flapping notification is already running, we can not send "
            "a start notification now.";
-    log_v2::notifications()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::notifications(),
         "A flapping notification is already running, we can not send "
         "a start notification now.");
     return false;
@@ -671,7 +696,8 @@ bool notifier::_is_notification_viable_flapping(reason_type type,
       engine_logger(dbg_notifications, more)
           << "A stop or cancellation flapping notification can only be sent "
              "after a start flapping notification.";
-      log_v2::notifications()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::notifications(),
           "A stop or cancellation flapping notification can only be sent "
           "after a start flapping notification.");
       return false;
@@ -684,9 +710,9 @@ bool notifier::_is_notification_viable_flapping(reason_type type,
     engine_logger(dbg_notifications, more)
         << "We shouldn't notify about a " << tab_notification_str[type]
         << " event: already sent.";
-    log_v2::notifications()->debug(
-        "We shouldn't notify about a {} event: already sent.",
-        tab_notification_str[type]);
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "We shouldn't notify about a {} event: already sent.",
+                        tab_notification_str[type]);
     return false;
   }
 
@@ -695,9 +721,9 @@ bool notifier::_is_notification_viable_flapping(reason_type type,
     engine_logger(dbg_notifications, more)
         << "We shouldn't notify about FLAPPING "
            "events during scheduled downtime.";
-    log_v2::notifications()->debug(
-        "We shouldn't notify about FLAPPING "
-        "events during scheduled downtime.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "We shouldn't notify about FLAPPING "
+                        "events during scheduled downtime.");
     return false;
   }
   return true;
@@ -708,14 +734,15 @@ bool notifier::_is_notification_viable_downtime(reason_type type
                                                 notification_option options) {
   engine_logger(dbg_functions, basic)
       << "notifier::is_notification_viable_downtime()";
-  log_v2::functions()->trace("notifier::is_notification_viable_downtime()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "notifier::is_notification_viable_downtime()");
 
   /* forced notifications bust through everything */
   if (options & notification_option_forced) {
     engine_logger(dbg_notifications, more)
         << "This is a forced notification, so we'll send it out.";
-    log_v2::notifications()->debug(
-        "This is a forced notification, so we'll send it out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "This is a forced notification, so we'll send it out.");
     return true;
   }
 
@@ -724,9 +751,9 @@ bool notifier::_is_notification_viable_downtime(reason_type type
     engine_logger(dbg_notifications, more)
         << "Notifications are disabled, so notifications will "
            "not be sent out.";
-    log_v2::notifications()->debug(
-        "Notifications are disabled, so notifications will "
-        "not be sent out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "Notifications are disabled, so notifications will "
+                        "not be sent out.");
     return false;
   }
 
@@ -735,16 +762,17 @@ bool notifier::_is_notification_viable_downtime(reason_type type
     engine_logger(dbg_notifications, more)
         << "Notifications are temporarily disabled for "
            "this notifier, so we won't send one out.";
-    log_v2::notifications()->debug(
-        "Notifications are temporarily disabled for "
-        "this notifier, so we won't send one out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "Notifications are temporarily disabled for "
+                        "this notifier, so we won't send one out.");
     return false;
   }
 
   if (!config->enable_notifications()) {
     engine_logger(dbg_notifications, more)
         << "Notifications are disabled, so notifications won't be sent out.";
-    log_v2::notifications()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::notifications(),
         "Notifications are disabled, so notifications won't be sent out.");
     return false;
   }
@@ -753,7 +781,8 @@ bool notifier::_is_notification_viable_downtime(reason_type type
   if (!get_notify_on(downtime)) {
     engine_logger(dbg_notifications, more)
         << "We shouldn't notify about DOWNTIME events for this notifier.";
-    log_v2::notifications()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::notifications(),
         "We shouldn't notify about DOWNTIME events for this notifier.");
     return false;
   }
@@ -765,9 +794,9 @@ bool notifier::_is_notification_viable_downtime(reason_type type
     engine_logger(dbg_notifications, more)
         << "We shouldn't notify about DOWNTIME "
            "events during scheduled downtime.";
-    log_v2::notifications()->debug(
-        "We shouldn't notify about DOWNTIME "
-        "events during scheduled downtime.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "We shouldn't notify about DOWNTIME "
+                        "events during scheduled downtime.");
     return false;
   }
   return true;
@@ -778,13 +807,14 @@ bool notifier::_is_notification_viable_custom(reason_type type
                                               notification_option options) {
   engine_logger(dbg_functions, basic)
       << "notifier::is_notification_viable_custom()";
-  log_v2::functions()->trace("notifier::is_notification_viable_custom()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "notifier::is_notification_viable_custom()");
   /* forced notifications bust through everything */
   if (options & notification_option_forced) {
     engine_logger(dbg_notifications, more)
         << "This is a forced notification, so we'll send it out.";
-    log_v2::notifications()->debug(
-        "This is a forced notification, so we'll send it out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "This is a forced notification, so we'll send it out.");
     return true;
   }
 
@@ -793,9 +823,9 @@ bool notifier::_is_notification_viable_custom(reason_type type
     engine_logger(dbg_notifications, more)
         << "Notifications are disabled, so notifications will "
            "not be sent out.";
-    log_v2::notifications()->debug(
-        "Notifications are disabled, so notifications will "
-        "not be sent out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "Notifications are disabled, so notifications will "
+                        "not be sent out.");
     return false;
   }
 
@@ -804,9 +834,9 @@ bool notifier::_is_notification_viable_custom(reason_type type
     engine_logger(dbg_notifications, more)
         << "Notifications are temporarily disabled for "
            "this notifier, so we won't send one out.";
-    log_v2::notifications()->debug(
-        "Notifications are temporarily disabled for "
-        "this notifier, so we won't send one out.");
+    SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                        "Notifications are temporarily disabled for "
+                        "this notifier, so we won't send one out.");
     return false;
   }
 
@@ -814,7 +844,8 @@ bool notifier::_is_notification_viable_custom(reason_type type
   if (is_in_downtime()) {
     engine_logger(dbg_notifications, more)
         << "We shouldn't send a CUSTOM notification during scheduled downtime.";
-    log_v2::notifications()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::notifications(),
         "We shouldn't send a CUSTOM notification during scheduled downtime.");
     return false;
   }
@@ -923,7 +954,7 @@ int notifier::notify(notifier::reason_type type,
                      std::string const& not_data,
                      notification_option options) {
   engine_logger(dbg_functions, basic) << "notifier::notify()";
-  log_v2::functions()->trace("notifier::notify({})", type);
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "notifier::notify({})", type);
   notification_category cat{get_category(type)};
 
   /* Has this notification got sense? */
@@ -933,9 +964,9 @@ int notifier::notify(notifier::reason_type type,
   /* For a first notification, we store what type of notification we try to
    * send and we fix the notification number to 1. */
   if (type != reason_recovery) {
-    log_v2::notifications()->trace("_notification_number notify: {} -> {}",
-                                   _notification_number,
-                                   _notification_number + 1);
+    SPDLOG_LOGGER_TRACE(log_v2::notifications(),
+                        "_notification_number notify: {} -> {}",
+                        _notification_number, _notification_number + 1);
     ++_notification_number;
   }
 
@@ -988,8 +1019,9 @@ int notifier::notify(notifier::reason_type type,
       /* In case of an acknowledgement, we must keep the _notification_number
        * otherwise the recovery notification won't be sent when needed. */
       if (cat != cat_acknowledgement && cat != cat_downtime) {
-        log_v2::notifications()->trace("_notification_number notify: {} => 0",
-                                       _notification_number);
+        SPDLOG_LOGGER_TRACE(log_v2::notifications(),
+                            "_notification_number notify: {} => 0",
+                            _notification_number);
         _notification_number = 0;
       }
     }
@@ -1338,7 +1370,8 @@ void notifier::resolve(int& w, int& e) {
           << "Error: Event handler command '" << cmd_name
           << "' specified for host '" << get_display_name()
           << "' not defined anywhere";
-      log_v2::config()->error(
+      SPDLOG_LOGGER_ERROR(
+          log_v2::config(),
           "Error: Event handler command '{}' specified for host '{}' not "
           "defined anywhere",
           cmd_name, get_display_name());
@@ -1361,21 +1394,23 @@ void notifier::resolve(int& w, int& e) {
           << "Error: Notifier check command '" << cmd_name
           << "' specified for host '" << get_display_name()
           << "' is not defined anywhere!";
-      log_v2::config()->error(
+      SPDLOG_LOGGER_ERROR(
+          log_v2::config(),
           "Error: Notifier check command '{}' specified for host '{}' is not "
           "defined anywhere!",
           cmd_name, get_display_name());
       errors++;
     } else
       /* save the pointer to the check command for later */
-      set_check_command_ptr(cmd_found->second.get());
+      set_check_command_ptr(cmd_found->second);
   }
 
   if (check_period().empty()) {
     engine_logger(log_verification_error, basic)
         << "Warning: Notifier '" << get_display_name()
         << "' has no check time period defined!";
-    log_v2::config()->warn(
+    SPDLOG_LOGGER_WARN(
+        log_v2::config(),
         "Warning: Notifier '{}' has no check time period defined!",
         get_display_name());
     warnings++;
@@ -1389,7 +1424,8 @@ void notifier::resolve(int& w, int& e) {
           << "Error: Check period '" << check_period()
           << "' specified for host '" << get_display_name()
           << "' is not defined anywhere!";
-      log_v2::config()->error(
+      SPDLOG_LOGGER_ERROR(
+          log_v2::config(),
           "Error: Check period '{}' specified for host '{}' is not defined "
           "anywhere!",
           check_period(), get_display_name());
@@ -1409,7 +1445,8 @@ void notifier::resolve(int& w, int& e) {
       engine_logger(log_verification_error, basic)
           << "Error: Contact '" << it->first << "' specified in notifier '"
           << get_display_name() << "' is not defined anywhere!";
-      log_v2::config()->error(
+      SPDLOG_LOGGER_ERROR(
+          log_v2::config(),
           "Error: Contact '{}' specified in notifier '{}' is not defined "
           "anywhere!",
           it->first, get_display_name());
@@ -1431,7 +1468,8 @@ void notifier::resolve(int& w, int& e) {
       engine_logger(log_verification_error, basic)
           << "Error: Contact group '" << it->first << "' specified in host '"
           << get_display_name() << "' is not defined anywhere!";
-      log_v2::config()->error(
+      SPDLOG_LOGGER_ERROR(
+          log_v2::config(),
           "Error: Contact group '{}' specified in host '{}' is not defined "
           "anywhere!",
           it->first, get_display_name());
@@ -1450,7 +1488,8 @@ void notifier::resolve(int& w, int& e) {
           << "Error: Notification period '" << notification_period()
           << "' specified for notifier '" << get_display_name()
           << "' is not defined anywhere!";
-      log_v2::config()->error(
+      SPDLOG_LOGGER_ERROR(
+          log_v2::config(),
           "Error: Notification period '{}' specified for notifier '{}' is not "
           "defined anywhere!",
           notification_period(), get_display_name());
@@ -1463,7 +1502,8 @@ void notifier::resolve(int& w, int& e) {
     engine_logger(log_verification_error, basic)
         << "Warning: Notifier '" << get_display_name()
         << "' has no notification time period defined!";
-    log_v2::config()->warn(
+    SPDLOG_LOGGER_WARN(
+        log_v2::config(),
         "Warning: Notifier '{}' has no notification time period defined!",
         get_display_name());
     warnings++;
@@ -1516,17 +1556,20 @@ time_t notifier::get_next_notification_time(time_t offset) {
 
   engine_logger(dbg_functions, basic)
       << "notifier::get_next_notification_time()";
-  log_v2::functions()->trace("notifier::get_next_notification_time()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "notifier::get_next_notification_time()");
   engine_logger(dbg_notifications, most)
       << "Calculating next valid notification time...";
-  log_v2::notifications()->info("Calculating next valid notification time...");
+  SPDLOG_LOGGER_INFO(log_v2::notifications(),
+                     "Calculating next valid notification time...");
 
   /* default notification interval */
   uint32_t interval_to_use{_notification_interval};
 
   engine_logger(dbg_notifications, most)
       << "Default interval: " << interval_to_use;
-  log_v2::notifications()->info("Default interval: {}", interval_to_use);
+  SPDLOG_LOGGER_INFO(log_v2::notifications(), "Default interval: {}",
+                     interval_to_use);
 
   /*
    * search all the escalation entries for valid matches for this service (at
@@ -1544,8 +1587,9 @@ time_t notifier::get_next_notification_time(time_t offset) {
     engine_logger(dbg_notifications, most)
         << "Found a valid escalation w/ interval of "
         << e->get_notification_interval();
-    log_v2::notifications()->info("Found a valid escalation w/ interval of {}",
-                                  e->get_notification_interval());
+    SPDLOG_LOGGER_INFO(log_v2::notifications(),
+                       "Found a valid escalation w/ interval of {}",
+                       e->get_notification_interval());
 
     /*
      * if we haven't used a notification interval from an escalation yet,
@@ -1561,7 +1605,8 @@ time_t notifier::get_next_notification_time(time_t offset) {
 
     engine_logger(dbg_notifications, most)
         << "New interval: " << interval_to_use;
-    log_v2::notifications()->info("New interval: {}", interval_to_use);
+    SPDLOG_LOGGER_INFO(log_v2::notifications(), "New interval: {}",
+                       interval_to_use);
   }
 
   /*
@@ -1577,10 +1622,10 @@ time_t notifier::get_next_notification_time(time_t offset) {
       << "Interval used for calculating next valid "
          "notification time: "
       << interval_to_use;
-  log_v2::notifications()->info(
-      "Interval used for calculating next valid "
-      "notification time: {}",
-      interval_to_use);
+  SPDLOG_LOGGER_INFO(log_v2::notifications(),
+                     "Interval used for calculating next valid "
+                     "notification time: {}",
+                     interval_to_use);
 
   /* calculate next notification time */
   time_t next_notification{
@@ -1621,7 +1666,8 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
     engine_logger(log_config_error, basic)
         << "Error: Bad format in the notification part, the line should start "
            "with 'type: '";
-    log_v2::config()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::config(),
         "Error: Bad format in the notification part, the line should start "
         "with 'type: '");
     return;
@@ -1634,7 +1680,8 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
     engine_logger(log_config_error, basic)
         << "Error: Bad format in the notification part, the separator between "
         << "two fields is ', '";
-    log_v2::config()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::config(),
         "Error: Bad format in the notification part, the separator between two "
         "fields is ', '");
     return;
@@ -1645,7 +1692,8 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
     engine_logger(log_config_error, basic)
         << "Error: Bad format in the notification part, the expected field "
            " after 'type' is 'author'";
-    log_v2::config()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::config(),
         "Error: Bad format in the notification part, the expected field after "
         "'type' is 'author'");
     return;
@@ -1661,7 +1709,8 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
     engine_logger(log_config_error, basic)
         << "Error: Bad format in the notification part, the expected field "
            " after 'author' is 'options'";
-    log_v2::config()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::config(),
         "Error: Bad format in the notification part, the expected field after "
         "'author' is 'options'");
     return;
@@ -1673,7 +1722,8 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
     engine_logger(log_config_error, basic)
         << "Error: Bad format in the notification part, the separator between "
         << "two fields is ', '";
-    log_v2::config()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::config(),
         "Error: Bad format in the notification part, the separator between two "
         "fields is ', '");
     return;
@@ -1684,7 +1734,8 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
     engine_logger(log_config_error, basic)
         << "Error: Bad format in the notification part, the expected field "
            " after 'options' is 'escalated'";
-    log_v2::config()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::config(),
         "Error: Bad format in the notification part, the expected field "
         " after 'options' is 'escalated'");
     return;
@@ -1696,7 +1747,8 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
     engine_logger(log_config_error, basic)
         << "Error: Bad format in the notification part, the separator between "
         << "two fields is ', '";
-    log_v2::config()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::config(),
         "Error: Bad format in the notification part, the separator between two "
         "fields is ', '");
     return;
@@ -1707,7 +1759,8 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
     engine_logger(log_config_error, basic)
         << "Error: Bad format in the notification part, the expected field "
            " after 'escalated' is 'id'";
-    log_v2::config()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::config(),
         "Error: Bad format in the notification part, the expected field "
         " after 'escalated' is 'id'");
     return;
@@ -1719,7 +1772,8 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
     engine_logger(log_config_error, basic)
         << "Error: Bad format in the notification part, the separator between "
         << "two fields is ', '";
-    log_v2::config()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::config(),
         "Error: Bad format in the notification part, the separator between two "
         "fields is ', '");
     return;
@@ -1730,7 +1784,8 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
     engine_logger(log_config_error, basic)
         << "Error: Bad format in the notification part, the expected field "
            " after 'id' is 'number'";
-    log_v2::config()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::config(),
         "Error: Bad format in the notification part, the expected field "
         " after 'id' is 'number'");
     return;
@@ -1742,7 +1797,8 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
     engine_logger(log_config_error, basic)
         << "Error: Bad format in the notification part, the separator between "
         << "two fields is ', '";
-    log_v2::config()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::config(),
         "Error: Bad format in the notification part, the separator between two "
         "fields is ', '");
     return;
@@ -1753,7 +1809,8 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
     engine_logger(log_config_error, basic)
         << "Error: Bad format in the notification part, the expected field "
            " after 'number' is 'interval'";
-    log_v2::config()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::config(),
         "Error: Bad format in the notification part, the expected field "
         " after 'number' is 'interval'");
     return;
@@ -1765,7 +1822,8 @@ void notifier::set_notification(int32_t idx, std::string const& value) {
     engine_logger(log_config_error, basic)
         << "Error: Bad format in the notification part, the 'interval' value "
            "should be an integer";
-    log_v2::config()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::config(),
         "Error: Bad format in the notification part, the 'interval' value "
         "should be an integer");
     return;

--- a/engine/src/service.cc
+++ b/engine/src/service.cc
@@ -142,6 +142,12 @@ service::service(const std::string& hostname,
   set_current_attempt(initial_state == service::state_ok ? 1 : max_attempts);
 }
 
+service::~service() noexcept {
+  if (get_check_command_ptr()) {
+    get_check_command_ptr()->remove_caller(this);
+  }
+}
+
 time_t service::get_last_time_ok() const {
   return _last_time_ok;
 }
@@ -820,7 +826,8 @@ void service::check_for_expired_acknowledgement() {
             << "Acknowledgement of service '" << get_description()
             << "' on host '" << this->get_host_ptr()->name()
             << "' just expired";
-        log_v2::events()->info(
+        SPDLOG_LOGGER_INFO(
+            log_v2::events(),
             "Acknowledgement of service '{}' on host '{}' just expired",
             get_description(), this->get_host_ptr()->name());
         set_problem_has_been_acknowledged(false);
@@ -998,7 +1005,8 @@ static constexpr bool state_changes_use_cached_state = true;
  * @return OK or ERROR.
  *
  */
-int service::handle_async_check_result(check_result* queued_check_result) {
+int service::handle_async_check_result(
+    const check_result& queued_check_result) {
   time_t next_service_check = 0L;
   time_t preferred_time = 0L;
   time_t next_valid_time = 0L;
@@ -1015,21 +1023,18 @@ int service::handle_async_check_result(check_result* queued_check_result) {
   int flapping_check_done = false;
 
   engine_logger(dbg_functions, basic) << "handle_async_service_check_result()";
-  log_v2::functions()->trace("handle_async_service_check_result()");
-
-  /* make sure we have what we need */
-  if (!queued_check_result)
-    return ERROR;
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "handle_async_service_check_result()");
 
   /* get the current time */
   time_t current_time = std::time(nullptr);
 
   /* update the execution time for this check (millisecond resolution) */
   double execution_time =
-      static_cast<double>(queued_check_result->get_finish_time().tv_sec -
-                          queued_check_result->get_start_time().tv_sec) +
-      static_cast<double>(queued_check_result->get_finish_time().tv_usec -
-                          queued_check_result->get_start_time().tv_usec) /
+      static_cast<double>(queued_check_result.get_finish_time().tv_sec -
+                          queued_check_result.get_start_time().tv_sec) +
+      static_cast<double>(queued_check_result.get_finish_time().tv_usec -
+                          queued_check_result.get_start_time().tv_usec) /
           1000000.0;
   if (execution_time < 0.0)
     execution_time = 0.0;
@@ -1037,47 +1042,48 @@ int service::handle_async_check_result(check_result* queued_check_result) {
   engine_logger(dbg_checks, basic)
       << "** Handling check result for service '" << name() << "' on host '"
       << _hostname << "'...";
-  log_v2::checks()->trace(
+  SPDLOG_LOGGER_TRACE(
+      log_v2::checks(),
       "** Handling check result for service '{}' on host '{}'...", name(),
       _hostname);
   engine_logger(dbg_checks, more)
       << "HOST: " << _hostname << ", SERVICE: " << name() << ", CHECK TYPE: "
-      << (queued_check_result->get_check_type() == check_active ? "Active"
-                                                                : "Passive")
-      << ", OPTIONS: " << queued_check_result->get_check_options()
+      << (queued_check_result.get_check_type() == check_active ? "Active"
+                                                               : "Passive")
+      << ", OPTIONS: " << queued_check_result.get_check_options()
       << ", RESCHEDULE: "
-      << (queued_check_result->get_reschedule_check() ? "Yes" : "No")
-      << ", EXITED OK: "
-      << (queued_check_result->get_exited_ok() ? "Yes" : "No")
+      << (queued_check_result.get_reschedule_check() ? "Yes" : "No")
+      << ", EXITED OK: " << (queued_check_result.get_exited_ok() ? "Yes" : "No")
       << ", EXEC TIME: " << execution_time
-      << ", return CODE: " << queued_check_result->get_return_code()
-      << ", OUTPUT: " << queued_check_result->get_output();
-  log_v2::checks()->debug(
+      << ", return CODE: " << queued_check_result.get_return_code()
+      << ", OUTPUT: " << queued_check_result.get_output();
+  SPDLOG_LOGGER_DEBUG(
+      log_v2::checks(),
       "HOST: {}, SERVICE: {}, CHECK TYPE: {}, OPTIONS: {}, RESCHEDULE: {}, "
       "EXITED OK: {}, EXEC TIME: {}, return CODE: {}, OUTPUT: {}",
       _hostname, name(),
-      queued_check_result->get_check_type() == check_active ? "Active"
-                                                            : "Passive",
-      queued_check_result->get_check_options(),
-      queued_check_result->get_reschedule_check() ? "Yes" : "No",
-      queued_check_result->get_exited_ok() ? "Yes" : "No", execution_time,
-      queued_check_result->get_return_code(),
-      queued_check_result->get_output());
+      queued_check_result.get_check_type() == check_active ? "Active"
+                                                           : "Passive",
+      queued_check_result.get_check_options(),
+      queued_check_result.get_reschedule_check() ? "Yes" : "No",
+      queued_check_result.get_exited_ok() ? "Yes" : "No", execution_time,
+      queued_check_result.get_return_code(), queued_check_result.get_output());
 
   /* decrement the number of service checks still out there... */
-  if (queued_check_result->get_check_type() == check_active &&
+  if (queued_check_result.get_check_type() == check_active &&
       currently_running_service_checks > 0)
     currently_running_service_checks--;
 
   /*
    * skip this service check results if its passive and we aren't accepting
    * passive check results */
-  if (queued_check_result->get_check_type() == check_passive) {
+  if (queued_check_result.get_check_type() == check_passive) {
     if (!config->accept_passive_service_checks()) {
       engine_logger(dbg_checks, basic)
           << "Discarding passive service check result because passive "
              "service checks are disabled globally.";
-      log_v2::checks()->trace(
+      SPDLOG_LOGGER_TRACE(
+          log_v2::checks(),
           "Discarding passive service check result because passive "
           "service checks are disabled globally.");
       return ERROR;
@@ -1086,7 +1092,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
       engine_logger(dbg_checks, basic)
           << "Discarding passive service check result because passive "
              "checks are disabled for this service.";
-      log_v2::checks()->trace(
+      SPDLOG_LOGGER_TRACE(
+          log_v2::checks(),
           "Discarding passive service check result because passive "
           "checks are disabled for this service.");
       return ERROR;
@@ -1097,11 +1104,11 @@ int service::handle_async_check_result(check_result* queued_check_result) {
    * clear the freshening flag (it would have been set if this service was
    * determined to be stale)
    */
-  if (queued_check_result->get_check_options() & CHECK_OPTION_FRESHNESS_CHECK)
+  if (queued_check_result.get_check_options() & CHECK_OPTION_FRESHNESS_CHECK)
     set_is_being_freshened(false);
 
   /* clear the execution flag if this was an active check */
-  if (queued_check_result->get_check_type() == check_active)
+  if (queued_check_result.get_check_type() == check_active)
     set_is_executing(false);
 
   /* DISCARD INVALID FRESHNESS CHECK RESULTS */
@@ -1113,39 +1120,40 @@ int service::handle_async_check_result(check_result* queued_check_result) {
   ** make sure the service is still stale before we accept the check
   ** result.
   */
-  if ((queued_check_result->get_check_options() &
+  if ((queued_check_result.get_check_options() &
        CHECK_OPTION_FRESHNESS_CHECK) &&
       is_result_fresh(current_time, false)) {
     engine_logger(dbg_checks, basic)
         << "Discarding service freshness check result because the service "
            "is currently fresh (race condition avoided).";
-    log_v2::checks()->trace(
+    SPDLOG_LOGGER_TRACE(
+        log_v2::checks(),
         "Discarding service freshness check result because the service "
         "is currently fresh (race condition avoided).");
     return OK;
   }
 
   /* check latency is passed to us */
-  set_latency(queued_check_result->get_latency());
+  set_latency(queued_check_result.get_latency());
 
   set_execution_time(execution_time);
 
   /* get the last check time */
-  set_last_check(queued_check_result->get_start_time().tv_sec);
+  set_last_check(queued_check_result.get_start_time().tv_sec);
 
   /* was this check passive or active? */
-  set_check_type(queued_check_result->get_check_type());
+  set_check_type(queued_check_result.get_check_type());
 
   /* update check statistics for passive checks */
-  if (queued_check_result->get_check_type() == check_passive)
+  if (queued_check_result.get_check_type() == check_passive)
     update_check_stats(PASSIVE_SERVICE_CHECK_STATS,
-                       queued_check_result->get_start_time().tv_sec);
+                       queued_check_result.get_start_time().tv_sec);
 
   /*
    * should we reschedule the next service check? NOTE: This may be overridden
    * later...
    */
-  reschedule_check = queued_check_result->get_reschedule_check();
+  reschedule_check = queued_check_result.get_reschedule_check();
 
   /* save the old service status info */
   _last_state = _current_state;
@@ -1157,11 +1165,12 @@ int service::handle_async_check_result(check_result* queued_check_result) {
    * if there was some error running the command, just skip it (this
    * shouldn't be happening)
    */
-  if (!queued_check_result->get_exited_ok()) {
+  if (!queued_check_result.get_exited_ok()) {
     engine_logger(log_runtime_warning, basic)
         << "Warning:  Check of service '" << name() << "' on host '"
         << _hostname << "' did not exit properly!";
-    log_v2::runtime()->warn(
+    SPDLOG_LOGGER_WARN(
+        log_v2::runtime(),
         "Warning:  Check of service '{}' on host '{}' did not exit properly!",
         name(), _hostname);
 
@@ -1169,35 +1178,36 @@ int service::handle_async_check_result(check_result* queued_check_result) {
     _current_state = service::state_unknown;
   }
   /* make sure the return code is within bounds */
-  else if (queued_check_result->get_return_code() < 0 ||
-           queued_check_result->get_return_code() > 3) {
+  else if (queued_check_result.get_return_code() < 0 ||
+           queued_check_result.get_return_code() > 3) {
     engine_logger(log_runtime_warning, basic)
-        << "Warning: return (code of " << queued_check_result->get_return_code()
+        << "Warning: return (code of " << queued_check_result.get_return_code()
         << " for check of service '" << name() << "' on host '" << _hostname
         << "' was out of bounds."
-        << (queued_check_result->get_return_code() == 126
+        << (queued_check_result.get_return_code() == 126
                 ? "Make sure the plugin you're trying to run is executable."
-                : (queued_check_result->get_return_code() == 127
+                : (queued_check_result.get_return_code() == 127
                        ? " Make sure the plugin you're trying to run actually "
                          "exists."
                        : ""));
-    log_v2::runtime()->warn(
+    SPDLOG_LOGGER_WARN(
+        log_v2::runtime(),
         "Warning: return (code of {} for check of service '{}' on host '{}' "
         "was out of bounds.{}",
-        queued_check_result->get_return_code(), name(), _hostname,
-        (queued_check_result->get_return_code() == 126
+        queued_check_result.get_return_code(), name(), _hostname,
+        (queued_check_result.get_return_code() == 126
              ? "Make sure the plugin you're trying to run is executable."
-             : (queued_check_result->get_return_code() == 127
+             : (queued_check_result.get_return_code() == 127
                     ? " Make sure the plugin you're trying to run actually "
                       "exists."
                     : "")));
 
     std::ostringstream oss;
-    oss << "(Return code of " << queued_check_result->get_return_code()
+    oss << "(Return code of " << queued_check_result.get_return_code()
         << " is out of bounds"
-        << (queued_check_result->get_return_code() == 126
+        << (queued_check_result.get_return_code() == 126
                 ? " - plugin may not be executable"
-                : (queued_check_result->get_return_code() == 127
+                : (queued_check_result.get_return_code() == 127
                        ? " - plugin may be missing"
                        : ""))
         << ')';
@@ -1211,7 +1221,7 @@ int service::handle_async_check_result(check_result* queued_check_result) {
      * parse check output to get: (1) short output, (2) long output,
      * (3) perf data
      */
-    std::string output{queued_check_result->get_output()};
+    std::string output{queued_check_result.get_output()};
     std::string plugin_output;
     std::string long_plugin_output;
     std::string perf_data;
@@ -1243,7 +1253,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
         << "\n"
         << "Perf Data:\n"
         << (get_perf_data().empty() ? "NULL" : get_perf_data());
-    log_v2::checks()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::checks(),
         "Parsing check output Short Output: {} Long Output: {} Perf Data: {}",
         get_plugin_output().empty() ? "NULL" : get_plugin_output(),
         get_long_plugin_output().empty() ? "NULL" : get_long_plugin_output(),
@@ -1251,7 +1262,7 @@ int service::handle_async_check_result(check_result* queued_check_result) {
 
     /* grab the return code */
     _current_state = static_cast<service::service_state>(
-        queued_check_result->get_return_code());
+        queued_check_result.get_return_code());
   }
 
   /* record the last state time */
@@ -1285,8 +1296,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
       engine_logger(log_passive_check, basic)
           << "PASSIVE SERVICE CHECK: " << _hostname << ";" << name() << ";"
           << _current_state << ";" << get_plugin_output();
-    log_v2::checks()->info("PASSIVE SERVICE CHECK: {};{};{};{}", _hostname,
-                           name(), _current_state, get_plugin_output());
+    SPDLOG_LOGGER_INFO(log_v2::checks(), "PASSIVE SERVICE CHECK: {};{};{};{}",
+                       _hostname, name(), _current_state, get_plugin_output());
   }
 
   host* hst{get_host_ptr()};
@@ -1319,16 +1330,17 @@ int service::handle_async_check_result(check_result* queued_check_result) {
       << "  CA: " << get_current_attempt() << "  MA: " << max_check_attempts()
       << "  CS: " << _current_state << "  LS: " << _last_state
       << "  LHS: " << _last_hard_state;
-  log_v2::checks()->debug("ST: {}  CA: {} MA: {} CS: {} LS: {} LHS: {}",
-                          (get_state_type() == soft ? "SOFT" : "HARD"),
-                          get_current_attempt(), max_check_attempts(),
-                          _current_state, _last_state, _last_hard_state);
+  SPDLOG_LOGGER_DEBUG(
+      log_v2::checks(), "ST: {}  CA: {} MA: {} CS: {} LS: {} LHS: {}",
+      (get_state_type() == soft ? "SOFT" : "HARD"), get_current_attempt(),
+      max_check_attempts(), _current_state, _last_state, _last_hard_state);
 
   /* check for a state change (either soft or hard) */
   if (_current_state != _last_state) {
     engine_logger(dbg_checks, most)
         << "Service has changed state since last check!";
-    log_v2::checks()->debug("Service has changed state since last check!");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                        "Service has changed state since last check!");
     state_change = true;
   }
 
@@ -1340,7 +1352,7 @@ int service::handle_async_check_result(check_result* queued_check_result) {
    */
   if (_host_problem_at_last_check && _current_state == service::state_ok) {
     engine_logger(dbg_checks, most) << "Service had a HARD STATE CHANGE!!";
-    log_v2::checks()->debug("Service had a HARD STATE CHANGE!!");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Service had a HARD STATE CHANGE!!");
     hard_state_change = true;
   }
 
@@ -1352,7 +1364,7 @@ int service::handle_async_check_result(check_result* queued_check_result) {
       (_current_state != _last_hard_state ||
        get_last_state_change() > get_last_hard_state_change())) {
     engine_logger(dbg_checks, most) << "Service had a HARD STATE CHANGE!!";
-    log_v2::checks()->debug("Service had a HARD STATE CHANGE!!");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Service had a HARD STATE CHANGE!!");
     hard_state_change = true;
   }
 
@@ -1442,7 +1454,7 @@ int service::handle_async_check_result(check_result* queued_check_result) {
   /* if the service is up and running OK... */
   if (_current_state == service::state_ok) {
     engine_logger(dbg_checks, more) << "Service is OK.";
-    log_v2::checks()->debug("Service is OK.");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Service is OK.");
 
     /* reset the acknowledgement flag (this should already have been done, but
      * just in case...) */
@@ -1453,7 +1465,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
     if (hst->get_current_state() != host::state_up) {
       engine_logger(dbg_checks, more)
           << "Host is NOT UP, so we'll check it to see if it recovered...";
-      log_v2::checks()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::checks(),
           "Host is NOT UP, so we'll check it to see if it recovered...");
 
       /* 09/23/07 EG don't launch a new host check if we already did so earlier
@@ -1462,7 +1475,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
         engine_logger(dbg_checks, more)
             << "First host check was already initiated, so we'll skip a "
                "new host check.";
-        log_v2::checks()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::checks(),
             "First host check was already initiated, so we'll skip a "
             "new host check.");
       } else {
@@ -1475,8 +1489,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
              config->cached_host_check_horizon())) {
           engine_logger(dbg_checks, more)
               << "* Using cached host state: " << hst->get_current_state();
-          log_v2::checks()->debug("* Using cached host state: {}",
-                                  hst->get_current_state());
+          SPDLOG_LOGGER_DEBUG(log_v2::checks(), "* Using cached host state: {}",
+                              hst->get_current_state());
           update_check_stats(ACTIVE_ONDEMAND_HOST_CHECK_STATS, current_time);
           update_check_stats(ACTIVE_CACHED_HOST_CHECK_STATS, current_time);
         }
@@ -1491,7 +1505,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
     /* if a hard service recovery has occurred... */
     if (hard_state_change) {
       engine_logger(dbg_checks, more) << "Service experienced a HARD RECOVERY.";
-      log_v2::checks()->debug("Service experienced a HARD RECOVERY.");
+      SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                          "Service experienced a HARD RECOVERY.");
 
       /* set the state type macro */
       set_state_type(hard);
@@ -1520,7 +1535,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
     /* else if a soft service recovery has occurred... */
     else if (state_change) {
       engine_logger(dbg_checks, more) << "Service experienced a SOFT RECOVERY.";
-      log_v2::checks()->debug("Service experienced a SOFT RECOVERY.");
+      SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                          "Service experienced a SOFT RECOVERY.");
 
       /* this is a soft recovery */
       set_state_type(soft);
@@ -1538,7 +1554,7 @@ int service::handle_async_check_result(check_result* queued_check_result) {
     /* else no service state change has occurred... */
     else {
       engine_logger(dbg_checks, more) << "Service did not change state.";
-      log_v2::checks()->debug("Service did not change state.");
+      SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Service did not change state.");
     }
     /* Check if we need to send a recovery notification */
     notify(reason_recovery, "", "", notification_option_none);
@@ -1558,9 +1574,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
     set_no_more_notifications(false);
 
     if (reschedule_check)
-      next_service_check =
-          (time_t)(get_last_check() +
-                   check_interval() * config->interval_length());
+      next_service_check = (time_t)(
+          get_last_check() + check_interval() * config->interval_length());
   }
 
   /*******************************************/
@@ -1570,16 +1585,16 @@ int service::handle_async_check_result(check_result* queued_check_result) {
   /* hey, something's not working quite like it should... */
   else {
     engine_logger(dbg_checks, more) << "Service is in a non-OK state!";
-    log_v2::checks()->debug("Service is in a non-OK state!");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Service is in a non-OK state!");
 
     /* check the route to the host if its up right now... */
     if (hst->get_current_state() == host::state_up) {
       engine_logger(dbg_checks, more)
           << "Host is currently UP, so we'll recheck its state to "
              "make sure...";
-      log_v2::checks()->debug(
-          "Host is currently UP, so we'll recheck its state to "
-          "make sure...");
+      SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                          "Host is currently UP, so we'll recheck its state to "
+                          "make sure...");
 
       /* previous logic was to simply run a sync (serial) host check */
       /* can we use the last cached host state? */
@@ -1592,8 +1607,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
         route_result = hst->get_current_state();
         engine_logger(dbg_checks, more)
             << "* Using cached host state: " << hst->get_current_state();
-        log_v2::checks()->debug("* Using cached host state: {}",
-                                hst->get_current_state());
+        SPDLOG_LOGGER_DEBUG(log_v2::checks(), "* Using cached host state: {}",
+                            hst->get_current_state());
         update_check_stats(ACTIVE_ONDEMAND_HOST_CHECK_STATS, current_time);
         update_check_stats(ACTIVE_CACHED_HOST_CHECK_STATS, current_time);
       }
@@ -1614,8 +1629,9 @@ int service::handle_async_check_result(check_result* queued_check_result) {
         route_result = hst->get_current_state();
         engine_logger(dbg_checks, more)
             << "* Using last known host state: " << hst->get_current_state();
-        log_v2::checks()->debug("* Using last known host state: {}",
-                                hst->get_current_state());
+        SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                            "* Using last known host state: {}",
+                            hst->get_current_state());
         update_check_stats(ACTIVE_ONDEMAND_HOST_CHECK_STATS, current_time);
         update_check_stats(ACTIVE_CACHED_HOST_CHECK_STATS, current_time);
       }
@@ -1625,7 +1641,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
      */
     else {
       engine_logger(dbg_checks, more) << "Host is currently DOWN/UNREACHABLE.";
-      log_v2::checks()->debug("Host is currently DOWN/UNREACHABLE.");
+      SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                          "Host is currently DOWN/UNREACHABLE.");
 
       /* the service wobbled between non-OK states, so check the host... */
       if ((state_change && !state_changes_use_cached_state) &&
@@ -1633,7 +1650,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
         engine_logger(dbg_checks, more)
             << "Service wobbled between non-OK states, so we'll recheck"
                " the host state...";
-        log_v2::checks()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::checks(),
             "Service wobbled between non-OK states, so we'll recheck"
             " the host state...");
         /* previous logic was to simply run a sync (serial) host check */
@@ -1650,7 +1668,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
       else {
         engine_logger(dbg_checks, more)
             << "Assuming host is in same state as before...";
-        log_v2::checks()->debug("Assuming host is in same state as before...");
+        SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                            "Assuming host is in same state as before...");
 
         /* if the host has never been checked before, set the checked flag and
          * last check time */
@@ -1676,7 +1695,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
     if (route_result != host::state_up) {
       engine_logger(dbg_checks, most)
           << "Host is not UP, so we mark state changes if appropriate";
-      log_v2::checks()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::checks(),
           "Host is not UP, so we mark state changes if appropriate");
 
       /* "fake" a hard state change for the service - well, its not really fake,
@@ -1722,8 +1742,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
     engine_logger(dbg_checks, more)
         << "Current/Max Attempt(s): " << get_current_attempt() << '/'
         << max_check_attempts();
-    log_v2::checks()->debug("Current/Max Attempt(s): {}/{}",
-                            get_current_attempt(), max_check_attempts());
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(), "Current/Max Attempt(s): {}/{}",
+                        get_current_attempt(), max_check_attempts());
 
     /* if we should retry the service check, do so (except it the host is down
      * or unreachable!) */
@@ -1733,15 +1753,15 @@ int service::handle_async_check_result(check_result* queued_check_result) {
       if (route_result != host::state_up) {
         engine_logger(dbg_checks, more)
             << "Host isn't UP, so we won't retry the service check...";
-        log_v2::checks()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::checks(),
             "Host isn't UP, so we won't retry the service check...");
 
         /* the host is not up, so reschedule the next service check at regular
          * interval */
         if (reschedule_check)
-          next_service_check =
-              (time_t)(get_last_check() +
-                       check_interval() * config->interval_length());
+          next_service_check = (time_t)(
+              get_last_check() + check_interval() * config->interval_length());
 
         /* log the problem as a hard state if the host just went down */
         if (hard_state_change) {
@@ -1757,8 +1777,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
       else {
         engine_logger(dbg_checks, more)
             << "Host is UP, so we'll retry the service check...";
-        log_v2::checks()->debug(
-            "Host is UP, so we'll retry the service check...");
+        SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                            "Host is UP, so we'll retry the service check...");
 
         /* this is a soft state */
         set_state_type(soft);
@@ -1771,9 +1791,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
         handle_service_event();
 
         if (reschedule_check)
-          next_service_check =
-              (time_t)(get_last_check() +
-                       retry_interval() * config->interval_length());
+          next_service_check = (time_t)(
+              get_last_check() + retry_interval() * config->interval_length());
       }
 
       /* perform dependency checks on the second to last check of the service */
@@ -1782,9 +1801,9 @@ int service::handle_async_check_result(check_result* queued_check_result) {
         engine_logger(dbg_checks, more)
             << "Looking for services to check for predictive "
                "dependency checks...";
-        log_v2::checks()->debug(
-            "Looking for services to check for predictive "
-            "dependency checks...");
+        SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                            "Looking for services to check for predictive "
+                            "dependency checks...");
 
         /* check services that THIS ONE depends on for notification AND
          * execution */
@@ -1803,7 +1822,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
                 << "Predictive check of service '"
                 << master_service->get_description() << "' on host '"
                 << master_service->get_hostname() << "' queued.";
-            log_v2::checks()->debug(
+            SPDLOG_LOGGER_DEBUG(
+                log_v2::checks(),
                 "Predictive check of service '{}' on host '{}' queued.",
                 master_service->get_description(),
                 master_service->get_hostname());
@@ -1819,7 +1839,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
       engine_logger(dbg_checks, more)
           << "Service has reached max number of rechecks, so we'll "
              "handle the error...";
-      log_v2::checks()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::checks(),
           "Service has reached max number of rechecks, so we'll "
           "handle the error...");
 
@@ -1871,9 +1892,8 @@ int service::handle_async_check_result(check_result* queued_check_result) {
 
       /* reschedule the next check at the regular interval */
       if (reschedule_check)
-        next_service_check =
-            (time_t)(get_last_check() +
-                     check_interval() * config->interval_length());
+        next_service_check = (time_t)(
+            get_last_check() + check_interval() * config->interval_length());
     }
 
     /* should we obsessive over service checks? */
@@ -1886,8 +1906,9 @@ int service::handle_async_check_result(check_result* queued_check_result) {
   if (reschedule_check) {
     engine_logger(dbg_checks, more) << "Rescheduling next check of service at "
                                     << my_ctime(&next_service_check);
-    log_v2::checks()->debug("Rescheduling next check of service at {}",
-                            my_ctime(&next_service_check));
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                        "Rescheduling next check of service at {}",
+                        my_ctime(&next_service_check));
 
     /* default is to reschedule service check unless a test below fails... */
     set_should_be_scheduled(true);
@@ -1945,13 +1966,13 @@ int service::handle_async_check_result(check_result* queued_check_result) {
   }
 
   /* send data to event broker */
-  broker_service_check(
-      NEBTYPE_SERVICECHECK_PROCESSED, NEBFLAG_NONE, NEBATTR_NONE, this,
-      get_check_type(), queued_check_result->get_start_time(),
-      queued_check_result->get_finish_time(), get_latency(),
-      get_execution_time(), config->service_check_timeout(),
-      queued_check_result->get_early_timeout(),
-      queued_check_result->get_return_code(), nullptr, nullptr);
+  broker_service_check(NEBTYPE_SERVICECHECK_PROCESSED, NEBFLAG_NONE,
+                       NEBATTR_NONE, this, get_check_type(),
+                       queued_check_result.get_start_time(),
+                       queued_check_result.get_finish_time(), get_latency(),
+                       get_execution_time(), config->service_check_timeout(),
+                       queued_check_result.get_early_timeout(),
+                       queued_check_result.get_return_code(), nullptr, nullptr);
 
   if (!(reschedule_check && get_should_be_scheduled() && has_been_checked()) ||
       !active_checks_enabled()) {
@@ -2022,9 +2043,9 @@ int service::log_event() {
       << "SERVICE ALERT: " << _hostname << ";" << name() << ";" << state << ";"
       << state_type << ";" << get_current_attempt() << ";"
       << get_plugin_output();
-  log_v2::events()->info("SERVICE ALERT: {};{};{};{};{};{}", _hostname, name(),
-                         state, state_type, get_current_attempt(),
-                         get_plugin_output());
+  SPDLOG_LOGGER_INFO(log_v2::events(), "SERVICE ALERT: {};{};{};{};{};{}",
+                     _hostname, name(), state, state_type,
+                     get_current_attempt(), get_plugin_output());
   return OK;
 }
 
@@ -2048,13 +2069,14 @@ void service::check_for_flapping(bool update,
    * change calculation */
 
   engine_logger(dbg_functions, basic) << "check_for_flapping()";
-  log_v2::functions()->trace("check_for_flapping()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "check_for_flapping()");
 
   engine_logger(dbg_flapping, more)
       << "Checking service '" << name() << "' on host '" << _hostname
       << "' for flapping...";
-  log_v2::checks()->debug("Checking service '{}' on host '{}' for flapping...",
-                          name(), _hostname);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Checking service '{}' on host '{}' for flapping...",
+                      name(), _hostname);
 
   /* what threshold values should we use (global or service-specific)? */
   low_threshold = (get_low_flap_threshold() <= 0.0)
@@ -2124,9 +2146,10 @@ void service::check_for_flapping(bool update,
       << com::centreon::logging::setprecision(2) << "LFT=" << low_threshold
       << ", HFT=" << high_threshold << ", CPC=" << curved_percent_change
       << ", PSC=" << curved_percent_change << "%";
-  log_v2::checks()->debug("LFT={:.2f}, HFT={:.2f}, CPC={:.2f}, PSC={:.2f}%",
-                          low_threshold, high_threshold, curved_percent_change,
-                          curved_percent_change);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "LFT={:.2f}, HFT={:.2f}, CPC={:.2f}, PSC={:.2f}%",
+                      low_threshold, high_threshold, curved_percent_change,
+                      curved_percent_change);
 
   /* don't do anything if we don't have flap detection enabled on a program-wide
    * basis */
@@ -2157,8 +2180,9 @@ void service::check_for_flapping(bool update,
       << com::centreon::logging::setprecision(2) << "Service "
       << (is_flapping ? "is" : "is not") << " flapping ("
       << curved_percent_change << "% state change).";
-  log_v2::checks()->debug("Service {} flapping ({:.2f}% state change).",
-                          is_flapping ? "is" : "is not", curved_percent_change);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Service {} flapping ({:.2f}% state change).",
+                      is_flapping ? "is" : "is not", curved_percent_change);
 
   /* did the service just start flapping? */
   if (is_flapping && !get_is_flapping())
@@ -2175,7 +2199,7 @@ int service::handle_service_event() {
   nagios_macros* mac(get_global_macros());
 
   engine_logger(dbg_functions, basic) << "handle_service_event()";
-  log_v2::functions()->trace("handle_service_event()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "handle_service_event()");
 
   /* send event data to broker */
   broker_statechange_data(NEBTYPE_STATECHANGE_END, NEBFLAG_NONE, NEBATTR_NONE,
@@ -2225,7 +2249,8 @@ int service::obsessive_compulsive_service_check_processor() {
 
   engine_logger(dbg_functions, basic)
       << "obsessive_compulsive_service_check_processor()";
-  log_v2::functions()->trace("obsessive_compulsive_service_check_processor()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "obsessive_compulsive_service_check_processor()");
 
   /* bail out if we shouldn't be obsessing */
   if (config->obsess_over_services() == false)
@@ -2257,10 +2282,10 @@ int service::obsessive_compulsive_service_check_processor() {
       << "Raw obsessive compulsive service processor "
          "command line: "
       << raw_command;
-  log_v2::checks()->debug(
-      "Raw obsessive compulsive service processor "
-      "command line: {}",
-      raw_command);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Raw obsessive compulsive service processor "
+                      "command line: {}",
+                      raw_command);
 
   /* process any macros in the raw command line */
   process_macros_r(mac, raw_command, processed_command, macro_options);
@@ -2272,10 +2297,10 @@ int service::obsessive_compulsive_service_check_processor() {
   engine_logger(dbg_checks, most) << "Processed obsessive compulsive service "
                                      "processor command line: "
                                   << processed_command;
-  log_v2::checks()->debug(
-      "Processed obsessive compulsive service "
-      "processor command line: {}",
-      processed_command);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Processed obsessive compulsive service "
+                      "processor command line: {}",
+                      processed_command);
 
   /* run the command */
   try {
@@ -2286,7 +2311,8 @@ int service::obsessive_compulsive_service_check_processor() {
     engine_logger(log_runtime_error, basic)
         << "Error: can't execute compulsive service processor command line '"
         << processed_command << "' : " << e.what();
-    log_v2::runtime()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::runtime(),
         "Error: can't execute compulsive service processor command line '{}' : "
         "{}",
         processed_command, e.what());
@@ -2300,7 +2326,8 @@ int service::obsessive_compulsive_service_check_processor() {
         << "Warning: OCSP command '" << processed_command << "' for service '"
         << name() << "' on host '" << _hostname << "' timed out after "
         << config->ocsp_timeout() << " seconds";
-  log_v2::runtime()->warn(
+  SPDLOG_LOGGER_WARN(
+      log_v2::runtime(),
       "Warning: OCSP command '{}' for service '{}' on host '{}' timed out "
       "after {} seconds",
       processed_command, name(), _hostname, config->ocsp_timeout());
@@ -2332,12 +2359,13 @@ int service::run_scheduled_check(int check_options, double latency) {
   bool time_is_valid = true;
 
   engine_logger(dbg_functions, basic) << "run_scheduled_service_check()";
-  log_v2::functions()->trace("run_scheduled_service_check()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "run_scheduled_service_check()");
   engine_logger(dbg_checks, basic)
       << "Attempting to run scheduled check of service '" << name()
       << "' on host '" << _hostname << "': check options=" << check_options
       << ", latency=" << latency;
-  log_v2::checks()->trace(
+  SPDLOG_LOGGER_TRACE(
+      log_v2::checks(),
       "Attempting to run scheduled check of service '{}' on host '{}': check "
       "options={}, latency={}",
       name(), _hostname, check_options, latency);
@@ -2350,8 +2378,8 @@ int service::run_scheduled_check(int check_options, double latency) {
   if (result == ERROR) {
     engine_logger(dbg_checks, more)
         << "Unable to run scheduled service check at this time";
-    log_v2::checks()->debug(
-        "Unable to run scheduled service check at this time");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                        "Unable to run scheduled service check at this time");
 
     /* only attempt to (re)schedule checks that should get checked... */
     if (get_should_be_scheduled()) {
@@ -2387,14 +2415,16 @@ int service::run_scheduled_check(int check_options, double latency) {
               << _hostname
               << "' could not be "
                  "rescheduled properly. Scheduling check for next week...";
-          log_v2::runtime()->warn(
+          SPDLOG_LOGGER_WARN(
+              log_v2::runtime(),
               "Warning: Check of service '{}' on host '{}' could not be "
               "rescheduled properly. Scheduling check for next week...",
               name(), _hostname);
           engine_logger(dbg_checks, more)
               << "Unable to find any valid times to reschedule the next "
                  "service check!";
-          log_v2::checks()->debug(
+          SPDLOG_LOGGER_DEBUG(
+              log_v2::checks(),
               "Unable to find any valid times to reschedule the next "
               "service check!");
         }
@@ -2405,8 +2435,9 @@ int service::run_scheduled_check(int check_options, double latency) {
           engine_logger(dbg_checks, more)
               << "Rescheduled next service check for "
               << my_ctime(&next_valid_time);
-          log_v2::checks()->debug("Rescheduled next service check for {}",
-                                  my_ctime(&next_valid_time));
+          SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                              "Rescheduled next service check for {}",
+                              my_ctime(&next_valid_time));
         }
       }
     }
@@ -2443,10 +2474,11 @@ int service::run_async_check(int check_options,
       << "service::run_async_check, check_options=" << check_options
       << ", latency=" << latency << ", scheduled_check=" << scheduled_check
       << ", reschedule_check=" << reschedule_check;
-  log_v2::functions()->trace(
-      "service::run_async_check, check_options={}, latency={}, "
-      "scheduled_check={}, reschedule_check={}",
-      check_options, latency, scheduled_check, reschedule_check);
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "service::run_async_check, check_options={}, latency={}, "
+                      "scheduled_check={}, reschedule_check={}",
+                      check_options, latency, scheduled_check,
+                      reschedule_check);
 
   // Preamble.
   if (!get_check_command_ptr()) {
@@ -2454,7 +2486,8 @@ int service::run_async_check(int check_options,
         << "Error: Attempt to run active check on service '"
         << get_description() << "' on host '" << get_host_ptr()->name()
         << "' with no check command";
-    log_v2::runtime()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::runtime(),
         "Error: Attempt to run active check on service '{}' on host '{}' with "
         "no check command",
         get_description(), get_host_ptr()->name());
@@ -2464,9 +2497,9 @@ int service::run_async_check(int check_options,
   engine_logger(dbg_checks, basic)
       << "** Running async check of service '" << get_description()
       << "' on host '" << get_hostname() << "'...";
-  log_v2::checks()->trace(
-      "** Running async check of service '{} on host '{}'...",
-      get_description(), get_hostname());
+  SPDLOG_LOGGER_TRACE(log_v2::checks(),
+                      "** Running async check of service '{} on host '{}'...",
+                      get_description(), get_hostname());
 
   // Check if the service is viable now.
   if (!verify_check_viability(check_options, time_is_valid, preferred_time))
@@ -2488,7 +2521,8 @@ int service::run_async_check(int check_options,
     engine_logger(log_runtime_error, basic)
         << "Error: Some broker module cancelled check of service '"
         << get_description() << "' on host '" << get_hostname();
-    log_v2::runtime()->error(
+    SPDLOG_LOGGER_ERROR(
+        log_v2::runtime(),
         "Error: Some broker module cancelled check of service '{}' on host "
         "'{}'",
         get_description(), get_hostname());
@@ -2499,7 +2533,8 @@ int service::run_async_check(int check_options,
     engine_logger(dbg_functions, basic)
         << "Some broker module overrode check of service '" << get_description()
         << "' on host '" << get_hostname() << "' so we'll bail out";
-    log_v2::functions()->trace(
+    SPDLOG_LOGGER_TRACE(
+        log_v2::functions(),
         "Some broker module overrode check of service '{}' on host '{}' so "
         "we'll bail out",
         get_description(), get_hostname());
@@ -2509,8 +2544,8 @@ int service::run_async_check(int check_options,
   // Checking starts.
   engine_logger(dbg_checks, basic) << "Checking service '" << get_description()
                                    << "' on host '" << get_hostname() << "'...";
-  log_v2::checks()->trace("Checking service '{}' on host '{}'...",
-                          get_description(), get_hostname());
+  SPDLOG_LOGGER_TRACE(log_v2::checks(), "Checking service '{}' on host '{}'...",
+                      get_description(), get_hostname());
 
   // Clear check options.
   if (scheduled_check)
@@ -2535,14 +2570,14 @@ int service::run_async_check(int check_options,
   ++currently_running_service_checks;
   engine_logger(dbg_checks, basic)
       << "Current running service checks: " << currently_running_service_checks;
-  log_v2::checks()->trace("Current running service checks: {}",
-                          currently_running_service_checks);
+  SPDLOG_LOGGER_TRACE(log_v2::checks(), "Current running service checks: {}",
+                      currently_running_service_checks);
 
   // Set the execution flag.
   set_is_executing(true);
 
   // Get command object.
-  commands::command* cmd = get_check_command_ptr();
+  commands::command* cmd = get_check_command_ptr().get();
   std::string processed_cmd(cmd->process_cmd(macros));
 
   // Send event broker.
@@ -2567,22 +2602,23 @@ int service::run_async_check(int check_options,
                      start_time.tv_sec);
 
   bool retry;
-  std::unique_ptr<check_result> check_result_info;
+  check_result::pointer check_result_info;
   do {
     // Init check result info.
-    check_result_info.reset(
-        new check_result(service_check, this, checkable::check_active,
-                         check_options, reschedule_check, latency, start_time,
-                         start_time, false, true, service::state_ok, ""));
+    check_result_info = std::make_shared<check_result>(
+        service_check, this, checkable::check_active, check_options,
+        reschedule_check, latency, start_time, start_time, false, true,
+        service::state_ok, "");
 
     retry = false;
     try {
       // Run command.
       uint64_t id =
-          cmd->run(processed_cmd, *macros, config->service_check_timeout());
-      if (id != 0)
-        checks::checker::instance().add_check_result(
-            id, check_result_info.release());
+          cmd->run(processed_cmd, *macros, config->service_check_timeout(),
+                   check_result_info, this);
+      SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                          "run id={} {} for service {} host {}", id,
+                          processed_cmd, _service_id, _hostname);
     } catch (com::centreon::exceptions::interruption const& e) {
       retry = true;
     } catch (std::exception const& e) {
@@ -2596,13 +2632,13 @@ int service::run_async_check(int check_options,
       check_result_info->set_output("(Execute command failed)");
 
       // Queue check result.
-      checks::checker::instance().add_check_result_to_reap(
-          check_result_info.release());
+      checks::checker::instance().add_check_result_to_reap(check_result_info);
 
       engine_logger(log_runtime_warning, basic)
           << "Error: Service check command execution failed: " << e.what();
-      log_v2::runtime()->warn(
-          "Error: Service check command execution failed: {}", e.what());
+      SPDLOG_LOGGER_WARN(log_v2::runtime(),
+                         "Error: Service check command execution failed: {}",
+                         e.what());
     }
   } while (retry);
 
@@ -2625,14 +2661,15 @@ bool service::schedule_check(time_t check_time,
                              uint32_t options,
                              bool no_update_status_now) {
   engine_logger(dbg_functions, basic) << "schedule_service_check()";
-  log_v2::functions()->trace("schedule_service_check()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "schedule_service_check()");
 
   engine_logger(dbg_checks, basic)
       << "Scheduling a "
       << (options & CHECK_OPTION_FORCE_EXECUTION ? "forced" : "non-forced")
       << ", active check of service '" << name() << "' on host '" << _hostname
       << "' @ " << my_ctime(&check_time);
-  log_v2::checks()->trace(
+  SPDLOG_LOGGER_TRACE(
+      log_v2::checks(),
       "Scheduling a {}, active check of service '{}' on host '{}' @ {}",
       options & CHECK_OPTION_FORCE_EXECUTION ? "forced" : "non-forced", name(),
       _hostname, my_ctime(&check_time));
@@ -2642,7 +2679,8 @@ bool service::schedule_check(time_t check_time,
   if (!active_checks_enabled() && !(options & CHECK_OPTION_FORCE_EXECUTION)) {
     engine_logger(dbg_checks, basic)
         << "Active checks of this service are disabled.";
-    log_v2::checks()->trace("Active checks of this service are disabled.");
+    SPDLOG_LOGGER_TRACE(log_v2::checks(),
+                        "Active checks of this service are disabled.");
     return false;
   }
 
@@ -2657,7 +2695,8 @@ bool service::schedule_check(time_t check_time,
     engine_logger(dbg_checks, most)
         << "Found another service check event for this service @ "
         << my_ctime(&temp_event->run_time);
-    log_v2::checks()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::checks(),
         "Found another service check event for this service @ {}",
         my_ctime(&temp_event->run_time));
 
@@ -2674,7 +2713,8 @@ bool service::schedule_check(time_t check_time,
         engine_logger(dbg_checks, most)
             << "New service check event is forced and occurs before the "
                "existing event, so the new event will be used instead.";
-        log_v2::checks()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::checks(),
             "New service check event is forced and occurs before the "
             "existing event, so the new event will be used instead.");
       }
@@ -2687,7 +2727,8 @@ bool service::schedule_check(time_t check_time,
         engine_logger(dbg_checks, most)
             << "New service check event is forced, so it will be used "
                "instead of the existing event.";
-        log_v2::checks()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::checks(),
             "New service check event is forced, so it will be used "
             "instead of the existing event.");
       }
@@ -2698,7 +2739,8 @@ bool service::schedule_check(time_t check_time,
         engine_logger(dbg_checks, most)
             << "New service check event occurs before the existing "
                "(older) event, so it will be used instead.";
-        log_v2::checks()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::checks(),
             "New service check event occurs before the existing "
             "(older) event, so it will be used instead.");
       }
@@ -2707,7 +2749,8 @@ bool service::schedule_check(time_t check_time,
         engine_logger(dbg_checks, most)
             << "New service check event occurs after the existing event, "
                "so we'll ignore it.";
-        log_v2::checks()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::checks(),
             "New service check event occurs after the existing event, "
             "so we'll ignore it.");
       }
@@ -2727,7 +2770,8 @@ bool service::schedule_check(time_t check_time,
     }
 
     engine_logger(dbg_checks, most) << "Scheduling new service check event.";
-    log_v2::checks()->debug("Scheduling new service check event.");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                        "Scheduling new service check event.");
 
     // Allocate memory for a new event item.
     try {
@@ -2755,7 +2799,8 @@ bool service::schedule_check(time_t check_time,
 
     engine_logger(dbg_checks, most)
         << "Keeping original service check event (ignoring the new one).";
-    log_v2::checks()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::checks(),
         "Keeping original service check event (ignoring the new one).");
   }
 
@@ -2770,12 +2815,13 @@ void service::set_flap(double percent_change,
                        double low_threshold,
                        int allow_flapstart_notification) {
   engine_logger(dbg_functions, basic) << "set_service_flap()";
-  log_v2::functions()->trace("set_service_flap()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "set_service_flap()");
 
   engine_logger(dbg_flapping, more) << "Service '" << name() << "' on host '"
                                     << _hostname << "' started flapping!";
-  log_v2::checks()->debug("Service '{}' on host '{}' started flapping!", name(),
-                          _hostname);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Service '{}' on host '{}' started flapping!", name(),
+                      _hostname);
 
   /* log a notice - this one is parsed by the history CGI */
   engine_logger(log_runtime_warning, basic)
@@ -2783,7 +2829,8 @@ void service::set_flap(double percent_change,
       << "SERVICE FLAPPING ALERT: " << _hostname << ";" << name()
       << ";STARTED; Service appears to have started flapping ("
       << percent_change << "% change >= " << high_threshold << "% threshold)";
-  log_v2::runtime()->warn(
+  SPDLOG_LOGGER_WARN(
+      log_v2::runtime(),
       "SERVICE FLAPPING ALERT: {};{};STARTED; Service appears to have started "
       "flapping ({:.1f}% change >= {:.1f}% threshold)",
       _hostname, name(), percent_change, high_threshold);
@@ -2827,12 +2874,13 @@ void service::clear_flap(double percent_change,
                          double high_threshold,
                          double low_threshold) {
   engine_logger(dbg_functions, basic) << "clear_service_flap()";
-  log_v2::functions()->trace("clear_service_flap()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "clear_service_flap()");
 
   engine_logger(dbg_flapping, more) << "Service '" << name() << "' on host '"
                                     << _hostname << "' stopped flapping.";
-  log_v2::checks()->debug("Service '{}' on host '{}' stopped flapping.", name(),
-                          _hostname);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Service '{}' on host '{}' stopped flapping.", name(),
+                      _hostname);
 
   /* log a notice - this one is parsed by the history CGI */
   engine_logger(log_info_message, basic)
@@ -2840,7 +2888,8 @@ void service::clear_flap(double percent_change,
       << "SERVICE FLAPPING ALERT: " << _hostname << ";" << name()
       << ";STOPPED; Service appears to have stopped flapping ("
       << percent_change << "% change < " << low_threshold << "% threshold)";
-  log_v2::events()->info(
+  SPDLOG_LOGGER_INFO(
+      log_v2::events(),
       "SERVICE FLAPPING ALERT: {};{};STOPPED; Service appears to have stopped "
       "flapping ({:.1f}% change < {:.1f}% threshold)",
       _hostname, name(), percent_change, low_threshold);
@@ -2870,14 +2919,14 @@ void service::enable_flap_detection() {
   unsigned long attr = MODATTR_FLAP_DETECTION_ENABLED;
 
   engine_logger(dbg_functions, basic) << "service::enable_flap_detection()";
-  log_v2::functions()->trace("service::enable_flap_detection()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "service::enable_flap_detection()");
 
   engine_logger(dbg_flapping, more)
       << "Enabling flap detection for service '" << name() << "' on host '"
       << _hostname << "'.";
-  log_v2::checks()->debug(
-      "Enabling flap detection for service '{}' on host '{}'.", name(),
-      _hostname);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Enabling flap detection for service '{}' on host '{}'.",
+                      name(), _hostname);
 
   /* nothing to do... */
   if (flap_detection_enabled())
@@ -2908,14 +2957,14 @@ void service::disable_flap_detection() {
   unsigned long attr = MODATTR_FLAP_DETECTION_ENABLED;
 
   engine_logger(dbg_functions, basic) << "disable_service_flap_detection()";
-  log_v2::functions()->trace("disable_service_flap_detection()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "disable_service_flap_detection()");
 
   engine_logger(dbg_flapping, more)
       << "Disabling flap detection for service '" << name() << "' on host '"
       << _hostname << "'.";
-  log_v2::checks()->debug(
-      "Disabling flap detection for service '{}' on host '{}'.", name(),
-      _hostname);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Disabling flap detection for service '{}' on host '{}'.",
+                      name(), _hostname);
 
   /* nothing to do... */
   if (!flap_detection_enabled())
@@ -2968,7 +3017,7 @@ bool service::verify_check_viability(int check_options,
   int check_interval = 0;
 
   engine_logger(dbg_functions, basic) << "check_service_check_viability()";
-  log_v2::functions()->trace("check_service_check_viability()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "check_service_check_viability()");
 
   /* get the check interval to use if we need to reschedule the check */
   if (get_state_type() == soft && _current_state != service::state_ok)
@@ -2993,7 +3042,8 @@ bool service::verify_check_viability(int check_options,
 
       engine_logger(dbg_checks, most)
           << "Active checks of the service are currently disabled.";
-      log_v2::checks()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::checks(),
           "Active checks of the service are currently disabled.");
     }
 
@@ -3009,7 +3059,8 @@ bool service::verify_check_viability(int check_options,
         engine_logger(dbg_checks, most)
             << "This is not a valid time for this service to be actively "
                "checked.";
-        log_v2::checks()->debug(
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::checks(),
             "This is not a valid time for this service to be actively "
             "checked.");
       }
@@ -3023,7 +3074,8 @@ bool service::verify_check_viability(int check_options,
       engine_logger(dbg_checks, most)
           << "Execution dependencies for this service failed, so it will "
              "not be actively checked.";
-      log_v2::checks()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::checks(),
           "Execution dependencies for this service failed, so it will "
           "not be actively checked.");
     }
@@ -3059,7 +3111,7 @@ int service::notify_contact(nagios_macros* mac,
   int neb_result;
 
   engine_logger(dbg_functions, basic) << "notify_contact_of_service()";
-  log_v2::functions()->trace("notify_contact_of_service()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "notify_contact_of_service()");
   engine_logger(dbg_notifications, most)
       << "** Notifying contact '" << cntct->get_name() << "'";
   log_v2::notifications()->info("** Notifying contact '{}'", cntct->get_name());
@@ -3099,7 +3151,7 @@ int service::notify_contact(nagios_macros* mac,
       continue;
 
     /* get the raw command line */
-    get_raw_command_line_r(mac, cmd.get(), cmd->get_command_line().c_str(),
+    get_raw_command_line_r(mac, cmd, cmd->get_command_line().c_str(),
                            raw_command, macro_options);
     if (raw_command.empty())
       continue;
@@ -3165,9 +3217,9 @@ int service::notify_contact(nagios_macros* mac,
       engine_logger(log_runtime_error, basic)
           << "Error: can't execute service notification '" << cntct->get_name()
           << "' : " << e.what();
-      log_v2::runtime()->error(
-          "Error: can't execute service notification '{}' : {}",
-          cntct->get_name(), e.what());
+      SPDLOG_LOGGER_ERROR(log_v2::runtime(),
+                          "Error: can't execute service notification '{}' : {}",
+                          cntct->get_name(), e.what());
     }
 
     /* check to see if the notification command timed out */
@@ -3229,7 +3281,8 @@ bool service::is_valid_escalation_for_notification(escalation const* e,
 
   engine_logger(dbg_functions, basic)
       << "service::is_valid_escalation_for_notification()";
-  log_v2::functions()->trace("service::is_valid_escalation_for_notification()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "service::is_valid_escalation_for_notification()");
 
   /* get the current time */
   time(&current_time);
@@ -3301,8 +3354,9 @@ bool service::is_result_fresh(time_t current_time, int log_this) {
   engine_logger(dbg_checks, most)
       << "Checking freshness of service '" << this->get_description()
       << "' on host '" << this->get_hostname() << "'...";
-  log_v2::checks()->debug("Checking freshness of service '{}' on host '{}'...",
-                          this->get_description(), this->get_hostname());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Checking freshness of service '{}' on host '{}'...",
+                      this->get_description(), this->get_hostname());
 
   /* use user-supplied freshness threshold or auto-calculate a freshness
    * threshold to use? */
@@ -3321,8 +3375,9 @@ bool service::is_result_fresh(time_t current_time, int log_this) {
   engine_logger(dbg_checks, most)
       << "Freshness thresholds: service=" << this->get_freshness_threshold()
       << ", use=" << freshness_threshold;
-  log_v2::checks()->debug("Freshness thresholds: service={}, use={}",
-                          this->get_freshness_threshold(), freshness_threshold);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Freshness thresholds: service={}, use={}",
+                      this->get_freshness_threshold(), freshness_threshold);
 
   /* calculate expiration time */
   /* CHANGED 11/10/05 EG - program start is only used in expiration time
@@ -3342,9 +3397,9 @@ bool service::is_result_fresh(time_t current_time, int log_this) {
    * suggested by Altinity */
   else if (this->active_checks_enabled() && event_start > get_last_check() &&
            this->get_freshness_threshold() == 0)
-    expiration_time = (time_t)(event_start + freshness_threshold +
-                               (config->max_service_check_spread() *
-                                config->interval_length()));
+    expiration_time = (time_t)(
+        event_start + freshness_threshold +
+        (config->max_service_check_spread() * config->interval_length()));
   else
     expiration_time = (time_t)(get_last_check() + freshness_threshold);
 
@@ -3352,9 +3407,10 @@ bool service::is_result_fresh(time_t current_time, int log_this) {
       << "HBC: " << this->has_been_checked() << ", PS: " << program_start
       << ", ES: " << event_start << ", LC: " << get_last_check()
       << ", CT: " << current_time << ", ET: " << expiration_time;
-  log_v2::checks()->debug("HBC: {}, PS: {}, ES: {}, LC: {}, CT: {}, ET: {}",
-                          this->has_been_checked(), program_start, event_start,
-                          get_last_check(), current_time, expiration_time);
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "HBC: {}, PS: {}, ES: {}, LC: {}, CT: {}, ET: {}",
+                      this->has_been_checked(), program_start, event_start,
+                      get_last_check(), current_time, expiration_time);
 
   /* the results for the last check of this service are stale */
   if (expiration_time < current_time) {
@@ -3373,7 +3429,8 @@ bool service::is_result_fresh(time_t current_time, int log_this) {
           << "m " << tseconds
           << "s).  I'm forcing an immediate check "
              "of the service.";
-    log_v2::runtime()->warn(
+    SPDLOG_LOGGER_WARN(
+        log_v2::runtime(),
         "Warning: The results of service '{}' on host '{}' are stale by {}d "
         "{}h {}m {}s (threshold={}d {}h {}m {}s).  I'm forcing an immediate "
         "check "
@@ -3389,7 +3446,8 @@ bool service::is_result_fresh(time_t current_time, int log_this) {
         << "m " << tseconds
         << "s).  Forcing an immediate check of "
            "the service...";
-    log_v2::checks()->debug(
+    SPDLOG_LOGGER_DEBUG(
+        log_v2::checks(),
         "Check results for service '{}' on host '{}' are stale by {}d {}h {}m "
         "{}s (threshold={}d {}h {}m {}s). Forcing an immediate check of the "
         "service...",
@@ -3402,9 +3460,9 @@ bool service::is_result_fresh(time_t current_time, int log_this) {
   engine_logger(dbg_checks, more)
       << "Check results for service '" << this->get_description()
       << "' on host '" << this->get_hostname() << "' are fresh.";
-  log_v2::checks()->debug(
-      "Check results for service '{}' on host '{}' are fresh.",
-      this->get_description(), this->get_hostname());
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Check results for service '{}' on host '{}' are fresh.",
+                      this->get_description(), this->get_hostname());
 
   return true;
 }
@@ -3416,7 +3474,8 @@ bool service::is_result_fresh(time_t current_time, int log_this) {
 void service::handle_flap_detection_disabled() {
   engine_logger(dbg_functions, basic)
       << "handle_service_flap_detection_disabled()";
-  log_v2::functions()->trace("handle_service_flap_detection_disabled()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "handle_service_flap_detection_disabled()");
 
   /* if the service was flapping, remove the flapping indicator */
   if (get_is_flapping()) {
@@ -3480,7 +3539,8 @@ bool service::authorized_by_dependencies(
     dependency::types dependency_type) const {
   engine_logger(dbg_functions, basic)
       << "service::authorized_by_dependencies()";
-  log_v2::functions()->trace("service::authorized_by_dependencies()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(),
+                      "service::authorized_by_dependencies()");
 
   auto p(
       servicedependency::servicedependencies.equal_range({_hostname, name()}));
@@ -3536,7 +3596,7 @@ void service::check_for_orphaned() {
   time_t expected_time{0L};
 
   engine_logger(dbg_functions, basic) << "check_for_orphaned_services()";
-  log_v2::functions()->trace("check_for_orphaned_services()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "check_for_orphaned_services()");
 
   /* get the current time */
   time(&current_time);
@@ -3566,7 +3626,8 @@ void service::check_for_orphaned() {
           << "' looks like it was orphaned "
              "(results never came back).  I'm scheduling an immediate check "
              "of the service...";
-      log_v2::runtime()->warn(
+      SPDLOG_LOGGER_WARN(
+          log_v2::runtime(),
           "Warning: The check of service '{}' on host '{}' looks like it was "
           "orphaned "
           "(results never came back).  I'm scheduling an immediate check "
@@ -3576,7 +3637,8 @@ void service::check_for_orphaned() {
       engine_logger(dbg_checks, more)
           << "Service '" << it->first.second << "' on host '" << it->first.first
           << "' was orphaned, so we're scheduling an immediate check...";
-      log_v2::checks()->debug(
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::checks(),
           "Service '{}' on host '{}' was orphaned, so we're scheduling an "
           "immediate check...",
           it->first.second, it->first.first);
@@ -3599,16 +3661,18 @@ void service::check_result_freshness() {
   time_t current_time{0L};
 
   engine_logger(dbg_functions, basic) << "check_service_result_freshness()";
-  log_v2::functions()->trace("check_service_result_freshness()");
+  SPDLOG_LOGGER_TRACE(log_v2::functions(), "check_service_result_freshness()");
   engine_logger(dbg_checks, more)
       << "Checking the freshness of service check results...";
-  log_v2::checks()->debug("Checking the freshness of service check results...");
+  SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                      "Checking the freshness of service check results...");
 
   /* bail out if we're not supposed to be checking freshness */
   if (!config->check_service_freshness()) {
     engine_logger(dbg_checks, more)
         << "Service freshness checking is disabled.";
-    log_v2::checks()->debug("Service freshness checking is disabled.");
+    SPDLOG_LOGGER_DEBUG(log_v2::checks(),
+                        "Service freshness checking is disabled.");
     return;
   }
   /* get the current time */

--- a/engine/src/utils.cc
+++ b/engine/src/utils.cc
@@ -76,7 +76,7 @@ int my_system_r(nagios_macros* mac,
   }
 
   engine_logger(dbg_commands, more) << "Running command '" << cmd << "'...";
-  log_v2::commands()->debug("Running command '{}'...", cmd);
+  SPDLOG_LOGGER_DEBUG(log_v2::commands(), "Running command '{}'...", cmd);
 
   timeval start_time = timeval();
   timeval end_time = timeval();
@@ -109,7 +109,8 @@ int my_system_r(nagios_macros* mac,
       << "Execution time=" << *exectime
       << " sec, early timeout=" << *early_timeout << ", result=" << result
       << ", output=" << output;
-  log_v2::commands()->debug(
+  SPDLOG_LOGGER_DEBUG(
+      log_v2::commands(),
       "Execution time={:.3f} sec, early timeout={}, result={}, output={}",
       *exectime, *early_timeout, result, output);
 
@@ -156,8 +157,8 @@ int get_raw_command_line_r(nagios_macros* mac,
 
   engine_logger(dbg_commands | dbg_checks | dbg_macros, most)
       << "Raw Command Input: " << cmd_ptr->get_command_line();
-  log_v2::commands()->debug("Raw Command Input: {}",
-                            cmd_ptr->get_command_line());
+  SPDLOG_LOGGER_DEBUG(log_v2::commands(), "Raw Command Input: {}",
+                      cmd_ptr->get_command_line());
 
   /* get the full command line */
   full_command = cmd_ptr->get_command_line();
@@ -209,7 +210,8 @@ int get_raw_command_line_r(nagios_macros* mac,
 
   engine_logger(dbg_commands | dbg_checks | dbg_macros, most)
       << "Expanded Command Output: " << full_command;
-  log_v2::commands()->debug("Expanded Command Output: {}", full_command);
+  SPDLOG_LOGGER_DEBUG(log_v2::commands(), "Expanded Command Output: {}",
+                      full_command);
 
   return OK;
 }

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -1,48 +1,48 @@
-##
-## Copyright 2016, 2020-2021 Centreon
-##
+# #
+# # Copyright 2016, 2020-2021 Centreon
+# #
 
-## This file is part of Centreon Engine.
-##
-## Centreon Engine is free software : you can redistribute it and / or 
-## modify it under the terms of the GNU General Public License version 2
-## as published by the Free Software Foundation.
-##
-## Centreon Engine is distributed in the hope that it will be useful,
-## but WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-## General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with Centreon Engine. If not, see
-## <http://www.gnu.org/licenses/>.
-##
+# # This file is part of Centreon Engine.
+# #
+# # Centreon Engine is free software : you can redistribute it and / or
+# # modify it under the terms of the GNU General Public License version 2
+# # as published by the Free Software Foundation.
+# #
+# # Centreon Engine is distributed in the hope that it will be useful,
+# # but WITHOUT ANY WARRANTY; without even the implied warranty of
+# # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# # General Public License for more details.
+# #
+# # You should have received a copy of the GNU General Public License
+# # along with Centreon Engine. If not, see
+# # <http://www.gnu.org/licenses/>.
+# #
 
 # Enable unit tests or not .
-if (WITH_TESTING)
-
-# Tests directory.
+if(WITH_TESTING)
+  # Tests directory.
   # Add root inclusion direction.
   set(MODULE_DIR "${PROJECT_SOURCE_DIR}/modules/external_commands")
   set(INC_DIR "${MODULE_DIR}/inc/com/centreon/engine/modules/external_commands")
   include_directories(${PROJECT_SOURCE_DIR} ${MODULE_DIR}/inc)
 
-#Set directory.
+  # Set directory.
   set(TESTS_DIR "${PROJECT_SOURCE_DIR}/tests")
   include_directories(${PROJECT_SOURCE_DIR}/enginerpc)
   add_definitions(-DENGINERPC_TESTS_PATH="${TESTS_DIR}/enginerpc")
 
   add_executable(rpc_client_engine
-      ${TESTS_DIR}/enginerpc/client.cc)
+    ${TESTS_DIR}/enginerpc/client.cc)
 
   target_link_libraries(rpc_client_engine cerpc CONAN_PKG::grpc CONAN_PKG::openssl CONAN_PKG::zlib dl pthread)
 
   add_executable(bin_connector_test_run
-      "${TESTS_DIR}/commands/bin_connector_test_run.cc")
+    "${TESTS_DIR}/commands/bin_connector_test_run.cc")
   target_link_libraries(bin_connector_test_run cce_core pthread)
-  target_precompile_headers(bin_connector_test_run PRIVATE ../precomp_inc/precomp.hh)
+  target_precompile_headers(bin_connector_test_run REUSE_FROM cce_core)
 
   set(ut_sources
+
     # Sources.
     "${TESTS_DIR}/parse-check-output.cc"
     "${TESTS_DIR}/checks/service_check.cc"
@@ -114,7 +114,8 @@ if (WITH_TESTING)
     "${TESTS_DIR}/timeperiod/get_next_valid_time/skip_interval.cc"
     "${TESTS_DIR}/timeperiod/get_next_valid_time/specific_month_date.cc"
     "${TESTS_DIR}/timeperiod/utils.cc"
-#    # Headers.
+
+    # # Headers.
     "${TESTS_DIR}/test_engine.hh"
     "${TESTS_DIR}/timeperiod/utils.hh"
   )
@@ -123,32 +124,32 @@ if (WITH_TESTING)
   include_directories(${TESTS_DIR})
 
   add_executable(ut_engine ${ut_sources})
-  target_precompile_headers(ut_engine PRIVATE ../precomp_inc/precomp.hh)
+  target_precompile_headers(ut_engine REUSE_FROM cce_core)
 
   set_target_properties(
-      ut_engine rpc_client_engine bin_connector_test_run
-      PROPERTIES
-      RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests
-      RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/tests
-      RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/tests
-      RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_BINARY_DIR}/tests
-      RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_BINARY_DIR}/tests
+    ut_engine rpc_client_engine bin_connector_test_run
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests
+    RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/tests
+    RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/tests
+    RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO ${CMAKE_BINARY_DIR}/tests
+    RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL ${CMAKE_BINARY_DIR}/tests
   )
 
-  #file used by timeperiod-test.cc
-  file(COPY ${TESTS_DIR}/configuration/timeperiods.cfg DESTINATION ${CMAKE_BINARY_DIR}/tests/ ) 
+  # file used by timeperiod-test.cc
+  file(COPY ${TESTS_DIR}/configuration/timeperiods.cfg DESTINATION ${CMAKE_BINARY_DIR}/tests/)
 
   add_test(NAME tests COMMAND ut_engine)
 
-  if (WITH_COVERAGE)
+  if(WITH_COVERAGE)
     set(COVERAGE_EXCLUDES '${PROJECT_BINARY_DIR}/*' '${PROJECT_SOURCE_DIR}/tests/*' '/usr/include/* ')
     SETUP_TARGET_FOR_COVERAGE(
-        NAME engine-test-coverage
-        EXECUTABLE ut_engine
-        DEPENDENCIES ut_engine
+      NAME engine-test-coverage
+      EXECUTABLE ut_engine
+      DEPENDENCIES ut_engine
     )
     set(GCOV gcov)
-  endif ()
-  target_link_libraries(ut_engine ${ENGINERPC} cce_core pthread ${GCOV} CONAN_PKG::gtest CONAN_PKG::grpc CONAN_PKG::openssl CONAN_PKG::zlib CONAN_PKG::fmt dl)
+  endif()
 
-endif ()
+  target_link_libraries(ut_engine ${ENGINERPC} cce_core pthread ${GCOV} CONAN_PKG::gtest CONAN_PKG::grpc CONAN_PKG::openssl CONAN_PKG::zlib CONAN_PKG::fmt dl)
+endif()

--- a/engine/tests/commands/connector.cc
+++ b/engine/tests/commands/connector.cc
@@ -105,7 +105,7 @@ TEST_F(Connector, RunConnectorAsync) {
   nagios_macros macros = nagios_macros();
   connector cmd_connector("RunConnectorAsync", "tests/bin_connector_test_run");
   cmd_connector.set_listener(lstnr.get());
-  cmd_connector.run("commande", macros, 1);
+  cmd_connector.run("commande", macros, 1, std::make_shared<check_result>());
 
   int timeout = 0;
   int max_timeout{15};
@@ -123,10 +123,11 @@ TEST_F(Connector, RunWithConnectorSwitchedOff) {
   connector cmd_connector("RunWithConnectorSwitchedOff",
                           "tests/bin_connector_test_run");
   {
-    std::unique_ptr<my_listener> lstnr(new my_listener);
+    std::unique_ptr<my_listener> lstnr(std::make_unique<my_listener>());
     nagios_macros macros = nagios_macros();
     cmd_connector.set_listener(lstnr.get());
-    cmd_connector.run("commande --kill=1", macros, 1);
+    cmd_connector.run("commande --kill=1", macros, 1,
+                      std::make_shared<check_result>());
 
     int timeout = 0;
     int max_timeout{15};
@@ -146,7 +147,7 @@ TEST_F(Connector, RunConnectorSetCommandLine) {
   nagios_macros macros = nagios_macros();
   connector cmd_connector("SetCommandLine", "tests/bin_connector_test_run");
   cmd_connector.set_listener(&lstnr);
-  cmd_connector.run("commande1", macros, 1);
+  cmd_connector.run("commande1", macros, 1, std::make_shared<check_result>());
 
   int timeout = 0;
   int max_timeout{15};
@@ -161,7 +162,7 @@ TEST_F(Connector, RunConnectorSetCommandLine) {
 
   lstnr.clear();
   cmd_connector.set_command_line("tests/bin_connector_test_run");
-  cmd_connector.run("commande2", macros, 1);
+  cmd_connector.run("commande2", macros, 1, std::make_shared<check_result>());
 
   timeout = 0;
   max_timeout = 15;

--- a/engine/tests/commands/simple-command.cc
+++ b/engine/tests/commands/simple-command.cc
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 #include <com/centreon/engine/macros.hh>
+#include "com/centreon/engine/log_v2.hh"
 
 #include "../timeperiod/utils.hh"
 #include "com/centreon/engine/commands/raw.hh"
@@ -28,11 +29,17 @@ using namespace com::centreon;
 using namespace com::centreon::engine;
 using namespace com::centreon::engine::commands;
 
+void CreateFile(std::string const& filename, std::string const& content) {
+  std::ofstream oss(filename);
+  oss << content;
+}
+
 class SimpleCommand : public ::testing::Test {
  public:
   void SetUp() override {
     set_time(-1);
     init_config_state();
+    config->interval_length(1);
   }
 
   void TearDown() override { deinit_config_state(); }
@@ -40,7 +47,7 @@ class SimpleCommand : public ::testing::Test {
 
 class my_listener : public commands::command_listener {
  public:
-  result const& get_result() const {
+  result& get_result() {
     std::lock_guard<std::mutex> guard(_mutex);
     return _res;
   }
@@ -107,7 +114,7 @@ TEST_F(SimpleCommand, NewCommandAsync) {
   nagios_macros* mac(get_global_macros());
   std::string cc(cmd->process_cmd(mac));
   ASSERT_EQ(cc, "/bin/echo bonjour");
-  cmd->run(cc, *mac, 2);
+  cmd->run(cc, *mac, 2, std::make_shared<check_result>());
   int timeout{0};
   int max_timeout{3000};
   while (timeout < max_timeout && lstnr->get_result().output == "") {
@@ -130,7 +137,7 @@ TEST_F(SimpleCommand, LongCommandAsync) {
   // We force the time to be coherent with now because the function gettimeofday
   // that is not simulated.
   set_time(std::time(nullptr));
-  cmd->run(cc, *mac, 2);
+  cmd->run(cc, *mac, 2, std::make_shared<check_result>());
   int timeout{0};
   int max_timeout{15};
   while (timeout < max_timeout && lstnr->get_result().output == "") {
@@ -139,4 +146,90 @@ TEST_F(SimpleCommand, LongCommandAsync) {
     ++timeout;
   }
   ASSERT_EQ(lstnr->get_result().output, "(Process Timeout)");
+}
+
+TEST_F(SimpleCommand, TooRecentDoubleCommand) {
+  log_v2::commands()->set_level(spdlog::level::trace);
+  CreateFile("/tmp/TooRecentDoubleCommand.sh",
+             "echo -n tutu | tee -a /tmp/TooRecentDoubleCommand;");
+
+  const char* path = "/tmp/TooRecentDoubleCommand";
+  ::unlink(path);
+  std::unique_ptr<my_listener> lstnr(std::make_unique<my_listener>());
+  std::unique_ptr<commands::command> cmd{std::make_unique<commands::raw>(
+      "test", "/bin/sh /tmp/TooRecentDoubleCommand.sh")};
+  cmd->set_listener(lstnr.get());
+  const void* caller[] = {nullptr, path};
+  cmd->add_caller_group(caller, caller + 2);
+  nagios_macros* mac(get_global_macros());
+  std::string cc(cmd->process_cmd(mac));
+  time_t now = 10000;
+  set_time(now);
+  cmd->run(cc, *mac, 2, std::make_shared<check_result>(), caller[0]);
+  for (int wait_ind = 0; wait_ind != 50 && lstnr->get_result().output == "";
+       ++wait_ind) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  ASSERT_EQ(lstnr->get_result().exit_code, 0);
+  ASSERT_EQ(lstnr->get_result().exit_status, process::status::normal);
+  ASSERT_EQ(lstnr->get_result().output, "tutu");
+  struct stat file_stat;
+  ASSERT_EQ(stat(path, &file_stat), 0);
+  ASSERT_EQ(file_stat.st_size, 4);
+  ++now;
+  cmd->run(cc, *mac, 2, std::make_shared<check_result>(), caller[1]);
+  for (int wait_ind = 0; wait_ind != 50 && lstnr->get_result().output == "";
+       ++wait_ind) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+  ASSERT_EQ(lstnr->get_result().exit_code, 0);
+  ASSERT_EQ(lstnr->get_result().exit_status, process::status::normal);
+  ASSERT_EQ(lstnr->get_result().output, "tutu");
+  ASSERT_EQ(stat(path, &file_stat), 0);
+  ASSERT_EQ(file_stat.st_size, 4);
+}
+
+TEST_F(SimpleCommand, SufficientOldDoubleCommand) {
+  log_v2::commands()->set_level(spdlog::level::trace);
+  CreateFile("/tmp/TooRecentDoubleCommand.sh",
+             "echo -n tutu | tee -a /tmp/TooRecentDoubleCommand;");
+
+  const char* path = "/tmp/TooRecentDoubleCommand";
+  ::unlink(path);
+  std::unique_ptr<my_listener> lstnr(new my_listener);
+  std::unique_ptr<commands::command> cmd{
+      new commands::raw("test", "/bin/sh /tmp/TooRecentDoubleCommand.sh")};
+  cmd->set_listener(lstnr.get());
+  const void* caller[] = {nullptr, path};
+  cmd->add_caller_group(caller, caller + 2);
+  nagios_macros* mac(get_global_macros());
+  std::string cc(cmd->process_cmd(mac));
+  time_t now = 10000;
+  set_time(now);
+  cmd->run(cc, *mac, 2, std::make_shared<check_result>(), caller[0]);
+  for (int wait_ind = 0; wait_ind != 50 && lstnr->get_result().output == "";
+       ++wait_ind) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  ASSERT_EQ(lstnr->get_result().exit_code, 0);
+  ASSERT_EQ(lstnr->get_result().exit_status, process::status::normal);
+  ASSERT_EQ(lstnr->get_result().output, "tutu");
+  struct stat file_stat;
+  ASSERT_EQ(stat(path, &file_stat), 0);
+  ASSERT_EQ(file_stat.st_size, 4);
+  now += 10;
+  set_time(now);
+  lstnr->get_result().output = "";
+  cmd->run(cc, *mac, 2, std::make_shared<check_result>(), caller[1]);
+  for (int wait_ind = 0; wait_ind != 50 && lstnr->get_result().output == "";
+       ++wait_ind) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+  ASSERT_EQ(lstnr->get_result().exit_code, 0);
+  ASSERT_EQ(lstnr->get_result().exit_status, process::status::normal);
+  ASSERT_EQ(lstnr->get_result().output, "tutu");
+  ASSERT_EQ(stat(path, &file_stat), 0);
+  ASSERT_EQ(file_stat.st_size, 8);
 }

--- a/engine/tests/helper.cc
+++ b/engine/tests/helper.cc
@@ -22,6 +22,7 @@
 #include <com/centreon/engine/checks/checker.hh>
 #include <com/centreon/engine/configuration/applier/logging.hh>
 #include <com/centreon/engine/configuration/applier/state.hh>
+#include "com/centreon/engine/log_v2.hh"
 
 using namespace com::centreon::engine;
 
@@ -31,9 +32,14 @@ void init_config_state(void) {
   if (config == nullptr)
     config = new configuration::state;
 
+  config->log_file_line(true);
+  config->log_file("");
+
   // Hack to instanciate the logger.
-  configuration::applier::logging::instance();
-  checks::checker::init();
+  configuration::applier::logging::instance().apply(*config);
+  log_v2::instance().apply(*config);
+
+  checks::checker::init(true);
 }
 
 void deinit_config_state(void) {

--- a/engine/tests/notifications/host_normal_notification.cc
+++ b/engine/tests/notifications/host_normal_notification.cc
@@ -38,6 +38,7 @@
 #include "com/centreon/engine/configuration/state.hh"
 #include "com/centreon/engine/downtimes/downtime_manager.hh"
 #include "com/centreon/engine/exceptions/error.hh"
+#include "com/centreon/engine/log_v2.hh"
 #include "com/centreon/engine/retention/dump.hh"
 #include "com/centreon/engine/timezone_manager.hh"
 
@@ -52,6 +53,8 @@ class HostNotification : public TestEngine {
  public:
   void SetUp() override {
     init_config_state();
+
+    log_v2::events()->set_level(spdlog::level::off);
 
     configuration::applier::contact ct_aply;
     configuration::contact ctct{new_configuration_contact("admin", true)};

--- a/tests/bam/inherited_downtime.robot
+++ b/tests/bam/inherited_downtime.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	BAM Setup
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker and BAM
 Library	Process

--- a/tests/broker-engine/anomaly-detection.robot
+++ b/tests/broker-engine/anomaly-detection.robot
@@ -1,0 +1,90 @@
+*** Settings ***
+Resource	../resources/resources.robot
+Suite Setup	Clean Before Suite
+Suite Teardown	Clean After Suite
+Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
+
+Documentation	Centreon Broker and Engine anomaly detection
+
+
+Library	DateTime
+Library	Process
+Library	OperatingSystem
+Library	../resources/Engine.py
+Library	../resources/Broker.py
+Library	../resources/Common.py
+
+
+*** Test Cases ***
+ANO_NOFILE
+	[Documentation]	an anomaly detection without threshold file must be in unknown state
+	[Tags]  Broker	Engine  Anomaly
+	Config Engine	${1}	${50}	${20}
+	Config Broker	central
+	Config Broker	module	${1}
+	Broker Config Log	central	sql	debug
+	Config Broker Sql Output	central	unified_sql
+    ${serv_id}=  Create Anomaly Detection  ${0}  ${1}  ${1}  metric
+    Remove File  /tmp/anomaly_threshold.json
+    Clear Retention
+    Clear Db  services
+    Start Broker
+    Start Engine
+    Process Service Check result	host_1	anomaly_${serv_id}	2	taratata
+    Check Service Status With Timeout  host_1  anomaly_${serv_id}  3  30
+
+ANO_TOO_OLD_FILE
+	[Documentation]	an anomaly detection with an oldest threshold file must be in unknown state
+	[Tags]  Broker	Engine  Anomaly
+	Config Engine	${1}	${50}	${20}
+	Config Broker	central
+	Config Broker	module	${1}
+	Broker Config Log	central	sql	debug
+	Config Broker Sql Output	central	unified_sql
+    ${serv_id}=  Create Anomaly Detection  ${0}  ${1}  ${1}  metric
+    ${predict_data} =  Evaluate  [[0,0,2],[1648812678,0,3]]
+    Create Anomaly Threshold File  /tmp/anomaly_threshold.json  ${1}  ${serv_id}  metric  ${predict_data}
+    Clear Retention
+    Clear Db  services
+    Start Broker
+    Start Engine
+    Process Service Check result	host_1	anomaly_${serv_id}	2	taratata|metric=70%;50;75
+    Check Service Status With Timeout  host_1  anomaly_${serv_id}  3  30
+
+
+ANO_OUT_LOWER_THAN_LIMIT
+	[Documentation]	an anomaly detection with a perfdata lower than lower limit make a critical state
+	[Tags]  Broker	Engine  Anomaly
+	Config Engine	${1}	${50}	${20}
+	Config Broker	central
+	Config Broker	module	${1}
+	Broker Config Log	central	sql	debug
+	Config Broker Sql Output	central	unified_sql
+    ${serv_id}=  Create Anomaly Detection  ${0}  ${1}  ${1}  metric
+    ${predict_data} =  Evaluate  [[0,50,52],[2648812678,50,63]]
+    Create Anomaly Threshold File  /tmp/anomaly_threshold.json  ${1}  ${serv_id}  metric  ${predict_data}
+    Clear Retention
+    Clear Db  services
+    Start Broker
+    Start Engine
+    Process Service Check result	host_1	anomaly_${serv_id}	2	taratata|metric=20%;50;75
+    Check Service Status With Timeout  host_1  anomaly_${serv_id}  2  30
+
+ANO_OUT_UPPER_THAN_LIMIT
+	[Documentation]	an anomaly detection with a perfdata upper than upper limit make a critical state
+	[Tags]  Broker	Engine  Anomaly
+	Config Engine	${1}	${50}	${20}
+	Config Broker	central
+	Config Broker	module	${1}
+	Broker Config Log	central	sql	debug
+	Config Broker Sql Output	central	unified_sql
+    ${serv_id}=  Create Anomaly Detection  ${0}  ${1}  ${1}  metric
+    ${predict_data} =  Evaluate  [[0,50,52],[2648812678,50,63]]
+    Create Anomaly Threshold File  /tmp/anomaly_threshold.json  ${1}  ${serv_id}  metric  ${predict_data}
+    Clear Retention
+    Clear Db  services
+    Start Broker
+    Start Engine
+    Process Service Check result	host_1	anomaly_${serv_id}	2	taratata|metric=80%;50;75
+    Check Service Status With Timeout  host_1  anomaly_${serv_id}  2  30

--- a/tests/broker-engine/bbdo-protobuf.robot
+++ b/tests/broker-engine/bbdo-protobuf.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Engine/Broker tests on bbdo_version 3.0.0 and protobuf bbdo embedded events.
 Library	Process
@@ -45,6 +46,7 @@ BEPBBEE2
         Broker Config Add Item	central	bbdo_version	3.0.0
         Broker Config Add Item	rrd	bbdo_version	3.0.0
 	Broker Config Log	central	sql	debug
+        Broker Config Flush Log	central	0
 	Clear Retention
 	${start}=	Get Current Date
 	Start Broker

--- a/tests/broker-engine/compression.robot
+++ b/tests/broker-engine/compression.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker and Engine communication with or without compression
 Library	Process

--- a/tests/broker-engine/downtimes.robot
+++ b/tests/broker-engine/downtimes.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker and Engine progressively add services
 Library	Process

--- a/tests/broker-engine/external-commands.robot
+++ b/tests/broker-engine/external-commands.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker and Engine progressively add services
 Library	DatabaseLibrary

--- a/tests/broker-engine/hostgroups.robot
+++ b/tests/broker-engine/hostgroups.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker and Engine add Hostgroup
 Library	DatabaseLibrary

--- a/tests/broker-engine/hosts-with-notes-and-actions.robot
+++ b/tests/broker-engine/hosts-with-notes-and-actions.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker and Engine Creation of hosts with long action_url, notes and notes_url.
 Library	DatabaseLibrary

--- a/tests/broker-engine/log-v2_engine.robot
+++ b/tests/broker-engine/log-v2_engine.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker and Engine log_v2
 Library	DatabaseLibrary

--- a/tests/broker-engine/output-tables.robot
+++ b/tests/broker-engine/output-tables.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Engine/Broker tests on bbdo_version 3.0.0 and protobuf bbdo embedded events.
 Library	Process

--- a/tests/broker-engine/retention-duplicates.robot
+++ b/tests/broker-engine/retention-duplicates.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker tests on dublicated data that could come from retention when centengine or cbd are restarted
 Library	Process

--- a/tests/broker-engine/reverse-connection.robot
+++ b/tests/broker-engine/reverse-connection.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker and Engine communication with or without compression
 Library	Process
@@ -36,11 +37,11 @@ BRGC1
 	Kindly Stop Broker
 	Stop Engine
 
-	${content}=	Create List	New incoming connection 'centreon-broker-master-map-2'	file: end of file '/var/lib/centreon-broker//central-broker-master.queue.centreon-broker-master-map-2' reached, erasing it
+	${content}=	Create List	New incoming connection 'centreon-broker-master-map-2'	file: end of file '${VarRoot}/lib/centreon-broker//central-broker-master.queue.centreon-broker-master-map-2' reached, erasing it
 	${log}=	Catenate	SEPARATOR=	${BROKER_LOG}	/central-broker-master.log
 	${result}=	Find In Log With Timeout	${log}	${start}	${content}	40
 	Should Be True	${result}	msg=Connection to map has failed.
-	File Should Not Exist	/var/lib/centreon-broker/central-broker-master.queue.centreon-broker-master-map*	msg=There should not exist que map files.
+	File Should Not Exist	${VarRoot}/lib/centreon-broker/central-broker-master.queue.centreon-broker-master-map*	msg=There should not exist que map files.
 
 
 BRCTS1
@@ -64,11 +65,11 @@ BRCTS1
 	Kindly Stop Broker
 	Stop Engine
 
-	${content}=	Create List	New incoming connection 'centreon-broker-master-map-2'	file: end of file '/var/lib/centreon-broker//central-broker-master.queue.centreon-broker-master-map-2' reached, erasing it
+	${content}=	Create List	New incoming connection 'centreon-broker-master-map-2'	file: end of file '${VarRoot}/lib/centreon-broker//central-broker-master.queue.centreon-broker-master-map-2' reached, erasing it
 	${log}=	Catenate	SEPARATOR=	${BROKER_LOG}	/central-broker-master.log
 	${result}=	Find In Log With Timeout	${log}	${start}	${content}	40
 	Should Be True	${result}	msg=Connection to map has failed
-	File Should Not Exist	/var/lib/centreon-broker/central-broker-master.queue.centreon-broker-master-map*	msg=There should not exist queue map files.
+	File Should Not Exist	${VarRoot}/lib/centreon-broker/central-broker-master.queue.centreon-broker-master-map*	msg=There should not exist queue map files.
 
 
 BRCS1
@@ -90,8 +91,8 @@ BRCS1
 	Kindly Stop Broker
 	Stop Engine
 
-	${content}=	Create List	New incoming connection 'centreon-broker-master-map-2'	file: end of file '/var/lib/centreon-broker//central-broker-master.queue.centreon-broker-master-map-2' reached, erasing it
+	${content}=	Create List	New incoming connection 'centreon-broker-master-map-2'	file: end of file '${VarRoot}/lib/centreon-broker//central-broker-master.queue.centreon-broker-master-map-2' reached, erasing it
 	${log}=	Catenate	SEPARATOR=	${BROKER_LOG}	/central-broker-master.log
 	${result}=	Find In Log With Timeout	${log}	${start}	${content}	40
 	Should Not Be True	${result}	msg=Connection to map has failed
-	File Should Not Exist	/var/lib/centreon-broker/central-broker-master.queue.centreon-broker-master-map-2	msg=There should not exist queue map files.
+	File Should Not Exist	${VarRoot}/lib/centreon-broker/central-broker-master.queue.centreon-broker-master-map-2	msg=There should not exist queue map files.

--- a/tests/broker-engine/rrd-from-db.robot
+++ b/tests/broker-engine/rrd-from-db.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker RRD metric deletion from the legacy query made by the php.
 Library	DatabaseLibrary
@@ -49,8 +50,8 @@ BRRDDMDB1
 	${result}=	Find In Log With Timeout	${centralLog}	${start}	${content}	30
 	Should Be True	${result}	msg=No log message telling about metrics ${metrics_str} deletion.
 	FOR	${m}	IN	@{metrics}
-		Log to Console	Waiting for /var/lib/centreon/metrics/${m}.rrd to be deleted
-		Wait Until Removed	/var/lib/centreon/metrics/${m}.rrd      20s
+		Log to Console	Waiting for ${VarRoot}/lib/centreon/metrics/${m}.rrd to be deleted
+		Wait Until Removed	${VarRoot}/lib/centreon/metrics/${m}.rrd      20s
 	END
 
 BRRDDIDDB1
@@ -89,12 +90,12 @@ BRRDDIDDB1
 	${result}=	Find In Log With Timeout	${centralLog}	${start}	${content}	30
 	Should Be True	${result}	msg=No log message telling about indexes ${indexes_str} deletion.
 	FOR	${i}	IN	@{indexes}
-		log to console	Wait for /var/lib/centreon/status/${i}.rrd to be deleted
-		Wait Until Removed	/var/lib/centreon/status/${i}.rrd	20s
+		log to console	Wait for ${VarRoot}/lib/centreon/status/${i}.rrd to be deleted
+		Wait Until Removed	${VarRoot}/lib/centreon/status/${i}.rrd	20s
 	END
 	FOR	${m}	IN	@{metrics}
-		log to console	Wait for /var/lib/centreon/metrics/${m}.rrd to be deleted
-		Wait Until Removed	/var/lib/centreon/metrics/${m}.rrd	20s
+		log to console	Wait for ${VarRoot}/lib/centreon/metrics/${m}.rrd to be deleted
+		Wait Until Removed	${VarRoot}/lib/centreon/metrics/${m}.rrd	20s
 	END
 
 BRRDRBDB1

--- a/tests/broker-engine/rrd.robot
+++ b/tests/broker-engine/rrd.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker RRD metric deletion
 Library	DatabaseLibrary
@@ -45,7 +46,7 @@ BRRDDM1
 	${result}=	Find In Log With Timeout	${centralLog}	${start}	${content}	30
 	Should Be True	${result}	msg=No log message telling about metrics ${metrics_str} deletion.
 	FOR	${m}	IN	@{metrics}
-		Wait Until Removed	/var/lib/centreon/metrics/${m}.rrd      20s
+		Wait Until Removed	${VarRoot}/lib/centreon/metrics/${m}.rrd      20s
 	END
 
 BRRDDID1
@@ -61,6 +62,7 @@ BRRDDID1
 	Create Metrics	3
 
 	${start}=	Get Current Date
+	Sleep	1s
 	Start Broker
 	Start Engine
 	${result}=	Check Connections
@@ -78,10 +80,10 @@ BRRDDID1
 	${result}=	Find In Log With Timeout	${centralLog}	${start}	${content}	30
 	Should Be True	${result}	msg=No log message telling about indexes ${indexes_str} deletion.
 	FOR	${i}	IN	@{indexes}
-		Wait Until Removed	/var/lib/centreon/status/${i}.rrd	20s
+		Wait Until Removed	${VarRoot}/lib/centreon/status/${i}.rrd	20s
 	END
 	FOR	${m}	IN	@{metrics}
-		Wait Until Removed	/var/lib/centreon/metrics/${m}.rrd	20s
+		Wait Until Removed	${VarRoot}/lib/centreon/metrics/${m}.rrd	20s
 	END
 
 BRRDDMID1
@@ -141,7 +143,7 @@ BRRDDMU1
 	${result}=	Find In Log With Timeout	${centralLog}	${start}	${content}	50
 	Should Be True	${result}	msg=No log message telling about metrics ${metrics_str} deletion.
 	FOR	${m}	IN	@{metrics}
-		Wait Until Removed	/var/lib/centreon/metrics/${m}.rrd	20s
+		Wait Until Removed	${VarRoot}/lib/centreon/metrics/${m}.rrd	20s
 	END
 
 BRRDDIDU1
@@ -175,10 +177,10 @@ BRRDDIDU1
 	${result}=	Find In Log With Timeout	${centralLog}	${start}	${content}	30
 	Should Be True	${result}	msg=No log message telling about indexes ${indexes_str} deletion.
 	FOR	${i}	IN	@{indexes}
-		Wait Until Removed	/var/lib/centreon/status/${i}.rrd	20s
+		Wait Until Removed	${VarRoot}/lib/centreon/status/${i}.rrd	20s
 	END
 	FOR	${m}	IN	@{metrics}
-		Wait Until Removed	/var/lib/centreon/metrics/${m}.rrd	20s
+		Wait Until Removed	${VarRoot}/lib/centreon/metrics/${m}.rrd	20s
 	END
 
 BRRDDMIDU1

--- a/tests/broker-engine/scheduler.robot
+++ b/tests/broker-engine/scheduler.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker and Engine log_v2
 Library	DatabaseLibrary

--- a/tests/broker-engine/servicegroups.robot
+++ b/tests/broker-engine/servicegroups.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker and Engine add servicegroup
 Library	Process

--- a/tests/broker-engine/services-increased.robot
+++ b/tests/broker-engine/services-increased.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker and Engine progressively add services
 Library	Process

--- a/tests/broker-engine/start-stop.robot
+++ b/tests/broker-engine/start-stop.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown    Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker and Engine start/stop tests
 Library	Process

--- a/tests/broker-engine/tags.robot
+++ b/tests/broker-engine/tags.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown	Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Engine/Broker tests on tags.
 Library	Process

--- a/tests/broker-engine/tls.robot
+++ b/tests/broker-engine/tls.robot
@@ -3,6 +3,7 @@ Resource	../resources/resources.robot
 Suite Setup	Clean Before Suite
 Suite Teardown    Clean After Suite
 Test Setup	Stop Processes
+Test Teardown	Save logs If Failed
 
 Documentation	Centreon Broker and Engine communication with or without TLS
 Library	Process
@@ -60,15 +61,15 @@ BECT2
 	Config Broker	module
 
 	${hostname}=	Get Hostname
-	Create Key And Certificate	${hostname}	/etc/centreon-broker/server.key	/etc/centreon-broker/server.crt
-	Create Key And Certificate	${hostname}	/etc/centreon-broker/client.key	/etc/centreon-broker/client.crt
+	Create Key And Certificate	localhost	${EtcRoot}/centreon-broker/server.key	${EtcRoot}/centreon-broker/server.crt
+	Create Key And Certificate	localhost	${EtcRoot}/centreon-broker/client.key	${EtcRoot}/centreon-broker/client.crt
 
-	Broker Config Input set	central	central-broker-master-input	private_key	/etc/centreon-broker/client.key
-	Broker Config Input set	central	central-broker-master-input	public_cert	/etc/centreon-broker/client.crt
-	Broker Config Input set	central	central-broker-master-input	ca_certificate	/etc/centreon-broker/server.crt
-	Broker Config Output set	module0	central-module-master-output	private_key	/etc/centreon-broker/server.key
-	Broker Config Output set	module0	central-module-master-output	public_cert	/etc/centreon-broker/server.crt
-	Broker Config Output set	module0	central-module-master-output	ca_certificate	/etc/centreon-broker/client.crt
+	Broker Config Input set	central	central-broker-master-input	private_key	${EtcRoot}/centreon-broker/client.key
+	Broker Config Input set	central	central-broker-master-input	public_cert	${EtcRoot}/centreon-broker/client.crt
+	Broker Config Input set	central	central-broker-master-input	ca_certificate	${EtcRoot}/centreon-broker/server.crt
+	Broker Config Output set	module0	central-module-master-output	private_key	${EtcRoot}/centreon-broker/server.key
+	Broker Config Output set	module0	central-module-master-output	public_cert	${EtcRoot}/centreon-broker/server.crt
+	Broker Config Output set	module0	central-module-master-output	ca_certificate	${EtcRoot}/centreon-broker/client.crt
 	Broker Config Log	central	tls	debug
 	Broker Config Log	module0	tls	debug
 	Broker Config Log	central	bbdo	info
@@ -102,11 +103,11 @@ BECT3
 	Config Broker	module
 
 	${hostname}=	Get Hostname
-	Create Certificate	${hostname}	/etc/centreon-broker/server.crt
-	Create Certificate	${hostname}	/etc/centreon-broker/client.crt
+	Create Certificate	${hostname}	${EtcRoot}/centreon-broker/server.crt
+	Create Certificate	${hostname}	${EtcRoot}/centreon-broker/client.crt
 
-	Broker Config Input set	central	central-broker-master-input	ca_certificate	/etc/centreon-broker/server.crt
-	Broker Config Output set	module0	central-module-master-output	ca_certificate	/etc/centreon-broker/client.crt
+	Broker Config Input set	central	central-broker-master-input	ca_certificate	${EtcRoot}/centreon-broker/server.crt
+	Broker Config Output set	module0	central-module-master-output	ca_certificate	${EtcRoot}/centreon-broker/client.crt
 	Broker Config Log	central	tls	debug
 	Broker Config Log	module0	tls	debug
 	Broker Config Log	central	bbdo	info
@@ -141,24 +142,24 @@ BECT4
 	Config Broker	module
 
 	Set Local Variable	${hostname}	centreon
-	Create Key And Certificate	${hostname}	/etc/centreon-broker/server.key	/etc/centreon-broker/server.crt
-	Create Key And Certificate	${hostname}	/etc/centreon-broker/client.key	/etc/centreon-broker/client.crt
+	Create Key And Certificate	${hostname}	${EtcRoot}/centreon-broker/server.key	${EtcRoot}/centreon-broker/server.crt
+	Create Key And Certificate	${hostname}	${EtcRoot}/centreon-broker/client.key	${EtcRoot}/centreon-broker/client.crt
 
-	Broker Config Input set	central	central-broker-master-input	ca_certificate	/etc/centreon-broker/server.crt
-	Broker Config Output set	module0	central-module-master-output	ca_certificate	/etc/centreon-broker/client.crt
+	Broker Config Input set	central	central-broker-master-input	ca_certificate	${EtcRoot}/centreon-broker/server.crt
+	Broker Config Output set	module0	central-module-master-output	ca_certificate	${EtcRoot}/centreon-broker/client.crt
 	Broker Config Log	central	tls	debug
 	Broker Config Log	module0	tls	debug
 	Broker Config Log	central	bbdo	info
 	Broker Config Log	module0	bbdo	info
 	Broker Config Input set	central	central-broker-master-input	tls	yes
-	Broker Config Input set	central	central-broker-master-input	private_key	/etc/centreon-broker/client.key
-	Broker Config Input set	central	central-broker-master-input	public_cert	/etc/centreon-broker/client.crt
-	Broker Config Input set	central	central-broker-master-input	ca_certificate	/etc/centreon-broker/server.crt
+	Broker Config Input set	central	central-broker-master-input	private_key	${EtcRoot}/centreon-broker/client.key
+	Broker Config Input set	central	central-broker-master-input	public_cert	${EtcRoot}/centreon-broker/client.crt
+	Broker Config Input set	central	central-broker-master-input	ca_certificate	${EtcRoot}/centreon-broker/server.crt
 	Broker Config Input set	central	central-broker-master-input	tls_hostname	centreon
 	Broker Config Output set	module0	central-module-master-output	tls	yes
-	Broker Config Output set	module0	central-module-master-output	private_key	/etc/centreon-broker/server.key
-	Broker Config Output set	module0	central-module-master-output	public_cert	/etc/centreon-broker/server.crt
-	Broker Config Output set	module0	central-module-master-output	ca_certificate	/etc/centreon-broker/client.crt
+	Broker Config Output set	module0	central-module-master-output	private_key	${EtcRoot}/centreon-broker/server.key
+	Broker Config Output set	module0	central-module-master-output	public_cert	${EtcRoot}/centreon-broker/server.crt
+	Broker Config Output set	module0	central-module-master-output	ca_certificate	${EtcRoot}/centreon-broker/client.crt
         # We get the current date just before starting broker
 	${start}=	Get Current Date
 	Start Broker
@@ -225,16 +226,15 @@ BECT_GRPC2
 	Config Broker	central
 	Config Broker	module
 
-	${hostname}=	Get Hostname
-	Create Key And Certificate	${hostname}	/etc/centreon-broker/server.key	/etc/centreon-broker/server.crt
-	Create Key And Certificate	${hostname}	/etc/centreon-broker/client.key	/etc/centreon-broker/client.crt
+	Create Key And Certificate	localhost	${EtcRoot}/centreon-broker/server.key	${EtcRoot}/centreon-broker/server.crt
+	Create Key And Certificate	localhost	${EtcRoot}/centreon-broker/client.key	${EtcRoot}/centreon-broker/client.crt
 
-	Broker Config Input set	central	central-broker-master-input	private_key	/etc/centreon-broker/client.key
-	Broker Config Input set	central	central-broker-master-input	public_cert	/etc/centreon-broker/client.crt
-	Broker Config Input set	central	central-broker-master-input	ca_certificate	/etc/centreon-broker/server.crt
-	Broker Config Output set	module0	central-module-master-output	private_key	/etc/centreon-broker/server.key
-	Broker Config Output set	module0	central-module-master-output	public_cert	/etc/centreon-broker/server.crt
-	Broker Config Output set	module0	central-module-master-output	ca_certificate	/etc/centreon-broker/client.crt
+	Broker Config Input set	central	central-broker-master-input	private_key	${EtcRoot}/centreon-broker/client.key
+	Broker Config Input set	central	central-broker-master-input	public_cert	${EtcRoot}/centreon-broker/client.crt
+	Broker Config Input set	central	central-broker-master-input	ca_certificate	${EtcRoot}/centreon-broker/server.crt
+	Broker Config Output set	module0	central-module-master-output	private_key	${EtcRoot}/centreon-broker/server.key
+	Broker Config Output set	module0	central-module-master-output	public_cert	${EtcRoot}/centreon-broker/server.crt
+	Broker Config Output set	module0	central-module-master-output	ca_certificate	${EtcRoot}/centreon-broker/client.crt
 	Broker Config Log	central	tls	debug
 	Broker Config Log	module0	tls	debug
 	Broker Config Log	central	bbdo	info
@@ -270,11 +270,11 @@ BECT_GRPC3
 	Config Broker	module
 
 	${hostname}=	Get Hostname
-	Create Certificate	${hostname}	/etc/centreon-broker/server.crt
-	Create Certificate	${hostname}	/etc/centreon-broker/client.crt
+	Create Certificate	${hostname}	${EtcRoot}/centreon-broker/server.crt
+	Create Certificate	${hostname}	${EtcRoot}/centreon-broker/client.crt
 
-	Broker Config Input set	central	central-broker-master-input	ca_certificate	/etc/centreon-broker/server.crt
-	Broker Config Output set	module0	central-module-master-output	ca_certificate	/etc/centreon-broker/client.crt
+	Broker Config Input set	central	central-broker-master-input	ca_certificate	${EtcRoot}/centreon-broker/server.crt
+	Broker Config Output set	module0	central-module-master-output	ca_certificate	${EtcRoot}/centreon-broker/client.crt
 	Broker Config Log	central	tls	debug
 	Broker Config Log	module0	tls	debug
 	Broker Config Log	central	bbdo	info
@@ -311,11 +311,11 @@ BECT_GRPC4
 	Config Broker	module
 
 	Set Local Variable	${hostname}	centreon
-	Create Key And Certificate	${hostname}	/etc/centreon-broker/server.key	/etc/centreon-broker/server.crt
-	Create Key And Certificate	${hostname}	/etc/centreon-broker/client.key	/etc/centreon-broker/client.crt
+	Create Key And Certificate	${hostname}	${EtcRoot}/centreon-broker/server.key	${EtcRoot}/centreon-broker/server.crt
+	Create Key And Certificate	${hostname}	${EtcRoot}/centreon-broker/client.key	${EtcRoot}/centreon-broker/client.crt
 
-	Broker Config Input set	central	central-broker-master-input	ca_certificate	/etc/centreon-broker/server.crt
-	Broker Config Output set	module0	central-module-master-output	ca_certificate	/etc/centreon-broker/client.crt
+	Broker Config Input set	central	central-broker-master-input	ca_certificate	${EtcRoot}/centreon-broker/server.crt
+	Broker Config Output set	module0	central-module-master-output	ca_certificate	${EtcRoot}/centreon-broker/client.crt
 	Broker Config Log	central	tls	debug
 	Broker Config Log	module0	tls	debug
 	Broker Config Log	central	bbdo	info
@@ -323,14 +323,14 @@ BECT_GRPC4
 	Change Broker tcp output to grpc	module0
 	Change Broker tcp input to grpc     central
 	Broker Config Input set	central	central-broker-master-input	tls	yes
-	Broker Config Input set	central	central-broker-master-input	private_key	/etc/centreon-broker/client.key
-	Broker Config Input set	central	central-broker-master-input	public_cert	/etc/centreon-broker/client.crt
-	Broker Config Input set	central	central-broker-master-input	ca_certificate	/etc/centreon-broker/server.crt
+	Broker Config Input set	central	central-broker-master-input	private_key	${EtcRoot}/centreon-broker/client.key
+	Broker Config Input set	central	central-broker-master-input	public_cert	${EtcRoot}/centreon-broker/client.crt
+	Broker Config Input set	central	central-broker-master-input	ca_certificate	${EtcRoot}/centreon-broker/server.crt
 	Broker Config Input set	central	central-broker-master-input	tls_hostname	centreon
 	Broker Config Output set	module0	central-module-master-output	tls	yes
-	Broker Config Output set	module0	central-module-master-output	private_key	/etc/centreon-broker/server.key
-	Broker Config Output set	module0	central-module-master-output	public_cert	/etc/centreon-broker/server.crt
-	Broker Config Output set	module0	central-module-master-output	ca_certificate	/etc/centreon-broker/client.crt
+	Broker Config Output set	module0	central-module-master-output	private_key	${EtcRoot}/centreon-broker/server.key
+	Broker Config Output set	module0	central-module-master-output	public_cert	${EtcRoot}/centreon-broker/server.crt
+	Broker Config Output set	module0	central-module-master-output	ca_certificate	${EtcRoot}/centreon-broker/client.crt
         # We get the current date just before starting broker
 	${start}=	Get Current Date
 	Start Broker

--- a/tests/broker/command-line.robot
+++ b/tests/broker/command-line.robot
@@ -27,10 +27,10 @@ BCL2
 	Config Broker	central
 	${start}=	Get Current Date	exclude_millis=True
 	Sleep	1s
-	Start Broker With Args	-s5	/etc/centreon-broker/central-broker.json
+	Start Broker With Args	-s5	${EtcRoot}/centreon-broker/central-broker.json
 	${table}=	Create List	Starting the TCP thread pool of 5 threads
 	${logger_res}=	Find in log with timeout	${centralLog}	${start}	${table}	30
-	Should be True	${logger_res}	msg=Didn't found 5 threads in /var/log/centreon-broker/central-broker-master.log
+	Should be True	${logger_res}	msg=Didn't found 5 threads in ${VarRoot}/log/centreon-broker/central-broker-master.log
 	Stop Broker With Args
 
 BCL3
@@ -39,7 +39,7 @@ BCL3
 	Config Broker	central
 	${start}=	Get Current Date	exclude_millis=True
 	Sleep	1s
-	Start Broker With Args	-D	/etc/centreon-broker/central-broker.json
+	Start Broker With Args	-D	${EtcRoot}/centreon-broker/central-broker.json
 	${result}=	Wait For Broker
 	${expected}=	Evaluate	"diagnostic:" in """${result}"""
 	Should be True	${expected}	msg=diagnostic mode didn't launch
@@ -48,7 +48,7 @@ BCL4
 	[Documentation]	Starting broker with options '-s2' and '-D' should work.
 	[Tags]	Broker	start-stop
 	Config Broker	central
-	Start Broker With Args	-s2	-D	/etc/centreon-broker/central-broker.json
+	Start Broker With Args	-s2	-D	${EtcRoot}/centreon-broker/central-broker.json
 	${result}=	Wait For Broker
 	${expected}=	Evaluate	"diagnostic:" in """${result}"""
 	Should be True	${expected}	msg=diagnostic mode didn't launch

--- a/tests/broker/grpc-stream.robot
+++ b/tests/broker/grpc-stream.robot
@@ -97,8 +97,8 @@ BGRPCSSU5
 *** Keywords ***
 Start Stop Service
 	[Arguments]	${interval}
-	Start Process	/usr/sbin/cbd	/etc/centreon-broker/central-broker.json	alias=b1
-	Start Process	/usr/sbin/cbd	/etc/centreon-broker/central-rrd.json	alias=b2
+	Start Process	/usr/sbin/cbd	${EtcRoot}/centreon-broker/central-broker.json	alias=b1
+	Start Process	/usr/sbin/cbd	${EtcRoot}/centreon-broker/central-rrd.json	alias=b2
 	Sleep	${interval}
 	Send Signal To Process	SIGTERM	b1
 	${result}=	Wait For Process	b1	timeout=60s	on_timeout=kill
@@ -109,7 +109,7 @@ Start Stop Service
 
 Start Stop Instance
 	[Arguments]	${interval}
-	Start Process	/usr/sbin/cbd	/etc/centreon-broker/central-broker.json	alias=b1
+	Start Process	/usr/sbin/cbd	${EtcRoot}/centreon-broker/central-broker.json	alias=b1
 	Sleep	${interval}
 	Send Signal To Process	SIGTERM	b1
 	${result}=	Wait For Process	b1	timeout=60s	on_timeout=kill

--- a/tests/broker/start-stop.robot
+++ b/tests/broker/start-stop.robot
@@ -85,8 +85,8 @@ BSSU5
 *** Keywords ***
 Start Stop Service
 	[Arguments]	${interval}
-	Start Process	/usr/sbin/cbd	/etc/centreon-broker/central-broker.json	alias=b1
-	Start Process	/usr/sbin/cbd	/etc/centreon-broker/central-rrd.json	alias=b2
+	Start Process	/usr/sbin/cbd	${EtcRoot}/centreon-broker/central-broker.json	alias=b1
+	Start Process	/usr/sbin/cbd	${EtcRoot}/centreon-broker/central-rrd.json	alias=b2
 	Sleep	${interval}
 	Send Signal To Process	SIGTERM	b1
 	${result}=	Wait For Process	b1	timeout=60s	on_timeout=kill
@@ -97,7 +97,7 @@ Start Stop Service
 
 Start Stop Instance
 	[Arguments]	${interval}
-	Start Process	/usr/sbin/cbd	/etc/centreon-broker/central-broker.json	alias=b1
+	Start Process	/usr/sbin/cbd	${EtcRoot}/centreon-broker/central-broker.json	alias=b1
 	Sleep	${interval}
 	Send Signal To Process	SIGTERM	b1
 	${result}=	Wait For Process	b1	timeout=60s	on_timeout=kill

--- a/tests/ccc/ccc.robot
+++ b/tests/ccc/ccc.robot
@@ -65,7 +65,7 @@ BECCC2
 	 EXIT FOR LOOP IF	len("${content.strip()}") > 0
 	 Sleep	1s
 	END
-	Should Be Equal As Strings	${content.strip()}	Connected to a Centreon Broker 22.10.0 gRPC server
+	Should Be Equal As Strings	${content.strip()}	Connected to a Centreon Broker 22.04.1 gRPC server
 	Stop Engine
 	Kindly Stop Broker
 	Remove File	/tmp/output.txt
@@ -97,7 +97,7 @@ BECCC3
 	 EXIT FOR LOOP IF	len("${content.strip()}") > 0
 	 Sleep	1s
 	END
-	Should Be Equal As Strings	${content.strip()}	Connected to a Centreon Engine 22.10.0 gRPC server
+	Should Be Equal As Strings	${content.strip()}	Connected to a Centreon Engine 22.04.1 gRPC server
 	Stop Engine
 	Kindly Stop Broker
 	Remove File	/tmp/output.txt
@@ -195,7 +195,7 @@ BECCC6
 	 EXIT FOR LOOP IF	len("""${content.strip().split()}""") > 50
 	 Sleep	1s
 	END
-	Should Contain	${content}	{\n \"major\": 22,\n \"minor\": 10\n}	msg=A version as json string should be returned
+	Should Contain	${content}	{\n \"major\": 22,\n \"minor\": 4,\n \"patch\": 1\n}	msg=A version as json string should be returned
 	Stop Engine
 	Kindly Stop Broker
 	Remove File	/tmp/output.txt
@@ -263,3 +263,4 @@ BECCC8
 	Stop Engine
 	Kindly Stop Broker
 	Remove File	/tmp/output.txt
+

--- a/tests/connector_perl/conf_engine/central-module.json
+++ b/tests/connector_perl/conf_engine/central-module.json
@@ -9,9 +9,8 @@
         "log_thread_id": false,
         "event_queue_max_size": 100000,
         "command_file": "",
-        "cache_directory": "/var/lib/centreon-engine",
         "log": {
-            "directory": "/tmp/test_connector_ssh/log/",
+            "directory": "/tmp/test_connector_perl/log/",
             "filename": "centengine-cbmod.log",
             "max_size": 0,
             "loggers": {
@@ -40,13 +39,6 @@
                 "one_peer_retention_mode": "no",
                 "compression": "no",
                 "type": "ipv4"
-            }
-        ],
-        "stats": [
-            {
-                "type": "stats",
-                "name": "central-module-master-stats",
-                "json_fifo": "/var/lib/centreon-engine/central-module-master-stats.json"
             }
         ],
         "grpc": {

--- a/tests/connector_ssh/conf_engine/central-module.json
+++ b/tests/connector_ssh/conf_engine/central-module.json
@@ -9,7 +9,6 @@
         "log_thread_id": false,
         "event_queue_max_size": 100000,
         "command_file": "",
-        "cache_directory": "/var/lib/centreon-engine",
         "log": {
             "directory": "/tmp/test_connector_ssh/log/",
             "filename": "centengine-cbmod.log",
@@ -40,13 +39,6 @@
                 "one_peer_retention_mode": "no",
                 "compression": "no",
                 "type": "ipv4"
-            }
-        ],
-        "stats": [
-            {
-                "type": "stats",
-                "name": "central-module-master-stats",
-                "json_fifo": "/var/lib/centreon-engine/central-module-master-stats.json"
             }
         ],
         "grpc": {

--- a/tests/engine/forced_checks.robot
+++ b/tests/engine/forced_checks.robot
@@ -35,7 +35,7 @@ EFHC1
         Should Be True	${result}	msg=An Initial host state on host_1 should be raised before we can start our external commands.
         Process host check result	host_1	0	host_1 UP
         FOR	${i}	IN RANGE	${4}
-         Schedule Forced HOST CHECK	host_1	/var/lib/centreon-engine/config0/rw/centengine.cmd
+         Schedule Forced HOST CHECK	host_1	${VarRoot}/lib/centreon-engine/config0/rw/centengine.cmd
          Sleep	5s
         END
         ${content}=	Create List	EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;	HOST ALERT: host_1;DOWN;SOFT;1;	EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;	HOST ALERT: host_1;DOWN;SOFT;2;	EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;    HOST ALERT: host_1;DOWN;HARD;3;
@@ -67,7 +67,7 @@ EFHC2
         Should Be True	${result}	msg=An Initial host state on host_1 should be raised before we can start our external commands.
         Process host check result	host_1	0	host_1 UP
         FOR	${i}	IN RANGE	${4}
-         Schedule Forced HOST CHECK	host_1	/var/lib/centreon-engine/config0/rw/centengine.cmd
+         Schedule Forced HOST CHECK	host_1	${VarRoot}/lib/centreon-engine/config0/rw/centengine.cmd
          Sleep	5s
         END
         ${content}=	Create List	EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;	HOST ALERT: host_1;DOWN;SOFT;1;	EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;	HOST ALERT: host_1;DOWN;SOFT;2;	EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;    HOST ALERT: host_1;DOWN;HARD;3;
@@ -108,7 +108,7 @@ EFHCU1
         Should Be True	${result}	msg=An Initial host state on host_1 should be raised before we can start our external commands.
         Process host check result	host_1	0	host_1 UP
         FOR	${i}	IN RANGE	${4}
-         Schedule Forced HOST CHECK	host_1	/var/lib/centreon-engine/config0/rw/centengine.cmd
+         Schedule Forced HOST CHECK	host_1	${VarRoot}/lib/centreon-engine/config0/rw/centengine.cmd
          Sleep	5s
         END
         ${content}=	Create List	EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;	HOST ALERT: host_1;DOWN;SOFT;1;	EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;	HOST ALERT: host_1;DOWN;SOFT;2;	EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;    HOST ALERT: host_1;DOWN;HARD;3;
@@ -148,7 +148,7 @@ EFHCU2
         Should Be True	${result}	msg=An Initial host state on host_1 should be raised before we can start our external commands.
         Process host check result	host_1	0	host_1 UP
         FOR	${i}	IN RANGE	${4}
-         Schedule Forced HOST CHECK	host_1	/var/lib/centreon-engine/config0/rw/centengine.cmd
+         Schedule Forced HOST CHECK	host_1	${VarRoot}/lib/centreon-engine/config0/rw/centengine.cmd
          Sleep	5s
         END
         ${content}=	Create List	EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;	HOST ALERT: host_1;DOWN;SOFT;1;	EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;	HOST ALERT: host_1;DOWN;SOFT;2;	EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;    HOST ALERT: host_1;DOWN;HARD;3;

--- a/tests/resources/Engine.py
+++ b/tests/resources/Engine.py
@@ -1,7 +1,9 @@
+from array import array
 from os import makedirs, chmod
 from os.path import exists, dirname
 from xml.etree.ElementTree import Comment
 from robot.api import logger
+from robot.libraries.BuiltIn import BuiltIn
 import db_conf
 import random
 import shutil
@@ -9,15 +11,18 @@ import sys
 import time
 import re
 import stat
+import string
 
 import grpc
 import engine_pb2
 import engine_pb2_grpc
 
 
-CONF_DIR = "/etc/centreon-engine"
-ENGINE_HOME = "/var/lib/centreon-engine"
 SCRIPT_DIR: str = dirname(__file__) + "/engine-scripts/"
+VAR_ROOT = BuiltIn().get_variable_value("${VarRoot}")
+ETC_ROOT = BuiltIn().get_variable_value("${EtcRoot}")
+CONF_DIR = ETC_ROOT + "/centreon-engine"
+ENGINE_HOME = VAR_ROOT + "/lib/centreon-engine"
 
 
 class EngineInstance:
@@ -31,6 +36,13 @@ class EngineInstance:
         self.instances = count
         self.service_cmd = {}
         self.build_configs(hosts, srv_by_host)
+        makedirs(ETC_ROOT, mode=0o777, exist_ok=True)
+        makedirs(VAR_ROOT, mode=0o777, exist_ok=True)
+        makedirs(CONF_DIR, mode=0o777, exist_ok=True)
+        makedirs(ENGINE_HOME, mode=0o777, exist_ok=True)
+        makedirs(ETC_ROOT + "/centreon-broker", mode=0o777, exist_ok=True)
+        makedirs(VAR_ROOT + "/log/centreon-engine/", mode=0o777, exist_ok=True)
+        makedirs(VAR_ROOT + "/log/centreon-broker/", mode=0o777, exist_ok=True)
 
     def create_centengine(self, id: int, debug_level=0):
         return ("cfg_file={2}/config{0}/hosts.cfg\n"
@@ -48,15 +60,15 @@ class EngineInstance:
                 "#cfg_file={2}/config{0}/meta_host.cfg\n"
                 "#cfg_file={2}/config{0}/meta_services.cfg\n"
                 "broker_module=/usr/lib64/centreon-engine/externalcmd.so\n"
-                "broker_module=/usr/lib64/nagios/cbmod.so /etc/centreon-broker/central-module{0}.json\n"
+                "broker_module=/usr/lib64/nagios/cbmod.so {4}/centreon-broker/central-module{0}.json\n"
                 "interval_length=60\n"
                 "use_timezone=:Europe/Paris\n"
                 "resource_file={2}/config{0}/resource.cfg\n"
-                "log_file=/var/log/centreon-engine/config{0}/centengine.log\n"
-                "status_file=/var/log/centreon-engine/config{0}/status.dat\n"
+                "log_file={3}/log/centreon-engine/config{0}/centengine.log\n"
+                "status_file={3}/log/centreon-engine/config{0}/status.dat\n"
                 "command_check_interval=1s\n"
-                "command_file=/var/lib/centreon-engine/config{0}/rw/centengine.cmd\n"
-                "state_retention_file=/var/log/centreon-engine/config{0}/retention.dat\n"
+                "command_file={3}/lib/centreon-engine/config{0}/rw/centengine.cmd\n"
+                "state_retention_file={3}/log/centreon-engine/config{0}/retention.dat\n"
                 "retention_update_interval=60\n"
                 "sleep_time=0.2\n"
                 "service_inter_check_delay_method=s\n"
@@ -82,7 +94,7 @@ class EngineInstance:
                 "admin_pager=admin\n"
                 "event_broker_options=-1\n"
                 "cached_host_check_horizon=60\n"
-                "debug_file=/var/log/centreon-engine/config{0}/centengine.debug\n"
+                "debug_file={3}/log/centreon-engine/config{0}/centengine.debug\n"
                 "debug_level={1}\n"
                 "debug_verbosity=2\n"
                 "log_pid=1\n"
@@ -120,13 +132,14 @@ class EngineInstance:
                 "log_level_macros=info\n"
                 "log_level_process=info\n"
                 "log_level_runtime=info\n"
+                "log_flush_period=0\n"
                 "soft_state_dependencies=0\n"
                 "obsess_over_services=0\n"
                 "process_performance_data=0\n"
                 "check_for_orphaned_services=0\n"
                 "check_for_orphaned_hosts=0\n"
                 "check_service_freshness=1\n"
-                "enable_flap_detection=0\n").format(id, debug_level, CONF_DIR)
+                "enable_flap_detection=0\n").format(id, debug_level, CONF_DIR, VAR_ROOT, ETC_ROOT)
 
     def create_host(self):
         self.last_host_id += 1
@@ -170,6 +183,21 @@ class EngineInstance:
 }}
 """.format(
             host_id, service_id, self.service_cmd[service_id])
+        return retval
+
+    def create_anomaly_detection(self, host_id: int, dependent_service_id: int, metric_name: string):
+        self.last_service_id += 1
+        service_id = self.last_service_id
+        retval = """define anomalydetection {{
+    host_id {0}
+    host_name host_{0}
+    service_id {1}
+    service_description      anomaly_{1}
+    dependent_service_id {2}
+    metric_name {3}
+    status_change 1
+    thresholds_file /tmp/anomaly_threshold.json
+}} """.format(host_id, service_id, dependent_service_id, metric_name)
         return retval
 
     def create_bam_timeperiod(self):
@@ -474,10 +502,21 @@ define timeperiod {
         f = open(config_dir + "/centengine.cfg", "r")
         lines = f.readlines()
         f.close
-        lines_to_prep = ["cfg_file=/etc/centreon-engine/config0/centreon-bam-command.cfg\n", "cfg_file=/etc/centreon-engine/config0/centreon-bam-timeperiod.cfg\n",
-                         "cfg_file=/etc/centreon-engine/config0/centreon-bam-host.cfg\n", "cfg_file=/etc/centreon-engine/config0/centreon-bam-services.cfg\n"]
+        lines_to_prep = ["cfg_file=" + ETC_ROOT + "/centreon-engine/config0/centreon-bam-command.cfg\n", "cfg_file=" + ETC_ROOT + "/centreon-engine/config0/centreon-bam-timeperiod.cfg\n",
+                         "cfg_file=" + ETC_ROOT + "/centreon-engine/config0/centreon-bam-host.cfg\n", "cfg_file=" + ETC_ROOT + "/centreon-engine/config0/centreon-bam-services.cfg\n"]
         f = open(config_dir + "/centengine.cfg", "w")
         f.writelines(lines_to_prep)
+        f.writelines(lines)
+        f.close()
+
+    def centengine_conf_add_anomaly(self):
+        config_dir = "{}/config0".format(CONF_DIR)
+        f = open(config_dir + "/centengine.cfg", "r")
+        lines = f.readlines()
+        f.close
+        f = open(config_dir + "/centengine.cfg", "w")
+        f.writelines("cfg_file=" + config_dir +
+                     "/anomaly_detection.cfg\n")
         f.writelines(lines)
         f.close()
 
@@ -507,7 +546,8 @@ def get_engines_count():
 # @param value the new value to set to the key variable.
 #
 def engine_config_set_value(idx: int, key: str, value: str, force: bool = False):
-    filename = "/etc/centreon-engine/config{}/centengine.cfg".format(idx)
+    filename = ETC_ROOT + \
+        "/centreon-engine/config{}/centengine.cfg".format(idx)
     f = open(filename, "r")
     lines = f.readlines()
     f.close()
@@ -533,7 +573,7 @@ def engine_config_set_value(idx: int, key: str, value: str, force: bool = False)
 # @param value the new value to set to the key variable.
 #
 def engine_config_set_value_in_services(idx: int, desc: str, key: str, value: str):
-    filename = "/etc/centreon-engine/config{}/services.cfg".format(idx)
+    filename = ETC_ROOT + "/centreon-engine/config{}/services.cfg".format(idx)
     f = open(filename, "r")
     lines = f.readlines()
     f.close()
@@ -557,7 +597,7 @@ def engine_config_set_value_in_services(idx: int, desc: str, key: str, value: st
 # @param value the new value to set to the key variable.
 #
 def engine_config_set_value_in_hosts(idx: int, desc: str, key: str, value: str):
-    filename = "/etc/centreon-engine/config{}/hosts.cfg".format(idx)
+    filename = ETC_ROOT + "/centreon-engine/config{}/hosts.cfg".format(idx)
     f = open(filename, "r")
     lines = f.readlines()
     f.close()
@@ -574,7 +614,7 @@ def engine_config_set_value_in_hosts(idx: int, desc: str, key: str, value: str):
 
 def add_host_group(index: int, id_host_group: int, members: list):
     mbs = [l for l in members if l in engine.hosts]
-    f = open("/etc/centreon-engine/config{}/hostgroups.cfg".format(index), "a+")
+    f = open(ETC_ROOT + "/centreon-engine/config{}/hostgroups.cfg".format(index), "a+")
     logger.console(mbs)
     f.write(engine.create_host_group(id_host_group, mbs))
     f.close()
@@ -582,7 +622,7 @@ def add_host_group(index: int, id_host_group: int, members: list):
 
 def rename_host_group(index: int, id_host_group: int, name: str, members: list):
     mbs = [l for l in members if l in engine.hosts]
-    f = open("/etc/centreon-engine/config{}/hostgroups.cfg".format(index), "w")
+    f = open(ETC_ROOT + "/centreon-engine/config{}/hostgroups.cfg".format(index), "w")
     logger.console(mbs)
     f.write("""define hostgroup {{
     hostgroup_id                    {0}
@@ -595,14 +635,15 @@ def rename_host_group(index: int, id_host_group: int, name: str, members: list):
 
 
 def add_service_group(index: int, id_service_group: int, members: list):
-    f = open("/etc/centreon-engine/config{}/servicegroups.cfg".format(index), "a+")
+    f = open(
+        ETC_ROOT + "/centreon-engine/config{}/servicegroups.cfg".format(index), "a+")
     logger.console(members)
     f.write(engine.create_service_group(id_service_group, members))
     f.close()
 
 
 def create_service(index: int, host_id: int, cmd_id: int):
-    f = open("/etc/centreon-engine/config{}/services.cfg".format(index), "a+")
+    f = open(ETC_ROOT + "/centreon-engine/config{}/services.cfg".format(index), "a+")
     svc = engine.create_service(host_id, [1, cmd_id])
     lst = svc.split('\n')
     good = [l for l in lst if "_SERVICE_ID" in l][0]
@@ -615,6 +656,26 @@ def create_service(index: int, host_id: int, cmd_id: int):
         m = 0
     f.write(svc)
     f.close()
+    return retval
+
+
+def create_anomaly_detection(index: int, host_id: int, dependent_service_id: int, metric_name: string):
+    f = open(
+        ETC_ROOT + "/centreon-engine/config{}/anomaly_detection.cfg".format(index), "a+")
+    to_append = engine.create_anomaly_detection(
+        host_id, dependent_service_id, metric_name)
+    lst = to_append.split('\n')
+    good = [l for l in lst if "service_id" in l][0]
+    m = re.search(r"service_id\s+([^\s]*)$", good)
+    if m is not None:
+        retval = int(m.group(1))
+    else:
+        raise Exception(
+            "Impossible to get the service id from '{}'".format(good))
+        m = 0
+    f.write(to_append)
+    f.close()
+    engine.centengine_conf_add_anomaly()
     return retval
 
 
@@ -653,7 +714,7 @@ def process_service_check_result(hst: str, svc: str, state: int, output: str):
     now = int(time.time())
     cmd = "[{}] PROCESS_SERVICE_CHECK_RESULT;{};{};{};{}\n".format(
         now, hst, svc, state, output)
-    f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+    f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
     f.write(cmd)
     f.close()
 
@@ -668,7 +729,7 @@ def change_normal_svc_check_interval(use_grpc: int, hst: str, svc: str, check_in
         now = int(time.time())
         cmd = "[{}] CHANGE_NORMAL_SVC_CHECK_INTERVAL;{};{};{}\n".format(
             now, hst, svc, check_interval)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -683,7 +744,7 @@ def change_normal_host_check_interval(use_grpc: int, hst: str, check_interval: i
         now = int(time.time())
         cmd = "[{}] CHANGE_NORMAL_HOST_CHECK_INTERVAL;{};{}\n".format(
             now, hst, check_interval)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -698,7 +759,7 @@ def change_retry_svc_check_interval(use_grpc: int, hst: str, svc: str, retry_int
         now = int(time.time())
         cmd = "[{}] CHANGE_RETRY_SVC_CHECK_INTERVAL;{};{};{}\n".format(
             now, hst, svc, retry_interval)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -713,7 +774,7 @@ def change_retry_host_check_interval(use_grpc: int, hst: str, retry_interval: in
         now = int(time.time())
         cmd = "[{}] CHANGE_RETRY_HOST_CHECK_INTERVAL;{};{}\n".format(
             now, hst, retry_interval)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -728,7 +789,7 @@ def change_max_svc_check_attempts(use_grpc: int, hst: str, svc: str, max_check_a
         now = int(time.time())
         cmd = "[{}] CHANGE_MAX_SVC_CHECK_ATTEMPTS;{};{};{}\n".format(
             now, hst, svc, max_check_attempts)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -743,18 +804,9 @@ def change_max_host_check_attempts(use_grpc: int, hst: str, max_check_attempts: 
         now = int(time.time())
         cmd = "[{}] CHANGE_MAX_HOST_CHECK_ATTEMPTS;{};{}\n".format(
             now, hst, max_check_attempts)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
-
-
-def change_host_check_command(hst: str, Check_Command: str):
-    now = int(time.time())
-    cmd = "[{}] CHANGE_HOST_CHECK_COMMAND;{};{}\n".format(
-        now, hst, Check_Command)
-    f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
-    f.write(cmd)
-    f.close()
 
 
 def change_host_check_timeperiod(use_grpc: int, hst: str, check_timeperiod: str):
@@ -767,7 +819,7 @@ def change_host_check_timeperiod(use_grpc: int, hst: str, check_timeperiod: str)
         now = int(time.time())
         cmd = "[{}] CHANGE_HOST_CHECK_TIMEPERIOD;{};{}\n".format(
             now, hst, check_timeperiod)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -782,7 +834,7 @@ def change_host_notification_timeperiod(use_grpc: int, hst: str, notification_ti
         now = int(time.time())
         cmd = "[{}] CHANGE_HOST_NOTIFICATION_TIMEPERIOD;{};{}\n".format(
             now, hst, notification_timeperiod)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -797,7 +849,7 @@ def change_svc_check_timeperiod(use_grpc: int, hst: str, svc: str, check_timeper
         now = int(time.time())
         cmd = "[{}] CHANGE_SVC_CHECK_TIMEPERIOD;{};{};{}\n".format(
             now, hst, svc, check_timeperiod)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -812,7 +864,7 @@ def change_svc_notification_timeperiod(use_grpc: int, hst: str, svc: str, notifi
         now = int(time.time())
         cmd = "[{}] CHANGE_SVC_NOTIFICATION_TIMEPERIOD;{};{};{}\n".format(
             now, hst, svc, notification_timeperiod)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -827,7 +879,7 @@ def disable_host_and_child_notifications(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] DISABLE_HOST_AND_CHILD_NOTIFICATIONS;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -842,7 +894,7 @@ def enable_host_and_child_notifications(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] ENABLE_HOST_AND_CHILD_NOTIFICATIONS;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -852,7 +904,7 @@ def disable_host_check(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] DISABLE_HOST_CHECK;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -862,7 +914,7 @@ def enable_host_check(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] ENABLE_HOST_CHECK;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -872,7 +924,7 @@ def disable_host_event_handler(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] DISABLE_HOST_EVENT_HANDLER;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -882,7 +934,7 @@ def enable_host_event_handler(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] ENABLE_HOST_EVENT_HANDLER;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -892,7 +944,7 @@ def disable_host_flap_detection(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] DISABLE_HOST_FLAP_DETECTION;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -902,7 +954,7 @@ def enable_host_flap_detection(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] ENABLE_HOST_FLAP_DETECTION;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -917,7 +969,7 @@ def disable_host_notifications(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] DISABLE_HOST_NOTIFICATIONS;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -932,7 +984,7 @@ def enable_host_notifications(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] ENABLE_HOST_NOTIFICATIONS;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -942,7 +994,7 @@ def disable_host_svc_checks(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] DISABLE_HOST_SVC_CHECKS;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -952,7 +1004,7 @@ def enable_host_svc_checks(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] ENABLE_HOST_SVC_CHECKS;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -962,7 +1014,7 @@ def disable_host_svc_notifications(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] DISABLE_HOST_SVC_NOTIFICATIONS;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -972,7 +1024,7 @@ def enable_host_svc_notifications(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] ENABLE_HOST_SVC_NOTIFICATIONS;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -982,7 +1034,7 @@ def disable_passive_host_checks(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] DISABLE_PASSIVE_HOST_CHECKS;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -992,7 +1044,7 @@ def enable_passive_host_checks(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] ENABLE_PASSIVE_HOST_CHECKS;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -1002,7 +1054,7 @@ def disable_passive_svc_checks(use_grpc: int, hst: str, svc: str):
         now = int(time.time())
         cmd = "[{}] DISABLE_PASSIVE_SVC_CHECKS;{};{}\n".format(
             now, hst, svc)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -1012,7 +1064,7 @@ def enable_passive_svc_checks(use_grpc: int, hst: str, svc: str):
         now = int(time.time())
         cmd = "[{}] ENABLE_PASSIVE_SVC_CHECKS;{};{}\n".format(
             now, hst, svc)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -1022,7 +1074,7 @@ def start_obsessing_over_host(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] START_OBSESSING_OVER_HOST;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -1032,7 +1084,7 @@ def stop_obsessing_over_host(use_grpc: int, hst: str):
         now = int(time.time())
         cmd = "[{}] STOP_OBSESSING_OVER_HOST;{}\n".format(
             now, hst)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -1042,7 +1094,7 @@ def start_obsessing_over_svc(use_grpc: int, hst: str, svc: str):
         now = int(time.time())
         cmd = "[{}] START_OBSESSING_OVER_SVC;{};{}\n".format(
             now, hst, svc)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -1052,7 +1104,7 @@ def stop_obsessing_over_svc(use_grpc: int, hst: str, svc: str):
         now = int(time.time())
         cmd = "[{}] STOP_OBSESSING_OVER_SVC;{};{}\n".format(
             now, hst, svc)
-        f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+        f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
         f.write(cmd)
         f.close()
 
@@ -1061,7 +1113,7 @@ def service_ext_commands(hst: str, svc: str, state: int, output: str):
     now = int(time.time())
     cmd = "[{}] PROCESS_SERVICE_CHECK_RESULT;{};{};{};{}\n".format(
         now, hst, svc, state, output)
-    f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+    f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
     f.write(cmd)
     f.close()
 
@@ -1070,7 +1122,7 @@ def process_host_check_result(hst: str, state: int, output: str):
     now = int(time.time())
     cmd = "[{}] PROCESS_HOST_CHECK_RESULT;{};{};{}\n".format(
         now, hst, state, output)
-    f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+    f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
     f.write(cmd)
     f.close()
 
@@ -1079,7 +1131,7 @@ def schedule_service_downtime(hst: str, svc: str, duration: int):
     now = int(time.time())
     cmd = "[{2}] SCHEDULE_SVC_DOWNTIME;{0};{1};{2};{3};1;0;{4};admin;Downtime set by admin".format(
         hst, svc, now, now + duration, duration)
-    f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+    f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
     f.write(cmd)
     f.close()
 
@@ -1090,7 +1142,8 @@ def schedule_host_downtime(poller: int, hst: str, duration: int):
         hst, now, now + duration, duration)
     cmd2 = "[{1}] SCHEDULE_HOST_SVC_DOWNTIME;{0};{1};{2};1;0;{3};admin;Downtime set by admin\n".format(
         hst, now, now + duration, duration)
-    f = open("/var/lib/centreon-engine/config{}/rw/centengine.cmd".format(poller), "w")
+    f = open(
+        VAR_ROOT + "/lib/centreon-engine/config{}/rw/centengine.cmd".format(poller), "w")
     f.write(cmd1)
     f.write(cmd2)
     f.close()
@@ -1099,12 +1152,13 @@ def schedule_host_downtime(poller: int, hst: str, duration: int):
 def delete_host_downtimes(poller: int, hst: str):
     now = int(time.time())
     cmd = "[{}] DEL_HOST_DOWNTIME_FULL;{};;;;;;;;\n".format(now, hst)
-    f = open("/var/lib/centreon-engine/config{}/rw/centengine.cmd".format(poller), "w")
+    f = open(
+        VAR_ROOT + "/lib/centreon-engine/config{}/rw/centengine.cmd".format(poller), "w")
     f.write(cmd)
     f.close()
 
 
-def schedule_forced_svc_check(host: str, svc: str, pipe: str = "/var/lib/centreon-engine/rw/centengine.cmd"):
+def schedule_forced_svc_check(host: str, svc: str, pipe: str = VAR_ROOT + "/lib/centreon-engine/rw/centengine.cmd"):
     now = int(time.time())
     f = open(pipe, "w")
     cmd = "[{2}] SCHEDULE_FORCED_SVC_CHECK;{0};{1};{2}".format(host, svc, now)
@@ -1113,7 +1167,7 @@ def schedule_forced_svc_check(host: str, svc: str, pipe: str = "/var/lib/centreo
     time.sleep(0.05)
 
 
-def schedule_forced_host_check(host: str, pipe: str = "/var/lib/centreon-engine/rw/centengine.cmd"):
+def schedule_forced_host_check(host: str, pipe: str = VAR_ROOT + "/lib/centreon-engine/rw/centengine.cmd"):
     now = int(time.time())
     f = open(pipe, "w")
     cmd = "[{1}] SCHEDULE_FORCED_HOST_CHECK;{0};{1}".format(host, now)
@@ -1346,7 +1400,7 @@ def config_engine_remove_cfg_file(poller: int, fic: str):
     lines = ff.readlines()
     ff.close()
     r = re.compile(
-        r"^\s*cfg_file=/etc/centreon-engine/config{}/{}".format(poller, fic))
+        r"^\s*cfg_file=" + ETC_ROOT + "/centreon-engine/config{}/{}".format(poller, fic))
     linesearch = [l for l in lines if not r.match(l)]
     ff = open("{}/config{}/centengine.cfg".format(CONF_DIR, poller), "w")
     ff.writelines(linesearch)
@@ -1356,7 +1410,7 @@ def config_engine_remove_cfg_file(poller: int, fic: str):
 def send_custom_host_notification(hst, notification_option, author, comment):
     now = int(time.time())
     cmd = f"[{now}] SEND_CUSTOM_HOST_NOTIFICATION;{hst};{notification_option};{author};{comment}\n"
-    f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+    f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
     f.write(cmd)
     f.close()
 
@@ -1364,7 +1418,7 @@ def send_custom_host_notification(hst, notification_option, author, comment):
 def add_svc_comment(host_name, svc_description, persistent, user_name, comment):
     now = int(time.time())
     cmd = f"[{now}] ADD_SVC_COMMENT;{host_name};{svc_description};{persistent};{user_name};{comment}\n"
-    f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+    f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
     f.write(cmd)
     f.close()
 
@@ -1372,7 +1426,7 @@ def add_svc_comment(host_name, svc_description, persistent, user_name, comment):
 def add_host_comment(host_name, persistent, user_name, comment):
     now = int(time.time())
     cmd = f"[{now}] ADD_HOST_COMMENT;{host_name};{persistent};{user_name};{comment}\n"
-    f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+    f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
     f.write(cmd)
     f.close()
 
@@ -1380,6 +1434,32 @@ def add_host_comment(host_name, persistent, user_name, comment):
 def del_host_comment(comment_id):
     now = int(time.time())
     cmd = f"[{now}] DEL_HOST_COMMENT;{comment_id}\n"
-    f = open("/var/lib/centreon-engine/config0/rw/centengine.cmd", "w")
+    f = open(VAR_ROOT + "/lib/centreon-engine/config0/rw/centengine.cmd", "w")
     f.write(cmd)
+    f.close()
+
+def create_anomaly_threshold_file(path: string, host_id: int, service_id: int, metric_name: string, values: array):
+    f = open(path, "w")
+    f.write("""[
+    {{
+        "host_id": "{0}",
+        "service_id": "{1}",
+        "metric_name": "{2}",
+        "predict": [
+            """.format(host_id, service_id, metric_name))
+    sep = ""
+    for ts_lower_upper in values:
+        f.write(sep)
+        sep = ","
+        f.write("""
+            {{
+                "timestamp": {0},
+                "lower": {1},
+                "upper": {2}
+            }}""".format(ts_lower_upper[0], ts_lower_upper[1], ts_lower_upper[2]))
+    f.write("""
+        ]
+    }
+]
+""")
     f.close()

--- a/tests/resources/db_conf.py
+++ b/tests/resources/db_conf.py
@@ -4,9 +4,6 @@ import pymysql.cursors
 from robot.libraries.BuiltIn import BuiltIn
 
 
-CONF_DIR = "/etc/centreon-engine"
-ENGINE_HOME = "/var/lib/centreon-engine"
-
 BuiltIn().import_resource('db_variables.robot')
 DB_NAME_STORAGE = BuiltIn().get_variable_value("${DBName}")
 DB_NAME_CONF = BuiltIn().get_variable_value("${DBNameConf}")
@@ -14,6 +11,11 @@ DB_USER = BuiltIn().get_variable_value("${DBUser}")
 DB_PASS = BuiltIn().get_variable_value("${DBPass}")
 DB_HOST = BuiltIn().get_variable_value("${DBHost}")
 DB_PORT = BuiltIn().get_variable_value("${DBPort}")
+VAR_ROOT = BuiltIn().get_variable_value("${VarRoot}")
+ETC_ROOT = BuiltIn().get_variable_value("${EtcRoot}")
+
+CONF_DIR = ETC_ROOT + "/centreon-engine"
+ENGINE_HOME = VAR_ROOT + "/lib/centreon-engine"
 
 
 class DbConf:

--- a/tests/resources/db_variables.robot
+++ b/tests/resources/db_variables.robot
@@ -1,4 +1,6 @@
 *** Variables ***
+${EtcRoot}  /tmp/etc
+${VarRoot}  /tmp/var
 ${DBName}	centreon_storage
 ${DBNameConf}	centreon
 ${DBHost}	localhost

--- a/tests/resources/resources.robot
+++ b/tests/resources/resources.robot
@@ -28,8 +28,8 @@ Clear Broker Logs
 	Create Directory	${BROKER_LOG}
 
 Start Broker
-	Start Process	/usr/sbin/cbd	/etc/centreon-broker/central-broker.json	alias=b1
-	Start Process	/usr/sbin/cbd	/etc/centreon-broker/central-rrd.json	alias=b2
+	Start Process	/usr/sbin/cbd	${EtcRoot}/centreon-broker/central-broker.json	alias=b1
+	Start Process	/usr/sbin/cbd	${EtcRoot}/centreon-broker/central-rrd.json	alias=b2
 #	${log_pid1}=  Get Process Id	b1
 #	${log_pid2}=  Get Process Id	b2
 #	Log To Console  \npidcentral=${log_pid1} pidrrd=${log_pid2}\n
@@ -61,9 +61,9 @@ Start Engine
 	${count}=	Get Engines Count
 	FOR	${idx}	IN RANGE	0	${count}
 	 ${alias}=	Catenate	SEPARATOR=	e	${idx}
-	 ${conf}=	Catenate	SEPARATOR=	/etc/centreon-engine/config	${idx}	/centengine.cfg
-	 ${log}=	Catenate	SEPARATOR=	/var/log/centreon-engine/config	${idx}
-	 ${lib}=	Catenate	SEPARATOR=	/var/lib/centreon-engine/config	${idx}
+	 ${conf}=	Catenate	SEPARATOR=	${EtcRoot}  /centreon-engine/config	${idx}	/centengine.cfg
+	 ${log}=	Catenate	SEPARATOR=	${VarRoot}  /log/centreon-engine/config	${idx}
+	 ${lib}=	Catenate	SEPARATOR=	${VarRoot}  /lib/centreon-engine/config	${idx}
 	 Create Directory	${log}
 	 Create Directory	${lib}
 	 Start Process	/usr/sbin/centengine	${conf}	alias=${alias}
@@ -118,9 +118,20 @@ Reset Eth Connection
 	Run	iptables -F
 	Run	iptables -X
 
+Save Logs If failed
+	Run Keyword If Test Failed	Save Logs
+
+Save Logs
+	Create Directory	failed
+        ${failDir}=	Catenate	SEPARATOR=	failed/	${Test Name}
+        Create Directory	${failDir}
+        Copy files	${centralLog}	${failDir}
+        Copy files	${moduleLog}	${failDir}
+        Copy files	${logEngine0}	${failDir}
+
 *** Variables ***
-${BROKER_LOG}	/var/log/centreon-broker
-${ENGINE_LOG}	/var/log/centreon-engine
+${BROKER_LOG}	${VarRoot}/log/centreon-broker
+${ENGINE_LOG}	${VarRoot}/log/centreon-engine
 ${SCRIPTS}	${CURDIR}${/}scripts${/}
 ${centralLog}	${BROKER_LOG}/central-broker-master.log
 ${moduleLog}	${BROKER_LOG}/central-module-master0.log


### PR DESCRIPTION
## Description

A part of anomaly detection have been rewritten.
Now anomaly detection can do a check if his state is not OK.
Command has also a new feature, it supports group of services. The goal of this feature is to prevent anomaly detection and dependent service from do check more often than interval_length

**Fixes** # (issue)
anomaly detection can't do a check
## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [X] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

