### PR TITLE
MON-14511 engine wait end loop event sent before shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 22.04.2
+
+### engine
+
+#### Fixes
+
+engine waits up to 5 seconds to send bye event to broker
 ## 22.04.1
 
 ### ccc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,35 +1,36 @@
-##
-## Copyright 2009-2021 Centreon
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##     http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-##
-## For more information : contact@centreon.com
-##
+# #
+# # Copyright 2009-2021 Centreon
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+# #
+# # For more information : contact@centreon.com
+# #
 
 #
 # Global settings.
 #
 
-
 # Set necessary settings.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 cmake_minimum_required(VERSION 3.16)
 project("Centreon Collect" C CXX)
-if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   message(FATAL_ERROR "You can build broker with g++ or clang++. CMake will exit.")
-endif ()
-#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -stdlib=libc++")
-#set(CMAKE_CXX_COMPILER "clang++")
+endif()
+
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -stdlib=libc++")
+# set(CMAKE_CXX_COMPILER "clang++")
 add_definitions("-D_GLIBCXX_USE_CXX11_ABI=1")
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -42,57 +43,60 @@ set(BUILD_ARGS "-w" "dupbuild=warn")
 #
 # Get distributions name
 #
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   file(STRINGS "/etc/os-release" release
-       REGEX "^ID")
-  foreach (l ${release})
-    if (${l} MATCHES "ID_LIKE=.*")
-      string(REGEX REPLACE "ID_LIKE=\"(.*)\"" "\\1" like ${l})
-    endif ()
+    REGEX "^ID")
 
-    if (${l} MATCHES "ID=.*")
+  foreach(l ${release})
+    if(${l} MATCHES "ID_LIKE=.*")
+      string(REGEX REPLACE "ID_LIKE=\"(.*)\"" "\\1" like ${l})
+    endif()
+
+    if(${l} MATCHES "ID=.*")
       string(REGEX REPLACE "ID=\"(.*)\"" "\\1" id ${l})
-    endif ()
-  endforeach ()
+    endif()
+  endforeach()
+
   string(TOLOWER "${like}" like)
   string(TOLOWER "${id}" id)
 
-  if (("${id}" MATCHES "debian") OR ("${like}" MATCHES "debian") OR ("${id}" MATCHES "ubuntu") OR ("${like}" MATCHES "ubuntu"))
+  if(("${id}" MATCHES "debian") OR("${like}" MATCHES "debian") OR("${id}" MATCHES "ubuntu") OR("${like}" MATCHES "ubuntu"))
     set(OS_DISTRIBUTOR "Debian")
-  elseif (("${id}" MATCHES "centos") OR ("${like}" MATCHES "centos"))
+  elseif(("${id}" MATCHES "centos") OR("${like}" MATCHES "centos"))
     set(OS_DISTRIBUTOR "CentOS")
-  else ()
+  else()
     message(WARNING "lsb_release in not installed")
     set(OS_DISTRIBUTOR "${CMAKE_SYSTEM_NAME}")
-  endif ()
-else ()
+  endif()
+else()
   set(OS_DISTRIBUTOR "${CMAKE_SYSTEM_NAME}")
-endif ()
+endif()
 
 message(STATUS "${id} detected (compatible with ${OS_DISTRIBUTOR})")
 
 # set -latomic if OS is Raspbian.
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
   set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
-endif ()
+endif()
 
 # Version.
 set(COLLECT_MAJOR 22)
 set(COLLECT_MINOR 04)
-set(COLLECT_PATCH 1)
+set(COLLECT_PATCH 2)
 set(COLLECT_VERSION "${COLLECT_MAJOR}.${COLLECT_MINOR}.${COLLECT_PATCH}")
 add_definitions(-DCENTREON_CONNECTOR_VERSION=\"${COLLECT_VERSION}\")
 
-
-############ CONSTANTS ###########
+# ########### CONSTANTS ###########
 set(USER_BROKER centreon-broker)
 set(USER_ENGINE centreon-engine)
-##################################
 
-
-
+# #################################
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
+
+find_package(Protobuf REQUIRED)
+
+message(NOTICE "-- use protoc compiler: ${Protobuf_PROTOC_EXECUTABLE}")
 
 include(GNUInstallDirs)
 
@@ -110,19 +114,20 @@ option(WITH_CONF "Install configuration files." ON)
 
 # Code coverage on unit tests
 option(WITH_COVERAGE "Add code coverage on unit tests." OFF)
-if (WITH_TESTING AND WITH_COVERAGE)
+
+if(WITH_TESTING AND WITH_COVERAGE)
   set(CMAKE_BUILD_TYPE "Debug")
   include(cmake/CodeCoverage.cmake)
   APPEND_COVERAGE_COMPILER_FLAGS()
-endif ()
+endif()
 
 set(protobuf_MODULE_COMPATIBLE True)
 
 add_definitions(${spdlog_DEFINITIONS})
 
 include_directories(${CMAKE_SOURCE_DIR}
-                    ${CONAN_INCLUDE_DIRS}
-                    ${CMAKE_SOURCE_DIR}/clib/inc)
+  ${CONAN_INCLUDE_DIRS}
+  ${CMAKE_SOURCE_DIR}/clib/inc)
 
 add_subdirectory(bbdo)
 add_subdirectory(broker)
@@ -132,22 +137,22 @@ add_subdirectory(connectors)
 add_subdirectory(ccc)
 
 add_custom_target(test-broker
-    COMMAND tests/ut_broker
-    )
+  COMMAND tests/ut_broker
+)
 add_custom_target(test-engine
-    COMMAND tests/ut_engine
-    )
+  COMMAND tests/ut_engine
+)
 add_custom_target(test-clib
-    COMMAND tests/ut_clib
-    )
+  COMMAND tests/ut_clib
+)
 add_custom_target(test-connector
-    COMMAND tests/ut_connector
-    )
+  COMMAND tests/ut_connector
+)
 
 add_custom_target(test
-    DEPENDS test-broker test-engine test-clib test-connector
-    )
+  DEPENDS test-broker test-engine test-clib test-connector
+)
 
 add_custom_target(test-coverage
-    DEPENDS broker-test-coverage engine-test-coverage clib-test-coverage
-    )
+  DEPENDS broker-test-coverage engine-test-coverage clib-test-coverage
+)

--- a/broker/CMakeLists.txt
+++ b/broker/CMakeLists.txt
@@ -1,20 +1,20 @@
-##
-## Copyright 2009-2021 Centreon
-##
-## Licensed under the Apache License, Version 2.0 (the "License");
-## you may not use this file except in compliance with the License.
-## You may obtain a copy of the License at
-##
-##     http://www.apache.org/licenses/LICENSE-2.0
-##
-## Unless required by applicable law or agreed to in writing, software
-## distributed under the License is distributed on an "AS IS" BASIS,
-## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-## See the License for the specific language governing permissions and
-## limitations under the License.
-##
-## For more information : contact@centreon.com
-##
+# #
+# # Copyright 2009-2021 Centreon
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #     http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+# #
+# # For more information : contact@centreon.com
+# #
 
 #
 # Global settings.
