### PR TITLE
MON-14511 poller wait at most 5s to send goodbye to broker before shu…

### DIFF
--- a/centreon-broker/core/inc/com/centreon/broker/io/stream.hh
+++ b/centreon-broker/core/inc/com/centreon/broker/io/stream.hh
@@ -77,6 +77,8 @@ class stream {
   bool validate(std::shared_ptr<io::data> const& d, std::string const& error);
   virtual int write(std::shared_ptr<data> const& d) = 0;
   const std::string& get_name() const { return _name; }
+
+  virtual bool wait_for_all_events_written(unsigned ms_timeout);
 };
 }  // namespace io
 

--- a/centreon-broker/core/inc/com/centreon/broker/processing/acceptor.hh
+++ b/centreon-broker/core/inc/com/centreon/broker/processing/acceptor.hh
@@ -88,6 +88,7 @@ class acceptor : public endpoint {
   void set_read_filters(std::unordered_set<uint32_t> const& filters);
   void set_retry_interval(time_t retry_interval);
   void set_write_filters(std::unordered_set<uint32_t> const& filters);
+  bool wait_for_all_events_written(unsigned ms_timeout) override;
 };
 }  // namespace processing
 

--- a/centreon-broker/core/inc/com/centreon/broker/processing/endpoint.hh
+++ b/centreon-broker/core/inc/com/centreon/broker/processing/endpoint.hh
@@ -36,6 +36,8 @@ class endpoint : public stat_visitable {
   virtual void update() {}
   virtual void start() = 0;
   virtual void exit() = 0;
+
+  virtual bool wait_for_all_events_written(unsigned) { return true; }
 };
 }  // namespace processing
 

--- a/centreon-broker/core/inc/com/centreon/broker/processing/failover.hh
+++ b/centreon-broker/core/inc/com/centreon/broker/processing/failover.hh
@@ -79,6 +79,7 @@ class failover : public endpoint {
   void set_failover(std::shared_ptr<processing::failover> fo);
   void set_retry_interval(time_t retry_interval);
   void update() override;
+  bool wait_for_all_events_written(unsigned ms_timeout) override;
 
  protected:
   // From stat_visitable

--- a/centreon-broker/core/inc/com/centreon/broker/processing/feeder.hh
+++ b/centreon-broker/core/inc/com/centreon/broker/processing/feeder.hh
@@ -79,6 +79,8 @@ class feeder : public stat_visitable {
   feeder& operator=(const feeder&) = delete;
   bool is_finished() const noexcept;
   const char* get_state() const;
+
+  bool wait_for_all_events_written(unsigned ms_timeout);
 };
 }  // namespace processing
 

--- a/centreon-broker/core/inc/com/centreon/broker/processing/stat_visitable.hh
+++ b/centreon-broker/core/inc/com/centreon/broker/processing/stat_visitable.hh
@@ -54,6 +54,8 @@ class stat_visitable {
   virtual void _forward_statistic(nlohmann::json& tree);
 
  public:
+  static constexpr unsigned idle_microsec_wait_idle_thread_delay = 100000;
+
   stat_visitable(std::string const& name = std::string());
   virtual ~stat_visitable() noexcept = default;
   stat_visitable(stat_visitable const& other) = delete;

--- a/centreon-broker/core/src/io/stream.cc
+++ b/centreon-broker/core/src/io/stream.cc
@@ -106,3 +106,18 @@ bool stream::validate(std::shared_ptr<io::data> const& d,
   }
   return true;
 }
+
+/**
+ * @brief if it has a substream, it waits until the substream has sent all data
+ * on the wire
+ *
+ * @param ms_timeout
+ * @return true all data sent
+ * @return false timeout expires
+ */
+bool stream::wait_for_all_events_written(unsigned ms_timeout) {
+  if (_substream) {
+    return _substream->wait_for_all_events_written(ms_timeout);
+  }
+  return true;
+}

--- a/centreon-broker/core/src/processing/acceptor.cc
+++ b/centreon-broker/core/src/processing/acceptor.cc
@@ -248,3 +248,19 @@ void acceptor::_callback() noexcept {
   _state = acceptor::finished;
   _state_cv.notify_all();
 }
+
+/**
+ * @wait ms_timeout ms for all events sent
+ *
+ * @param ms_timeout
+ * @return true
+ * @return false
+ */
+bool acceptor::wait_for_all_events_written(unsigned ms_timeout) {
+  std::lock_guard<std::mutex> lock(_stat_mutex);
+  bool ret = true;
+  for (processing::feeder* to_wait : _feeders) {
+    ret &= to_wait->wait_for_all_events_written(ms_timeout);
+  }
+  return ret;
+}

--- a/centreon-broker/core/src/processing/failover.cc
+++ b/centreon-broker/core/src/processing/failover.cc
@@ -345,7 +345,7 @@ void failover::_run() {
             we = _stream->flush();
           }
           _subscriber->get_muxer().ack_events(we);
