### PR TITLE
MON-16390 no empty output and always fill host_id and service_id

### DIFF
--- a/broker/neb/src/callbacks.cc
+++ b/broker/neb/src/callbacks.cc
@@ -2248,19 +2248,6 @@ int neb::callback_process(int, void* data) {
     SPDLOG_LOGGER_INFO(log_v2::neb(),
                        "callbacks: generating process start event");
 
-    // Parse configuration file.
-    try {
-      config::parser parsr;
-      config::state conf{parsr.parse(gl_configuration_file)};
-
-      // Apply resulting configuration.
-      config::applier::state::instance().apply(conf);
-
-    } catch (msg_fmt const& e) {
-      SPDLOG_LOGGER_INFO(log_v2::neb(), e.what());
-      return 0;
-    }
-
     // Register callbacks.
     SPDLOG_LOGGER_DEBUG(
         log_v2::neb(), "callbacks: registering callbacks for old BBDO version");
@@ -2348,19 +2335,6 @@ int neb::callback_pb_process(int callback_type, void* data) {
   if (NEBTYPE_PROCESS_EVENTLOOPSTART == process_data->type) {
     SPDLOG_LOGGER_INFO(log_v2::neb(),
                        "callbacks: generating process start event");
-
-    // Parse configuration file.
-    try {
-      config::parser parsr;
-      config::state conf{parsr.parse(gl_configuration_file)};
-
-      // Apply resulting configuration.
-      config::applier::state::instance().apply(conf);
-
-    } catch (msg_fmt const& e) {
-      SPDLOG_LOGGER_INFO(log_v2::neb(), e.what());
-      return 0;
-    }
 
     // Register callbacks.
     SPDLOG_LOGGER_DEBUG(


### PR DESCRIPTION
## Description


**Fixes** # (issue)
in logs table, we find after engine startup lines without host_id and service_id a,nd output

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