@@ -24,45 +24,49 @@
 project("Centreon Broker" C CXX)
 
 # set -latomic if OS is Raspbian.
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
   set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
-endif ()
+endif()
 
 add_definitions("-D_GLIBCXX_USE_CXX11_ABI=1")
 
 option(WITH_LIBCXX "compiles and link cbd with clang++/libc++")
-if (WITH_LIBCXX)
+
+if(WITH_LIBCXX)
   set(CMAKE_CXX_COMPILER "clang++")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-#  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -Werror -O1 -fno-omit-frame-pointer")
-endif ()
+
+  # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -Werror -O1 -fno-omit-frame-pointer")
+endif()
 
 # With ASIO DEBUGGING ENABLED
 option(WITH_DEBUG_ASIO "Add the Asio debugging flags." OFF)
-if (WITH_DEBUG_ASIO)
+
+if(WITH_DEBUG_ASIO)
   set(CMAKE_BUILD_TYPE Debug)
-  set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DASIO_ENABLE_BUFFER_DEBUGGING -DASIO_ENABLE_HANDLER_TRACKING")
-endif ()
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DASIO_ENABLE_BUFFER_DEBUGGING -DASIO_ENABLE_HANDLER_TRACKING")
+endif()
 
 # With libasan
 option(WITH_ASAN "Add the libasan to check memory leaks and other memory issues." OFF)
-if (WITH_ASAN)
+
+if(WITH_ASAN)
   set(CMAKE_BUILD_TYPE Debug)
