### PR TITLE
Mon 15575 stats deadlock 22.04.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ stream connector accepts empty parameter values
   help the user to fix his configuration but Broker does not stop.
 * RRD graphs rebuilds flush data when the rebuild is over. This seems to improve
   the user experience.
+* A possible deadlock has been removed from stats center.
 
 ### Engine
 

--- a/broker/core/test/processing/feeder.cc
+++ b/broker/core/test/processing/feeder.cc
@@ -23,6 +23,7 @@
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/io/protocols.hh"
 #include "com/centreon/broker/multiplexing/engine.hh"
+#include "com/centreon/broker/pool.hh"
 #include "com/centreon/broker/stats/center.hh"
 
 using namespace com::centreon::broker;


### PR DESCRIPTION
## Description

Backport of a patch concerning a deadlock in the new stats center of cbd.

REFS: MON-15575

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
