### PR TITLE
MON-13875 lua stream connector accept empty parameters(21.10)

### DIFF
--- a/centreon-broker/lua/src/factory.cc
+++ b/centreon-broker/lua/src/factory.cc
@@ -85,18 +85,14 @@ io::endpoint* factory::new_endpoint(
     throw msg_fmt("lua: couldn't read a configuration json");
 
   if (js.is_object()) {
-    json const& name{js["name"]};
-    json const& type{js["type"]};
-    json const& value{js["value"]};
+    json const& name{js.at("name")};
+    json const& type{js.at("type")};
+    json const& value{js.at("value")};
 
     if (name.get<std::string>().empty())
       throw msg_fmt(
           "lua: couldn't read a configuration field because"
           " its name is empty");
-    if (value.get<std::string>().empty())
-      throw msg_fmt(
-          "lua: couldn't read a configuration field because"
-          "' configuration field because its value is empty");
     std::string t((type.get<std::string>().empty()) ? "string"
                                                     : type.get<std::string>());
     if (t == "string" || t == "password")
@@ -133,18 +129,14 @@ io::endpoint* factory::new_endpoint(
     }
   } else if (js.is_array()) {
     for (json const& obj : js) {
-      json const& name{obj["name"]};
-      json const& type{obj["type"]};
-      json const& value{obj["value"]};
+      json const& name{obj.at("name")};
+      json const& type{obj.at("type")};
+      json const& value{obj.at("value")};
 
       if (name.get<std::string>().empty())
         throw msg_fmt(
             "lua: couldn't read a configuration field because"
             " its name is empty");
-      if (value.get<std::string>().empty())
-        throw msg_fmt(
-            "lua: couldn't read a configuration field because"
-            " its value is empty");
       std::string t((type.get<std::string>().empty())
                         ? "string"
                         : type.get<std::string>());


### PR DESCRIPTION
## Description

lua stream connector now accept empty strings for connector params

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.04.x
- [X] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

