### PR TITLE
Mon 15681 macros on ad

### DIFF
--- a/engine/inc/com/centreon/engine/service.hh
+++ b/engine/inc/com/centreon/engine/service.hh
@@ -63,6 +63,14 @@ class service : public notifier {
  protected:
   service_type _service_type;
 
+  int run_async_check_local(int check_options,
+                            double latency,
+                            bool scheduled_check,
+                            bool reschedule_check,
+                            bool* time_is_valid,
+                            time_t* preferred_time,
+                            service* svc) noexcept;
+
  public:
   static std::array<std::pair<uint32_t, std::string>, 4> const
       tab_service_states;

--- a/engine/src/anomalydetection.cc
+++ b/engine/src/anomalydetection.cc
@@ -195,18 +195,16 @@ uint64_t cancellable_command::run(
   if (_fake_result) {
     checks::checker::instance().add_check_result_to_reap(_fake_result);
     return 0;  // no command => no async result
+  } else if (_original_command) {
+    uint64_t id = _original_command->run(processed_cmd, macros, timeout,
+                                         to_push_to_checker, caller);
+    log_v2::checks()->debug(
+        "cancellable_command::run command launched id={} cmd {}", id,
+        _original_command);
+    return id;
   } else {
-    if (_original_command) {
-      uint64_t id = _original_command->run(processed_cmd, macros, timeout,
-                                           to_push_to_checker, caller);
-      log_v2::checks()->debug(
-          "cancellable_command::run command launched id={} cmd {}", id,
-          _original_command);
-      return id;
-    } else {
-      log_v2::checks()->debug("cancellable_command::run no original command");
-      return 0;
-    }
+    log_v2::checks()->debug("cancellable_command::run no original command");
+    return 0;
   }
 }
 

--- a/engine/src/commands/environment.cc
+++ b/engine/src/commands/environment.cc
@@ -38,30 +38,6 @@ environment::~environment() noexcept {
 /**
  *  Add an environment variable.
  *
- *  @param[in] line  The name and value on form (name=value).
- */
-void environment::add(char const* line) {
-  if (!line)
-    return;
-  uint32_t size(strlen(line));
-  uint32_t new_pos = _pos_buffer + size + 1;
-  if (new_pos > _size_buffer) {
-    if (new_pos < _size_buffer + EXTRA_SIZE_BUFFER)
-      _realloc_buffer(_size_buffer + EXTRA_SIZE_BUFFER);
-    else
-      _realloc_buffer(new_pos + EXTRA_SIZE_BUFFER);
-  }
-  memcpy(_buffer + _pos_buffer, line, size + 1);
-  if (_pos_env + 1 >= _size_env)
-    _realloc_env(_size_env + EXTRA_SIZE_ENV);
-  _env[_pos_env++] = _buffer + _pos_buffer;
-  _env[_pos_env] = nullptr;
-  _pos_buffer += size + 1;
-}
-
-/**
- *  Add an environment variable.
- *
  *  @param[in] name   The name of the environment variable.
  *  @param[in] value  The environment variable value.
  */
@@ -87,6 +63,29 @@ void environment::add(char const* name, char const* value) {
   _pos_buffer += size_name + size_value + 2;
 }
 
+/**
+ *  Add an environment variable.
+ *
+ *  @param[in] line  The name and value on form (name=value).
+ */
+void environment::add(char const* line) {
+  if (!line)
+    return;
+  uint32_t size(strlen(line));
+  uint32_t new_pos = _pos_buffer + size + 1;
+  if (new_pos > _size_buffer) {
+    if (new_pos < _size_buffer + EXTRA_SIZE_BUFFER)
+      _realloc_buffer(_size_buffer + EXTRA_SIZE_BUFFER);
+    else
+      _realloc_buffer(new_pos + EXTRA_SIZE_BUFFER);
+  }
+  memcpy(_buffer + _pos_buffer, line, size + 1);
+  if (_pos_env + 1 >= _size_env)
+    _realloc_env(_size_env + EXTRA_SIZE_ENV);
+  _env[_pos_env++] = _buffer + _pos_buffer;
+  _env[_pos_env] = nullptr;
+  _pos_buffer += size + 1;
+}
 /**
  *  Add an environment variable.
  *
@@ -153,9 +152,9 @@ char** environment::data() const noexcept {
  */
 void environment::_realloc_buffer(uint32_t size) {
   if (_size_buffer >= size)
-    throw
-        engine_error() << "Invalid size for command environment reallocation: "
-                       << "Buffer size is greater than the requested size";
+    throw engine_error()
+        << "Invalid size for command environment reallocation: "
+        << "Buffer size is greater than the requested size";
   char* new_buffer(new char[size]);
   if (_buffer)
     memcpy(new_buffer, _buffer, _pos_buffer);

--- a/engine/src/commands/raw.cc
+++ b/engine/src/commands/raw.cc
@@ -347,10 +347,10 @@ void raw::finished(process& p) noexcept {
  */
 void raw::_build_argv_macro_environment(nagios_macros const& macros,
                                         environment& env) {
+  std::string line;
   for (uint32_t i(0); i < MAX_COMMAND_ARGUMENTS; ++i) {
-    std::ostringstream oss;
-    oss << MACRO_ENV_VAR_PREFIX "ARG" << (i + 1) << "=" << macros.argv[i];
-    env.add(oss.str());
+    line = fmt::format(MACRO_ENV_VAR_PREFIX "ARG{}={}", i + 1, macros.argv[i]);
+    env.add(line);
   }
 }
 
@@ -365,10 +365,11 @@ void raw::_build_contact_address_environment(nagios_macros const& macros,
   if (!macros.contact_ptr)
     return;
   std::vector<std::string> const& address(macros.contact_ptr->get_addresses());
+  std::string line;
   for (uint32_t i(0); i < address.size(); ++i) {
-    std::ostringstream oss;
-    oss << MACRO_ENV_VAR_PREFIX "CONTACTADDRESS" << i << "=" << address[i];
-    env.add(oss.str());
+    line =
+        fmt::format(MACRO_ENV_VAR_PREFIX "CONTACTADDRESS{}={}", i, address[i]);
+    env.add(line);
   }
 }
 

--- a/engine/src/service.cc
+++ b/engine/src/service.cc
@@ -2600,7 +2600,7 @@ int service::run_async_check_local(int check_options,
   grab_service_macros_r(macros, svc);
   std::string tmp;
   get_raw_command_line_r(macros, get_check_command_ptr(),
-                         check_command().c_str(), tmp, 0);
+                         svc->check_command().c_str(), tmp, 0);
 
   // Time to start command.
   gettimeofday(&start_time, nullptr);

--- a/engine/tests/checks/anomalydetection.cc
+++ b/engine/tests/checks/anomalydetection.cc
@@ -123,8 +123,8 @@ class AnomalydetectionCheck : public TestEngine {
 
 /* The following test comes from this array (inherited from Nagios behaviour):
  *
- * | Time | Check # | State | State type | State change | perf data in range | ad State  | ad state type | ad do check   
- * --------------------------------------------------------------------------------------------------------------------                
+ * | Time | Check # | State | State type | State change | perf data in range | ad State  | ad state type | ad do check
+ * --------------------------------------------------------------------------------------------------------------------
  * | 0    | 1       | OK    | HARD       | No           |  Y                 |  OK       | H             |  N
  * | 1    | 1       | CRTCL | SOFT       | Yes          |  Y                 |  OK       | H             |  N
  * | 2    | 2       | CRTCL | SOFT       | No           |  Y                 |  OK       | H             |  N
@@ -214,8 +214,7 @@ TEST_P(AnomalydetectionCheckStatusChange, StatusChanges) {
   now = std::time(nullptr);
   cmd = fmt::format(
       "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service "
-      "critical| "
-      "metric=80;25;60",
+      "critical| metric=80;25;60",
       now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
@@ -248,8 +247,7 @@ TEST_P(AnomalydetectionCheckStatusChange, StatusChanges) {
   now = std::time(nullptr);
   cmd = fmt::format(
       "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service "
-      "critical| "
-      "metric=80;25;60",
+      "critical| metric=80;25;60",
       now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
@@ -283,8 +281,7 @@ TEST_P(AnomalydetectionCheckStatusChange, StatusChanges) {
   time_t previous = now;
   cmd = fmt::format(
       "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service "
-      "ok| "
-      "metric=80foo;25;60",
+      "ok| metric=80foo;25;60",
       now);
   process_external_command(cmd.c_str());
   checks::checker::instance().reap();
@@ -343,6 +340,321 @@ TEST_P(AnomalydetectionCheckStatusChange, StatusChanges) {
   } else {
     ASSERT_EQ(_ad->get_perf_data(),
               "metric=30% metric_lower_thresholds=70.55% "
+              "metric_upper_thresholds=80.30% metric_fit=75.30% "
+              "metric_lower_margin=-4.75% metric_upper_margin=5.00%");
+  }
+
+  ASSERT_EQ(_ad->get_current_attempt(), 1);
+
+  // --- 6 ----
+  set_time(53000);
+
+  previous = now;
+  now = std::time(nullptr);
+  _ad->run_async_check(check_options, latency, true, true, &time_is_valid,
+                       &preferred_time);
+  checks::checker::instance().wait_completion();
+  checks::checker::instance().reap();
+  ASSERT_EQ(_ad->get_state_type(), checkable::soft);
+  ASSERT_EQ(_ad->get_current_state(), engine::service::state_critical);
+  ASSERT_EQ(_ad->get_last_state_change(), previous);
+  ASSERT_EQ(_ad->get_plugin_output(),
+            "NON-OK: Unusual activity, the actual value of metric is 12.00 "
+            "which is outside the forecasting range [69.86 : 79.56]");
+  if (GetParam().first == e_json_version::V1) {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "metric=12 metric_lower_thresholds=69.86 "
+              "metric_upper_thresholds=79.56 metric_fit=74.56 "
+              "metric_lower_margin=0.00 metric_upper_margin=0.00");
+
+  } else {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "metric=12 metric_lower_thresholds=69.86 "
+              "metric_upper_thresholds=79.56 metric_fit=74.56 "
+              "metric_lower_margin=-4.70 metric_upper_margin=5.00");
+  }
+  ASSERT_EQ(_ad->get_current_attempt(), 2);
+
+  // --- 7 ----
+  set_time(53500);
+
+  previous = now;
+  now = std::time(nullptr);
+  _ad->run_async_check(check_options, latency, true, true, &time_is_valid,
+                       &preferred_time);
+  checks::checker::instance().wait_completion();
+  checks::checker::instance().reap();
+  ASSERT_EQ(_ad->get_state_type(), checkable::hard);
+  ASSERT_EQ(_ad->get_current_state(), engine::service::state_critical);
+  ASSERT_EQ(_ad->get_last_hard_state_change(), now);
+  ASSERT_EQ(_ad->get_last_state_change(), 52500);
+  ASSERT_EQ(_ad->get_plugin_output(),
+            "NON-OK: Unusual activity, the actual value of metric is 12.00 "
+            "which is outside the forecasting range [69.17 : 78.82]");
+  if (GetParam().first == e_json_version::V1) {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "metric=12 metric_lower_thresholds=69.17 "
+              "metric_upper_thresholds=78.82 metric_fit=73.82 "
+              "metric_lower_margin=0.00 metric_upper_margin=0.00");
+  } else {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "metric=12 metric_lower_thresholds=69.17 "
+              "metric_upper_thresholds=78.82 metric_fit=73.82 "
+              "metric_lower_margin=-4.65 metric_upper_margin=5.00");
+  }
+  ASSERT_EQ(_ad->get_current_attempt(), 3);
+
+  // --- 8 ----
+  set_time(54000);
+  _ad->get_check_command_ptr()->set_command_line(
+      "echo 'output| metric=70%;50;75'");
+  previous = now;
+  now = std::time(nullptr);
+  _ad->run_async_check(check_options, latency, true, true, &time_is_valid,
+                       &preferred_time);
+  checks::checker::instance().wait_completion();
+  checks::checker::instance().reap();
+  ASSERT_EQ(_ad->get_state_type(), checkable::hard);
+  ASSERT_EQ(_ad->get_current_state(), engine::service::state_ok);
+  ASSERT_EQ(_ad->get_last_hard_state_change(), now);
+  ASSERT_EQ(_ad->get_last_state_change(), now);
+  ASSERT_EQ(_ad->get_plugin_output(), "OK: Regular activity, metric=70.00%");
+  if (GetParam().first == e_json_version::V1) {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "metric=70% metric_lower_thresholds=68.48% "
+              "metric_upper_thresholds=78.08% metric_fit=73.08% "
+              "metric_lower_margin=0.00% metric_upper_margin=0.00%");
+  } else {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "metric=70% metric_lower_thresholds=68.48% "
+              "metric_upper_thresholds=78.08% metric_fit=73.08% "
+              "metric_lower_margin=-4.60% metric_upper_margin=5.00%");
+  }
+  ASSERT_EQ(_ad->get_current_attempt(), 1);
+
+  // --- 9 ----
+  set_time(54500);
+
+  previous = now;
+  now = std::time(nullptr);
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;4;service unknown",
+      now);
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::soft);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_unknown);
+  ASSERT_EQ(_svc->get_last_hard_state_change(), 52000);
+  ASSERT_EQ(_svc->get_last_state_change(), now);
+  ASSERT_EQ(_svc->get_current_attempt(), 1);
+  ASSERT_EQ(_svc->get_plugin_output(), "service unknown");
+  _ad->run_async_check(check_options, latency, true, true, &time_is_valid,
+                       &preferred_time);
+  checks::checker::instance().reap();
+  ASSERT_EQ(_ad->get_state_type(), checkable::soft);
+  ASSERT_EQ(_ad->get_current_state(), engine::service::state_unknown);
+  ASSERT_EQ(_ad->get_last_hard_state_change(), 54000);
+  ASSERT_EQ(_svc->get_last_state_change(), now);
+  ASSERT_EQ(_ad->get_plugin_output(),
+            "UNKNOWN: Unknown activity, metric did not return any values");
+  ASSERT_EQ(_ad->get_current_attempt(), 1);
+
+  ::unlink("/tmp/thresholds_status_change.json");
+}
+
+TEST_P(AnomalydetectionCheckStatusChange, StatusChangesWithType) {
+  CreateFile("/tmp/thresholds_status_change.json", GetParam().second);
+  _ad->init_thresholds();
+  _ad->set_status_change(true);
+
+  set_time(50000);
+  _svc->set_current_state(engine::service::state_ok);
+  _svc->set_last_hard_state(engine::service::state_ok);
+  _svc->set_last_hard_state_change(50000);
+  _svc->set_state_type(checkable::hard);
+  _svc->set_accept_passive_checks(true);
+  _svc->set_current_attempt(1);
+  _svc->set_last_check(50000);
+
+  _ad->set_current_state(engine::service::state_ok);
+  _ad->set_last_hard_state(engine::service::state_ok);
+  _ad->set_last_hard_state_change(50000);
+  _ad->set_last_state_change(50000);
+  _ad->set_state_type(checkable::hard);
+  _ad->set_current_attempt(1);
+  _ad->set_last_check(50000);
+
+  // --- 1 ----
+  set_time(50500);
+  time_t now = std::time(nullptr);
+  std::string cmd(fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service "
+      "critical| 'g[metric]'=80;25;60",
+      now));
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::soft);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_critical);
+  ASSERT_EQ(_svc->get_last_state_change(), now);
+  ASSERT_EQ(_svc->get_current_attempt(), 1);
+  ASSERT_EQ(_svc->get_plugin_output(), "service critical");
+  ASSERT_EQ(_svc->get_perf_data(), "'g[metric]'=80;25;60");
+  int check_options = 0;
+  int latency = 0;
+  bool time_is_valid;
+  time_t preferred_time;
+  _ad->run_async_check(check_options, latency, true, true, &time_is_valid,
+                       &preferred_time);
+  checks::checker::instance().reap();
+  ASSERT_EQ(_ad->get_state_type(), checkable::hard);
+  ASSERT_EQ(_ad->get_current_state(), engine::service::state_ok);
+  ASSERT_EQ(_ad->get_last_state_change(), 50000);
+  ASSERT_EQ(_ad->get_current_attempt(), 1);
+  ASSERT_EQ(_ad->get_plugin_output(), "OK: Regular activity, metric=80.00");
+  if (GetParam().first == e_json_version::V1) {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "'g[metric]'=80 metric_lower_thresholds=73.31 "
+              "metric_upper_thresholds=83.26 metric_fit=78.26 "
+              "metric_lower_margin=0.00 metric_upper_margin=0.00");
+  } else {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "'g[metric]'=80 metric_lower_thresholds=73.31 "
+              "metric_upper_thresholds=83.26 metric_fit=78.26 "
+              "metric_lower_margin=-4.95 metric_upper_margin=5.00");
+  }
+
+  // --- 2 ----
+  set_time(51000);
+
+  now = std::time(nullptr);
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service "
+      "critical| 'g[metric]'=80;25;60",
+      now);
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::soft);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_critical);
+  ASSERT_EQ(_svc->get_last_state_change(), 50500);
+  ASSERT_EQ(_svc->get_current_attempt(), 2);
+  _ad->run_async_check(check_options, latency, true, true, &time_is_valid,
+                       &preferred_time);
+  checks::checker::instance().reap();
+  ASSERT_EQ(_ad->get_state_type(), checkable::hard);
+  ASSERT_EQ(_ad->get_current_state(), engine::service::state_ok);
+  ASSERT_EQ(_ad->get_last_state_change(), 50000);
+  ASSERT_EQ(_ad->get_current_attempt(), 1);
+  ASSERT_EQ(_ad->get_plugin_output(), "OK: Regular activity, metric=80.00");
+  if (GetParam().first == e_json_version::V1) {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "'g[metric]'=80 metric_lower_thresholds=72.62 "
+              "metric_upper_thresholds=82.52 metric_fit=77.52 "
+              "metric_lower_margin=0.00 metric_upper_margin=0.00");
+  } else {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "'g[metric]'=80 metric_lower_thresholds=72.62 "
+              "metric_upper_thresholds=82.52 metric_fit=77.52 "
+              "metric_lower_margin=-4.90 metric_upper_margin=5.00");
+  }
+  // --- 3 ----
+  set_time(51250);
+
+  now = std::time(nullptr);
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;2;service "
+      "critical| 'g[metric]'=80;25;60",
+      now);
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::hard);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_critical);
+  ASSERT_EQ(_svc->get_last_state_change(), 50500);
+  ASSERT_EQ(_svc->get_current_attempt(), 3);
+  _ad->run_async_check(check_options, latency, true, true, &time_is_valid,
+                       &preferred_time);
+  checks::checker::instance().reap();
+  ASSERT_EQ(_ad->get_state_type(), checkable::hard);
+  ASSERT_EQ(_ad->get_current_state(), engine::service::state_ok);
+  ASSERT_EQ(_ad->get_last_state_change(), 50000);
+  ASSERT_EQ(_ad->get_current_attempt(), 1);
+  ASSERT_EQ(_ad->get_plugin_output(), "OK: Regular activity, metric=80.00");
+  if (GetParam().first == e_json_version::V1) {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "'g[metric]'=80 metric_lower_thresholds=72.28 "
+              "metric_upper_thresholds=82.15 metric_fit=77.15 "
+              "metric_lower_margin=0.00 metric_upper_margin=0.00");
+  } else {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "'g[metric]'=80 metric_lower_thresholds=72.28 "
+              "metric_upper_thresholds=82.15 metric_fit=77.15 "
+              "metric_lower_margin=-4.88 metric_upper_margin=5.00");
+  }
+  // --- 4 ----
+  set_time(52000);
+
+  now = std::time(nullptr);
+  time_t previous = now;
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service "
+      "ok| 'g[metric]'=80foo;25;60",
+      now);
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::hard);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_ok);
+  ASSERT_EQ(_svc->get_last_hard_state_change(), now);
+  ASSERT_EQ(_svc->get_current_attempt(), 1);
+  _ad->run_async_check(check_options, latency, true, true, &time_is_valid,
+                       &preferred_time);
+  checks::checker::instance().reap();
+  ASSERT_EQ(_ad->get_state_type(), checkable::hard);
+  ASSERT_EQ(_ad->get_current_state(), engine::service::state_ok);
+  ASSERT_EQ(_ad->get_last_state_change(), 50000);
+  ASSERT_EQ(_ad->get_current_attempt(), 1);
+  ASSERT_EQ(_ad->get_plugin_output(), "OK: Regular activity, metric=80.00foo");
+  if (GetParam().first == e_json_version::V1) {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "'g[metric]'=80foo metric_lower_thresholds=71.24foo "
+              "metric_upper_thresholds=81.04foo metric_fit=76.04foo "
+              "metric_lower_margin=0.00foo metric_upper_margin=0.00foo");
+  } else {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "'g[metric]'=80foo metric_lower_thresholds=71.24foo "
+              "metric_upper_thresholds=81.04foo metric_fit=76.04foo "
+              "metric_lower_margin=-4.80foo metric_upper_margin=5.00foo");
+  }
+  // --- 5 ----
+  set_time(52500);
+
+  now = std::time(nullptr);
+  cmd = fmt::format(
+      "[{}] PROCESS_SERVICE_CHECK_RESULT;test_host;test_svc;0;service ok| "
+      "'g[metric]'=30%;25;60",
+      now);
+  process_external_command(cmd.c_str());
+  checks::checker::instance().reap();
+  ASSERT_EQ(_svc->get_state_type(), checkable::hard);
+  ASSERT_EQ(_svc->get_current_state(), engine::service::state_ok);
+  ASSERT_EQ(_svc->get_last_hard_state_change(), 52000);
+  ASSERT_EQ(_svc->get_last_state_change(), 52000);
+  ASSERT_EQ(_svc->get_current_attempt(), 1);
+  _ad->run_async_check(check_options, latency, true, true, &time_is_valid,
+                       &preferred_time);
+  checks::checker::instance().reap();
+  ASSERT_EQ(_ad->get_state_type(), checkable::soft);
+  ASSERT_EQ(_ad->get_current_state(), engine::service::state_critical);
+  ASSERT_EQ(_ad->get_last_state_change(), now);
+  ASSERT_EQ(_ad->get_plugin_output(),
+            "NON-OK: Unusual activity, the actual value of metric is 30.00% "
+            "which is outside the forecasting range [70.55% : 80.30%]");
+  if (GetParam().first == e_json_version::V1) {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "'g[metric]'=30% metric_lower_thresholds=70.55% "
+              "metric_upper_thresholds=80.30% metric_fit=75.30% "
+              "metric_lower_margin=0.00% metric_upper_margin=0.00%");
+  } else {
+    ASSERT_EQ(_ad->get_perf_data(),
+              "'g[metric]'=30% metric_lower_thresholds=70.55% "
               "metric_upper_thresholds=80.30% metric_fit=75.30% "
               "metric_lower_margin=-4.75% metric_upper_margin=5.00%");
   }

--- a/engine/tests/test_engine.cc
+++ b/engine/tests/test_engine.cc
@@ -176,8 +176,8 @@ configuration::service TestEngine::new_configuration_service(
   svc.set_host_id(12);
 
   configuration::command cmd("cmd");
-  cmd.parse("command_line", "echo 'output| metric=12;50;75'");
-  svc.parse("check_command", "cmd");
+  cmd.parse("command_line", "echo 'output| metric=$ARG1$;50;75'");
+  svc.parse("check_command", "cmd!12");
   configuration::applier::command cmd_aply;
   cmd_aply.add_object(cmd);
 


### PR DESCRIPTION
## Description

Anomalydetection can force dependent service check. This feature was broken in case of arguments given to the command.
This patch fixes this issue.

REFS: MON-15681

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
