### PR TITLE
fix(broker/log_v2): it is now possible to change the log level live

### DIFF
--- a/broker/core/inc/com/centreon/broker/broker_impl.hh
+++ b/broker/core/inc/com/centreon/broker/broker_impl.hh
@@ -94,6 +94,12 @@ class broker_impl final : public Broker::Service {
                             __attribute__((unused)),
                             const GenericNameOrIndex* request,
                             ::google::protobuf::Empty* response) override;
+  grpc::Status GetLogInfo(grpc::ServerContext* context [[maybe_unused]],
+                          const GenericString* request,
+                          LogInfo* response) override;
+  grpc::Status SetLogLevel(grpc::ServerContext* context [[maybe_unused]],
+                           const LogLevel* request,
+                           ::google::protobuf::Empty*) override;
 
  public:
   void set_broker_name(const std::string& s);

--- a/broker/core/inc/com/centreon/broker/log_v2.hh
+++ b/broker/core/inc/com/centreon/broker/log_v2.hh
@@ -79,6 +79,8 @@ class log_v2 {
   static std::shared_ptr<spdlog::logger> grpc();
   static bool contains_logger(const std::string& logger);
   static bool contains_level(const std::string& level);
+  std::vector<std::pair<std::string, std::string>> levels() const;
+  void set_level(const std::string& logger, const std::string& level);
 };
 
 CCB_END();

--- a/broker/core/src/broker.proto
+++ b/broker/core/src/broker.proto
@@ -47,12 +47,33 @@ service Broker {
    * @return An Empty object.
    */
   rpc RemovePoller(GenericNameOrIndex) returns (google.protobuf.Empty) {}
+
+  /**
+   * @brief Retrieve some informations about loggers. If a name is specified,
+   * Informations are concentrated on the logger of that name.
+   *
+   * @param A logger name.
+   *
+   * @return A LogInfo message.
+   */
+  rpc GetLogInfo(GenericString) returns (LogInfo) {}
+  rpc SetLogLevel(LogLevel) returns (google.protobuf.Empty) {}
 }
 
 message Version {
   int32 major = 1;
   int32 minor = 2;
   int32 patch = 3;
+}
+
+message LogInfo {
+  string log_file = 1;
+  map<string, string> level = 2;
+}
+
+message LogLevel {
+  string logger = 1;
+  string level = 2;
 }
 
 message GenericString {

--- a/broker/core/src/broker.proto
+++ b/broker/core/src/broker.proto
@@ -57,6 +57,14 @@ service Broker {
    * @return A LogInfo message.
    */
   rpc GetLogInfo(GenericString) returns (LogInfo) {}
+
+  /**
+   * @brief Set a new level to the given logger.
+   *
+   * @param A message with a logger and a level as strings.
+   *
+   * @return nothing.
+   */
   rpc SetLogLevel(LogLevel) returns (google.protobuf.Empty) {}
 }
 

--- a/broker/core/src/broker_impl.cc
+++ b/broker/core/src/broker_impl.cc
@@ -272,3 +272,44 @@ grpc::Status broker_impl::RemovePoller(grpc::ServerContext* context
   pblshr.write(e);
   return grpc::Status::OK;
 }
+
+grpc::Status broker_impl::GetLogInfo(grpc::ServerContext* context
+                                     [[maybe_unused]],
+                                     const GenericString* request,
+                                     LogInfo* response) {
+  auto& name{request->str_arg()};
+  auto& map = *response->mutable_level();
+  auto lvs = log_v2::instance().levels();
+  response->set_log_file(log_v2::instance().log_name());
+  if (!name.empty()) {
+    auto found = std::find_if(lvs.begin(), lvs.end(),
+                              [&name](std::pair<std::string, std::string>& p) {
+                                return p.first == name;
+                              });
+    if (found != lvs.end()) {
+      map[name] = std::move(found->second);
+      return grpc::Status::OK;
+    } else {
+      std::string msg{fmt::format("'{}' is not a logger in broker", name)};
+      return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, msg);
+    }
+  } else {
+    for (auto& p : lvs)
+      map[p.first] = p.second;
+    return grpc::Status::OK;
+  }
+}
+
+grpc::Status broker_impl::SetLogLevel(grpc::ServerContext* context
+                                      [[maybe_unused]],
+                                      const LogLevel* request,
+                                      ::google::protobuf::Empty*) {
+  const std::string& logger = request->logger();
+  const std::string& level = request->level();
+  try {
+    log_v2::instance().set_level(logger, level);
+  } catch (const std::exception& e) {
+    return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, e.what());
+  }
+  return grpc::Status::OK;
+}

--- a/broker/core/src/broker_impl.cc
+++ b/broker/core/src/broker_impl.cc
@@ -304,10 +304,10 @@ grpc::Status broker_impl::SetLogLevel(grpc::ServerContext* context
                                       [[maybe_unused]],
                                       const LogLevel* request,
                                       ::google::protobuf::Empty*) {
-  const std::string& logger = request->logger();
-  const std::string& level = request->level();
+  const std::string& logger_name{request->logger()};
+  const std::string& level{request->level()};
   try {
-    log_v2::instance().set_level(logger, level);
+    log_v2::instance().set_level(logger_name, level);
   } catch (const std::exception& e) {
     return grpc::Status(grpc::StatusCode::INVALID_ARGUMENT, e.what());
   }

--- a/broker/core/src/log_v2.cc
+++ b/broker/core/src/log_v2.cc
@@ -418,10 +418,21 @@ std::shared_ptr<spdlog::logger> log_v2::grpc() {
   }
 }
 
+/**
+ * @brief Accessor to the log file.
+ *
+ * @return 
+ */
 const std::string& log_v2::log_name() const {
   return _log_name;
 }
 
