### PR TITLE
fix(broker): bbdo events not totally registered

### DIFF
--- a/broker/core/src/bbdo/internal.cc
+++ b/broker/core/src/bbdo/internal.cc
@@ -40,7 +40,8 @@ void bbdo::load() {
   // Register BBDO category.
   io::events& e(io::events::instance());
 
-  // Register BBDO events.
+  // Register BBDO events. Be careful, on Broker, these events are initialized
+  // in core/src/io/events, method events::events().
   e.register_event(make_type(io::bbdo, bbdo::de_version_response),
                    "version_response", &version_response::operations,
                    version_response::entries);

--- a/broker/core/src/io/events.cc
+++ b/broker/core/src/io/events.cc
@@ -227,6 +227,10 @@ events::events() {
                  &bbdo::ack::operations, bbdo::ack::entries);
   register_event(make_type(io::bbdo, bbdo::de_stop), "stop",
                  &bbdo::stop::operations, bbdo::stop::entries);
+  register_event(make_type(io::bbdo, bbdo::de_pb_ack), "ack",
+                 &bbdo::pb_ack::operations);
+  register_event(make_type(io::bbdo, bbdo::de_pb_stop), "stop",
+                 &bbdo::pb_stop::operations);
 
   // Register BBDO protocol.
   io::protocols::instance().reg("BBDO", std::make_shared<bbdo::factory>(), 7,

--- a/cmake.sh
+++ b/cmake.sh
@@ -244,10 +244,10 @@ fi
 
 pip3 install conan --upgrade
 
-if [[ "$my_id" == 0 ]] ; then
-  conan='/usr/local/bin/conan'
-elif which conan ; then
+if which conan ; then
   conan=$(which conan)
+elif [[ -x /usr/local/bin/conan ]] ; then
+  conan='/usr/local/bin/conan'
 else
   conan="$HOME/.local/bin/conan"
 fi


### PR DESCRIPTION
## Description

Ack, stop, start events were not correctly registered.

REFS: MON-16489

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
