### PR TITLE
delete from hostgroups and servicegroups is delayed of one minute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ with the Engine configuration file.
 *core*
 
 Unknown filters applied in the configuration file do not hang broker anymore.
+Improve future usage
 
 *log*
 
@@ -48,8 +49,7 @@ If a logger was at the 'off'/'disabled' state, then broker did not start.
 
 *sql*
 
-Hostgroups and servicegroups are no more deleted during an instance restart.
-This could lead to issues when several pollers are restarted simultaneously.
+Hostgroups and servicegroups are deleted 5s after the last instance restart.
 
 Size of notes\_url, notes and action\_url columns are reviewed to match the
 web configuration.
@@ -70,6 +70,7 @@ too much.
 *lua*
 
 New function `broker.bbdo_version()` implemented in broker streamconnector.
+stream connector accepts empty parameters
 
 ### centreon-engine
 

--- a/centreon-broker/storage/inc/com/centreon/broker/storage/conflict_manager.hh
+++ b/centreon-broker/storage/inc/com/centreon/broker/storage/conflict_manager.hh
@@ -199,6 +199,9 @@ class conflict_manager {
       _metric_cache;
   std::mutex _metric_cache_m;
 
+  std::mutex _group_clean_timer_m;
+  asio::system_timer _group_clean_timer;
+
   std::unordered_set<uint32_t> _hostgroup_cache;
   std::unordered_set<uint32_t> _servicegroup_cache;
 
@@ -333,6 +336,7 @@ class conflict_manager {
   void _load_deleted_instances();
   void _load_caches();
   void _clean_tables(uint32_t instance_id);
+  void _clean_group_table();
   void _prepare_hg_insupdate_statement();
   void _prepare_sg_insupdate_statement();
   void _finish_action(int32_t conn, uint32_t action);

--- a/centreon-broker/storage/src/conflict_manager_sql.cc
+++ b/centreon-broker/storage/src/conflict_manager_sql.cc
@@ -40,6 +40,12 @@ using namespace com::centreon::broker::storage;
  *  @param[in] instance_id Instance ID to remove.
  */
 void conflict_manager::_clean_tables(uint32_t instance_id) {
+  // no hostgroup and servicegroup clean during this function
+  {
+    std::lock_guard<std::mutex> l(_group_clean_timer_m);
+    _group_clean_timer.cancel();
+  }
+
   /* Database version. */
 
   int32_t conn = _mysql.choose_connection_by_instance(instance_id);
@@ -167,6 +173,35 @@ void conflict_manager::_clean_tables(uint32_t instance_id) {
   _mysql.run_query(query, database::mysql_error::clean_customvariables, false,
                    conn);
   _add_action(conn, actions::custom_variables);
+
+  std::lock_guard<std::mutex> l(_group_clean_timer_m);
+  _group_clean_timer.expires_after(std::chrono::minutes(1));
+  _group_clean_timer.async_wait([this](const asio::error_code& err) {
+    if (!err) {
+      _clean_group_table();
+    }
+  });
+}
+
+void conflict_manager::_clean_group_table() {
+  int32_t conn = _mysql.choose_best_connection(-1);
+  /* Remove host groups. */
+  log_v2::sql()->debug("conflict_manager: remove empty host groups ");
+  _mysql.run_query(
+      "DELETE hg FROM hostgroups AS hg LEFT JOIN hosts_hostgroups AS hhg ON "
+      "hg.hostgroup_id=hhg.hostgroup_id WHERE hhg.hostgroup_id IS NULL",
+      database::mysql_error::clean_empty_hostgroups, false, conn);
+  _add_action(conn, actions::hostgroups);
+
+  /* Remove service groups. */
+  log_v2::sql()->debug("conflict_manager: remove empty service groups");
+
+  _mysql.run_query(
+      "DELETE sg FROM servicegroups AS sg LEFT JOIN services_servicegroups as "
+      "ssg ON sg.servicegroup_id=ssg.servicegroup_id WHERE ssg.servicegroup_id "
+      "IS NULL",
+      database::mysql_error::clean_empty_servicegroups, false, conn);
+  _add_action(conn, actions::servicegroups);
 }
 
 /**

--- a/tests/broker-engine/hostgroups.robot
+++ b/tests/broker-engine/hostgroups.robot
@@ -90,3 +90,59 @@ EBNHG4
 
 	Stop Engine
 	Kindly Stop Broker
+
+
+EBNHG5
+	[Documentation]	New host group with several pollers and connections to DB with broker and delete this hostgroup
+	[Tags]	Broker	Engine	hostgroup
+	Config Engine	${3}
+	Config Broker	rrd
+	Config Broker	central
+	Config Broker	module	${3}
+
+	Broker Config Log	central	sql	info
+	Broker Config Output Set	central	central-broker-master-sql	connections_count	5
+	Broker Config Output Set	central	central-broker-master-perfdata	connections_count	5
+	${start}=	Get Current Date
+	Start Broker
+	Start Engine
+	Sleep	3s
+	Add Host Group	${0}	${1}	["host_1", "host_2", "host_3"]
+
+	Reload Broker
+	Reload Engine
+
+	${content}=	Create List	enabling membership of host 3 to host group 1 on instance 1	enabling membership of host 2 to host group 1
+
+	${result}=	Find In Log With Timeout	${centralLog}	${start}	${content}	45
+	Should Be True	${result}	msg=One of the new host groups not found in logs.
+
+	Sleep	10s
+	${start}=	Get Current Date
+
+	Config Engine	${3}
+	Reload Broker
+	Reload Engine
+
+	Connect To Database	pymysql	${DBName}	${DBUser}	${DBPass}	${DBHost}	${DBPort}
+	Sleep	5s
+	FOR	${index}	IN RANGE	10
+	 Log To Console	SELECT count(*) FROM hosts_hostgroups 
+	 ${output}=	Query	SELECT count(*) FROM hosts_hostgroups 
+	 Log To Console	${output}
+	 Sleep	1s
+	 EXIT FOR LOOP IF	"${output}" == "((0,),)"
+	END
+	Should Be Equal As Strings	${output}	((0,),)
+
+	FOR	${index}	IN RANGE	60
+	 Log To Console	SELECT count(*) FROM hostgroups 
+	 ${output}=	Query	SELECT count(*) FROM hostgroups 
+	 Log To Console	${output}
+	 Sleep	1s
+	 EXIT FOR LOOP IF	"${output}" == "((0,),)"
+	END
+	Should Be Equal As Strings	${output}	((0,),)
+
+	Stop Engine
+	Kindly Stop Broker

--- a/tests/resources/Broker.py
+++ b/tests/resources/Broker.py
@@ -14,8 +14,6 @@ import json
 import glob
 import os.path
 import grpc
-import broker_pb2
-import broker_pb2_grpc
 from google.protobuf import empty_pb2
 from robot.libraries.BuiltIn import BuiltIn
 
@@ -441,7 +439,8 @@ def config_broker(name, poller_inst: int = 1):
             f.close()
     else:
         f = open("/etc/centreon-broker/{}".format(filename), "w")
-        f.write(config[name].format(broker_id, broker_name, DB_HOST, DB_PORT, DB_USER, DB_PASS, DB_NAME_STORAGE))
+        f.write(config[name].format(broker_id, broker_name,
+                DB_HOST, DB_PORT, DB_USER, DB_PASS, DB_NAME_STORAGE))
         f.close()
 
 

--- a/tests/resources/Engine.py
+++ b/tests/resources/Engine.py
@@ -10,8 +10,6 @@ import re
 import stat
 
 import grpc
-import engine_pb2
-import engine_pb2_grpc
 
 
 CONF_DIR = "/etc/centreon-engine"
@@ -1082,6 +1080,7 @@ def schedule_service_downtime(hst: str, svc: str, duration: int):
     f.write(cmd)
     f.close()
 
+
 def schedule_host_downtime(poller: int, hst: str, duration: int):
     now = int(time.time())
     cmd1 = "[{1}] SCHEDULE_HOST_DOWNTIME;{0};{1};{2};1;0;{3};admin;Downtime set by admin\n".format(
@@ -1092,6 +1091,7 @@ def schedule_host_downtime(poller: int, hst: str, duration: int):
     f.write(cmd1)
     f.write(cmd2)
     f.close()
+
 
 def delete_host_downtimes(poller: int, hst: str):
     now = int(time.time())


### PR DESCRIPTION
## Description

hostgroups and servicegroups are never cleaned. 
After hosts_hostgroup and services_servicegroups clean, hostgroups and servicegroups are cleand one minute later.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.04.x
- [X] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