+/**
+ * @brief Set the level of a logger.
+ *
+ * @param logger The logger name
+ * @param level The level as a string
+ */
 void log_v2::set_level(const std::string& logger, const std::string& level) {
   if (_running) {
     bool found = false;

--- a/broker/core/src/log_v2.cc
+++ b/broker/core/src/log_v2.cc
@@ -236,6 +236,12 @@ bool log_v2::contains_logger(const std::string& logger) {
   return std::find(loggers.begin(), loggers.end(), logger) != loggers.end();
 }
 
+/**
+ * @brief Accessor to the various levels of loggers
+ *
+ * @return A vector of pairs of strings. The first string is the logger name and
+ * the second string is its level.
+ */
 std::vector<std::pair<std::string, std::string>> log_v2::levels() const {
   std::vector<std::pair<std::string, std::string>> retval;
   if (_running) {

--- a/ccc/client.cc
+++ b/ccc/client.cc
@@ -59,8 +59,7 @@ client::client(std::shared_ptr<grpc::Channel> channel, bool color_enabled)
         &context, absl::StrFormat("/%s/GetVersion", sn), request_buf, &_cq);
     resp->StartCall();
     grpc::ByteBuffer resp_buf;
-    grpc::Status status1;
-    resp->Finish(&resp_buf, &status1, reinterpret_cast<void*>(1));
+    resp->Finish(&resp_buf, &status, reinterpret_cast<void*>(1));
 
     google::protobuf::DynamicMessageFactory factory;
 
@@ -192,7 +191,7 @@ std::string client::call(const std::string& cmd, const std::string& args) {
   auto resp = _stub->PrepareUnaryCall(&context, cmd_str, request_buf, &_cq);
   resp->StartCall();
   grpc::ByteBuffer resp_buf;
-  resp->Finish(&resp_buf, &status_res, static_cast<void*>(this));
+  resp->Finish(&resp_buf, &status_res, reinterpret_cast<void*>(1));
 
   void* tag;
   bool ok = false;

--- a/tests/broker/log.robot
+++ b/tests/broker/log.robot
@@ -28,3 +28,41 @@ BLDIS1
         ${result}=	Find In Log	${centralLog}	${start}	${content}
         Should Be Equal	${result[0]}	${False}	msg="We should not have core logs"
         Kindly Stop Broker
+
+BLEC1
+	[Documentation]	Change live the core level log from trace to debug
+	[Tags]	Broker	log-v2	grpc
+	Config Broker	central
+        Broker Config Log	central	core	trace
+        Broker Config Log	central	sql	debug
+        ${start}=	Get Current Date
+	Start Broker
+        ${result}=	Get Broker Log Level	51001	central	core
+        Should Be Equal	${result}	trace
+        Set Broker Log Level	51001	central	core	debug
+        ${result}=	Get Broker Log Level	51001	central	core
+        Should Be Equal	${result}	debug
+
+BLEC2
+	[Documentation]	Change live the core level log from trace to foo raises an error
+	[Tags]	Broker	log-v2	grpc
+	Config Broker	central
+        Broker Config Log	central	core	trace
+        Broker Config Log	central	sql	debug
+        ${start}=	Get Current Date
+	Start Broker
+        ${result}=	Get Broker Log Level	51001	central	core
+        Should Be Equal	${result}	trace
+        ${result}=	Set Broker Log Level	51001	central	core	foo
+        Should Be Equal	${result}	The 'foo' level is unknown
+
+BLEC3
+	[Documentation]	Change live the foo level log to trace raises an error
+	[Tags]	Broker	log-v2	grpc
+	Config Broker	central
+        Broker Config Log	central	core	trace
+        Broker Config Log	central	sql	debug
+        ${start}=	Get Current Date
+	Start Broker
+        ${result}=	Set Broker Log Level	51001	central	foo	trace
+        Should Be Equal	${result}	The 'foo' logger does not exist

--- a/tests/resources/Broker.py
+++ b/tests/resources/Broker.py
@@ -1620,3 +1620,42 @@ def check_poller_enabled_in_database(poller_id: int, timeout: int):
                     return True
         time.sleep(5)
     return False
+
+def get_broker_log_level(port, name, log, timeout=TIMEOUT):
+    limit = time.time() + timeout
+    while time.time() < limit:
+        logger.console("Try to call GetLogInfo")
+        time.sleep(1)
+        with grpc.insecure_channel("127.0.0.1:{}".format(port)) as channel:
+            stub = broker_pb2_grpc.BrokerStub(channel)
+            ref = broker_pb2.GenericString()
+            ref.str_arg = log
+            try:
+                res = stub.GetLogInfo(ref)
+                res = res.level[log]
+                return res
+                break
+            except:
+                logger.console("gRPC server not ready")
+
+
+def set_broker_log_level(port, name, log, level, timeout=TIMEOUT):
+    limit = time.time() + timeout
+    while time.time() < limit:
+        logger.console("Try to call SetLogLevel")
+        time.sleep(1)
+        with grpc.insecure_channel("127.0.0.1:{}".format(port)) as channel:
+            stub = broker_pb2_grpc.BrokerStub(channel)
+            ref = broker_pb2.LogLevel()
+            ref.logger = log
+            ref.level = level
+            try:
+                res = stub.SetLogLevel(ref)
+                break
+            except grpc.RpcError as rpc_error:
+                if rpc_error.code() == grpc.StatusCode.INVALID_ARGUMENT:
+                    res = rpc_error.details()
+                break
+            except:
+                logger.console("gRPC server not ready")
+    return res


### PR DESCRIPTION
## Description

Two new external commands for broker:
* GetLogInfo
* SetLogLevel

They can be used while broker is running without restart nor reload.

REFS: MON-15049.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
