### PR TITLE
15571 add tcp keep alive paquet on tcp stream

### DIFF
--- a/broker/grpc/inc/com/centreon/broker/grpc/grpc_config.hh
+++ b/broker/grpc/inc/com/centreon/broker/grpc/grpc_config.hh
@@ -33,13 +33,17 @@ class grpc_config {
   // grpc_compression_level _compress_level;
   std::string _ca_name;
   compression_active _compress;
+  int _second_keepalive_interval;
 
  public:
   using pointer = std::shared_ptr<grpc_config>;
 
-  grpc_config() : _compress(NO) {}
+  grpc_config() : _compress(NO), _second_keepalive_interval(30) {}
   grpc_config(const std::string& hostp)
-      : _hostport(hostp), _crypted(false), _compress(NO) {}
+      : _hostport(hostp),
+        _crypted(false),
+        _compress(NO),
+        _second_keepalive_interval(30) {}
   grpc_config(const std::string& hostp,
               bool crypted,
               const std::string& certificate,
@@ -47,7 +51,8 @@ class grpc_config {
               const std::string& ca_cert,
               const std::string& authorization,
               const std::string& ca_name,
-              compression_active compression)
+              compression_active compression,
+              int second_keepalive_interval = 30)
       : _hostport(hostp),
         _crypted(crypted),
         _certificate(certificate),
@@ -55,7 +60,8 @@ class grpc_config {
         _ca_cert(ca_cert),
         _authorization(authorization),
         _ca_name(ca_name),
-        _compress(compression) {}
+        _compress(compression),
+        _second_keepalive_interval(second_keepalive_interval) {}
 
   constexpr const std::string& get_hostport() const { return _hostport; }
   constexpr bool is_crypted() const { return _crypted; }
@@ -67,6 +73,10 @@ class grpc_config {
   }
   const std::string& get_ca_name() const { return _ca_name; }
   constexpr compression_active get_compression() const { return _compress; }
+
+  int get_second_keepalive_interval() const {
+    return _second_keepalive_interval;
+  }
 
   friend class factory;
 };

--- a/broker/grpc/src/client.cc
+++ b/broker/grpc/src/client.cc
@@ -33,8 +33,10 @@ client::client(const grpc_config::pointer& conf)
   SPDLOG_LOGGER_TRACE(log_v2::grpc(), "this={:p}", static_cast<void*>(this));
   ::grpc::ChannelArguments args;
   args.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
-  args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 30000);
-  args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 10000);
+  args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS,
+              conf->get_second_keepalive_interval() * 1000);
+  args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
+              conf->get_second_keepalive_interval() * 300);
   args.SetInt(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA, 0);
   if (!conf->get_ca_name().empty())
     args.SetString(GRPC_SSL_TARGET_NAME_OVERRIDE_ARG, conf->get_ca_name());

--- a/broker/grpc/src/factory.cc
+++ b/broker/grpc/src/factory.cc
@@ -205,9 +205,23 @@ io::endpoint* factory::new_endpoint(
   else
     enable_compression = grpc_config::AUTO;
 
+  // keepalive conf
+  int keepalive_interval = 30;
+  it = cfg.params.find("keepalive_interval");
+  if (it != cfg.params.end()) {
+    if (!absl::SimpleAtoi(it->second, &keepalive_interval)) {
+      log_v2::grpc()->error(
+          "GRPC: 'keepalive_interval' field should be an integer and not '{}'",
+          it->second);
+      throw msg_fmt(
+          "GRPC: 'keepalive_interval' field should be an integer and not '{}'",
+          it->second);
+    }
+  }
+
   grpc_config::pointer conf(std::make_shared<grpc_config>(
       "", encrypted, certificate, certificate_key, certificate_authority,
-      authorization, ca_name, enable_compression));
+      authorization, ca_name, enable_compression, keepalive_interval));
 
   std::unique_ptr<io::endpoint> endp;
   if (host.empty())
@@ -405,9 +419,23 @@ io::endpoint* factory::_new_endpoint_bbdo_cs(
                     it->second);
   }
 
+  // keepalive conf
+  int keepalive_interval = 30;
+  it = cfg.params.find("keepalive_interval");
+  if (it != cfg.params.end()) {
+    if (!absl::SimpleAtoi(it->second, &keepalive_interval)) {
+      log_v2::grpc()->error(
+          "GRPC: 'keepalive_interval' field should be an integer and not '{}'",
+          it->second);
+      throw msg_fmt(
+          "GRPC: 'keepalive_interval' field should be an integer and not '{}'",
+          it->second);
+    }
+  }
+
   grpc_config::pointer conf(std::make_shared<grpc_config>(
       "", encryption, certificate, private_key, ca_certificate, authorization,
-      ca_name, enable_compression));
+      ca_name, enable_compression, keepalive_interval));
 
   // Acceptor.
   std::unique_ptr<io::endpoint> endp;