-  set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
-  set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
-endif ()
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+  set(CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+endif()
 
 # Default MySQL socket
-if (OS_DISTRIBUTOR STREQUAL "Debian" OR OS_DISTRIBUTOR STREQUAL "Ubuntu")
+if(OS_DISTRIBUTOR STREQUAL "Debian" OR OS_DISTRIBUTOR STREQUAL "Ubuntu")
   message(STATUS "deb based os")
   add_definitions("-DMYSQL_SOCKET=\"/var/run/mysqld/mysqld.sock\"")
-elseif (OS_DISTRIBUTOR STREQUAL "CentOS" OR OS_DISTRIBUTOR STREQUAL "RedHat")
+elseif(OS_DISTRIBUTOR STREQUAL "CentOS" OR OS_DISTRIBUTOR STREQUAL "RedHat")
   message(STATUS "rpm based os")
   add_definitions("-DMYSQL_SOCKET=\"/var/lib/mysql/mysql.sock\"")
-else ()
+else()
   message(STATUS "other os: ${OS_DISTRIBUTOR}")
   add_definitions("-DMYSQL_SOCKET=/tmp/mysql.sock")
-endif ()
+endif()
 
 include_directories("${PROJECT_SOURCE_DIR}/core/inc")
 include_directories("${PROJECT_SOURCE_DIR}/neb/inc")
@@ -87,8 +91,7 @@ add_definitions(${spdlog_DEFINITIONS} ${mariadb-connector-c_DEFINITIONS})
 
 include_directories(${CONAN_INCLUDE_DIRS_MARIADB-CONNECTOR-C})
 
-#link_directories(${mariadb-connector-c_LIB_DIRS})
-
+# link_directories(${mariadb-connector-c_LIB_DIRS})
 add_custom_command(
   DEPENDS ${SRC_DIR}/broker.proto
   COMMENT "Generating interface files of the proto file (grpc)"
@@ -117,11 +120,12 @@ target_link_libraries(berpc CONAN_PKG::protobuf)
 set_target_properties(berpc PROPERTIES COMPILE_FLAGS "-fPIC")
 
 # Version.
-if (CENTREON_BROKER_PRERELEASE)
+if(CENTREON_BROKER_PRERELEASE)
   set(CENTREON_BROKER_VERSION "${COLLECT_MAJOR}.${COLLECT_MINOR}.${COLLECT_PATCH}-${CENTREON_BROKER_PRERELEASE}")
-else ()
+else()
   set(CENTREON_BROKER_VERSION "${COLLECT_MAJOR}.${COLLECT_MINOR}.${COLLECT_PATCH}")
-endif ()
+endif()
+
 add_definitions(-DCENTREON_BROKER_VERSION=\"${CENTREON_BROKER_VERSION}\" -DCENTREON_BROKER_PATCH=${COLLECT_PATCH})
 configure_file(
   ${INC_DIR}/version.hh.in
@@ -134,14 +138,12 @@ include(cmake/tool.cmake)
 #
 # Check and/or find required components.
 #
-
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 add_definitions("-DASIO_STANDALONE")
 
 #
 # Options.
 #
-
 set(PREFIX_BROKER_CONF ${CMAKE_INSTALL_FULL_SYSCONFDIR}/centreon-broker)
 
 # Modules directories.
@@ -149,58 +151,58 @@ set(PREFIX_MODULES "${CMAKE_INSTALL_FULL_DATADIR}/centreon/lib/centreon-broker")
 set(PREFIX_CBMOD "${CMAKE_INSTALL_PREFIX}/lib64/nagios")
 
 # User.
-if (WITH_USER_BROKER)
+if(WITH_USER_BROKER)
   set(USER "${WITH_USER_BROKER}")
-else ()
+else()
   set(USER "root")
-endif ()
+endif()
 
 # Group.
-if (WITH_GROUP_BROKER)
+if(WITH_GROUP_BROKER)
   set(GROUP "${WITH_GROUP_BROKER}")
-else ()
+else()
   set(GROUP "root")
-endif ()
+endif()
 
 # Set startup script to auto if not defined.
-if (NOT WITH_STARTUP_SCRIPT)
+if(NOT WITH_STARTUP_SCRIPT)
   set(WITH_STARTUP_SCRIPT "auto")
-endif ()
+endif()
 
 # Check which startup script to use.
-if (WITH_STARTUP_SCRIPT STREQUAL "auto")
-  if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(WITH_STARTUP_SCRIPT STREQUAL "auto")
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(WITH_STARTUP_SCRIPT "sysv")
-  else ()
+  else()
     message(STATUS "Centreon Broker does not provide startup script for ${CMAKE_SYSTEM_NAME}.")
     set(WITH_STARTUP_SCRIPT "no")
-  endif ()
-endif ()
+  endif()
+endif()
 
 # Startup dir.
-if (WITH_STARTUP_SCRIPT STREQUAL "sysv"
+if(WITH_STARTUP_SCRIPT STREQUAL "sysv"
   OR WITH_STARTUP_SCRIPT STREQUAL "systemd")
   # Set destination directory.
-  if (WITH_STARTUP_DIR)
+  if(WITH_STARTUP_DIR)
     set(STARTUP_DIR "${WITH_STARTUP_DIR}")
-  else ()
+  else()
     set(STARTUP_DIR "/etc/init.d")
-  endif ()
-endif ()
+  endif()
+endif()
 
 # Configure files.
-if (WITH_DAEMONS)
-  if (WITH_STARTUP_SCRIPT STREQUAL "systemd")
+if(WITH_DAEMONS)
+  if(WITH_STARTUP_SCRIPT STREQUAL "systemd")
     configure_file("${PROJECT_SOURCE_DIR}/script/systemd/cbd.service.in"
       "${PROJECT_SOURCE_DIR}/script/cbd.service"
       @ONLY)
     install(FILES "${PROJECT_SOURCE_DIR}/script/cbd.service"
       DESTINATION "${STARTUP_DIR}")
-  elseif (OS_DISTRIBUTOR STREQUAL "CentOS" OR OS_DISTRIBUTOR STREQUAL "RedHat")
+  elseif(OS_DISTRIBUTOR STREQUAL "CentOS" OR OS_DISTRIBUTOR STREQUAL "RedHat")
     configure_file("${PROJECT_SOURCE_DIR}/script/redhat/cbd.init.d.in"
       "${PROJECT_SOURCE_DIR}/script/cbd.init"
       @ONLY)
-  elseif (OS_DISTRIBUTOR STREQUAL "Debian" OR OS_DISTRIBUTOR STREQUAL "Ubuntu")
+  elseif(OS_DISTRIBUTOR STREQUAL "Debian" OR OS_DISTRIBUTOR STREQUAL "Ubuntu")
     configure_file("${PROJECT_SOURCE_DIR}/script/debian/cbd.init.d.in"
       "${PROJECT_SOURCE_DIR}/script/cbd.init"
       @ONLY)
@@ -210,25 +212,26 @@ if (WITH_DAEMONS)
     install(FILES "${PROJECT_SOURCE_DIR}/script/cbd.default"
       DESTINATION "/etc/default"
       RENAME "cbd")
-  else ()
+  else()
     configure_file("${PROJECT_SOURCE_DIR}/script/other/cbd.init.d.in"
       "${PROJECT_SOURCE_DIR}/script/cbd.init"
       @ONLY)
-  endif ()
+  endif()
 
   configure_file("${PROJECT_SOURCE_DIR}/script/watchdog.json.in"
     "${PROJECT_SOURCE_DIR}/script/watchdog.json"
     @ONLY)
   install(FILES "${PROJECT_SOURCE_DIR}/script/watchdog.json"
     DESTINATION "${PREFIX_BROKER_CONF}")
-  if (WITH_STARTUP_SCRIPT STREQUAL "sysv")
+
+  if(WITH_STARTUP_SCRIPT STREQUAL "sysv")
     install(PROGRAMS "${PROJECT_SOURCE_DIR}/script/cbd.init"
       DESTINATION "${STARTUP_DIR}"
       RENAME "cbd")
-  endif ()
-endif ()
+  endif()
+endif()
 
-if (WITH_CONFIG_FILES)
+if(WITH_CONFIG_FILES)
   configure_file("${PROJECT_SOURCE_DIR}/config/central-module.json.in"
     "${PROJECT_SOURCE_DIR}/config/central-module.json"
     @ONLY)
@@ -245,24 +248,26 @@ if (WITH_CONFIG_FILES)
     DESTINATION "${PREFIX_BROKER_CONF}")
   install(FILES "${PROJECT_SOURCE_DIR}/config/central-broker.json"
     DESTINATION "${PREFIX_BROKER_CONF}")
-endif ()
+endif()
 
 # Monitoring engine (for testing).
-if (WITH_MONITORING_ENGINE)
+if(WITH_MONITORING_ENGINE)
   set(MONITORING_ENGINE_ADDITIONAL "")
   set(MONITORING_ENGINE "${WITH_MONITORING_ENGINE}")
-  if (WITH_MONITORING_ENGINE_MODULES)
-    foreach (MODULE IN LISTS WITH_MONITORING_ENGINE_MODULES)
+
+  if(WITH_MONITORING_ENGINE_MODULES)
+    foreach(MODULE IN LISTS WITH_MONITORING_ENGINE_MODULES)
       set(MONITORING_ENGINE_ADDITIONAL
         "${MONITORING_ENGINE_ADDITIONAL}broker_module=${MODULE}\\n")
-    endforeach ()
-  endif ()
-  if (WITH_MONITORING_ENGINE_INTERVAL_LENGTH)
+    endforeach()
+  endif()
+
+  if(WITH_MONITORING_ENGINE_INTERVAL_LENGTH)
     set(MONITORING_ENGINE_INTERVAL_LENGTH "${WITH_MONITORING_ENGINE_INTERVAL_LENGTH}")
-  else ()
+  else()
     set(MONITORING_ENGINE_INTERVAL_LENGTH 1)
-  endif ()
-endif ()
+  endif()
+endif()
 
 # Broker vars
 configure_file(
@@ -273,6 +278,7 @@ configure_file(
 
 # Core library.
 set(LIBROKER_SOURCES
+
   # Sources.
   ${SRC_DIR}/bbdo/acceptor.cc
   ${SRC_DIR}/bbdo/connector.cc
@@ -350,6 +356,7 @@ set(LIBROKER_SOURCES
   ${SRC_DIR}/time/timerange.cc
   ${SRC_DIR}/time/timezone_locker.cc
   ${SRC_DIR}/time/timezone_manager.cc
+
   # Headers.
   ${INC_DIR}/bbdo/acceptor.hh
   ${INC_DIR}/bbdo/connector.hh
@@ -442,7 +449,7 @@ set(LIBROKER_SOURCES
   ${INC_DIR}/timestamp.hh
   ${INC_DIR}/vars.hh
   ${INC_DIR}/version.hh
-  )
+)
 
 # Static libraries.
 add_library(rokerbase STATIC ${LIBROKER_SOURCES})
@@ -455,19 +462,19 @@ add_library(roker STATIC
   ${SRC_DIR}/config/applier/init.cc)
 target_link_libraries(roker rokerbase dl CONAN_PKG::openssl CONAN_PKG::grpc pthread)
 
-
 # Standalone binary.
 add_executable(cbd ${SRC_DIR}/main.cc)
 
-#Flags needed to include all symbols in binary.
+# Flags needed to include all symbols in binary.
 target_link_libraries(cbd
-"-export-dynamic" "-Wl,--whole-archive" rokerbase roker "-Wl,--no-whole-archive" CONAN_PKG::nlohmann_json CONAN_PKG::fmt -L${CONAN_LIB_DIRS_GRPC} "-Wl,--whole-archive" grpc++ "-Wl,--no-whole-archive" CONAN_PKG::spdlog CONAN_PKG::grpc )
+  "-export-dynamic" "-Wl,--whole-archive" rokerbase roker "-Wl,--no-whole-archive" CONAN_PKG::nlohmann_json CONAN_PKG::fmt -L${CONAN_LIB_DIRS_GRPC} "-Wl,--whole-archive" grpc++ "-Wl,--no-whole-archive" CONAN_PKG::spdlog CONAN_PKG::grpc)
 
 # Centreon Broker Watchdog
 option(WITH_CBWD "Build centreon broker watchdog." ON)
-if (WITH_CBWD)
+
+if(WITH_CBWD)
   add_subdirectory(watchdog)
-endif ()
+endif()
 
 # Module list.
 unset(MODULE_LIST)
@@ -491,34 +498,39 @@ add_broker_module(GRPC ON)
 
 # Lua module.
 option(WITH_MODULE_LUA "Build lua module." ON)
+
 # Simu module.
 option(WITH_MODULE_SIMU "Build simu module." OFF)
-if (WITH_MODULE_LUA OR WITH_MODULE_SIMU)
-  foreach (vers "Lua" "Lua52" "Lua51")
+
+if(WITH_MODULE_LUA OR WITH_MODULE_SIMU)
+  foreach(vers "Lua" "Lua52" "Lua51")
     find_package("${vers}")
-    if (DEFINED LUA_VERSION_STRING)
+
+    if(DEFINED LUA_VERSION_STRING)
       string(REGEX REPLACE "^([0-9]+)\\.([0-9]+)\\.[0-9]+" "\\1\\2" v "${LUA_VERSION_STRING}")
       add_definitions(-DLUA${v})
       include_directories("${LUA_INCLUDE_DIR}")
-      if (WITH_MODULE_LUA)
+
+      if(WITH_MODULE_LUA)
         add_subdirectory("lua")
         list(APPEND MODULE_LIST "lua")
-      endif ()
-      if (WITH_MODULE_SIMU)
+      endif()
+
+      if(WITH_MODULE_SIMU)
         add_subdirectory("simu")
         list(APPEND MODULE_LIST "simu")
-      endif ()
+      endif()
       break()
-    endif ()
-  endforeach ()
-  if (NOT DEFINED LUA_VERSION_STRING)
+    endif()
+  endforeach()
+
+  if(NOT DEFINED LUA_VERSION_STRING)
     message(FATAL_ERROR "No Lua development package found.")
-  endif ()
-endif ()
+  endif()
+endif()
 
 # Format string.
 string(REPLACE ";" ", " MODULE_LIST "${MODULE_LIST}")
-
 
 #
 # Install stuff.
@@ -561,36 +573,33 @@ install(CODE "
 # Install rule.
 install(TARGETS cbd
   RUNTIME DESTINATION "${CMAKE_INSTALL_FULL_SBINDIR}"
-  )
-
+)
 
 # Install header files for development.
 install(DIRECTORY "${INC_DIR}/../../../"
   DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/centreon-broker"
   COMPONENT "development"
   FILES_MATCHING PATTERN "*.hh" PATTERN "*.h"
-  )
+)
 
 #
 # Packaging.
 #
-
 include(cmake/package.cmake)
 
 #
 # Unit tests.
 #
 # Enable testing.
-if (WITH_TESTING)
+if(WITH_TESTING)
   add_subdirectory(test)
-endif ()
+endif()
 
 option(WITH_SQL_TESTS "Sql unit tests are enabled." OFF)
 
 #
 # Print summary.
 #
-
 message(STATUS "")
 message(STATUS "")
 message(STATUS "Configuration Summary")
@@ -608,38 +617,46 @@ message(STATUS "")
 message(STATUS "  Build")
 message(STATUS "    - Compiler                   ${CMAKE_CXX_COMPILER} (${CMAKE_CXX_COMPILER_ID})")
 message(STATUS "    - Extra compilation flags    ${CMAKE_CXX_FLAGS}")
-if (WITH_TESTING)
+
+if(WITH_TESTING)
   message(STATUS "    - Unit tests                 enabled")
-  if (MONITORING_ENGINE)
+
+  if(MONITORING_ENGINE)
     message(STATUS "      - Monitoring engine        ${MONITORING_ENGINE}")
-  else ()
+  else()
     message(STATUS "      - Monitoring engine        none")
-  endif ()
-  if (WITH_COVERAGE)
+  endif()
+
+  if(WITH_COVERAGE)
     message(STATUS "      - Code coverage            enabled")
-  else ()
+  else()
     message(STATUS "      - Code coverage            disabled")
-  endif ()
-else ()
+  endif()
+else()
   message(STATUS "    - Unit tests                 disabled")
-endif ()
-if (WITH_STARTUP_SCRIPT STREQUAL "no")
+endif()
+
+if(WITH_STARTUP_SCRIPT STREQUAL "no")
   message(STATUS "    - Startup script             disabled")
-else ()
+else()
   message(STATUS "    - Startup script             ${WITH_STARTUP_SCRIPT}")
-endif ()
+endif()
+
 message(STATUS "    - Module                     ${MODULE_LIST}")
 message(STATUS "")
 message(STATUS "  Install")
 message(STATUS "    - Prefix                     ${CMAKE_INSTALL_PREFIX}")
-#message(STATUS "    - Binary prefix              ${CMAKE_INSTALL_SBINDIR}")
-#message(STATUS "    - Library prefix             ${PREFIX_LIB}")
+
+# message(STATUS "    - Binary prefix              ${CMAKE_INSTALL_SBINDIR}")
+# message(STATUS "    - Library prefix             ${PREFIX_LIB}")
 message(STATUS "    - Modules prefix             ${PREFIX_MODULES}")
 message(STATUS "    - Include prefix             ${CMAKE_INSTALL_INCLUDEDIR}/centreon-broker")
 message(STATUS "    - Configuration prefix       ${PREFIX_BROKER_CONF}")
-if (NOT WITH_STARTUP_SCRIPT STREQUAL "no")
+
+if(NOT WITH_STARTUP_SCRIPT STREQUAL "no")
   message(STATUS "    - Startup dir                ${STARTUP_DIR}")
-endif ()
+endif()
+
 message(STATUS "    - User                       ${USER}")
 message(STATUS "    - Group                      ${GROUP}")
 message(STATUS "    - Package                    ${PACKAGE_LIST}")

--- a/broker/core/inc/com/centreon/broker/io/stream.hh
+++ b/broker/core/inc/com/centreon/broker/io/stream.hh
@@ -74,6 +74,8 @@ class stream {
   bool validate(std::shared_ptr<io::data> const& d, std::string const& error);
   virtual int write(std::shared_ptr<data> const& d) = 0;
   const std::string& get_name() const { return _name; }
+
+  virtual bool wait_for_all_events_written(unsigned ms_timeout);
 };
 }  // namespace io
 

--- a/broker/core/inc/com/centreon/broker/processing/acceptor.hh
+++ b/broker/core/inc/com/centreon/broker/processing/acceptor.hh
@@ -80,6 +80,8 @@ class acceptor : public endpoint {
   void set_read_filters(const absl::flat_hash_set<uint32_t>& filters);
   void set_retry_interval(time_t retry_interval);
   void set_write_filters(const absl::flat_hash_set<uint32_t>& filters);
+
+  bool wait_for_all_events_written(unsigned ms_timeout) override;
 };
 }  // namespace processing
 

--- a/broker/core/inc/com/centreon/broker/processing/endpoint.hh
+++ b/broker/core/inc/com/centreon/broker/processing/endpoint.hh
@@ -36,6 +36,8 @@ class endpoint : public stat_visitable {
   virtual void update() {}
   virtual void start() = 0;
   virtual void exit() = 0;
+
+  virtual bool wait_for_all_events_written(unsigned) { return true; }
 };
 }  // namespace processing
 

--- a/broker/core/inc/com/centreon/broker/processing/failover.hh
+++ b/broker/core/inc/com/centreon/broker/processing/failover.hh
@@ -75,6 +75,7 @@ class failover : public endpoint {
   void set_failover(std::shared_ptr<processing::failover> fo);
   void set_retry_interval(time_t retry_interval);
   void update() override;
+  bool wait_for_all_events_written(unsigned ms_timeout) override;
 
  protected:
   // From stat_visitable

--- a/broker/core/inc/com/centreon/broker/processing/feeder.hh
+++ b/broker/core/inc/com/centreon/broker/processing/feeder.hh
@@ -74,6 +74,8 @@ class feeder : public stat_visitable {
   feeder& operator=(const feeder&) = delete;
   bool is_finished() const noexcept;
   const char* get_state() const;
+
+  bool wait_for_all_events_written(unsigned ms_timeout);
 };
 }  // namespace processing
 

--- a/broker/core/inc/com/centreon/broker/processing/stat_visitable.hh
+++ b/broker/core/inc/com/centreon/broker/processing/stat_visitable.hh
@@ -50,6 +50,8 @@ class stat_visitable {
   virtual void _forward_statistic(nlohmann::json& tree);
 
  public:
+  static constexpr unsigned idle_microsec_wait_idle_thread_delay = 100000;
+
   stat_visitable(std::string const& name = std::string());
   virtual ~stat_visitable() noexcept = default;
   stat_visitable(stat_visitable const& other) = delete;

--- a/broker/core/src/config/applier/endpoint.cc
+++ b/broker/core/src/config/applier/endpoint.cc
@@ -206,6 +206,9 @@ void endpoint::_discard() {
   _discarding = true;
   log_v2::config()->debug("endpoint applier: destruction");
 
+  // wait for failover and feeder to push endloop event
+  ::usleep(processing::stat_visitable::idle_microsec_wait_idle_thread_delay +
+           100000);
   // Exit threads.
   {
     log_v2::config()->debug("endpoint applier: requesting threads termination");
@@ -215,6 +218,7 @@ void endpoint::_discard() {
     // We begin with feeders
     for (auto it = _endpoints.begin(); it != _endpoints.end();) {
       if (it->second->is_feeder()) {
+        it->second->wait_for_all_events_written(5000);
         log_v2::config()->trace(
             "endpoint applier: send exit signal to endpoint '{}'",
             it->second->get_name());
@@ -240,6 +244,7 @@ void endpoint::_discard() {
 
     // We continue with failovers
     for (auto it = _endpoints.begin(); it != _endpoints.end();) {
+      it->second->wait_for_all_events_written(5000);
       log_v2::config()->trace(
           "endpoint applier: send exit signal on endpoint '{}'",
           it->second->get_name());

--- a/broker/core/src/io/stream.cc
+++ b/broker/core/src/io/stream.cc
@@ -106,3 +106,18 @@ bool stream::validate(std::shared_ptr<io::data> const& d,
   }
   return true;
 }
+
+/**
+ * @brief if it has a substream, it waits until the substream has sent all data
+ * on the wire
+ *
+ * @param ms_timeout
+ * @return true all data sent
+ * @return false timeout expires
+ */
+bool stream::wait_for_all_events_written(unsigned ms_timeout) {
+  if (_substream) {
+    return _substream->wait_for_all_events_written(ms_timeout);
+  }
+  return true;
+}

--- a/broker/core/src/multiplexing/engine.cc
+++ b/broker/core/src/multiplexing/engine.cc
@@ -84,13 +84,16 @@ void engine::publish(const std::shared_ptr<io::data>& e) {
   std::lock_guard<std::mutex> lock(_engine_m);
   switch (_state) {
     case stopped:
+      log_v2::core()->trace("engine::publish one event to file");
       _cache_file->add(e);
       _unprocessed_events++;
       break;
     case not_started:
+      log_v2::core()->trace("engine::publish one event to queue");
       _kiew.push_back(e);
       break;
     default:
+      log_v2::core()->trace("engine::publish one event to queue_");
       _kiew.push_back(e);
       if (!_sending_to_subscribers) {
         _sending_to_subscribers = true;
@@ -104,16 +107,22 @@ void engine::publish(const std::list<std::shared_ptr<io::data>>& to_publish) {
   std::lock_guard<std::mutex> lock(_engine_m);
   switch (_state) {
     case stopped:
+      log_v2::core()->trace("engine::publish {} event to file",
+                            to_publish.size());
       for (auto& e : to_publish) {
         _cache_file->add(e);
         _unprocessed_events++;
       }
       break;
     case not_started:
+      log_v2::core()->trace("engine::publish {} event to queue",
+                            to_publish.size());
       for (auto& e : to_publish)
         _kiew.push_back(e);
       break;
     default:
+      log_v2::core()->trace("engine::publish {} event to queue_",
+                            to_publish.size());
       for (auto& e : to_publish)
         _kiew.push_back(e);
       if (!_sending_to_subscribers) {
@@ -184,7 +193,9 @@ void engine::stop() {
       // Make sure that no more data is available.
       if (!_sending_to_subscribers) {
         log_v2::core()->info(
-            "multiplexing: sending events to muxers for the last time");
+            "multiplexing: sending events to muxers for the last time {} "
+            "events to send",
+            _kiew.size());
         _sending_to_subscribers = true;
         lock.unlock();
         std::promise<void> promise;

--- a/broker/core/src/multiplexing/muxer.cc
+++ b/broker/core/src/multiplexing/muxer.cc
@@ -145,7 +145,7 @@ void muxer::ack_events(int count) {
       --_events_size;
     }
     log_v2::core()->trace("multiplexing: still {} events in {} event queue",
-                              _events_size, _name);
+                          _events_size, _name);
 
     // Fill memory from file.
     std::shared_ptr<io::data> e;
@@ -200,6 +200,7 @@ uint32_t muxer::event_queue_max_size() noexcept {
  */
 void muxer::publish(const std::shared_ptr<io::data> event) {
   if (event) {
+    log_v2::core()->trace("muxer::publish {} publish one event", _name);
     std::lock_guard<std::mutex> lock(_mutex);
     // Check if we should process this event.
     if (_write_filters.find(event->type()) == _write_filters.end())

--- a/broker/core/src/processing/acceptor.cc
+++ b/broker/core/src/processing/acceptor.cc
@@ -248,3 +248,19 @@ void acceptor::_callback() noexcept {
   _state = acceptor::finished;
   _state_cv.notify_all();
 }
+
+/**
+ * @brief
+ *
+ * @param ms_timeout
+ * @return true
+ * @return false
+ */
+bool acceptor::wait_for_all_events_written(unsigned ms_timeout) {
+  std::lock_guard<std::mutex> lock(_stat_mutex);
+  bool ret = true;
+  for (processing::feeder* to_wait : _feeders) {
+    ret &= to_wait->wait_for_all_events_written(ms_timeout);
+  }
+  return ret;
+}

--- a/broker/core/src/processing/failover.cc
+++ b/broker/core/src/processing/failover.cc
@@ -344,7 +344,7 @@ void failover::_run() {
             we = _stream->flush();
           }
           _muxer->ack_events(we);
-          ::usleep(100000);
+          ::usleep(idle_microsec_wait_idle_thread_delay);
         }
       }
     }
@@ -575,4 +575,12 @@ void failover::start() {
  */
 bool failover::should_exit() const {
   return _should_exit;
+}
+
+bool failover::wait_for_all_events_written(unsigned ms_timeout) {
+  std::lock_guard<std::timed_mutex> stream_lock(_stream_m);
+  if (_stream) {
+    return _stream->wait_for_all_events_written(ms_timeout);
+  }
+  return true;
 }

--- a/broker/core/src/processing/feeder.cc
+++ b/broker/core/src/processing/feeder.cc
@@ -189,7 +189,7 @@ void feeder::_callback() noexcept {
         log_v2::processing()->trace(
             "feeder '{}': timeout on stream and muxer, waiting for 100000µs",
             _name);
-        ::usleep(100000);
+        ::usleep(idle_microsec_wait_idle_thread_delay);
       }
     }
   } catch (exceptions::shutdown const& e) {
@@ -251,4 +251,12 @@ const char* feeder::get_state() const {
       return "finished";
   }
   return "unknown";
+}
+
+bool feeder::wait_for_all_events_written(unsigned ms_timeout) {
+  misc::read_lock lock(_client_m);
+  if (_client) {
+    return _client->wait_for_all_events_written(ms_timeout);
+  }
+  return true;
 }

--- a/broker/grpc/inc/com/centreon/broker/grpc/channel.hh
+++ b/broker/grpc/inc/com/centreon/broker/grpc/channel.hh
@@ -85,7 +85,7 @@ class channel : public std::enable_shared_from_this<channel> {
   grpc_config::pointer _conf;
 
   mutable std::mutex _protect;
-  mutable std::condition_variable _read_cond;
+  mutable std::condition_variable _read_cond, _write_cond;
 
   channel(const std::string& class_name, const grpc_config::pointer& conf);
 
@@ -120,6 +120,8 @@ class channel : public std::enable_shared_from_this<channel> {
   int write(const event_ptr&);
   int flush();
   virtual int stop();
+
+  bool wait_for_all_events_written(unsigned ms_timeout);
 };
 }  // namespace grpc
 

--- a/broker/grpc/inc/com/centreon/broker/grpc/stream.hh
+++ b/broker/grpc/inc/com/centreon/broker/grpc/stream.hh
@@ -53,6 +53,8 @@ class stream : public io::stream {
   int32_t stop() override;
 
   bool is_down() const;
+
+  bool wait_for_all_events_written(unsigned ms_timeout) override;
 };
 }  // namespace grpc
 

--- a/broker/grpc/src/channel.cc
+++ b/broker/grpc/src/channel.cc
@@ -228,6 +228,7 @@ void channel::on_write_done(bool ok) {
       _write_queue.pop_front();
       data_to_write = !_write_queue.empty();
     }
+    _write_cond.notify_all();
     if (data_to_write) {
       start_write();
     }
@@ -241,4 +242,19 @@ void channel::on_write_done(bool ok) {
 
 int channel::flush() {
   return 0;
+}
+
+/**
+ * @brief wait for all events sent on the wire
+ *
+ * @param ms_timeout
+ * @return true if all events are sent
+ * @return false if timeout expires
+ */
+bool channel::wait_for_all_events_written(unsigned ms_timeout) {
+  log_v2::grpc()->trace("wait_for_all_events_written _write_queue.size()={}",
+                        _write_queue.size());
+  unique_lock l(_protect);
+  return _write_cond.wait_for(l, std::chrono::milliseconds(ms_timeout),
+                              [this]() { return _write_queue.empty(); });
 }

--- a/broker/grpc/src/stream.cc
+++ b/broker/grpc/src/stream.cc
@@ -103,3 +103,19 @@ int32_t com::centreon::broker::grpc::stream::stop() {
 bool com::centreon::broker::grpc::stream::is_down() const {
   return _channel->is_down();
 }
+
+/**
+ * @brief wait for connection write queue empty
+ *
+ * @param ms_timeout
+ * @return true queue is empty
+ * @return false timeout expired
+ */
+bool com::centreon::broker::grpc::stream::wait_for_all_events_written(
+    unsigned ms_timeout) {
+  if (_channel->is_down()) {
+    return true;
+  }
+
+  return _channel->wait_for_all_events_written(ms_timeout);
+}

--- a/broker/tcp/inc/com/centreon/broker/tcp/stream.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/stream.hh
@@ -55,6 +55,7 @@ class stream : public io::stream {
   int32_t flush() override;
   int32_t stop() override;
   int32_t write(std::shared_ptr<io::data> const& d) override;
+  bool wait_for_all_events_written(unsigned ms_timeout) override;
 };
 }  // namespace tcp
 

--- a/broker/tcp/inc/com/centreon/broker/tcp/tcp_connection.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/tcp_connection.hh
@@ -37,6 +37,7 @@ class tcp_connection : public std::enable_shared_from_this<tcp_connection> {
   std::queue<std::vector<char>> _write_queue;
   std::atomic_bool _write_queue_has_events;
   std::atomic_bool _writing;
+  std::condition_variable _writing_cv;
 
   std::atomic<int32_t> _acks;
   std::atomic_bool _reading;
@@ -79,6 +80,8 @@ class tcp_connection : public std::enable_shared_from_this<tcp_connection> {
   const std::string peer() const;
   const std::string& address() const;
   uint16_t port() const;
+
+  bool wait_for_all_events_written(unsigned ms_timeout);
 };
 
 }  // namespace tcp

--- a/broker/tcp/src/stream.cc
+++ b/broker/tcp/src/stream.cc
@@ -194,3 +194,18 @@ int32_t stream::write(std::shared_ptr<io::data> const& d) {
   }
   return 1;
 }
+
+/**
+ * @brief wait for connection write queue empty
+ *
+ * @param ms_timeout
+ * @return true queue is empty
+ * @return false timeout expired
+ */
+bool stream::wait_for_all_events_written(unsigned ms_timeout) {
+  if (_connection->is_closed()) {
+    return true;
+  }
+
+  return _connection->wait_for_all_events_written(ms_timeout);
+}

--- a/broker/tcp/src/tcp_connection.cc
+++ b/broker/tcp/src/tcp_connection.cc
@@ -152,6 +152,21 @@ int32_t tcp_connection::write(const std::vector<char>& v) {
 }
 
 /**
+ * @brief wait for all events sent on the wire
+ *
+ * @param ms_timeout
+ * @return true if all events are sent
+ * @return false if timeout expires
+ */
+bool tcp_connection::wait_for_all_events_written(unsigned ms_timeout) {
+  log_v2::tcp()->trace("wait_for_all_events_written _writing={}", _writing);
+  std::mutex dummy;
+  std::unique_lock<std::mutex> l(dummy);
+  return _writing_cv.wait_for(l, std::chrono::milliseconds(ms_timeout),
+                              [this]() { return _writing == false; });
+}
+
+/**
  * @brief Execute the real writing on the socket. Infact, this function:
  *  * checks if the _write_queue is empty, and then exchanges its content with
  *    the _exposed_write_queue. No mutex is needed because if this function is
@@ -168,6 +183,7 @@ void tcp_connection::writing() {
   }
   if (!_write_queue_has_events) {
     _writing = false;
+    _writing_cv.notify_all();
     return;
   }
 

--- a/tests/broker-engine/start-stop.robot
+++ b/tests/broker-engine/start-stop.robot
@@ -38,7 +38,11 @@ BESS2
 	Start Engine
 	${result}=	Check Connections
 	Should Be True	${result}
+	${result}=  Check Poller Enabled In Database  1  5
+	Should Be True	${result}
 	Stop Engine
+	${result}=  Check Poller Disabled In Database  1  5
+	Should Be True	${result}
 	Kindly Stop Broker
 
 BESS3
@@ -52,7 +56,11 @@ BESS3
 	Start Broker
 	${result}=	Check Connections
 	Should Be True	${result}
+	${result}=  Check Poller Enabled In Database  1  10
+	Should Be True	${result}
 	Stop Engine
+	${result}=  Check Poller Disabled In Database  1  5
+	Should Be True	${result}
 	Kindly Stop Broker
 
 BESS4
@@ -65,6 +73,8 @@ BESS4
 	Start Engine
 	Start Broker
 	${result}=	Check Connections
+	Should Be True	${result}
+	${result}=  Check Poller Enabled In Database  1  10
 	Should Be True	${result}
 	Kindly Stop Broker
 	Stop Engine
@@ -84,263 +94,3 @@ BESS5
 	Kindly Stop Broker
 	Stop Engine
 
-BESS_GRPC1
-	[Documentation]	Start-Stop grpc version Broker/Engine - Broker started first - Broker stopped first
-	[Tags]	Broker	Engine	start-stop
-	Config Engine	${1}
-	Config Broker	central
-	Config Broker	module
-	Config Broker	rrd
-	Change Broker tcp output to grpc	central
-	Change Broker tcp output to grpc	module0
-	Change Broker tcp input to grpc     central
-	Change Broker tcp input to grpc     rrd
-	Start Broker
-	Start Engine
-	${result}=	Check Connections
-	Should Be True	${result}
-	Kindly Stop Broker
-	Stop Engine
-
-BESS_GRPC2
-	[Documentation]	Start-Stop grpc version Broker/Engine - Broker started first - Engine stopped first
-	[Tags]	Broker	Engine	start-stop
-	Config Engine	${1}
-	Config Broker	central
-	Config Broker	module
-	Config Broker	rrd
-	Change Broker tcp output to grpc	central
-	Change Broker tcp output to grpc	module0
-	Change Broker tcp input to grpc     central
-	Change Broker tcp input to grpc     rrd
-	Start Broker
-	Start Engine
-	${result}=	Check Connections
-	Should Be True	${result}
-	Stop Engine
-	Kindly Stop Broker
-
-BESS_GRPC3
-	[Documentation]	Start-Stop grpc version Broker/Engine - Engine started first - Engine stopped first
-	[Tags]	Broker	Engine	start-stop
-	Config Engine	${1}
-	Config Broker	central
-	Config Broker	module
-	Config Broker	rrd
-	Change Broker tcp output to grpc	central
-	Change Broker tcp output to grpc	module0
-	Change Broker tcp input to grpc     central
-	Change Broker tcp input to grpc     rrd
-	Start Engine
-	Start Broker
-	${result}=	Check Connections
-	Should Be True	${result}
-	Stop Engine
-	Kindly Stop Broker
-
-BESS_GRPC4
-	[Documentation]	Start-Stop grpc version Broker/Engine - Engine started first - Broker stopped first
-	[Tags]	Broker	Engine	start-stop
-	Config Engine	${1}
-	Config Broker	central
-	Config Broker	module
-	Config Broker	rrd
-	Change Broker tcp output to grpc	central
-	Change Broker tcp output to grpc	module0
-	Change Broker tcp input to grpc     central
-	Change Broker tcp input to grpc     rrd
-	Start Engine
-	Start Broker
-	${result}=	Check Connections
-	Should Be True	${result}
-	Kindly Stop Broker
-	Stop Engine
-
-BESS_GRPC5
-	[Documentation]	Start-Stop grpc version Broker/engine - Engine debug level is set to all, it should not hang
-	[Tags]	Broker	Engine	start-stop
-	Config Engine	${1}
-	Config Broker	central
-	Config Broker	module
-	Config Broker	rrd
-	Engine Config Set Value	${0}	debug_level	${-1}
-	Change Broker tcp output to grpc	central
-	Change Broker tcp output to grpc	module0
-	Change Broker tcp input to grpc     central
-	Change Broker tcp input to grpc     rrd
-	Start Broker
-	Start Engine
-	${result}=	Check Connections
-	Should Be True	${result}
-	Kindly Stop Broker
-	Stop Engine
-
-BESS_GRPC_COMPRESS1
-	[Documentation]	Start-Stop grpc version Broker/Engine - Broker started first - Broker stopped first compression activated
-	[Tags]	Broker	Engine	start-stop
-	Config Engine	${1}
-	Config Broker	central
-	Config Broker	module
-	Config Broker	rrd
-	Change Broker tcp output to grpc	central
-	Change Broker tcp output to grpc	module0
-	Change Broker tcp input to grpc     central
-	Change Broker tcp input to grpc     rrd
-	Change Broker Compression Output  module0  yes
-	Change Broker Compression Output  central  yes
-	Start Broker
-	Start Engine
-	${result}=	Check Connections
-	Should Be True	${result}
-	Kindly Stop Broker
-	Stop Engine
-
-
-BESS_CRYPTED_GRPC1
-	[Documentation]	Start-Stop grpc version Broker/Engine - well configured
-	[Tags]	Broker	Engine	start-stop
-	Config Engine	${1}
-	Config Broker	central
-	Config Broker	module
-	Config Broker	rrd
-	Copy File  ../broker/grpc/test/grpc_test_keys/ca_1234.crt  /tmp/
-	Copy File  ../broker/grpc/test/grpc_test_keys/server_1234.key  /tmp/
-	Copy File  ../broker/grpc/test/grpc_test_keys/server_1234.crt  /tmp/
-	Change Broker tcp output to grpc	central
-	Change Broker tcp output to grpc	module0
-	Change Broker tcp input to grpc     central
-	Change Broker tcp input to grpc     rrd
-	Add Broker tcp output grpc crypto  module0  True  False
-	Add Broker tcp input grpc crypto  central  True  False
-	Remove Host from broker output  module0  central-module-master-output
-	Add Host to broker output  module0  central-module-master-output  localhost
-	FOR	${i}	IN RANGE	0	5
-		Start Broker
-		Start Engine
-		${result}=	Check Connections
-		Should Be True	${result}
-		Kindly Stop Broker
-		Stop Engine
-	END
-
-BESS_CRYPTED_GRPC2
-	[Documentation]	Start-Stop grpc version Broker/Engine only server crypted
-	[Tags]	Broker	Engine	start-stop
-	Config Engine	${1}
-	Config Broker	central
-	Config Broker	module
-	Config Broker	rrd
-	Copy File  ../broker/grpc/test/grpc_test_keys/ca_1234.crt  /tmp/
-	Copy File  ../broker/grpc/test/grpc_test_keys/server_1234.key  /tmp/
-	Copy File  ../broker/grpc/test/grpc_test_keys/server_1234.crt  /tmp/
-	Change Broker tcp output to grpc	central
-	Change Broker tcp output to grpc	module0
-	Change Broker tcp input to grpc     central
-	Change Broker tcp input to grpc     rrd
-	Add Broker tcp input grpc crypto  central  True  False
-	FOR	${i}	IN RANGE	0	5
-		Start Broker
-		Start Engine
-		Sleep  2s
-		Kindly Stop Broker
-		Stop Engine
-	END
-
-BESS_CRYPTED_GRPC3
-	[Documentation]	Start-Stop grpc version Broker/Engine only engine crypted
-	[Tags]	Broker	Engine	start-stop
-	Config Engine	${1}
-	Config Broker	central
-	Config Broker	module
-	Config Broker	rrd
-	Copy File  ../broker/grpc/test/grpc_test_keys/ca_1234.crt  /tmp/
-	Copy File  ../broker/grpc/test/grpc_test_keys/server_1234.key  /tmp/
-	Copy File  ../broker/grpc/test/grpc_test_keys/server_1234.crt  /tmp/
-	Change Broker tcp output to grpc	central
-	Change Broker tcp output to grpc	module0
-	Change Broker tcp input to grpc     central
-	Change Broker tcp input to grpc     rrd
-	Add Broker tcp output grpc crypto  module0  True  False
-	FOR	${i}	IN RANGE	0	5
-		Start Broker
-		Start Engine
-		Sleep  2s
-		Kindly Stop Broker
-		Stop Engine
-	END
-
-BESS_CRYPTED_REVERSED_GRPC1
-	[Documentation]	Start-Stop grpc version Broker/Engine - well configured
-	[Tags]	Broker	Engine	start-stop
-	Config Engine	${1}
-	Config Broker	central
-	Config Broker	module
-	Config Broker	rrd
-	Copy File  ../broker/grpc/test/grpc_test_keys/ca_1234.crt  /tmp/
-	Copy File  ../broker/grpc/test/grpc_test_keys/server_1234.key  /tmp/
-	Copy File  ../broker/grpc/test/grpc_test_keys/server_1234.crt  /tmp/
-	Change Broker tcp output to grpc	central
-	Change Broker tcp output to grpc	module0
-	Change Broker tcp input to grpc     central
-	Change Broker tcp input to grpc     rrd
-	Add Broker tcp output grpc crypto  module0  True  True
-	Add Broker tcp input grpc crypto  central  True  True 
-	Add Host to broker input  central  central-broker-master-input  localhost
-	Remove Host from broker output  module0  central-module-master-output
-	FOR	${i}	IN RANGE	0	5
-		Start Broker
-		Start Engine
-		${result}=	Check Connections
-		Should Be True	${result}
-		Sleep  2s
-		Kindly Stop Broker
-		Stop Engine
-	END
-
-BESS_CRYPTED_REVERSED_GRPC2
-	[Documentation]	Start-Stop grpc version Broker/Engine only engine server crypted
-	[Tags]	Broker	Engine	start-stop
-	Config Engine	${1}
-	Config Broker	central
-	Config Broker	module
-	Config Broker	rrd
-	Copy File  ../broker/grpc/test/grpc_test_keys/ca_1234.crt  /tmp/
-	Copy File  ../broker/grpc/test/grpc_test_keys/server_1234.key  /tmp/
-	Copy File  ../broker/grpc/test/grpc_test_keys/server_1234.crt  /tmp/
-	Change Broker tcp output to grpc	central
-	Change Broker tcp output to grpc	module0
-	Change Broker tcp input to grpc     central
-	Change Broker tcp input to grpc     rrd
-	Add Broker tcp output grpc crypto  module0  True  True
-	Add Host to broker input  central  central-broker-master-input  localhost
-	Remove Host from broker output  module0  central-module-master-output
-	FOR	${i}	IN RANGE	0	5
-		Start Broker
-		Start Engine
-		Sleep  5s
-		Kindly Stop Broker
-		Stop Engine
-	END
-
-BESS_CRYPTED_REVERSED_GRPC3
-	[Documentation]	Start-Stop grpc version Broker/Engine only engine crypted
-	[Tags]	Broker	Engine	start-stop
-	Config Engine	${1}
-	Config Broker	central
-	Config Broker	module
-	Config Broker	rrd
-	Copy File  ../broker/grpc/test/grpc_test_keys/ca_1234.crt  /tmp/
-	Change Broker tcp output to grpc	central
-	Change Broker tcp output to grpc	module0
-	Change Broker tcp input to grpc     central
-	Change Broker tcp input to grpc     rrd
-	Add Broker tcp input grpc crypto  central  True  True 
-	Add Host to broker input  central  central-broker-master-input  localhost
-	Remove Host from broker output  module0  central-module-master-output
-	FOR	${i}	IN RANGE	0	5
-		Start Broker
-		Start Engine
-		Sleep  5s
-		Kindly Stop Broker
-		Stop Engine
-	END


### PR DESCRIPTION
## Description

**Fixes**
When you have a poller on a server with one core and a cbd on another server, if you shutdown engine, cbd don't receive engine bye message
So I have added wait methods on grpc and tcp modules and an usleep on config::applier::endpoint::_discard to wait one loop of failover and feeders threads.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [X] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

In order to test install a poller on a one core VM, insall a cbd on another VM. In the poller screen, you have to see the poller shutdown when you shurdown the distant poller.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

