### PR TITLE
MON-13875 lua stream connector accept empty parameters

### DIFF
--- a/broker/lua/src/factory.cc
+++ b/broker/lua/src/factory.cc
@@ -83,18 +83,14 @@ io::endpoint* factory::new_endpoint(
     throw msg_fmt("lua: couldn't read a configuration json");
 
   if (js.is_object()) {
-    json const& name{js["name"]};
-    json const& type{js["type"]};
-    json const& value{js["value"]};
+    json const& name{js.at("name")};
+    json const& type{js.at("type")};
+    json const& value{js.at("value")};
 
     if (name.get<std::string>().empty())
       throw msg_fmt(
           "lua: couldn't read a configuration field because"
           " its name is empty");
-    if (value.get<std::string>().empty())
-      throw msg_fmt(
-          "lua: couldn't read a configuration field because"
-          "' configuration field because its value is empty");
     std::string t((type.get<std::string>().empty()) ? "string"
                                                     : type.get<std::string>());
     if (t == "string" || t == "password")
@@ -131,18 +127,14 @@ io::endpoint* factory::new_endpoint(
     }
   } else if (js.is_array()) {
     for (json const& obj : js) {
-      json const& name{obj["name"]};
-      json const& type{obj["type"]};
-      json const& value{obj["value"]};
+      json const& name{obj.at("name")};
+      json const& type{obj.at("type")};
+      json const& value{obj.at("value")};
 
       if (name.get<std::string>().empty())
         throw msg_fmt(
             "lua: couldn't read a configuration field because"
             " its name is empty");
-      if (value.get<std::string>().empty())
-        throw msg_fmt(
-            "lua: couldn't read a configuration field because"
-            " its value is empty");
       std::string t((type.get<std::string>().empty())
                         ? "string"
                         : type.get<std::string>());


### PR DESCRIPTION
## Description

stream lua connector doesn't allow empty conf param.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [X] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>


## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

