### PR TITLE
 fix(broker/unified_sql): attribute _next_time not defined

### DIFF
--- a/broker/unified_sql/src/bulk_queries.cc
+++ b/broker/unified_sql/src/bulk_queries.cc
@@ -32,7 +32,7 @@ using namespace com::centreon::broker::unified_sql;
 bulk_queries::bulk_queries(const uint32_t max_interval,
                            const uint32_t max_queries,
                            const std::string& query)
-    : _interval{max_interval}, _max_size{max_queries}, _query(query) {}
+    : _interval{max_interval}, _max_size{max_queries}, _query(query), _next_time{std::time(nullptr) + max_interval} {}
 
 /**
  * @brief Compute the query to execute as a string and return it. The container

--- a/tests/broker-engine/scheduler.robot
+++ b/tests/broker-engine/scheduler.robot
@@ -17,7 +17,7 @@ Library	../resources/Common.py
 
 *** Test Cases ***
 ENRSCHE1
-	[Documentation]	check next check of reschedule is last_check+interval_check
+	[Documentation]	Verify that next check of a rescheduled host is made at last_check + interval_check
 	[Tags]	Broker	Engine	scheduler
 	Config Engine	${1}
 	Config Broker	rrd
@@ -26,6 +26,7 @@ ENRSCHE1
 	Engine Config Set Value	${0}	log_legacy_enabled	${0}
 	Engine Config Set Value	${0}	log_v2_enabled	${1}
 	Engine Config Set Value	${0}	log_level_checks	debug
+	Engine Config Set Value	${0}	log_flush_period	0	True
 
 	${start}=	Get Current Date
 
@@ -37,8 +38,7 @@ ENRSCHE1
 	${pid}=	Get Process Id	e0
 	${content}=	Set Variable	[checks] [debug] [${pid}] Rescheduling next check of host: host_14
 
-	${log}=	Catenate	SEPARATOR=	${ENGINE_LOG}	/config0/centengine.log
-	${result1}	${result2}=	check reschedule with timeout	${log}	${start}	${content}	240
+	${result1}	${result2}=	check reschedule with timeout	${logEngine0}	${start}	${content}	240
 	Should Be True	${result1}	msg=the delta of last_check and next_check is not equal to 60.
 	Should Be True	${result2}	msg=the delta of last_check and next_check is not equal to 300.
 	Stop Engine


### PR DESCRIPTION
REFS: MON-16231

## Description

next time was not initialized in bulk queries.

REFS: MON-16231

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

