### PR TITLE
MON-14908 servicegroups and hostgroups are cleaned later

### DIFF
--- a/broker/storage/inc/com/centreon/broker/storage/conflict_manager.hh
+++ b/broker/storage/inc/com/centreon/broker/storage/conflict_manager.hh
@@ -205,6 +205,9 @@ class conflict_manager {
   absl::flat_hash_map<std::pair<uint64_t, uint16_t>, uint64_t> _severity_cache;
   absl::flat_hash_map<std::pair<uint64_t, uint16_t>, uint64_t> _tags_cache;
 
+  std::mutex _group_clean_timer_m;
+  asio::system_timer _group_clean_timer;
+
   std::unordered_set<uint32_t> _hostgroup_cache;
   std::unordered_set<uint32_t> _servicegroup_cache;
 
@@ -346,6 +349,7 @@ class conflict_manager {
   void _load_deleted_instances();
   void _load_caches();
   void _clean_tables(uint32_t instance_id);
+  void _clean_group_table();
   void _prepare_hg_insupdate_statement();
   void _prepare_sg_insupdate_statement();
   void _finish_action(int32_t conn, uint32_t action);

--- a/broker/storage/src/conflict_manager.cc
+++ b/broker/storage/src/conflict_manager.cc
@@ -99,6 +99,7 @@ conflict_manager::conflict_manager(database_config const& dbcfg,
       _instance_timeout{instance_timeout},
       _stats{stats::center::instance().register_conflict_manager()},
       _ref_count{0},
+      _group_clean_timer{pool::io_context()},
       _oldest_timestamp{std::numeric_limits<time_t>::max()} {
   log_v2::sql()->debug("conflict_manager: class instanciation");
   stats::center::instance().update(&ConflictManagerStats::set_loop_timeout,
@@ -110,6 +111,8 @@ conflict_manager::conflict_manager(database_config const& dbcfg,
 
 conflict_manager::~conflict_manager() {
   log_v2::sql()->debug("conflict_manager: destruction");
+  std::lock_guard<std::mutex> l(_group_clean_timer_m);
+  _group_clean_timer.cancel();
 }
 
 /**

--- a/broker/storage/src/conflict_manager_sql.cc
+++ b/broker/storage/src/conflict_manager_sql.cc
@@ -40,6 +40,12 @@ using namespace com::centreon::broker::storage;
  *  @param[in] instance_id Instance ID to remove.
  */
 void conflict_manager::_clean_tables(uint32_t instance_id) {
+  // no hostgroup and servicegroup clean during this function
+  {
+    std::lock_guard<std::mutex> l(_group_clean_timer_m);
+    _group_clean_timer.cancel();
+  }
+
   /* Database version. */
 
   _finish_action(-1, -1);
@@ -168,6 +174,35 @@ void conflict_manager::_clean_tables(uint32_t instance_id) {
   _mysql.run_query(query, database::mysql_error::clean_customvariables, false,
                    conn);
   _add_action(conn, actions::custom_variables);
+
+  std::lock_guard<std::mutex> l(_group_clean_timer_m);
+  _group_clean_timer.expires_after(std::chrono::minutes(1));
+  _group_clean_timer.async_wait([this](const asio::error_code& err) {
+    if (!err) {
+      _clean_group_table();
+    }
+  });
+}
+
+void conflict_manager::_clean_group_table() {
+  int32_t conn = _mysql.choose_best_connection(-1);
+  /* Remove host groups. */
+  log_v2::sql()->debug("conflict_manager: remove empty host groups ");
+  _mysql.run_query(
+      "DELETE hg FROM hostgroups AS hg LEFT JOIN hosts_hostgroups AS hhg ON "
+      "hg.hostgroup_id=hhg.hostgroup_id WHERE hhg.hostgroup_id IS NULL",
+      database::mysql_error::clean_empty_hostgroups, false, conn);
+  _add_action(conn, actions::hostgroups);
+
+  /* Remove service groups. */
+  log_v2::sql()->debug("conflict_manager: remove empty service groups");
+
+  _mysql.run_query(
+      "DELETE sg FROM servicegroups AS sg LEFT JOIN services_servicegroups as "
+      "ssg ON sg.servicegroup_id=ssg.servicegroup_id WHERE ssg.servicegroup_id "
+      "IS NULL",
+      database::mysql_error::clean_empty_servicegroups, false, conn);
+  _add_action(conn, actions::servicegroups);
 }
 
 /**

--- a/broker/unified_sql/inc/com/centreon/broker/unified_sql/stream.hh
+++ b/broker/unified_sql/inc/com/centreon/broker/unified_sql/stream.hh
@@ -224,6 +224,9 @@ class stream : public io::stream {
 
   absl::flat_hash_map<std::pair<uint64_t, uint64_t>, uint64_t> _resource_cache;
 
+  std::mutex _group_clean_timer_m;
+  asio::system_timer _group_clean_timer;
+
   absl::flat_hash_set<uint32_t> _hostgroup_cache;
   absl::flat_hash_set<uint32_t> _servicegroup_cache;
 
@@ -359,6 +362,7 @@ class stream : public io::stream {
   void _load_deleted_instances();
   void _load_caches();
   void _clean_tables(uint32_t instance_id);
+  void _clean_group_table();
   void _prepare_hg_insupdate_statement();
   void _prepare_sg_insupdate_statement();
   void _finish_action(int32_t conn, uint32_t action);


### PR DESCRIPTION
## Description

tables servicegroups and hostgroups are cleand one minute after the last service_servicegroups wash

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [X] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