--- a/broker/grpc/src/server.cc
+++ b/broker/grpc/src/server.cc
@@ -163,8 +163,10 @@ void server::start() {
   builder.AddListeningPort(_conf->get_hostport(), server_creds);
   builder.RegisterService(this);
   builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
-  builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_TIME_MS, 30000);
-  builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 10000);
+  builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_TIME_MS,
+                             _conf->get_second_keepalive_interval() * 1000);
+  builder.AddChannelArgument(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
+                             _conf->get_second_keepalive_interval() * 300);
   builder.AddChannelArgument(GRPC_ARG_HTTP2_MAX_PING_STRIKES, 0);
   builder.AddChannelArgument(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA, 0);
   builder.AddChannelArgument(

--- a/broker/tcp/inc/com/centreon/broker/tcp/acceptor.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/acceptor.hh
@@ -21,6 +21,7 @@
 
 #include "com/centreon/broker/io/endpoint.hh"
 #include "com/centreon/broker/namespace.hh"
+#include "com/centreon/broker/tcp/tcp_config.hh"
 
 CCB_BEGIN()
 
@@ -32,18 +33,14 @@ namespace tcp {
  *  Accept TCP connections.
  */
 class acceptor : public io::endpoint {
-  const std::string _listen_address;
-  const uint16_t _port;
-  const int32_t _read_timeout;
+  tcp_config::pointer _conf;
 
   std::list<std::string> _children;
   std::mutex _childrenm;
   std::shared_ptr<asio::ip::tcp::acceptor> _acceptor;
 
  public:
-  acceptor(const std::string& listen_address,
-           uint16_t port,
-           int32_t read_timeout);
+  acceptor(const tcp_config::pointer& conf);
   ~acceptor() noexcept;
 
   acceptor(const acceptor&) = delete;

--- a/broker/tcp/inc/com/centreon/broker/tcp/connector.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/connector.hh
@@ -21,6 +21,7 @@
 
 #include "com/centreon/broker/io/limit_endpoint.hh"
 #include "com/centreon/broker/namespace.hh"
+#include "com/centreon/broker/tcp/tcp_config.hh"
 
 CCB_BEGIN()
 
@@ -32,12 +33,10 @@ namespace tcp {
  *  Connect to some remote TCP host.
  */
 class connector : public io::limit_endpoint {
-  const std::string _host;
-  const uint16_t _port;
-  const int32_t _read_timeout;
+  tcp_config::pointer _conf;
 
  public:
-  connector(const std::string& host, uint16_t port, int32_t read_timeout);
+  connector(const tcp_config::pointer& conf);
   ~connector();
 
   connector& operator=(const connector&) = delete;

--- a/broker/tcp/inc/com/centreon/broker/tcp/factory.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/factory.hh
@@ -32,17 +32,19 @@ namespace tcp {
  *  Build TCP protocol objects.
  */
 class factory : public io::factory {
-  io::endpoint* _new_endpoint_bbdo_cs(config::endpoint& cfg,
-                                      bool& is_acceptor) const;
+  io::endpoint* _new_endpoint_bbdo_cs(
+      com::centreon::broker::config::endpoint& cfg,
+      bool& is_acceptor) const;
 
  public:
   factory() = default;
   factory(factory const& other) = delete;
   ~factory() noexcept = default;
   factory& operator=(factory const& other) = delete;
-  bool has_endpoint(config::endpoint& cfg, io::extension* ext) override;
+  bool has_endpoint(com::centreon::broker::config::endpoint& cfg,
+                    io::extension* ext) override;
   io::endpoint* new_endpoint(
-      config::endpoint& cfg,
+      com::centreon::broker::config::endpoint& cfg,
       bool& is_acceptor,
       std::shared_ptr<persistent_cache> cache =
           std::shared_ptr<persistent_cache>()) const override;

--- a/broker/tcp/inc/com/centreon/broker/tcp/stream.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/stream.hh
@@ -20,6 +20,7 @@
 #define CCB_TCP_STREAM_HH
 
 #include "com/centreon/broker/io/stream.hh"
+#include "com/centreon/broker/tcp/tcp_config.hh"
 #include "com/centreon/broker/tcp/tcp_connection.hh"
 
 CCB_BEGIN()
@@ -37,15 +38,13 @@ class acceptor;
 class stream : public io::stream {
   static std::atomic<size_t> _total_tcp_count;
 
-  const std::string _host;
-  const uint16_t _port;
-  const int32_t _read_timeout;
+  tcp_config::pointer _conf;
   tcp_connection::pointer _connection;
   acceptor* _parent;
 
  public:
-  stream(std::string const& host, uint16_t port, int32_t read_timeout);
-  stream(const tcp_connection::pointer& conn, int32_t read_timeout);
+  stream(const tcp_config::pointer& conf);
+  stream(const tcp_connection::pointer& conn, const tcp_config::pointer& conf);
   ~stream() noexcept;
   stream& operator=(const stream&) = delete;
   stream(const stream&) = delete;

--- a/broker/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
@@ -19,6 +19,7 @@
 #define CENTREON_BROKER_TCP_INC_COM_CENTREON_BROKER_TCP_TCP_ASYNC_HH_
 
 #include "com/centreon/broker/pool.hh"
+#include "com/centreon/broker/tcp/tcp_config.hh"
 #include "com/centreon/broker/tcp/tcp_connection.hh"
 
 CCB_BEGIN()
@@ -75,6 +76,9 @@ class tcp_async {
 
   void _clear_available_con(asio::error_code ec);
 
+  static void _set_sock_opt(asio::ip::tcp::socket& sock,
+                            const tcp_config::pointer& conf);
+
  public:
   static void load();
   static void unload();
@@ -84,17 +88,18 @@ class tcp_async {
   tcp_async(const tcp_async&) = delete;
   tcp_async& operator=(const tcp_async&) = delete;
   std::shared_ptr<asio::ip::tcp::acceptor> create_acceptor(
-      const std::string& listen_address,
-      uint16_t port);
-  void start_acceptor(const std::shared_ptr<asio::ip::tcp::acceptor>& acceptor);
+      const tcp_config::pointer& conf);
+  void start_acceptor(const std::shared_ptr<asio::ip::tcp::acceptor>& acceptor,
+                      const tcp_config::pointer& conf);
   void stop_acceptor(std::shared_ptr<asio::ip::tcp::acceptor> acceptor);
 
-  std::shared_ptr<tcp_connection> create_connection(std::string const& address,
-                                                    uint16_t port);
+  std::shared_ptr<tcp_connection> create_connection(
+      const tcp_config::pointer& conf);
   void remove_acceptor(std::shared_ptr<asio::ip::tcp::acceptor> acceptor);
   void handle_accept(std::shared_ptr<asio::ip::tcp::acceptor> acceptor,
                      tcp_connection::pointer new_connection,
-                     const asio::error_code& error);
+                     const asio::error_code& error,
+                     const tcp_config::pointer& conf);
   tcp_connection::pointer get_connection(
       const std::shared_ptr<asio::ip::tcp::acceptor>& acceptor,
       uint32_t timeout_s);

--- a/broker/tcp/inc/com/centreon/broker/tcp/tcp_config.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/tcp_config.hh
@@ -1,0 +1,59 @@
+/*
+** Copyright 2022 Centreon
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+**
+** For more information : contact@centreon.com
+*/
+
+#ifndef CCB_TCP_CONFIG_HH
+#define CCB_TCP_CONFIG_HH
+
+CCB_BEGIN()
+
+namespace tcp {
+class tcp_config {
+  const std::string _host;
+  uint16_t _port;
+  int32_t _read_timeout;
+  int _second_keepalive_interval;
+  int _keepalive_count;
+
+ public:
+  using pointer = std::shared_ptr<tcp_config>;
+
+  tcp_config(const std::string& host,
+             uint16_t port,
+             int32_t read_timeout = -1,
+             int second_keepalive_interval = 30,
+             int keepalive_count = 2)
+      : _host(host),
+        _port(port),
+        _read_timeout(read_timeout),
+        _second_keepalive_interval(second_keepalive_interval),
+        _keepalive_count(keepalive_count) {}
+
+  const std::string& get_host() const { return _host; }
+  uint16_t get_port() const { return _port; }
+  int32_t get_read_timeout() const { return _read_timeout; }
+  int get_second_keepalive_interval() const {
+    return _second_keepalive_interval;
+  }
+  int get_keepalive_count() const { return _keepalive_count; }
+};
+
+}  // namespace tcp
+
+CCB_END()
+
+#endif

--- a/broker/tcp/src/acceptor.cc
+++ b/broker/tcp/src/acceptor.cc
@@ -35,13 +35,8 @@ using namespace com::centreon::broker::tcp;
  * @param port A port.
  * @param read_timeout A duration in seconds.
  */
-acceptor::acceptor(const std::string& listen_address,
-                   uint16_t port,
-                   int32_t read_timeout)
-    : io::endpoint(true),
-      _listen_address(listen_address),
-      _port(port),
-      _read_timeout(read_timeout) {}
+acceptor::acceptor(const tcp_config::pointer& conf)
+    : io::endpoint(true), _conf(conf) {}
 
 /**
  *  Destructor.
@@ -69,8 +64,8 @@ void acceptor::add_child(std::string const& child) {
  */
 std::unique_ptr<io::stream> acceptor::open() {
   if (!_acceptor) {
-    _acceptor = tcp_async::instance().create_acceptor(_listen_address, _port);
-    tcp_async::instance().start_acceptor(_acceptor);
+    _acceptor = tcp_async::instance().create_acceptor(_conf);
+    tcp_async::instance().start_acceptor(_acceptor, _conf);
   }
 
   /* Timeout in seconds during get_connection */
@@ -78,9 +73,8 @@ std::unique_ptr<io::stream> acceptor::open() {
   auto conn = tcp_async::instance().get_connection(_acceptor, timeout_s);
   if (conn) {
     assert(conn->port());
-    log_v2::tcp()->info("acceptor gets a new connection from {}",
-                         conn->peer());
-    return std::make_unique<stream>(conn, -1);
+    log_v2::tcp()->info("acceptor gets a new connection from {}", conn->peer());
+    return std::make_unique<stream>(conn, _conf);
   }
   return nullptr;
 }

--- a/broker/tcp/src/connector.cc
+++ b/broker/tcp/src/connector.cc
@@ -36,13 +36,8 @@ using namespace com::centreon::broker::tcp;
  * @param port The port used for the connection.
  * @param read_timeout The read timeout in seconds or -1 if no duration.
  */
-connector::connector(const std::string& host,
-                     uint16_t port,
-                     int32_t read_timeout)
-    : io::limit_endpoint(false),
-      _host(host),
-      _port(port),
-      _read_timeout(read_timeout) {}
+connector::connector(const tcp_config::pointer& conf)
+    : io::limit_endpoint(false), _conf(conf) {}
 
 /**
  *  Destructor.
@@ -56,13 +51,14 @@ connector::~connector() {}
  */
 std::unique_ptr<io::stream> connector::open() {
   // Launch connection process.
-  log_v2::tcp()->info("TCP: connecting to {}:{}", _host, _port);
+  log_v2::tcp()->info("TCP: connecting to {}:{}", _conf->get_host(),
+                      _conf->get_port());
   try {
     return limit_endpoint::open();
   } catch (const std::exception& e) {
     log_v2::tcp()->debug(
-        "Unable to establish the connection to {}:{} (attempt {}): {}", _host,
-        _port, _is_ready_count, e.what());
+        "Unable to establish the connection to {}:{} (attempt {}): {}",
+        _conf->get_host(), _conf->get_port(), _is_ready_count, e.what());
     return nullptr;
   }
 }
@@ -73,5 +69,5 @@ std::unique_ptr<io::stream> connector::open() {
  * @return std::shared_ptr<stream>
  */
 std::unique_ptr<io::stream> connector::create_stream() {
-  return std::make_unique<stream>(_host, _port, _read_timeout);
+  return std::make_unique<stream>(_conf);
 }

--- a/broker/tcp/src/stream.cc
+++ b/broker/tcp/src/stream.cc
@@ -46,16 +46,15 @@ std::atomic<size_t> stream::_total_tcp_count{0};
  * @param port The port used by the host to listen.
  * @param read_timeout The read_timeout in seconds or -1 if no timeout.
  */
-stream::stream(std::string const& host, uint16_t port, int32_t read_timeout)
+stream::stream(const tcp_config::pointer& conf)
     : io::stream("TCP"),
-      _host(host),
-      _port(port),
-      _read_timeout(read_timeout),
-      _connection(tcp_async::instance().create_connection(host, port)),
+      _conf(conf),
+      _connection(tcp_async::instance().create_connection(_conf)),
       _parent(nullptr) {
   assert(_connection->port());
   _total_tcp_count++;
-  log_v2::tcp()->trace("New stream to {}:{}", _host, _port);
+  log_v2::tcp()->trace("New stream to {}:{}", _conf->get_host(),
+                       _conf->get_port());
   log_v2::tcp()->info(
       "{} TCP streams are configured on a thread pool of {} threads",
       _total_tcp_count, pool::instance().get_pool_size());
@@ -68,16 +67,13 @@ stream::stream(std::string const& host, uint16_t port, int32_t read_timeout)
  * @param conn The connection to use by this stream.
  * @param read_timeout A duration in seconds or -1 if no timeout.
  */
-stream::stream(const tcp_connection::pointer& conn, int32_t read_timeout)
-    : io::stream("TCP"),
-      _host{conn->address()},
-      _port{conn->port()},
-      _read_timeout(read_timeout),
-      _connection(conn),
-      _parent(nullptr) {
+stream::stream(const tcp_connection::pointer& conn,
+               const tcp_config::pointer& conf)
+    : io::stream("TCP"), _conf(conf), _connection(conn), _parent(nullptr) {
   assert(_connection->port());
   _total_tcp_count++;
-  log_v2::tcp()->info("New stream to {}:{}", _host, _port);
+  log_v2::tcp()->info("New stream to {}:{}", _conf->get_host(),
+                      _conf->get_port());
   log_v2::tcp()->info(
       "{} TCP streams are configured on a thread pool of {} threads",
       _total_tcp_count, pool::instance().get_pool_size());
@@ -123,9 +119,10 @@ bool stream::read(std::shared_ptr<io::data>& d, time_t deadline) {
   // Set deadline.
   {
     time_t now = ::time(nullptr);
-    if (_read_timeout != -1 &&
-        (deadline == static_cast<time_t>(-1) || now + _read_timeout < deadline))
-      deadline = now + _read_timeout / 1000;
+    if (_conf->get_read_timeout() != -1 &&
+        (deadline == static_cast<time_t>(-1) ||
+         now + _conf->get_read_timeout() < deadline))
+      deadline = now + _conf->get_read_timeout() / 1000;
   }
 
   if (_connection->is_closed()) {
@@ -181,7 +178,7 @@ int32_t stream::write(std::shared_ptr<io::data> const& d) {
   if (d->type() == io::raw::static_type()) {
     std::shared_ptr<io::raw> r(std::static_pointer_cast<io::raw>(d));
     log_v2::tcp()->trace("TCP: write request of {} bytes to peer '{}:{}'",
-                         r->size(), _host, _port);
+                         r->size(), _conf->get_host(), _conf->get_port());
     log_v2::tcp()->trace("write {} bytes", r->size());
     std::error_code err;
     try {

--- a/broker/tcp/src/tcp_async.cc
+++ b/broker/tcp/src/tcp_async.cc
@@ -25,6 +25,36 @@ using namespace com::centreon::exceptions;
 using namespace com::centreon::broker;
 using namespace com::centreon::broker::tcp;
 
+/**
+ * @brief this option set the interval in seconds between two keepalive sent
+ *
+ */
+using tcp_keep_alive_interval =
+    asio::detail::socket_option::integer<IPPROTO_TCP, TCP_KEEPINTVL>;
+
+/**
+ * @brief this option set the delay after the first keepalive will be sent
+ *
+ */
+using tcp_keep_alive_idle =
+    asio::detail::socket_option::integer<IPPROTO_TCP, TCP_KEEPIDLE>;
+/**
+ * @brief this option set the maximum of not answered keepalive paquets
+ *
+ */
+using tcp_keep_alive_cnt =
+    asio::detail::socket_option::integer<IPPROTO_TCP, TCP_KEEPCNT>;
+/**
+ * This option takes an unsigned int as an argument.  When the value is greater
+ * than 0, it specifies the maximum amount of time in milliseconds that
+ * transmitted data may remain unacknowledged before TCP will forcibly close the
+ * corresponding connection and return ETIMEDOUT to the ap‐ plication.  If the
+ * option value is specified as 0, TCP will use the system default.
+ *
+ */
+using tcp_user_timeout =
+    asio::detail::socket_option::integer<IPPROTO_TCP, TCP_USER_TIMEOUT>;
+
 tcp_async* tcp_async::_instance{nullptr};
 
 /**
@@ -156,24 +186,26 @@ bool tcp_async::contains_available_acceptor_connections(
  * @return The created acceptor as a shared_ptr.
  */
 std::shared_ptr<asio::ip::tcp::acceptor> tcp_async::create_acceptor(
-    const std::string& listen_address,
-    uint16_t port) {
+    const tcp_config::pointer& conf) {
   asio::ip::tcp::endpoint listen_endpoint;
-  if (listen_address.empty())
-    listen_endpoint = asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port);
+  if (conf->get_host().empty())
+    listen_endpoint =
+        asio::ip::tcp::endpoint(asio::ip::tcp::v4(), conf->get_port());
   else {
-    asio::ip::tcp::resolver::query query(listen_address, std::to_string(port));
+    asio::ip::tcp::resolver::query query(conf->get_host(),
+                                         std::to_string(conf->get_port()));
     asio::ip::tcp::resolver resolver(pool::io_context());
     asio::error_code ec;
     asio::ip::tcp::resolver::iterator it = resolver.resolve(query, ec), end;
     if (ec) {
       log_v2::tcp()->error("TCP: error while resolving '{}' name: {}",
-                           listen_address, ec.message());
-      listen_endpoint = asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port);
+                           conf->get_host(), ec.message());
+      listen_endpoint =
+          asio::ip::tcp::endpoint(asio::ip::tcp::v4(), conf->get_port());
     } else {
       for (; it != end; ++it) {
         listen_endpoint = *it;
-        log_v2::tcp()->info("TCP: {} gives address {}", listen_address,
+        log_v2::tcp()->info("TCP: {} gives address {}", conf->get_host(),
                             listen_endpoint.address().to_string());
         if (listen_endpoint.address().is_v4())
           break;
@@ -227,7 +259,8 @@ void tcp_async::_clear_available_con(asio::error_code ec) {
  * @param acceptor The acceptor that you want it to accept.
  */
 void tcp_async::start_acceptor(
-    const std::shared_ptr<asio::ip::tcp::acceptor>& acceptor) {
+    const std::shared_ptr<asio::ip::tcp::acceptor>& acceptor,
+    const tcp_config::pointer& conf) {
   log_v2::tcp()->trace("Start acceptor");
   if (!_timer)
     _timer =
@@ -245,9 +278,11 @@ void tcp_async::start_acceptor(
       std::make_shared<tcp_connection>(pool::io_context());
 
   log_v2::tcp()->debug("Waiting for a connection");
-  acceptor->async_accept(new_connection->socket(),
-                         std::bind(&tcp_async::handle_accept, this, acceptor,
-                                   new_connection, std::placeholders::_1));
+  acceptor->async_accept(
+      new_connection->socket(),
+      [this, acceptor, new_connection, conf](const asio::error_code& ec) {
+        handle_accept(acceptor, new_connection, ec, conf);
+      });
 }
 
 /**
@@ -275,7 +310,8 @@ void tcp_async::stop_acceptor(
  */
 void tcp_async::handle_accept(std::shared_ptr<asio::ip::tcp::acceptor> acceptor,
                               tcp_connection::pointer new_connection,
-                              const asio::error_code& ec) {
+                              const asio::error_code& ec,
+                              const tcp_config::pointer& conf) {
   /* If we got a connection, we store it */
   if (!ec) {
     asio::error_code ecc;
@@ -287,9 +323,8 @@ void tcp_async::handle_accept(std::shared_ptr<asio::ip::tcp::acceptor> acceptor,
     else {
       std::time_t now = std::time(nullptr);
       asio::ip::tcp::socket& sock = new_connection->socket();
-      asio::socket_base::keep_alive option{true};
       try {
-        sock.set_option(option);
+        _set_sock_opt(sock, conf);
         _strand.post([new_connection, now, acceptor, this] {
           _acceptor_available_con.insert(std::make_pair(
               acceptor.get(), std::make_pair(new_connection, now)));
@@ -298,7 +333,7 @@ void tcp_async::handle_accept(std::shared_ptr<asio::ip::tcp::acceptor> acceptor,
         log_v2::tcp()->error(
             "fail to activate keepalive on accepted connection");
       }
-      start_acceptor(acceptor);
+      start_acceptor(acceptor, conf);
     }
   } else
     log_v2::tcp()->info("TCP acceptor interrupted: {}", ec.message());
@@ -312,15 +347,17 @@ void tcp_async::handle_accept(std::shared_ptr<asio::ip::tcp::acceptor> acceptor,
  *
  * @return A shared_ptr to the connection or an empty shared_ptr.
  */
-tcp_connection::pointer tcp_async::create_connection(std::string const& host,
-                                                     uint16_t port) {
-  log_v2::tcp()->trace("create connection to host {}:{}", host, port);
-  tcp_connection::pointer conn =
-      std::make_shared<tcp_connection>(pool::io_context(), host, port);
+tcp_connection::pointer tcp_async::create_connection(
+    const tcp_config::pointer& conf) {
+  log_v2::tcp()->trace("create connection to host {}:{}", conf->get_host(),
+                       conf->get_port());
+  tcp_connection::pointer conn = std::make_shared<tcp_connection>(
+      pool::io_context(), conf->get_host(), conf->get_port());
   asio::ip::tcp::socket& sock = conn->socket();
 
   asio::ip::tcp::resolver resolver(pool::io_context());
-  asio::ip::tcp::resolver::query query(host, std::to_string(port));
+  asio::ip::tcp::resolver::query query(conf->get_host(),
+                                       std::to_string(conf->get_port()));
   asio::ip::tcp::resolver::iterator it = resolver.resolve(query), end;
 
   std::error_code err{std::make_error_code(std::errc::host_unreachable)};
@@ -336,14 +373,51 @@ tcp_connection::pointer tcp_async::create_connection(std::string const& host,
 
   /* Connection refused */
   if (err.value() == 111) {
-    log_v2::tcp()->error("TCP: Connection refused to {}:{}", host, port);
+    log_v2::tcp()->error("TCP: Connection refused to {}:{}", conf->get_host(),
+                         conf->get_port());
     throw std::system_error(err);
   } else if (err) {
-    log_v2::tcp()->error("TCP: could not connect to {}:{}", host, port);
+    log_v2::tcp()->error("TCP: could not connect to {}:{}", conf->get_host(),
+                         conf->get_port());
     throw msg_fmt(err.message());
   } else {
-    asio::socket_base::keep_alive option{true};
-    sock.set_option(option);
+    _set_sock_opt(sock, conf);
     return conn;
+  }
+}
+
+void tcp_async::_set_sock_opt(asio::ip::tcp::socket& sock,
+                              const tcp_config::pointer& conf) {
+  asio::socket_base::keep_alive option1(true);
+  tcp_keep_alive_cnt option2(conf->get_keepalive_count());
+  tcp_keep_alive_idle option3(conf->get_second_keepalive_interval());
+  tcp_keep_alive_interval option4(conf->get_second_keepalive_interval());
+  tcp_user_timeout option5(1000 * (conf->get_second_keepalive_interval() *
+                                   (conf->get_keepalive_count() + 1)));
+  asio::error_code err;
+  sock.set_option(option1, err);
+  if (err) {
+    SPDLOG_LOGGER_ERROR(log_v2::tcp(), "fail to set keepalive option {}",
+                        err.message());
+  } else {
+    sock.set_option(option2, err);
+    if (err) {
+      SPDLOG_LOGGER_ERROR(log_v2::tcp(), "fail to set keepalive cnt {}",
+                          err.message());
+    }
+    sock.set_option(option3, err);
+    if (err) {
+      SPDLOG_LOGGER_ERROR(log_v2::tcp(), "fail to set keepalive idle {}",
+                          err.message());
+    }
+    sock.set_option(option4, err);
+    if (err) {
+      SPDLOG_LOGGER_ERROR(log_v2::tcp(), "fail to set keepalive interval {}",
+                          err.message());
+    }
+  }
+  sock.set_option(option5, err);
+  if (err) {
+    SPDLOG_LOGGER_ERROR(log_v2::tcp(), "fail to set keepalive option");
   }
 }

--- a/broker/tcp/test/acceptor.cc
+++ b/broker/tcp/test/acceptor.cc
@@ -36,6 +36,10 @@ using namespace com::centreon::exceptions;
 
 const static std::string test_addr("127.0.0.1");
 constexpr static uint16_t test_port(4444);
+static tcp::tcp_config::pointer test_conf(
+    std::make_shared<tcp::tcp_config>(test_addr, test_port));
+static tcp::tcp_config::pointer test_conf2(
+    std::make_shared<tcp::tcp_config>(test_addr, 4141));
 
 class TcpAcceptor : public ::testing::Test {
  public:
@@ -66,13 +70,14 @@ static auto try_connect =
 
 TEST_F(TcpAcceptor, BadPort) {
   if (getuid() != 0) {
-    tcp::acceptor acc("", 2, -1);
+    tcp::tcp_config::pointer conf(std::make_shared<tcp::tcp_config>("", 2));
+    tcp::acceptor acc(conf);
     ASSERT_THROW(acc.open(), std::exception);
   }
 }
 
 TEST_F(TcpAcceptor, NoConnector) {
-  tcp::acceptor acc("", test_port, -1);
+  tcp::acceptor acc(test_conf);
 
   ASSERT_EQ(acc.open(), std::unique_ptr<io::stream>());
 }
@@ -80,7 +85,7 @@ TEST_F(TcpAcceptor, NoConnector) {
 TEST_F(TcpAcceptor, Nominal) {
   std::thread cbd([] {
     std::unique_ptr<tcp::acceptor> a(
-        std::make_unique<tcp::acceptor>("", 4141, -1));
+        std::make_unique<tcp::acceptor>(test_conf2));
     std::unique_ptr<io::endpoint> endp(a.release());
 
     /* Nominal case, cbd is acceptor and read on the socket */
@@ -110,8 +115,7 @@ TEST_F(TcpAcceptor, Nominal) {
   });
 
   std::thread centengine([] {
-    std::unique_ptr<tcp::connector> c(
-        new tcp::connector("localhost", 4141, -1));
+    std::unique_ptr<tcp::connector> c(new tcp::connector(test_conf2));
     std::unique_ptr<io::endpoint> endp(c.release());
 
     /* Nominal case, centengine is connector and write on the socket */
@@ -147,7 +151,7 @@ TEST_F(TcpAcceptor, QuestionAnswer) {
 
   std::thread cbd([&cbd_m, &cbd_cv, &cbd_finished] {
     std::unique_ptr<io::endpoint> endp(
-        std::make_unique<tcp::acceptor>("", 4141, -1));
+        std::make_unique<tcp::acceptor>(test_conf2));
 
     /* Nominal case, cbd is acceptor and read on the socket */
     std::unique_ptr<io::stream> u_cbd;
@@ -190,8 +194,7 @@ TEST_F(TcpAcceptor, QuestionAnswer) {
   });
 
   std::thread centengine([&cbd_cv, &cbd_finished] {
-    std::unique_ptr<tcp::connector> c(
-        new tcp::connector("localhost", 4141, -1));
+    std::unique_ptr<tcp::connector> c(new tcp::connector(test_conf2));
     std::unique_ptr<io::endpoint> endp(c.release());
 
     std::unique_ptr<io::stream> u_centengine;
@@ -255,7 +258,7 @@ TEST_F(TcpAcceptor, MultiNominal) {
     {
       std::vector<std::unique_ptr<io::stream>> u_cbd(nb_poller);
       std::unique_ptr<io::endpoint> endp{
-          std::make_unique<tcp::acceptor>("", 4141, -1)};
+          std::make_unique<tcp::acceptor>(test_conf2)};
 
       /* Nominal case, cbd is acceptor and read on the socket */
       bool cont = true;
@@ -314,7 +317,7 @@ TEST_F(TcpAcceptor, MultiNominal) {
   for (size_t i = 0; i < nb_poller; i++) {
     pollers.emplace_back([&cbd_finished, &cbd_m, &cbd_cv] {
       std::unique_ptr<io::endpoint> endp{
-          std::make_unique<tcp::connector>("localhost", 4141, -1)};
+          std::make_unique<tcp::connector>(test_conf2)};
 
       /* Nominal case, centengine is connector and write on the socket */
       std::unique_ptr<io::stream> u_centengine;
@@ -359,8 +362,7 @@ TEST_F(TcpAcceptor, NominalReversed) {
   bool cbd_finished = false;
 
   std::thread centengine([&cbd_m, &cbd_cv, &cbd_finished] {
-    std::unique_ptr<tcp::connector> c(
-        new tcp::connector("localhost", 4141, -1));
+    std::unique_ptr<tcp::connector> c(new tcp::connector(test_conf2));
     std::unique_ptr<io::endpoint> endp(c.release());
 
     std::unique_ptr<io::stream> u_centengine;
@@ -394,7 +396,7 @@ TEST_F(TcpAcceptor, NominalReversed) {
 
   std::thread cbd([&cbd_m, &cbd_finished, &cbd_cv] {
     std::unique_ptr<io::endpoint> endp(
-        std::make_unique<tcp::acceptor>("localhost", 4141, -1));
+        std::make_unique<tcp::acceptor>(test_conf2));
 
     std::unique_ptr<io::stream> u_cbd;
     do {
@@ -431,7 +433,7 @@ TEST_F(TcpAcceptor, NominalReversed) {
 TEST_F(TcpAcceptor, OnePeer) {
   std::thread centengine([] {
     std::unique_ptr<tcp::acceptor> a(
-        std::make_unique<tcp::acceptor>("", 4141, -1));
+        std::make_unique<tcp::acceptor>(test_conf2));
     std::unique_ptr<io::endpoint> endp(a.release());
 
     std::unique_ptr<io::stream> u_centengine;
@@ -455,8 +457,7 @@ TEST_F(TcpAcceptor, OnePeer) {
   });
 
   std::thread cbd([] {
-    std::unique_ptr<tcp::connector> c(
-        new tcp::connector("localhost", 4141, -1));
+    std::unique_ptr<tcp::connector> c(new tcp::connector(test_conf2));
     std::unique_ptr<io::endpoint> endp(c.release());
 
     std::unique_ptr<io::stream> u_cbd;
@@ -490,8 +491,7 @@ TEST_F(TcpAcceptor, OnePeer) {
 
 TEST_F(TcpAcceptor, OnePeerReversed) {
   std::thread cbd([] {
-    std::unique_ptr<tcp::connector> c(
-        new tcp::connector("localhost", 4141, -1));
+    std::unique_ptr<tcp::connector> c(new tcp::connector(test_conf2));
     std::unique_ptr<io::endpoint> endp(c.release());
 
     std::unique_ptr<io::stream> u_cbd;
@@ -528,7 +528,7 @@ TEST_F(TcpAcceptor, OnePeerReversed) {
 
   std::thread centengine([] {
     std::unique_ptr<tcp::acceptor> a(
-        std::make_unique<tcp::acceptor>("", 4141, -1));
+        std::make_unique<tcp::acceptor>(test_conf2));
     std::unique_ptr<io::endpoint> endp(a.release());
 
     std::unique_ptr<io::stream> u_centengine;
@@ -560,7 +560,7 @@ TEST_F(TcpAcceptor, MultiOnePeer) {
 
   std::thread centengine([] {
     std::unique_ptr<tcp::acceptor> a(
-        std::make_unique<tcp::acceptor>("", 4141, -1));
+        std::make_unique<tcp::acceptor>(test_conf2));
     std::unique_ptr<io::endpoint> endp(a.release());
 
     std::unique_ptr<io::stream> u_centengine;
@@ -600,8 +600,7 @@ TEST_F(TcpAcceptor, MultiOnePeer) {
    * simulates a negotiation with the centengine instance */
   for (int i = 0; i < nb_steps; i++) {
     std::thread cbd([] {
-      std::unique_ptr<tcp::connector> c(
-          new tcp::connector("localhost", 4141, -1));
+      std::unique_ptr<tcp::connector> c(new tcp::connector(test_conf2));
       std::unique_ptr<io::endpoint> endp(c.release());
 
       std::unique_ptr<io::stream> u_cbd;
@@ -634,8 +633,7 @@ TEST_F(TcpAcceptor, NominalRepeated) {
   const int nb_steps = 5;
 
   std::thread centengine([] {
-    std::unique_ptr<tcp::connector> c(
-        new tcp::connector("localhost", 4141, -1));
+    std::unique_ptr<tcp::connector> c(new tcp::connector(test_conf2));
     std::unique_ptr<io::endpoint> endp(c.release());
 
     std::unique_ptr<io::stream> u_centengine;
@@ -683,7 +681,7 @@ TEST_F(TcpAcceptor, NominalRepeated) {
     std::thread cbd([i] {
       std::cout << "cbd  " << i << "\n";
       std::unique_ptr<tcp::acceptor> a(
-          std::make_unique<tcp::acceptor>("", 4141, -1));
+          std::make_unique<tcp::acceptor>(test_conf2));
       std::cout << "cbd1 " << i << "\n";
       std::cout << "cbd2 " << i << "\n";
       std::cout << "cbd3 " << i << "\n";
@@ -723,13 +721,13 @@ TEST_F(TcpAcceptor, NominalRepeated) {
 }
 
 TEST_F(TcpAcceptor, Wait2Connect) {
-  tcp::acceptor acc("localhost", 4141, -1);
+  tcp::acceptor acc(test_conf2);
   int i = 0;
   std::shared_ptr<io::stream> st;
 
   std::thread t{[&] {
     std::this_thread::sleep_for(std::chrono::seconds{2});
-    tcp::connector con(test_addr, 4141, -1);
+    tcp::connector con(test_conf2);
     std::shared_ptr<io::stream> str{try_connect(con)};
   }};
 
@@ -748,13 +746,13 @@ TEST_F(TcpAcceptor, Wait2Connect) {
 }
 
 TEST_F(TcpAcceptor, Simple) {
-  tcp::acceptor acc("", test_port, -1);
+  tcp::acceptor acc(test_conf);
   std::condition_variable cv;
   std::mutex m;
   bool finish = false;
 
   std::thread t([&] {
-    tcp::connector con(test_addr, test_port, -1);
+    tcp::connector con(test_conf);
     std::shared_ptr<io::stream> str{try_connect(con)};
     std::shared_ptr<io::raw> data{std::make_shared<io::raw>()};
     std::shared_ptr<io::data> data_read;
@@ -797,11 +795,11 @@ TEST_F(TcpAcceptor, Simple) {
 }
 
 TEST_F(TcpAcceptor, Multiple) {
-  tcp::acceptor acc("", test_port, -1);
+  tcp::acceptor acc(test_conf);
 
   {
     std::thread t{[] {
-      tcp::connector con(test_addr, test_port, -1);
+      tcp::connector con(test_conf);
       std::shared_ptr<io::stream> str{try_connect(con)};
       std::shared_ptr<io::raw> data{new io::raw()};
       std::shared_ptr<io::data> data_read;
@@ -832,7 +830,7 @@ TEST_F(TcpAcceptor, Multiple) {
   }
   {
     std::thread t{[] {
-      tcp::connector con(test_addr, test_port, -1);
+      tcp::connector con(test_conf);
       std::shared_ptr<io::stream> str{try_connect(con)};
       std::shared_ptr<io::raw> data{new io::raw()};
       std::shared_ptr<io::data> data_read;
@@ -864,10 +862,10 @@ TEST_F(TcpAcceptor, Multiple) {
 }
 
 TEST_F(TcpAcceptor, BigSend) {
-  tcp::acceptor acc("", test_port, -1);
+  tcp::acceptor acc(test_conf);
 
   std::thread t{[] {
-    tcp::connector con(test_addr, test_port, -1);
+    tcp::connector con(test_conf);
     std::shared_ptr<io::stream> str{try_connect(con)};
     std::shared_ptr<io::raw> data{new io::raw()};
     std::shared_ptr<io::data> data_read;
@@ -902,11 +900,11 @@ TEST_F(TcpAcceptor, BigSend) {
 }
 
 TEST_F(TcpAcceptor, CloseRead) {
-  tcp::acceptor acc("", test_port, -1);
+  tcp::acceptor acc(test_conf);
 
   std::thread t{[&] {
     {
-      tcp::connector con(test_addr, test_port, -1);
+      tcp::connector con(test_conf);
       std::shared_ptr<io::stream> str{try_connect(con)};
       std::shared_ptr<io::raw> data{new io::raw()};
       std::shared_ptr<io::data> data_read;
@@ -938,7 +936,7 @@ TEST_F(TcpAcceptor, CloseRead) {
 }
 
 TEST_F(TcpAcceptor, ChildsAndStats) {
-  tcp::acceptor acc("", test_port, -1);
+  tcp::acceptor acc(test_conf);
 
   acc.add_child("child1");
   acc.add_child("child2");
@@ -957,8 +955,9 @@ TEST_F(TcpAcceptor, QuestionAnswerMultiple) {
 
   for (int i = 0; i < nb_connections; i++) {
     cbd.emplace_back([i] {
-      std::unique_ptr<tcp::acceptor> a(
-          std::make_unique<tcp::acceptor>("", 4141 + i, -1));
+      tcp::tcp_config::pointer conf(
+          std::make_shared<tcp::tcp_config>("", 4141 + i));
+      std::unique_ptr<tcp::acceptor> a(std::make_unique<tcp::acceptor>(conf));
       std::unique_ptr<io::endpoint> endp(a.release());
 
       /* Nominal case, cbd is acceptor and read on the socket */
@@ -1000,8 +999,9 @@ TEST_F(TcpAcceptor, QuestionAnswerMultiple) {
     });
 
     centengine.emplace_back([i] {
-      std::unique_ptr<tcp::connector> c(
-          new tcp::connector("localhost", 4141 + i, -1));
+      tcp::tcp_config::pointer conf(
+          std::make_shared<tcp::tcp_config>("", 4141 + i));
+      std::unique_ptr<tcp::connector> c(new tcp::connector(conf));
       std::unique_ptr<io::endpoint> endp(c.release());
 
       std::unique_ptr<io::stream> u_centengine;
@@ -1045,12 +1045,12 @@ TEST_F(TcpAcceptor, QuestionAnswerMultiple) {
 }
 
 TEST_F(TcpAcceptor, MultipleBigSend) {
-  tcp::acceptor acc("", test_port, -1);
+  tcp::acceptor acc(test_conf);
   const int32_t nb_packet = 10;
   const int32_t len = 10024;
 
   std::thread t{[nb_packet] {
-    tcp::connector con(test_addr, test_port, -1);
+    tcp::connector con(test_conf);
     std::shared_ptr<io::stream> str{try_connect(con)};
     std::shared_ptr<io::data> data_read;
     for (int k = 0; k < nb_packet; k++) {

--- a/broker/tcp/test/connector.cc
+++ b/broker/tcp/test/connector.cc
@@ -31,6 +31,9 @@ using namespace com::centreon::broker;
 constexpr static char test_addr[] = "127.0.0.1";
 constexpr static uint16_t test_port(4242);
 
+static tcp::tcp_config::pointer test_conf(
+    std::make_shared<tcp::tcp_config>(test_addr, test_port));
+
 class TcpConnector : public testing::Test {
  public:
   void SetUp() override {
@@ -53,7 +56,10 @@ class TcpConnector : public testing::Test {
 };
 
 TEST_F(TcpConnector, Timeout) {
-  tcp::connector connector(test_addr, test_port, 1);
+  static tcp::tcp_config::pointer conf(
+      std::make_shared<tcp::tcp_config>(test_addr, test_port, 1));
+
+  tcp::connector connector(conf);
   std::shared_ptr<io::stream> io{connector.open()};
 
   std::shared_ptr<io::data> data{new io::raw()};
@@ -62,7 +68,7 @@ TEST_F(TcpConnector, Timeout) {
 }
 
 TEST_F(TcpConnector, Simple) {
-  tcp::connector connector(test_addr, test_port, -1);
+  tcp::connector connector(test_conf);
   std::shared_ptr<io::stream> io{connector.open()};
 
   std::shared_ptr<io::raw> data{new io::raw()};
@@ -80,7 +86,7 @@ TEST_F(TcpConnector, Simple) {
 }
 
 TEST_F(TcpConnector, ReadAfterTimeout) {
-  tcp::connector connector(test_addr, test_port, -1);
+  tcp::connector connector(test_conf);
   std::shared_ptr<io::stream> io{connector.open()};
 
   std::shared_ptr<io::raw> data{new io::raw()};
@@ -99,7 +105,7 @@ TEST_F(TcpConnector, ReadAfterTimeout) {
 }
 
 TEST_F(TcpConnector, MultipleSimple) {
-  tcp::connector connector(test_addr, test_port, -1);
+  tcp::connector connector(test_conf);
   std::shared_ptr<io::stream> io{connector.open()};
 
   std::shared_ptr<io::raw> data{new io::raw()};

--- a/broker/tls/test/acceptor.cc
+++ b/broker/tls/test/acceptor.cc
@@ -43,6 +43,11 @@ using namespace com::centreon::exceptions;
 const static std::string test_addr("127.0.0.1");
 constexpr static uint16_t test_port(4444);
 
+static tcp::tcp_config::pointer test_conf(
+    std::make_shared<tcp::tcp_config>(test_addr, test_port));
+static tcp::tcp_config::pointer test_conf2(
+    std::make_shared<tcp::tcp_config>(test_addr, 4141));
+
 class TlsTest : public ::testing::Test {
  public:
   void SetUp() override {
@@ -61,7 +66,7 @@ TEST_F(TlsTest, AnonTlsStream) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>("", 4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>("", "", "", "")};
 
@@ -92,7 +97,7 @@ TEST_F(TlsTest, AnonTlsStream) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     auto tls_c{std::make_unique<tls::connector>("", "", "", "")};
 
@@ -128,7 +133,7 @@ TEST_F(TlsTest, AnonTlsStreamContinuous) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>("", 4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>("", "", "", "")};
 
@@ -163,7 +168,7 @@ TEST_F(TlsTest, AnonTlsStreamContinuous) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     auto tls_c{std::make_unique<tls::connector>("", "", "", "")};
 
@@ -218,7 +223,7 @@ TEST_F(TlsTest, TlsStream) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>("", 4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>("/tmp/server.crt",
                                                "/tmp/server.key", "", "")};
@@ -248,7 +253,7 @@ TEST_F(TlsTest, TlsStream) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     auto tls_c{std::make_unique<tls::connector>("/tmp/client.crt",
                                                 "/tmp/client.key", "", "")};
@@ -300,7 +305,7 @@ TEST_F(TlsTest, TlsStreamCa) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>("", 4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>(
         "/tmp/server.crt", "/tmp/server.key", "/tmp/client.crt", "")};
@@ -330,7 +335,7 @@ TEST_F(TlsTest, TlsStreamCa) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     auto tls_c{std::make_unique<tls::connector>(
         "/tmp/client.crt", "/tmp/client.key", "/tmp/server.crt", "")};
@@ -382,7 +387,7 @@ TEST_F(TlsTest, TlsStreamCaError) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>("", 4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>(
         "/tmp/server.crt", "/tmp/server.key", "/tmp/client.crt", "")};
@@ -413,7 +418,7 @@ TEST_F(TlsTest, TlsStreamCaError) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     /* the name does not match with the CN of the server certificate */
     auto tls_c{
@@ -455,7 +460,7 @@ TEST_F(TlsTest, TlsStreamCaHostname) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>("", 4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>(
         "/tmp/server.crt", "/tmp/server.key", "/tmp/client.crt", "")};
@@ -485,7 +490,7 @@ TEST_F(TlsTest, TlsStreamCaHostname) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     auto tls_c{std::make_unique<tls::connector>(
         "/tmp/client.crt", "/tmp/client.key", "/tmp/server.crt", s_hostname)};
@@ -540,7 +545,7 @@ TEST_F(TlsTest, TlsStreamBigData) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>("", 4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>(
         "/tmp/server.crt", "/tmp/server.key", "/tmp/client.crt", "")};
@@ -589,7 +594,7 @@ TEST_F(TlsTest, TlsStreamBigData) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     auto tls_c{std::make_unique<tls::connector>(
         "/tmp/client.crt", "/tmp/client.key", "/tmp/server.crt", s_hostname)};
@@ -651,7 +656,7 @@ TEST_F(TlsTest, TlsStreamLongData) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>("", 4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>(
         "/tmp/server.crt", "/tmp/server.key", "/tmp/client.crt", "")};
@@ -701,7 +706,7 @@ TEST_F(TlsTest, TlsStreamLongData) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     auto tls_c{std::make_unique<tls::connector>(
         "/tmp/client.crt", "/tmp/client.key", "/tmp/server.crt", s_hostname)};


### PR DESCRIPTION
## Description

When clients have network errors, socket may stay forever up.
This story add keepalive parameters (cnt interval and idle) and a user timeout to add timeout on unacknowledged sent)

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [X] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

