### PR TITLE
Mon 15477 debian packaging

### DIFF
--- a/ci/debian/centreon-collect-client.install
+++ b/ci/debian/centreon-collect-client.install
@@ -1,1 +1,1 @@
-debian/tmp-centreon-collect/usr/bin/ccc   usr/bin/ccc
+debian/tmp-centreon-collect/usr/bin/ccc   usr/bin


### PR DESCRIPTION
## Description

ccc was released in a bad folder in debian packaging.

REFS: MON-15477

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
