### PR TITLE
MON-15083 default queries per transaction now is equal to 2000

### DIFF
--- a/broker/core/src/database_config.cc
+++ b/broker/core/src/database_config.cc
@@ -137,12 +137,12 @@ database_config::database_config(config::endpoint const& cfg) {
     } catch (std::exception const& e) {
       log_v2::core()->error(
           "queries_per_transaction is a number but must be given as a string. "
-          "Unable to read the value '{}' - value 10000 taken by default.",
+          "Unable to read the value '{}' - value 2000 taken by default.",
           it->second);
-      _queries_per_transaction = 10000;
+      _queries_per_transaction = 2000;
     }
   } else
-    _queries_per_transaction = 10000;
+    _queries_per_transaction = 2000;
 
   // check_replication
   it = cfg.params.find("check_replication");


### PR DESCRIPTION
## Description

Default queries per transaction now is equal to 2000

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [X] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

