### PR TITLE
fix(broker/stats): center concurrent access changed to use mutexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ with the Broker configuration file.
 
 #### Fixes
 
+*core*
+
+A possible deadlock has been removed from stats center.
+
 *rrd*
 
 Rebuild of graphs should work better.


### PR DESCRIPTION
## Description

Concurrency on stats center changed.

REFS: MON-15575

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
