### PR TITLE
Mon 16053 add keeaplive on tcp stream 22.04

### DIFF
--- a/broker/tcp/inc/com/centreon/broker/tcp/acceptor.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/acceptor.hh
@@ -21,6 +21,7 @@
 
 #include "com/centreon/broker/io/endpoint.hh"
 #include "com/centreon/broker/namespace.hh"
+#include "com/centreon/broker/tcp/tcp_config.hh"
 
 CCB_BEGIN()
 
@@ -32,15 +33,14 @@ namespace tcp {
  *  Accept TCP connections.
  */
 class acceptor : public io::endpoint {
-  const uint16_t _port;
-  const int32_t _read_timeout;
+  tcp_config::pointer _conf;
 
   std::list<std::string> _children;
   std::mutex _childrenm;
   std::shared_ptr<asio::ip::tcp::acceptor> _acceptor;
 
  public:
-  acceptor(uint16_t port, int32_t read_timeout);
+  acceptor(const tcp_config::pointer& conf);
   ~acceptor() noexcept;
 
   acceptor(const acceptor&) = delete;

--- a/broker/tcp/inc/com/centreon/broker/tcp/connector.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/connector.hh
@@ -21,6 +21,7 @@
 
 #include "com/centreon/broker/io/limit_endpoint.hh"
 #include "com/centreon/broker/namespace.hh"
+#include "com/centreon/broker/tcp/tcp_config.hh"
 
 CCB_BEGIN()
 
@@ -32,12 +33,10 @@ namespace tcp {
  *  Connect to some remote TCP host.
  */
 class connector : public io::limit_endpoint {
-  const std::string _host;
-  const uint16_t _port;
-  const int32_t _read_timeout;
+  tcp_config::pointer _conf;
 
  public:
-  connector(const std::string& host, uint16_t port, int32_t read_timeout);
+  connector(const tcp_config::pointer& conf);
   ~connector();
 
   connector& operator=(const connector&) = delete;

--- a/broker/tcp/inc/com/centreon/broker/tcp/factory.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/factory.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2011-2013 Centreon
+** Copyright 2011-2013, 2020-2022 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -35,11 +35,12 @@ class factory : public io::factory {
  public:
   factory() = default;
   factory(factory const& other) = delete;
-  ~factory() = default;
+  ~factory() noexcept = default;
   factory& operator=(factory const& other) = delete;
-  bool has_endpoint(config::endpoint& cfg, io::extension* ext) override;
+  bool has_endpoint(com::centreon::broker::config::endpoint& cfg,
+                    io::extension* ext) override;
   io::endpoint* new_endpoint(
-      config::endpoint& cfg,
+      com::centreon::broker::config::endpoint& cfg,
       bool& is_acceptor,
       std::shared_ptr<persistent_cache> cache =
           std::shared_ptr<persistent_cache>()) const override;

--- a/broker/tcp/inc/com/centreon/broker/tcp/stream.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/stream.hh
@@ -20,6 +20,7 @@
 #define CCB_TCP_STREAM_HH
 
 #include "com/centreon/broker/io/stream.hh"
+#include "com/centreon/broker/tcp/tcp_config.hh"
 #include "com/centreon/broker/tcp/tcp_connection.hh"
 
 CCB_BEGIN()
@@ -37,15 +38,13 @@ class acceptor;
 class stream : public io::stream {
   static std::atomic<size_t> _total_tcp_count;
 
-  const std::string _host;
-  const uint16_t _port;
-  const int32_t _read_timeout;
+  tcp_config::pointer _conf;
   tcp_connection::pointer _connection;
   acceptor* _parent;
 
  public:
-  stream(std::string const& host, uint16_t port, int32_t read_timeout);
-  stream(tcp_connection::pointer conn, int32_t read_timeout);
+  stream(const tcp_config::pointer& conf);
+  stream(const tcp_connection::pointer& conn, const tcp_config::pointer& conf);
   ~stream() noexcept;
   stream& operator=(const stream&) = delete;
   stream(const stream&) = delete;

--- a/broker/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/tcp_async.hh
@@ -19,6 +19,7 @@
 #define CENTREON_BROKER_TCP_INC_COM_CENTREON_BROKER_TCP_TCP_ASYNC_HH_
 
 #include "com/centreon/broker/pool.hh"
+#include "com/centreon/broker/tcp/tcp_config.hh"
 #include "com/centreon/broker/tcp/tcp_connection.hh"
 
 CCB_BEGIN()
@@ -75,6 +76,9 @@ class tcp_async {
 
   void _clear_available_con(asio::error_code ec);
 
+  static void _set_sock_opt(asio::ip::tcp::socket& sock,
+                            const tcp_config::pointer& conf);
+
  public:
   static void load();
   static void unload();
@@ -83,16 +87,19 @@ class tcp_async {
 
   tcp_async(const tcp_async&) = delete;
   tcp_async& operator=(const tcp_async&) = delete;
-  std::shared_ptr<asio::ip::tcp::acceptor> create_acceptor(uint16_t port);
-  void start_acceptor(std::shared_ptr<asio::ip::tcp::acceptor> acceptor);
+  std::shared_ptr<asio::ip::tcp::acceptor> create_acceptor(
+      const tcp_config::pointer& conf);
+  void start_acceptor(const std::shared_ptr<asio::ip::tcp::acceptor>& acceptor,
+                      const tcp_config::pointer& conf);
   void stop_acceptor(std::shared_ptr<asio::ip::tcp::acceptor> acceptor);
 
-  std::shared_ptr<tcp_connection> create_connection(std::string const& address,
-                                                    uint16_t port);
+  std::shared_ptr<tcp_connection> create_connection(
+      const tcp_config::pointer& conf);
   void remove_acceptor(std::shared_ptr<asio::ip::tcp::acceptor> acceptor);
   void handle_accept(std::shared_ptr<asio::ip::tcp::acceptor> acceptor,
                      tcp_connection::pointer new_connection,
-                     const asio::error_code& error);
+                     const asio::error_code& error,
+                     const tcp_config::pointer& conf);
   tcp_connection::pointer get_connection(
       std::shared_ptr<asio::ip::tcp::acceptor> acceptor,
       uint32_t timeout_s);

--- a/broker/tcp/inc/com/centreon/broker/tcp/tcp_config.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/tcp_config.hh
@@ -1,0 +1,59 @@
+/*
+** Copyright 2022 Centreon
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+**
+** For more information : contact@centreon.com
+*/
+
+#ifndef CCB_TCP_CONFIG_HH
+#define CCB_TCP_CONFIG_HH
+
+CCB_BEGIN()
+
+namespace tcp {
+class tcp_config {
+  const std::string _host;
+  uint16_t _port;
+  int32_t _read_timeout;
+  int _second_keepalive_interval;
+  int _keepalive_count;
+
+ public:
+  using pointer = std::shared_ptr<tcp_config>;
+
+  tcp_config(const std::string& host,
+             uint16_t port,
+             int32_t read_timeout = -1,
+             int second_keepalive_interval = 30,
+             int keepalive_count = 2)
+      : _host(host),
+        _port(port),
+        _read_timeout(read_timeout),
+        _second_keepalive_interval(second_keepalive_interval),
+        _keepalive_count(keepalive_count) {}
+
+  const std::string& get_host() const { return _host; }
+  uint16_t get_port() const { return _port; }
+  int32_t get_read_timeout() const { return _read_timeout; }
+  int get_second_keepalive_interval() const {
+    return _second_keepalive_interval;
+  }
+  int get_keepalive_count() const { return _keepalive_count; }
+};
+
+}  // namespace tcp
+
+CCB_END()
+
+#endif

--- a/broker/tcp/inc/com/centreon/broker/tcp/tcp_connection.hh
+++ b/broker/tcp/inc/com/centreon/broker/tcp/tcp_connection.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2020 Centreon
+** Copyright 2020-2021 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.

--- a/broker/tcp/src/acceptor.cc
+++ b/broker/tcp/src/acceptor.cc
@@ -35,8 +35,8 @@ using namespace com::centreon::broker::tcp;
  * @param port A port.
  * @param read_timeout A duration in seconds.
  */
-acceptor::acceptor(uint16_t port, int32_t read_timeout)
-    : io::endpoint(true), _port(port), _read_timeout(read_timeout) {}
+acceptor::acceptor(const tcp_config::pointer& conf)
+    : io::endpoint(true), _conf(conf) {}
 
 /**
  *  Destructor.
@@ -64,8 +64,8 @@ void acceptor::add_child(std::string const& child) {
  */
 std::unique_ptr<io::stream> acceptor::open() {
   if (!_acceptor) {
-    _acceptor = tcp_async::instance().create_acceptor(_port);
-    tcp_async::instance().start_acceptor(_acceptor);
+    _acceptor = tcp_async::instance().create_acceptor(_conf);
+    tcp_async::instance().start_acceptor(_acceptor, _conf);
   }
 
   /* Timeout in seconds during get_connection */
@@ -73,9 +73,8 @@ std::unique_ptr<io::stream> acceptor::open() {
   auto conn = tcp_async::instance().get_connection(_acceptor, timeout_s);
   if (conn) {
     assert(conn->port());
-    log_v2::tcp()->debug("acceptor gets a new connection from {}",
-                         conn->peer());
-    return std::make_unique<stream>(conn, -1);
+    log_v2::tcp()->info("acceptor gets a new connection from {}", conn->peer());
+    return std::make_unique<stream>(conn, _conf);
   }
   return nullptr;
 }

--- a/broker/tcp/src/connector.cc
+++ b/broker/tcp/src/connector.cc
@@ -36,13 +36,8 @@ using namespace com::centreon::broker::tcp;
  * @param port The port used for the connection.
  * @param read_timeout The read timeout in seconds or -1 if no duration.
  */
-connector::connector(const std::string& host,
-                     uint16_t port,
-                     int32_t read_timeout)
-    : io::limit_endpoint(false),
-      _host(host),
-      _port(port),
-      _read_timeout(read_timeout) {}
+connector::connector(const tcp_config::pointer& conf)
+    : io::limit_endpoint(false), _conf(conf) {}
 
 /**
  *  Destructor.
@@ -56,13 +51,14 @@ connector::~connector() {}
  */
 std::unique_ptr<io::stream> connector::open() {
   // Launch connection process.
-  log_v2::tcp()->info("TCP: connecting to {}:{}", _host, _port);
+  log_v2::tcp()->info("TCP: connecting to {}:{}", _conf->get_host(),
+                      _conf->get_port());
   try {
     return limit_endpoint::open();
   } catch (const std::exception& e) {
     log_v2::tcp()->debug(
-        "Unable to establish the connection to {}:{} (attempt {}): {}", _host,
-        _port, _is_ready_count, e.what());
+        "Unable to establish the connection to {}:{} (attempt {}): {}",
+        _conf->get_host(), _conf->get_port(), _is_ready_count, e.what());
     return nullptr;
   }
 }
@@ -73,5 +69,5 @@ std::unique_ptr<io::stream> connector::open() {
  * @return std::shared_ptr<stream>
  */
 std::unique_ptr<io::stream> connector::create_stream() {
-  return std::make_unique<stream>(_host, _port, _read_timeout);
+  return std::make_unique<stream>(_conf);
 }

--- a/broker/tcp/src/stream.cc
+++ b/broker/tcp/src/stream.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2011 - 2022 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,16 +46,15 @@ std::atomic<size_t> stream::_total_tcp_count{0};
  * @param port The port used by the host to listen.
  * @param read_timeout The read_timeout in seconds or -1 if no timeout.
  */
-stream::stream(std::string const& host, uint16_t port, int32_t read_timeout)
+stream::stream(const tcp_config::pointer& conf)
     : io::stream("TCP"),
-      _host(host),
-      _port(port),
-      _read_timeout(read_timeout),
-      _connection(tcp_async::instance().create_connection(host, port)),
+      _conf(conf),
+      _connection(tcp_async::instance().create_connection(_conf)),
       _parent(nullptr) {
   assert(_connection->port());
   _total_tcp_count++;
-  log_v2::tcp()->trace("New stream to {}:{}", _host, _port);
+  log_v2::tcp()->trace("New stream to {}:{}", _conf->get_host(),
+                       _conf->get_port());
   log_v2::tcp()->info(
       "{} TCP streams are configured on a thread pool of {} threads",
       _total_tcp_count, pool::instance().get_pool_size());
@@ -68,16 +67,13 @@ stream::stream(std::string const& host, uint16_t port, int32_t read_timeout)
  * @param conn The connection to use by this stream.
  * @param read_timeout A duration in seconds or -1 if no timeout.
  */
-stream::stream(tcp_connection::pointer conn, int32_t read_timeout)
-    : io::stream("TCP"),
-      _host{conn->address()},
-      _port{conn->port()},
-      _read_timeout(read_timeout),
-      _connection(conn),
-      _parent(nullptr) {
+stream::stream(const tcp_connection::pointer& conn,
+               const tcp_config::pointer& conf)
+    : io::stream("TCP"), _conf(conf), _connection(conn), _parent(nullptr) {
   assert(_connection->port());
   _total_tcp_count++;
-  log_v2::tcp()->info("New stream to {}:{}", _host, _port);
+  log_v2::tcp()->info("New stream to {}:{}", _conf->get_host(),
+                      _conf->get_port());
   log_v2::tcp()->info(
       "{} TCP streams are configured on a thread pool of {} threads",
       _total_tcp_count, pool::instance().get_pool_size());
@@ -117,16 +113,16 @@ std::string stream::peer() const {
  *
  *  @return Respects io::stream::read()'s return value.
  */
-
 bool stream::read(std::shared_ptr<io::data>& d, time_t deadline) {
   log_v2::tcp()->trace("read on stream");
 
   // Set deadline.
   {
     time_t now = ::time(nullptr);
-    if (_read_timeout != -1 &&
-        (deadline == static_cast<time_t>(-1) || now + _read_timeout < deadline))
-      deadline = now + _read_timeout / 1000;
+    if (_conf->get_read_timeout() != -1 &&
+        (deadline == static_cast<time_t>(-1) ||
+         now + _conf->get_read_timeout() < deadline))
+      deadline = now + _conf->get_read_timeout() / 1000;
   }
 
   if (_connection->is_closed()) {
@@ -182,7 +178,7 @@ int32_t stream::write(std::shared_ptr<io::data> const& d) {
   if (d->type() == io::raw::static_type()) {
     std::shared_ptr<io::raw> r(std::static_pointer_cast<io::raw>(d));
     log_v2::tcp()->trace("TCP: write request of {} bytes to peer '{}:{}'",
-                         r->size(), _host, _port);
+                         r->size(), _conf->get_host(), _conf->get_port());
     log_v2::tcp()->trace("write {} bytes", r->size());
     std::error_code err;
     try {

--- a/broker/tcp/test/acceptor.cc
+++ b/broker/tcp/test/acceptor.cc
@@ -36,6 +36,10 @@ using namespace com::centreon::exceptions;
 
 const static std::string test_addr("127.0.0.1");
 constexpr static uint16_t test_port(4444);
+static tcp::tcp_config::pointer test_conf(
+    std::make_shared<tcp::tcp_config>(test_addr, test_port));
+static tcp::tcp_config::pointer test_conf2(
+    std::make_shared<tcp::tcp_config>(test_addr, 4141));
 
 class TcpAcceptor : public ::testing::Test {
  public:
@@ -66,20 +70,22 @@ static auto try_connect =
 
 TEST_F(TcpAcceptor, BadPort) {
   if (getuid() != 0) {
-    tcp::acceptor acc(2, -1);
+    tcp::tcp_config::pointer conf(std::make_shared<tcp::tcp_config>("", 2));
+    tcp::acceptor acc(conf);
     ASSERT_THROW(acc.open(), std::exception);
   }
 }
 
 TEST_F(TcpAcceptor, NoConnector) {
-  tcp::acceptor acc(test_port, -1);
+  tcp::acceptor acc(test_conf);
 
   ASSERT_EQ(acc.open(), std::unique_ptr<io::stream>());
 }
 
 TEST_F(TcpAcceptor, Nominal) {
   std::thread cbd([] {
-    std::unique_ptr<tcp::acceptor> a(new tcp::acceptor(4141, -1));
+    std::unique_ptr<tcp::acceptor> a(
+        std::make_unique<tcp::acceptor>(test_conf2));
     std::unique_ptr<io::endpoint> endp(a.release());
 
     /* Nominal case, cbd is acceptor and read on the socket */
@@ -109,8 +115,7 @@ TEST_F(TcpAcceptor, Nominal) {
   });
 
   std::thread centengine([] {
-    std::unique_ptr<tcp::connector> c(
-        new tcp::connector("localhost", 4141, -1));
+    std::unique_ptr<tcp::connector> c(new tcp::connector(test_conf2));
     std::unique_ptr<io::endpoint> endp(c.release());
 
     /* Nominal case, centengine is connector and write on the socket */
@@ -146,7 +151,7 @@ TEST_F(TcpAcceptor, QuestionAnswer) {
 
   std::thread cbd([&cbd_m, &cbd_cv, &cbd_finished] {
     std::unique_ptr<io::endpoint> endp(
-        std::make_unique<tcp::acceptor>(4141, -1));
+        std::make_unique<tcp::acceptor>(test_conf2));
 
     /* Nominal case, cbd is acceptor and read on the socket */
     std::unique_ptr<io::stream> u_cbd;
@@ -189,8 +194,7 @@ TEST_F(TcpAcceptor, QuestionAnswer) {
   });
 
   std::thread centengine([&cbd_cv, &cbd_finished] {
-    std::unique_ptr<tcp::connector> c(
-        new tcp::connector("localhost", 4141, -1));
+    std::unique_ptr<tcp::connector> c(new tcp::connector(test_conf2));
     std::unique_ptr<io::endpoint> endp(c.release());
 
     std::unique_ptr<io::stream> u_centengine;
@@ -254,7 +258,7 @@ TEST_F(TcpAcceptor, MultiNominal) {
     {
       std::vector<std::unique_ptr<io::stream>> u_cbd(nb_poller);
       std::unique_ptr<io::endpoint> endp{
-          std::make_unique<tcp::acceptor>(4141, -1)};
+          std::make_unique<tcp::acceptor>(test_conf2)};
 
       /* Nominal case, cbd is acceptor and read on the socket */
       bool cont = true;
@@ -313,7 +317,7 @@ TEST_F(TcpAcceptor, MultiNominal) {
   for (size_t i = 0; i < nb_poller; i++) {
     pollers.emplace_back([&cbd_finished, &cbd_m, &cbd_cv] {
       std::unique_ptr<io::endpoint> endp{
-          std::make_unique<tcp::connector>("localhost", 4141, -1)};
+          std::make_unique<tcp::connector>(test_conf2)};
 
       /* Nominal case, centengine is connector and write on the socket */
       std::unique_ptr<io::stream> u_centengine;
@@ -358,8 +362,7 @@ TEST_F(TcpAcceptor, NominalReversed) {
   bool cbd_finished = false;
 
   std::thread centengine([&cbd_m, &cbd_cv, &cbd_finished] {
-    std::unique_ptr<tcp::connector> c(
-        new tcp::connector("localhost", 4141, -1));
+    std::unique_ptr<tcp::connector> c(new tcp::connector(test_conf2));
     std::unique_ptr<io::endpoint> endp(c.release());
 
     std::unique_ptr<io::stream> u_centengine;
@@ -393,7 +396,7 @@ TEST_F(TcpAcceptor, NominalReversed) {
 
   std::thread cbd([&cbd_m, &cbd_finished, &cbd_cv] {
     std::unique_ptr<io::endpoint> endp(
-        std::make_unique<tcp::acceptor>(4141, -1));
+        std::make_unique<tcp::acceptor>(test_conf2));
 
     std::unique_ptr<io::stream> u_cbd;
     do {
@@ -429,7 +432,8 @@ TEST_F(TcpAcceptor, NominalReversed) {
 
 TEST_F(TcpAcceptor, OnePeer) {
   std::thread centengine([] {
-    std::unique_ptr<tcp::acceptor> a(new tcp::acceptor(4141, -1));
+    std::unique_ptr<tcp::acceptor> a(
+        std::make_unique<tcp::acceptor>(test_conf2));
     std::unique_ptr<io::endpoint> endp(a.release());
 
     std::unique_ptr<io::stream> u_centengine;
@@ -453,8 +457,7 @@ TEST_F(TcpAcceptor, OnePeer) {
   });
 
   std::thread cbd([] {
-    std::unique_ptr<tcp::connector> c(
-        new tcp::connector("localhost", 4141, -1));
+    std::unique_ptr<tcp::connector> c(new tcp::connector(test_conf2));
     std::unique_ptr<io::endpoint> endp(c.release());
 
     std::unique_ptr<io::stream> u_cbd;
@@ -488,8 +491,7 @@ TEST_F(TcpAcceptor, OnePeer) {
 
 TEST_F(TcpAcceptor, OnePeerReversed) {
   std::thread cbd([] {
-    std::unique_ptr<tcp::connector> c(
-        new tcp::connector("localhost", 4141, -1));
+    std::unique_ptr<tcp::connector> c(new tcp::connector(test_conf2));
     std::unique_ptr<io::endpoint> endp(c.release());
 
     std::unique_ptr<io::stream> u_cbd;
@@ -525,7 +527,8 @@ TEST_F(TcpAcceptor, OnePeerReversed) {
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
   std::thread centengine([] {
-    std::unique_ptr<tcp::acceptor> a(new tcp::acceptor(4141, -1));
+    std::unique_ptr<tcp::acceptor> a(
+        std::make_unique<tcp::acceptor>(test_conf2));
     std::unique_ptr<io::endpoint> endp(a.release());
 
     std::unique_ptr<io::stream> u_centengine;
@@ -556,7 +559,8 @@ TEST_F(TcpAcceptor, MultiOnePeer) {
   const int nb_steps = 5;
 
   std::thread centengine([] {
-    std::unique_ptr<tcp::acceptor> a(new tcp::acceptor(4141, -1));
+    std::unique_ptr<tcp::acceptor> a(
+        std::make_unique<tcp::acceptor>(test_conf2));
     std::unique_ptr<io::endpoint> endp(a.release());
 
     std::unique_ptr<io::stream> u_centengine;
@@ -596,8 +600,7 @@ TEST_F(TcpAcceptor, MultiOnePeer) {
    * simulates a negotiation with the centengine instance */
   for (int i = 0; i < nb_steps; i++) {
     std::thread cbd([] {
-      std::unique_ptr<tcp::connector> c(
-          new tcp::connector("localhost", 4141, -1));
+      std::unique_ptr<tcp::connector> c(new tcp::connector(test_conf2));
       std::unique_ptr<io::endpoint> endp(c.release());
 
       std::unique_ptr<io::stream> u_cbd;
@@ -630,8 +633,7 @@ TEST_F(TcpAcceptor, NominalRepeated) {
   const int nb_steps = 5;
 
   std::thread centengine([] {
-    std::unique_ptr<tcp::connector> c(
-        new tcp::connector("localhost", 4141, -1));
+    std::unique_ptr<tcp::connector> c(new tcp::connector(test_conf2));
     std::unique_ptr<io::endpoint> endp(c.release());
 
     std::unique_ptr<io::stream> u_centengine;
@@ -678,7 +680,8 @@ TEST_F(TcpAcceptor, NominalRepeated) {
   for (int i = 0; i < nb_steps; i++) {
     std::thread cbd([i] {
       std::cout << "cbd  " << i << "\n";
-      std::unique_ptr<tcp::acceptor> a(new tcp::acceptor(4141, -1));
+      std::unique_ptr<tcp::acceptor> a(
+          std::make_unique<tcp::acceptor>(test_conf2));
       std::cout << "cbd1 " << i << "\n";
       std::cout << "cbd2 " << i << "\n";
       std::cout << "cbd3 " << i << "\n";
@@ -718,13 +721,13 @@ TEST_F(TcpAcceptor, NominalRepeated) {
 }
 
 TEST_F(TcpAcceptor, Wait2Connect) {
-  tcp::acceptor acc(4141, -1);
+  tcp::acceptor acc(test_conf2);
   int i = 0;
   std::shared_ptr<io::stream> st;
 
   std::thread t{[&] {
     std::this_thread::sleep_for(std::chrono::seconds{2});
-    tcp::connector con(test_addr, 4141, -1);
+    tcp::connector con(test_conf2);
     std::shared_ptr<io::stream> str{try_connect(con)};
   }};
 
@@ -743,13 +746,13 @@ TEST_F(TcpAcceptor, Wait2Connect) {
 }
 
 TEST_F(TcpAcceptor, Simple) {
-  tcp::acceptor acc(test_port, -1);
+  tcp::acceptor acc(test_conf);
   std::condition_variable cv;
   std::mutex m;
   bool finish = false;
 
   std::thread t([&] {
-    tcp::connector con(test_addr, test_port, -1);
+    tcp::connector con(test_conf);
     std::shared_ptr<io::stream> str{try_connect(con)};
     std::shared_ptr<io::raw> data{std::make_shared<io::raw>()};
     std::shared_ptr<io::data> data_read;
@@ -792,11 +795,11 @@ TEST_F(TcpAcceptor, Simple) {
 }
 
 TEST_F(TcpAcceptor, Multiple) {
-  tcp::acceptor acc(test_port, -1);
+  tcp::acceptor acc(test_conf);
 
   {
     std::thread t{[] {
-      tcp::connector con(test_addr, test_port, -1);
+      tcp::connector con(test_conf);
       std::shared_ptr<io::stream> str{try_connect(con)};
       std::shared_ptr<io::raw> data{new io::raw()};
       std::shared_ptr<io::data> data_read;
@@ -827,7 +830,7 @@ TEST_F(TcpAcceptor, Multiple) {
   }
   {
     std::thread t{[] {
-      tcp::connector con(test_addr, test_port, -1);
+      tcp::connector con(test_conf);
       std::shared_ptr<io::stream> str{try_connect(con)};
       std::shared_ptr<io::raw> data{new io::raw()};
       std::shared_ptr<io::data> data_read;
@@ -859,10 +862,10 @@ TEST_F(TcpAcceptor, Multiple) {
 }
 
 TEST_F(TcpAcceptor, BigSend) {
-  tcp::acceptor acc(test_port, -1);
+  tcp::acceptor acc(test_conf);
 
   std::thread t{[] {
-    tcp::connector con(test_addr, test_port, -1);
+    tcp::connector con(test_conf);
     std::shared_ptr<io::stream> str{try_connect(con)};
     std::shared_ptr<io::raw> data{new io::raw()};
     std::shared_ptr<io::data> data_read;
@@ -897,11 +900,11 @@ TEST_F(TcpAcceptor, BigSend) {
 }
 
 TEST_F(TcpAcceptor, CloseRead) {
-  tcp::acceptor acc(test_port, -1);
+  tcp::acceptor acc(test_conf);
 
   std::thread t{[&] {
     {
-      tcp::connector con(test_addr, test_port, -1);
+      tcp::connector con(test_conf);
       std::shared_ptr<io::stream> str{try_connect(con)};
       std::shared_ptr<io::raw> data{new io::raw()};
       std::shared_ptr<io::data> data_read;
@@ -933,7 +936,7 @@ TEST_F(TcpAcceptor, CloseRead) {
 }
 
 TEST_F(TcpAcceptor, ChildsAndStats) {
-  tcp::acceptor acc(test_port, -1);
+  tcp::acceptor acc(test_conf);
 
   acc.add_child("child1");
   acc.add_child("child2");
@@ -952,7 +955,9 @@ TEST_F(TcpAcceptor, QuestionAnswerMultiple) {
 
   for (int i = 0; i < nb_connections; i++) {
     cbd.emplace_back([i] {
-      std::unique_ptr<tcp::acceptor> a(new tcp::acceptor(4141 + i, -1));
+      tcp::tcp_config::pointer conf(
+          std::make_shared<tcp::tcp_config>("", 4141 + i));
+      std::unique_ptr<tcp::acceptor> a(std::make_unique<tcp::acceptor>(conf));
       std::unique_ptr<io::endpoint> endp(a.release());
 
       /* Nominal case, cbd is acceptor and read on the socket */
@@ -994,8 +999,9 @@ TEST_F(TcpAcceptor, QuestionAnswerMultiple) {
     });
 
     centengine.emplace_back([i] {
-      std::unique_ptr<tcp::connector> c(
-          new tcp::connector("localhost", 4141 + i, -1));
+      tcp::tcp_config::pointer conf(
+          std::make_shared<tcp::tcp_config>("", 4141 + i));
+      std::unique_ptr<tcp::connector> c(new tcp::connector(conf));
       std::unique_ptr<io::endpoint> endp(c.release());
 
       std::unique_ptr<io::stream> u_centengine;
@@ -1039,12 +1045,12 @@ TEST_F(TcpAcceptor, QuestionAnswerMultiple) {
 }
 
 TEST_F(TcpAcceptor, MultipleBigSend) {
-  tcp::acceptor acc(test_port, -1);
+  tcp::acceptor acc(test_conf);
   const int32_t nb_packet = 10;
   const int32_t len = 10024;
 
   std::thread t{[nb_packet] {
-    tcp::connector con(test_addr, test_port, -1);
+    tcp::connector con(test_conf);
     std::shared_ptr<io::stream> str{try_connect(con)};
     std::shared_ptr<io::data> data_read;
     for (int k = 0; k < nb_packet; k++) {

--- a/broker/tcp/test/connector.cc
+++ b/broker/tcp/test/connector.cc
@@ -31,6 +31,9 @@ using namespace com::centreon::broker;
 constexpr static char test_addr[] = "127.0.0.1";
 constexpr static uint16_t test_port(4242);
 
+static tcp::tcp_config::pointer test_conf(
+    std::make_shared<tcp::tcp_config>(test_addr, test_port));
+
 class TcpConnector : public testing::Test {
  public:
   void SetUp() override {
@@ -53,7 +56,10 @@ class TcpConnector : public testing::Test {
 };
 
 TEST_F(TcpConnector, Timeout) {
-  tcp::connector connector(test_addr, test_port, 1);
+  static tcp::tcp_config::pointer conf(
+      std::make_shared<tcp::tcp_config>(test_addr, test_port, 1));
+
+  tcp::connector connector(conf);
   std::shared_ptr<io::stream> io{connector.open()};
 
   std::shared_ptr<io::data> data{new io::raw()};
@@ -62,7 +68,7 @@ TEST_F(TcpConnector, Timeout) {
 }
 
 TEST_F(TcpConnector, Simple) {
-  tcp::connector connector(test_addr, test_port, -1);
+  tcp::connector connector(test_conf);
   std::shared_ptr<io::stream> io{connector.open()};
 
   std::shared_ptr<io::raw> data{new io::raw()};
@@ -80,7 +86,7 @@ TEST_F(TcpConnector, Simple) {
 }
 
 TEST_F(TcpConnector, ReadAfterTimeout) {
-  tcp::connector connector(test_addr, test_port, -1);
+  tcp::connector connector(test_conf);
   std::shared_ptr<io::stream> io{connector.open()};
 
   std::shared_ptr<io::raw> data{new io::raw()};
@@ -99,7 +105,7 @@ TEST_F(TcpConnector, ReadAfterTimeout) {
 }
 
 TEST_F(TcpConnector, MultipleSimple) {
-  tcp::connector connector(test_addr, test_port, -1);
+  tcp::connector connector(test_conf);
   std::shared_ptr<io::stream> io{connector.open()};
 
   std::shared_ptr<io::raw> data{new io::raw()};

--- a/broker/tls/test/acceptor.cc
+++ b/broker/tls/test/acceptor.cc
@@ -43,6 +43,11 @@ using namespace com::centreon::exceptions;
 const static std::string test_addr("127.0.0.1");
 constexpr static uint16_t test_port(4444);
 
+static tcp::tcp_config::pointer test_conf(
+    std::make_shared<tcp::tcp_config>(test_addr, test_port));
+static tcp::tcp_config::pointer test_conf2(
+    std::make_shared<tcp::tcp_config>(test_addr, 4141));
+
 class TlsTest : public ::testing::Test {
  public:
   void SetUp() override {
@@ -61,7 +66,7 @@ TEST_F(TlsTest, AnonTlsStream) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>(4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>("", "", "", "")};
 
@@ -92,7 +97,7 @@ TEST_F(TlsTest, AnonTlsStream) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     auto tls_c{std::make_unique<tls::connector>("", "", "", "")};
 
@@ -127,7 +132,7 @@ TEST_F(TlsTest, AnonTlsStreamContinuous) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>(4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>("", "", "", "")};
 
@@ -162,7 +167,7 @@ TEST_F(TlsTest, AnonTlsStreamContinuous) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     auto tls_c{std::make_unique<tls::connector>("", "", "", "")};
 
@@ -210,7 +215,7 @@ TEST_F(TlsTest, TlsStream) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>(4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>(
         "/tmp/server.crt", "/tmp/server.key", "", "")};
@@ -240,7 +245,7 @@ TEST_F(TlsTest, TlsStream) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     auto tls_c{std::make_unique<tls::connector>("/tmp/client.crt", "/tmp/client.key", "", "")};
 
@@ -284,7 +289,7 @@ TEST_F(TlsTest, TlsStreamCa) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>(4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>(
         "/tmp/server.crt", "/tmp/server.key", "/tmp/client.crt", "")};
@@ -314,7 +319,7 @@ TEST_F(TlsTest, TlsStreamCa) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     auto tls_c{std::make_unique<tls::connector>("/tmp/client.crt", "/tmp/client.key", "/tmp/server.crt", "")};
 
@@ -358,7 +363,7 @@ TEST_F(TlsTest, TlsStreamCaError) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>(4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>(
         "/tmp/server.crt", "/tmp/server.key", "/tmp/client.crt", "")};
@@ -389,7 +394,7 @@ TEST_F(TlsTest, TlsStreamCaError) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     /* the name does not match with the CN of the server certificate */
     auto tls_c{std::make_unique<tls::connector>("/tmp/client.crt", "/tmp/client.key", "/tmp/server.crt", "badhostname")};
@@ -423,7 +428,7 @@ TEST_F(TlsTest, TlsStreamCaHostname) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>(4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>(
         "/tmp/server.crt", "/tmp/server.key", "/tmp/client.crt", "")};
@@ -453,7 +458,7 @@ TEST_F(TlsTest, TlsStreamCaHostname) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     auto tls_c{std::make_unique<tls::connector>("/tmp/client.crt", "/tmp/client.key", "/tmp/server.crt", s_hostname)};
 
@@ -500,7 +505,7 @@ TEST_F(TlsTest, TlsStreamBigData) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>(4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>(
         "/tmp/server.crt", "/tmp/server.key", "/tmp/client.crt", "")};
@@ -548,7 +553,7 @@ TEST_F(TlsTest, TlsStreamBigData) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     auto tls_c{std::make_unique<tls::connector>(
         "/tmp/client.crt", "/tmp/client.key", "/tmp/server.crt", s_hostname)};
@@ -604,7 +609,7 @@ TEST_F(TlsTest, TlsStreamLongData) {
   std::atomic_bool cbd_finished{false};
 
   std::thread cbd([&cbd_finished] {
-    auto a{std::make_unique<tcp::acceptor>(4141, -1)};
+    auto a{std::make_unique<tcp::acceptor>(test_conf2)};
 
     auto tls_a{std::make_unique<tls::acceptor>(
         "/tmp/server.crt", "/tmp/server.key", "/tmp/client.crt", "")};
@@ -653,7 +658,7 @@ TEST_F(TlsTest, TlsStreamLongData) {
   });
 
   std::thread centengine([&cbd_finished] {
-    auto c{std::make_unique<tcp::connector>("localhost", 4141, -1)};
+    auto c{std::make_unique<tcp::connector>(test_conf2)};
 
     auto tls_c{std::make_unique<tls::connector>(
         "/tmp/client.crt", "/tmp/client.key", "/tmp/server.crt", s_hostname)};


### PR DESCRIPTION
## Description

keep alive packet  are sent every 30s to maintain NAT and to detect bad connection failure.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [X] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