-          ::usleep(100000);
+          ::usleep(idle_microsec_wait_idle_thread_delay);
         }
       }
     }
@@ -598,4 +598,12 @@ void failover::start() {
  */
 bool failover::should_exit() const {
   return _should_exit;
+}
+
+bool failover::wait_for_all_events_written(unsigned ms_timeout) {
+  std::lock_guard<std::timed_mutex> stream_lock(_stream_m);
+  if (_stream) {
+    return _stream->wait_for_all_events_written(ms_timeout);
+  }
+  return true;
 }

--- a/centreon-broker/core/src/processing/feeder.cc
+++ b/centreon-broker/core/src/processing/feeder.cc
@@ -192,7 +192,7 @@ void feeder::_callback() noexcept {
         log_v2::processing()->trace(
             "feeder '{}': timeout on stream and muxer, waiting for 100000µs",
             _name);
-        ::usleep(100000);
+        ::usleep(idle_microsec_wait_idle_thread_delay);
       }
     }
   } catch (exceptions::shutdown const& e) {
@@ -254,4 +254,12 @@ const char* feeder::get_state() const {
       return "finished";
   }
   return "unknown";
+}
+
+bool feeder::wait_for_all_events_written(unsigned ms_timeout) {
+  misc::read_lock lock(_client_m);
+  if (_client) {
+    return _client->wait_for_all_events_written(ms_timeout);
+  }
+  return true;
 }

--- a/centreon-broker/tcp/inc/com/centreon/broker/tcp/stream.hh
+++ b/centreon-broker/tcp/inc/com/centreon/broker/tcp/stream.hh
@@ -59,6 +59,7 @@ class stream : public io::stream {
   int32_t flush() override;
   int32_t stop() override;
   int32_t write(std::shared_ptr<io::data> const& d) override;
+  bool wait_for_all_events_written(unsigned ms_timeout) override;
 };
 }  // namespace tcp
 

--- a/centreon-broker/tcp/inc/com/centreon/broker/tcp/tcp_connection.hh
+++ b/centreon-broker/tcp/inc/com/centreon/broker/tcp/tcp_connection.hh
@@ -41,6 +41,7 @@ class tcp_connection : public std::enable_shared_from_this<tcp_connection> {
   std::queue<std::vector<char>> _write_queue;
   std::atomic_bool _write_queue_has_events;
   std::atomic_bool _writing;
+  std::condition_variable _writing_cv;
 
   std::atomic<int32_t> _acks;
   std::atomic_bool _reading;
@@ -83,6 +84,8 @@ class tcp_connection : public std::enable_shared_from_this<tcp_connection> {
   const std::string peer() const;
   const std::string& address() const;
   uint16_t port() const;
+
+  bool wait_for_all_events_written(unsigned ms_timeout);
 };
 
 }  // namespace tcp

--- a/centreon-broker/tcp/src/stream.cc
+++ b/centreon-broker/tcp/src/stream.cc
@@ -199,3 +199,18 @@ int32_t stream::write(std::shared_ptr<io::data> const& d) {
   }
   return 1;
 }
+
+/**
+ * @brief wait for connection write queue empty
+ *
+ * @param ms_timeout
+ * @return true queue is empty
+ * @return false timeout expired
+ */
+bool stream::wait_for_all_events_written(unsigned ms_timeout) {
+  if (_connection->is_closed()) {
+    return true;
+  }
+
+  return _connection->wait_for_all_events_written(ms_timeout);
+}

--- a/centreon-broker/tcp/src/tcp_connection.cc
+++ b/centreon-broker/tcp/src/tcp_connection.cc
@@ -201,6 +201,21 @@ int32_t tcp_connection::write(const std::vector<char>& v) {
 }
 
 /**
+ * @brief wait for all events sent on the wire
+ *
+ * @param ms_timeout
+ * @return true if all events are sent
+ * @return false if timeout expires
+ */
+bool tcp_connection::wait_for_all_events_written(unsigned ms_timeout) {
+  log_v2::tcp()->trace("wait_for_all_events_written _writing={}", _writing);
+  std::mutex dummy;
+  std::unique_lock<std::mutex> l(dummy);
+  return _writing_cv.wait_for(l, std::chrono::milliseconds(ms_timeout),
+                              [this]() { return _writing == false; });
+}
+
+/**
  * @brief Execute the real writing on the socket. Infact, this function:
  *  * checks if the _write_queue is empty, and then exchanges its content with
  *    the _exposed_write_queue. No mutex is needed because if this function is
@@ -217,6 +232,7 @@ void tcp_connection::writing() {
   }
   if (!_write_queue_has_events) {
     _writing = false;
+    _writing_cv.notify_all();
     return;
   }
 


### PR DESCRIPTION
## Description

When a distant poller shutdowns, sometimes broker doesn't receive endloop engine event. So Engine try to flush all his queues and waits up to 5s before shutdown

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.04.x
- [X] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

