### PR TITLE
fix(broker/bam): no need to read last_level in bam

### DIFF
--- a/broker/bam/inc/com/centreon/broker/bam/configuration/kpi.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/configuration/kpi.hh
@@ -44,7 +44,6 @@ class kpi {
   uint32_t _meta_id;
   uint32_t _boolexp_id;
   short _status;
-  short _last_level;
   bool _downtimed;
   bool _acknowledged;
   bool _ignore_downtime;
@@ -64,7 +63,6 @@ class kpi {
       uint32_t meta_id = 0,
       uint32_t boolexp_id = 0,
       short status = 0,
-      short last_level = 0,
       bool downtimed = false,
       bool acknowledged = false,
       bool ignoredowntime = false,
@@ -91,7 +89,6 @@ class kpi {
   uint32_t get_meta_id() const;
   uint32_t get_boolexp_id() const;
   short get_status() const;
-  short get_last_level() const;
   bool is_downtimed() const;
   bool is_acknowledged() const;
   bool ignore_downtime() const;
@@ -110,7 +107,6 @@ class kpi {
   void set_meta_id(uint32_t meta_id);
   void set_boolexp_id(uint32_t boolexp_id);
   void set_status(short status);
-  void set_last_level(short last_level);
   void set_downtimed(bool downtimed);
   void set_acknowledged(bool acknowledged);
   void ignore_downtime(bool ignore);

--- a/broker/bam/src/configuration/kpi.cc
+++ b/broker/bam/src/configuration/kpi.cc
@@ -34,7 +34,6 @@ kpi::kpi(uint32_t id,
          uint32_t meta_id,
          uint32_t boolexp_id,
          short status,
-         short last_level,
          bool downtimed,
          bool acknowledged,
          bool ignore_downtime,
@@ -51,7 +50,6 @@ kpi::kpi(uint32_t id,
       _meta_id(meta_id),
       _boolexp_id(boolexp_id),
       _status(status),
-      _last_level(last_level),
       _downtimed(downtimed),
       _acknowledged(acknowledged),
       _ignore_downtime(ignore_downtime),
@@ -76,7 +74,6 @@ kpi::kpi(kpi const& other)
       _meta_id(other._meta_id),
       _boolexp_id(other._boolexp_id),
       _status(other._status),
-      _last_level(other._last_level),
       _downtimed(other._downtimed),
       _acknowledged(other._acknowledged),
       _ignore_downtime(other._ignore_downtime),
@@ -109,7 +106,6 @@ kpi& kpi::operator=(kpi const& other) {
     _meta_id = other._meta_id;
     _boolexp_id = other._boolexp_id;
     _status = other._status;
-    _last_level = other._last_level;
     _downtimed = other._downtimed;
     _acknowledged = other._acknowledged;
     _ignore_downtime = other._ignore_downtime;
@@ -134,8 +130,7 @@ bool kpi::operator==(kpi const& other) const {
          _host_id == other._host_id && _service_id == other._service_id &&
          _ba_id == other._ba_id && _indicator_ba_id == other._indicator_ba_id &&
          _meta_id == other._meta_id && _boolexp_id == other._boolexp_id &&
-         _status == other._status && _last_level == other._last_level &&
-         _downtimed == other._downtimed &&
+         _status == other._status && _downtimed == other._downtimed &&
          _acknowledged == other._acknowledged &&
          _ignore_downtime == other._ignore_downtime &&
          _ignore_acknowledgement == other._ignore_acknowledgement &&
@@ -283,15 +278,6 @@ short kpi::get_status() const {
 }
 
 /**
- *  Get the last level of this kpi.
- *
- *  @return The last level of this kpi.
- */
-short kpi::get_last_level() const {
-  return _last_level;
-}
-
-/**
  *  Is this kpi set to downtime mode ?
  *
  *  @return Has this business interest been downtimed?
@@ -436,15 +422,6 @@ void kpi::set_boolexp_id(uint32_t boolexp_id) {
  */
 void kpi::set_status(short s) {
   _status = s;
-}
-
-/**
- *  Set last_level.
- *
- *  @param[in] s Set the last level of the kpi.
- */
-void kpi::set_last_level(short s) {
-  _last_level = s;
 }
 
 /**

--- a/broker/bam/src/configuration/reader_v2.cc
+++ b/broker/bam/src/configuration/reader_v2.cc
@@ -86,7 +86,7 @@ void reader_v2::_load(state::kpis& kpis) {
     std::string query(fmt::format(
         "SELECT  k.kpi_id, k.state_type, k.host_id, k.service_id, k.id_ba,"
         "        k.id_indicator_ba, k.meta_id, k.boolean_id,"
-        "        k.current_status, k.last_level, k.downtime,"
+        "        k.current_status, k.downtime,"
         "        k.acknowledged, k.ignore_downtime,"
         "        k.ignore_acknowledged,"
         "        COALESCE(COALESCE(k.drop_warning, ww.impact), "
@@ -133,21 +133,20 @@ void reader_v2::_load(state::kpis& kpis) {
                            res.value_as_u32(6),    // Meta-service ID.
                            res.value_as_u32(7),    // Boolean expression ID.
                            res.value_as_i32(8),    // Status.
-                           res.value_as_i32(9),    // Last level.
-                           res.value_as_f32(10),   // Downtimed.
-                           res.value_as_f32(11),   // Acknowledged.
-                           res.value_as_bool(12),  // Ignore downtime.
-                           res.value_as_bool(13),  // Ignore acknowledgement.
-                           res.value_as_f64(14),   // Warning.
-                           res.value_as_f64(15),   // Critical.
-                           res.value_as_f64(16));  // Unknown.
+                           res.value_as_f32(9),    // Downtimed.
+                           res.value_as_f32(10),   // Acknowledged.
+                           res.value_as_bool(11),  // Ignore downtime.
+                           res.value_as_bool(12),  // Ignore acknowledgement.
+                           res.value_as_f64(13),   // Warning.
+                           res.value_as_f64(14),   // Critical.
+                           res.value_as_f64(15));  // Unknown.
 
         // KPI state.
-        if (!res.value_is_null(17)) {
-          kpi_event e(kpi_id, res.value_as_u32(4), res.value_as_u64(17));
+        if (!res.value_is_null(16)) {
+          kpi_event e(kpi_id, res.value_as_u32(4), res.value_as_u64(16));
           e.status = res.value_as_i32(8);
-          e.in_downtime = res.value_as_bool(18);
-          e.impact_level = res.value_is_null(19) ? -1 : res.value_as_f64(19);
+          e.in_downtime = res.value_as_bool(17);
+          e.impact_level = res.value_is_null(18) ? -1 : res.value_as_f64(18);
           kpis[kpi_id].set_opened_event(e);
         }
       }


### PR DESCRIPTION
# Description

Issue with last_level on KPIs which is a float number and not an integer.

REFS: MON-15622
**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
