### PR TITLE
fix(broker/retry_interval): default value set to 15s

### DIFF
--- a/broker/core/inc/com/centreon/broker/processing/acceptor.hh
+++ b/broker/core/inc/com/centreon/broker/processing/acceptor.hh
@@ -53,7 +53,7 @@ class acceptor : public endpoint {
   std::list<processing::feeder*> _feeders;
   absl::flat_hash_set<uint32_t> _read_filters;
   std::string _read_filters_str;
-  time_t _retry_interval;
+  time_t _retry_interval = 15;
   absl::flat_hash_set<uint32_t> _write_filters;
   std::string _write_filters_str;
   std::atomic_bool _listening;

--- a/broker/core/inc/com/centreon/broker/processing/failover.hh
+++ b/broker/core/inc/com/centreon/broker/processing/failover.hh
@@ -96,7 +96,7 @@ class failover : public endpoint {
   bool _failover_launched;
   volatile bool _initialized;
   time_t _next_timeout;
-  volatile time_t _retry_interval;
+  volatile time_t _retry_interval = 15;
   std::shared_ptr<multiplexing::muxer> _muxer;
   volatile bool _update;
 

--- a/broker/core/src/processing/acceptor.cc
+++ b/broker/core/src/processing/acceptor.cc
@@ -38,8 +38,7 @@ acceptor::acceptor(std::shared_ptr<io::endpoint> endp, std::string const& name)
     : endpoint(true, name),
       _state(stopped),
       _should_exit(false),
-      _endp(endp),
-      _retry_interval(30) {}
+      _endp(endp) {}
 
 /**
  *  Destructor.

--- a/broker/core/src/processing/failover.cc
+++ b/broker/core/src/processing/failover.cc
@@ -46,7 +46,6 @@ failover::failover(std::shared_ptr<io::endpoint> endp,
       _failover_launched(false),
       _initialized(false),
       _next_timeout(0),
-      _retry_interval(30),
       _muxer(mux),
       _update(false) {
   log_v2::core()->trace("failover '{}' construction.", _name);


### PR DESCRIPTION
## Description

Retry interval default value set to 15s.

REFS: MON-12130

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
