### PR TITLE
MON-14908-clean-servicegroups-and-hostgroups-later-dev-22.04x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Broker
 
+#### Enhancements
+
+*lua*
+stream connector accepts empty parameter values
+
 #### Fixes
 
 * Broker is no more blocked when rows with unexpected values are encountered.
@@ -16,9 +21,18 @@
 
 ### Engine
 
+#### Enhancements
+
+Anomaly detection can do the check if it's in a no ok state
 #### Fixes
 
 Engine waits up to 5 seconds to send bye event to broker
+
+### perl connector
+
+#### Fixes
+
+correct status is forwarded to engine
 
 ## 22.04.1
 

--- a/broker/storage/inc/com/centreon/broker/storage/conflict_manager.hh
+++ b/broker/storage/inc/com/centreon/broker/storage/conflict_manager.hh
@@ -200,6 +200,9 @@ class conflict_manager {
   absl::flat_hash_map<std::pair<uint64_t, uint16_t>, uint64_t> _severity_cache;
   absl::flat_hash_map<std::pair<uint64_t, uint16_t>, uint64_t> _tags_cache;
 
+  std::mutex _group_clean_timer_m;
+  asio::system_timer _group_clean_timer;
+
   std::unordered_set<uint32_t> _hostgroup_cache;
   std::unordered_set<uint32_t> _servicegroup_cache;
 
@@ -341,6 +344,7 @@ class conflict_manager {
   void _load_deleted_instances();
   void _load_caches();
   void _clean_tables(uint32_t instance_id);
+  void _clean_group_table();
   void _prepare_hg_insupdate_statement();
   void _prepare_sg_insupdate_statement();
   void _finish_action(int32_t conn, uint32_t action);

--- a/broker/storage/src/conflict_manager.cc
+++ b/broker/storage/src/conflict_manager.cc
@@ -99,6 +99,7 @@ conflict_manager::conflict_manager(database_config const& dbcfg,
       _instance_timeout{instance_timeout},
       _stats{stats::center::instance().register_conflict_manager()},
       _ref_count{0},
+      _group_clean_timer{pool::io_context()},
       _oldest_timestamp{std::numeric_limits<time_t>::max()} {
   log_v2::sql()->debug("conflict_manager: class instanciation");
   stats::center::instance().update(&ConflictManagerStats::set_loop_timeout,
@@ -110,6 +111,10 @@ conflict_manager::conflict_manager(database_config const& dbcfg,
 
 conflict_manager::~conflict_manager() {
   log_v2::sql()->debug("conflict_manager: destruction");
+  {
+    std::lock_guard<std::mutex> l(_group_clean_timer_m);
+    _group_clean_timer.cancel();
+  }
 }
 
 /**

--- a/broker/storage/src/conflict_manager_sql.cc
+++ b/broker/storage/src/conflict_manager_sql.cc
@@ -40,6 +40,12 @@ using namespace com::centreon::broker::storage;
  *  @param[in] instance_id Instance ID to remove.
  */
 void conflict_manager::_clean_tables(uint32_t instance_id) {
+  // no hostgroup and servicegroup clean during this function
+  {
+    std::lock_guard<std::mutex> l(_group_clean_timer_m);
+    _group_clean_timer.cancel();
+  }
+
   /* Database version. */
 
   _finish_action(-1, -1);
@@ -168,6 +174,35 @@ void conflict_manager::_clean_tables(uint32_t instance_id) {
   _mysql.run_query(query, database::mysql_error::clean_customvariables, false,
                    conn);
   _add_action(conn, actions::custom_variables);
+
+  std::lock_guard<std::mutex> l(_group_clean_timer_m);
+  _group_clean_timer.expires_after(std::chrono::minutes(1));
+  _group_clean_timer.async_wait([this](const asio::error_code& err) {
+    if (!err) {
+      _clean_group_table();
+    }
+  });
+}
+
+void conflict_manager::_clean_group_table() {
+  int32_t conn = _mysql.choose_best_connection(-1);
+  /* Remove host groups. */
+  log_v2::sql()->debug("conflict_manager: remove empty host groups ");
+  _mysql.run_query(
+      "DELETE hg FROM hostgroups AS hg LEFT JOIN hosts_hostgroups AS hhg ON "
+      "hg.hostgroup_id=hhg.hostgroup_id WHERE hhg.hostgroup_id IS NULL",
+      database::mysql_error::clean_empty_hostgroups, false, conn);
+  _add_action(conn, actions::hostgroups);
+
+  /* Remove service groups. */
+  log_v2::sql()->debug("conflict_manager: remove empty service groups");
+
+  _mysql.run_query(
+      "DELETE sg FROM servicegroups AS sg LEFT JOIN services_servicegroups as "
+      "ssg ON sg.servicegroup_id=ssg.servicegroup_id WHERE ssg.servicegroup_id "
+      "IS NULL",
+      database::mysql_error::clean_empty_servicegroups, false, conn);
+  _add_action(conn, actions::servicegroups);
 }
 
 /**

--- a/broker/unified_sql/inc/com/centreon/broker/unified_sql/stream.hh
+++ b/broker/unified_sql/inc/com/centreon/broker/unified_sql/stream.hh
@@ -225,6 +225,9 @@ class stream : public io::stream {
 
   absl::flat_hash_map<std::pair<uint64_t, uint64_t>, uint64_t> _resource_cache;
 
+  std::mutex _group_clean_timer_m;
+  asio::system_timer _group_clean_timer;
+
   absl::flat_hash_set<uint32_t> _hostgroup_cache;
   absl::flat_hash_set<uint32_t> _servicegroup_cache;
 
@@ -360,6 +363,7 @@ class stream : public io::stream {
   void _load_deleted_instances();
   void _load_caches();
   void _clean_tables(uint32_t instance_id);
+  void _clean_group_table();
   void _prepare_hg_insupdate_statement();
   void _prepare_sg_insupdate_statement();
   void _finish_action(int32_t conn, uint32_t action);

--- a/broker/unified_sql/src/stream.cc
+++ b/broker/unified_sql/src/stream.cc
@@ -121,6 +121,7 @@ stream::stream(const database_config& dbcfg,
       _stop_check_queues{false},
       _check_queues_stopped{false},
       _stats{stats::center::instance().register_conflict_manager()},
+      _group_clean_timer{pool::io_context()},
       _oldest_timestamp{std::numeric_limits<time_t>::max()} {
   log_v2::sql()->debug("unified sql: stream class instanciation");
   stats::center::instance().execute([stats = _stats,
@@ -145,6 +146,11 @@ stream::stream(const database_config& dbcfg,
 }
 
 stream::~stream() noexcept {
+  {
+    std::lock_guard<std::mutex> l(_group_clean_timer_m);
+    _group_clean_timer.cancel();
+  }
+
   std::promise<void> p;
   asio::post(_queues_timer.get_executor(), [this, &p] {
     _queues_timer.cancel();

--- a/broker/unified_sql/src/stream_sql.cc
+++ b/broker/unified_sql/src/stream_sql.cc
@@ -45,6 +45,12 @@ static inline bool is_not_zero(const int64_t& value) {
  *  @param[in] instance_id Instance ID to remove.
  */
 void stream::_clean_tables(uint32_t instance_id) {
+  // no hostgroup and servicegroup clean during this function
+  {
+    std::lock_guard<std::mutex> l(_group_clean_timer_m);
+    _group_clean_timer.cancel();
+  }
+
   /* Database version. */
 
   int32_t conn;
@@ -190,6 +196,35 @@ void stream::_clean_tables(uint32_t instance_id) {
   _mysql.run_query(query, database::mysql_error::clean_customvariables, false,
                    conn);
   _add_action(conn, actions::custom_variables);
+
+  std::lock_guard<std::mutex> l(_group_clean_timer_m);
+  _group_clean_timer.expires_after(std::chrono::minutes(1));
+  _group_clean_timer.async_wait([this](const asio::error_code& err) {
+    if (!err) {
+      _clean_group_table();
+    }
+  });
+}
+
+void stream::_clean_group_table() {
+  int32_t conn = _mysql.choose_best_connection(-1);
+  /* Remove host groups. */
+  log_v2::sql()->debug("unified sql: remove empty host groups ");
+  _mysql.run_query(
+      "DELETE hg FROM hostgroups AS hg LEFT JOIN hosts_hostgroups AS hhg ON "
+      "hg.hostgroup_id=hhg.hostgroup_id WHERE hhg.hostgroup_id IS NULL",
+      database::mysql_error::clean_empty_hostgroups, false, conn);
+  _add_action(conn, actions::hostgroups);
+
+  /* Remove service groups. */
+  log_v2::sql()->debug("unified sql: remove empty service groups");
+
+  _mysql.run_query(
+      "DELETE sg FROM servicegroups AS sg LEFT JOIN services_servicegroups as "
+      "ssg ON sg.servicegroup_id=ssg.servicegroup_id WHERE ssg.servicegroup_id "
+      "IS NULL",
+      database::mysql_error::clean_empty_servicegroups, false, conn);
+  _add_action(conn, actions::servicegroups);
 }
 
 /**


### PR DESCRIPTION
## Description
tables servicegroups and hostgroups are cleand one minute after the last service_servicegroups wash

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [X] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

