### PR TITLE
fix(ci): use RELEASE instead of DISTRIB in package naming (#481)

### DIFF
--- a/ci/scripts/collect-deb-package.sh
+++ b/ci/scripts/collect-deb-package.sh
@@ -26,7 +26,13 @@ tar --exclude={".git","build"} -czpf centreon-collect-$VERSION.tar.gz "$ROOT"
 cd "$ROOT"
 cp -rf ci/debian-collect debian
 sed -i "s/^centreon:version=.*$/centreon:version=$(echo $VERSION-$RELEASE)/" debian/substvars
-#sed -i "s/^centreon:version=.*$/centreon:version=$(echo $VERSION | egrep -o '^[0-9][0-9].[0-9][0-9]')/" debian/substvars
-debmake -f "${AUTHOR}" -e "${AUTHOR_EMAIL}" -u "$VERSION" -r "$DISTRIB"
+echo "debmake begin"
+debmake -f "${AUTHOR}" -e "${AUTHOR_EMAIL}" -u "$VERSION" -r "$RELEASE"
+echo "version de dwz"
+/usr/bin/dwz -v
+echo "version de gcc"
+gcc --version
+echo "version de ld"
+ld --version
 debuild-pbuilder
 cd ../


### PR DESCRIPTION
## Description

Backport usage of RELEASE instead of DISTRIB.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

