### PR TITLE
fix(engine/logs): notification logs too verbose

### DIFF
--- a/ci/scripts/collect-rpm-delivery.sh
+++ b/ci/scripts/collect-rpm-delivery.sh
@@ -25,13 +25,13 @@ CONNECTOREL8RPMS=`echo output/*connector*.el8.*.rpm`
 # Publish RPMs
 if [ "$BUILD" '=' 'QA' ]
 then
-  put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $ENGINEEL7RPMS
+  put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $COLLECTEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "clib" "centreon-clib-$VERSION-$RELEASE" $CLIBEL7RPMS
 
-  put_rpms "standard" "$MAJOR" "el8" "unstable" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $ENGINEEL8RPMS
+  put_rpms "standard" "$MAJOR" "el8" "unstable" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $COLLECTEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "unstable" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "unstable" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "unstable" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL8RPMS
@@ -39,26 +39,26 @@ then
 elif [ "$BUILD" '=' 'RELEASE' ]
 then
   copy_internal_source_to_testing "standard" "centreon-collect" "centreon-collect-$VERSION-$RELEASE"
-  put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $ENGINEEL7RPMS
+  put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $COLLECTEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "clib" "centreon-clib-$VERSION-$RELEASE" $CLIBEL7RPMS
 
-  put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $ENGINEEL8RPMS
+  put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $COLLECTEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "clib" "centreon-clib-$VERSION-$RELEASE" $CLIBEL8RPMS
 
 else
-  put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $ENGINEEL7RPMS
+  put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $COLLECTEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "clib" "centreon-clib-$VERSION-$RELEASE" $CLIBEL7RPMS
 
-  put_rpms "standard" "$MAJOR" "el8" "canary" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $ENGINEEL8RPMS
+  put_rpms "standard" "$MAJOR" "el8" "canary" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $COLLECTEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "canary" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "canary" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "canary" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL8RPMS

--- a/ci/scripts/collect-rpm-delivery.sh
+++ b/ci/scripts/collect-rpm-delivery.sh
@@ -11,6 +11,8 @@ if [ -z "$VERSION" -o -z "$RELEASE" ] ; then
 fi
 
 MAJOR=`echo $VERSION | cut -d . -f 1,2`
+COLLECTEL7RPMS=`echo output/*collect*.el7.*.rpm`
+COLLECTEL8RPMS=`echo output/*collect*.el8.*.rpm`
 ENGINEEL7RPMS=`echo output/*engine*.el7.*.rpm`
 ENGINEEL8RPMS=`echo output/*engine*.el8.*.rpm`
 BROKEREL7RPMS=`echo output/*broker*.el7.*.rpm`
@@ -23,11 +25,13 @@ CONNECTOREL8RPMS=`echo output/*connector*.el8.*.rpm`
 # Publish RPMs
 if [ "$BUILD" '=' 'QA' ]
 then
+  put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $ENGINEEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "clib" "centreon-clib-$VERSION-$RELEASE" $CLIBEL7RPMS
 
+  put_rpms "standard" "$MAJOR" "el8" "unstable" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $ENGINEEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "unstable" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "unstable" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "unstable" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL8RPMS
@@ -35,22 +39,26 @@ then
 elif [ "$BUILD" '=' 'RELEASE' ]
 then
   copy_internal_source_to_testing "standard" "centreon-collect" "centreon-collect-$VERSION-$RELEASE"
+  put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $ENGINEEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "clib" "centreon-clib-$VERSION-$RELEASE" $CLIBEL7RPMS
 
+  put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $ENGINEEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "clib" "centreon-clib-$VERSION-$RELEASE" $CLIBEL8RPMS
 
 else
+  put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $ENGINEEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "clib" "centreon-clib-$VERSION-$RELEASE" $CLIBEL7RPMS
-  
+
+  put_rpms "standard" "$MAJOR" "el8" "canary" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $ENGINEEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "canary" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "canary" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "canary" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL8RPMS

--- a/engine/src/host.cc
+++ b/engine/src/host.cc
@@ -2524,7 +2524,8 @@ int host::notify_contact(nagios_macros* mac,
   SPDLOG_LOGGER_TRACE(log_v2::functions(), "notify_contact_of_host()");
   engine_logger(dbg_notifications, most)
       << "** Notifying contact '" << cntct->get_name() << "'";
-  log_v2::notifications()->info("** Notifying contact '{}'", cntct->get_name());
+  log_v2::notifications()->debug("** Notifying contact '{}'",
+                                 cntct->get_name());
 
   /* get start time */
   gettimeofday(&start_time, nullptr);

--- a/engine/src/host.cc
+++ b/engine/src/host.cc
@@ -2568,7 +2568,7 @@ int host::notify_contact(nagios_macros* mac,
 
     engine_logger(dbg_notifications, most)
         << "Raw notification command: " << raw_command;
-    log_v2::notifications()->info("Raw notification command: {}", raw_command);
+    log_v2::notifications()->debug("Raw notification command: {}", raw_command);
 
     /* process any macros contained in the argument */
     process_macros_r(mac, raw_command, processed_command, macro_options);
@@ -2579,7 +2579,7 @@ int host::notify_contact(nagios_macros* mac,
 
     engine_logger(dbg_notifications, most)
         << "Processed notification command: " << processed_command;
-    log_v2::notifications()->info("Processed notification command: {}",
+    log_v2::notifications()->trace("Processed notification command: {}",
                                   processed_command);
 
     /* log the notification to program log file */

--- a/engine/src/service.cc
+++ b/engine/src/service.cc
@@ -3117,7 +3117,8 @@ int service::notify_contact(nagios_macros* mac,
   SPDLOG_LOGGER_TRACE(log_v2::functions(), "notify_contact_of_service()");
   engine_logger(dbg_notifications, most)
       << "** Notifying contact '" << cntct->get_name() << "'";
-  log_v2::notifications()->info("** Notifying contact '{}'", cntct->get_name());
+  log_v2::notifications()->debug("** Notifying contact '{}'",
+                                 cntct->get_name());
 
   /* get start time */
   gettimeofday(&start_time, nullptr);

--- a/engine/src/service.cc
+++ b/engine/src/service.cc
@@ -3161,7 +3161,7 @@ int service::notify_contact(nagios_macros* mac,
 
     engine_logger(dbg_notifications, most)
         << "Raw notification command: " << raw_command;
-    log_v2::notifications()->info("Raw notification command: {}", raw_command);
+    log_v2::notifications()->debug("Raw notification command: {}", raw_command);
 
     /* process any macros contained in the argument */
     process_macros_r(mac, raw_command, processed_command, macro_options);
@@ -3172,7 +3172,7 @@ int service::notify_contact(nagios_macros* mac,
 
     engine_logger(dbg_notifications, most)
         << "Processed notification command: " << processed_command;
-    log_v2::notifications()->info("Processed notification command: {}",
+    log_v2::notifications()->trace("Processed notification command: {}",
                                   processed_command);
 
     /* log the notification to program log file */


### PR DESCRIPTION
## Description

Notifications log levels have been changed to be less verbose.

REFS: MON-14956

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
