### PR TITLE
Mon 13819 backport to 22.04

### DIFF
--- a/ci/scripts/collect-rpm-delivery.sh
+++ b/ci/scripts/collect-rpm-delivery.sh
@@ -11,6 +11,8 @@ if [ -z "$VERSION" -o -z "$RELEASE" ] ; then
 fi
 
 MAJOR=`echo $VERSION | cut -d . -f 1,2`
+COLLECTEL7RPMS=`echo output/*collect*.el7.*.rpm`
+COLLECTEL8RPMS=`echo output/*collect*.el8.*.rpm`
 ENGINEEL7RPMS=`echo output/*engine*.el7.*.rpm`
 ENGINEEL8RPMS=`echo output/*engine*.el8.*.rpm`
 BROKEREL7RPMS=`echo output/*broker*.el7.*.rpm`
@@ -23,11 +25,13 @@ CONNECTOREL8RPMS=`echo output/*connector*.el8.*.rpm`
 # Publish RPMs
 if [ "$BUILD" '=' 'QA' ]
 then
+  put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $COLLECTEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "unstable" "x86_64" "clib" "centreon-clib-$VERSION-$RELEASE" $CLIBEL7RPMS
 
+  put_rpms "standard" "$MAJOR" "el8" "unstable" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $COLLECTEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "unstable" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "unstable" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "unstable" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL8RPMS
@@ -35,22 +39,26 @@ then
 elif [ "$BUILD" '=' 'RELEASE' ]
 then
   copy_internal_source_to_testing "standard" "centreon-collect" "centreon-collect-$VERSION-$RELEASE"
+  put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $COLLECTEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "testing" "x86_64" "clib" "centreon-clib-$VERSION-$RELEASE" $CLIBEL7RPMS
 
+  put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $COLLECTEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "testing" "x86_64" "clib" "centreon-clib-$VERSION-$RELEASE" $CLIBEL8RPMS
 
 else
+  put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $COLLECTEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL7RPMS
   put_rpms "standard" "$MAJOR" "el7" "canary" "x86_64" "clib" "centreon-clib-$VERSION-$RELEASE" $CLIBEL7RPMS
-  
+
+  put_rpms "standard" "$MAJOR" "el8" "canary" "x86_64" "collect" "centreon-collect-$VERSION-$RELEASE" $COLLECTEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "canary" "x86_64" "engine" "centreon-engine-$VERSION-$RELEASE" $ENGINEEL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "canary" "x86_64" "broker" "centreon-broker-$VERSION-$RELEASE" $BROKEREL8RPMS
   put_rpms "standard" "$MAJOR" "el8" "canary" "x86_64" "connector" "centreon-connector-$VERSION-$RELEASE" $CONNECTOREL8RPMS

--- a/tests/README.md
+++ b/tests/README.md
@@ -262,9 +262,9 @@ Here is the list of the currently implemented tests:
 - [x] **EBNSGU1**: New service group with several pollers and connections to DB with broker configured with unified_sql
 - [x] **EBNSGU2**: New service group with several pollers and connections to DB with broker configured with unified_sql
 - [x] **EBNSVC1**: New services with several pollers
-- [x] **EBSAU2**: New hosts with action_url with more than 2000 characters
-- [x] **EBSN3**: New hosts with notes with more than 500 characters
-- [x] **EBSNU1**: New hosts with notes_url with more than 2000 characters
+- [x] **EBSAU2**: New services with action_url with more than 2000 characters
+- [x] **EBSN3**: New services with notes with more than 500 characters
+- [x] **EBSNU1**: New services with notes_url with more than 2000 characters
 - [x] **ENRSCHE1**: check next check of reschedule is last_check+interval_check
 - [x] **LOGV2BE2**: log-v2 enabled old log enabled check broker sink is equal
 - [x] **LOGV2DB1**: log-v2 disabled old log enabled check broker sink


### PR DESCRIPTION
## Description

Delivery improved to deliver ccc and debuginfo packages.

REFS: MON-13819

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
