### PR TITLE
fix wrong poller filter

### DIFF
--- a/stream-connectors/modules/centreon-stream-connectors-lib/sc_event.lua
+++ b/stream-connectors/modules/centreon-stream-connectors-lib/sc_event.lua
@@ -680,23 +680,23 @@ end
 --- is_valid_poller: check if the event is monitored from an accepted poller
 -- @return true|false (boolean)
 function ScEvent:is_valid_poller()
+  -- return false if instance id is not found in cache
+  if not self.event.cache.host.instance_id then
+    self.sc_logger:warning("[sc_event:is_valid_poller]: no instance ID found for host ID: " .. tostring(self.event.host_id))
+    return false
+  end
+
   self.event.cache.poller = self.sc_broker:get_instance(self.event.cache.host.instance_id)
 
   -- required if we want to easily have access to poller name with macros {cache.instance.name}
   self.event.cache.instance = {
-    id = self.event.cache.host.instance,
+    id = self.event.cache.host.instance_id,
     name = self.event.cache.poller
   }
   
   -- return true if option is not set
   if self.params.accepted_pollers == "" then
     return true
-  end
-
-  -- return false if instance id is not found in cache
-  if not self.event.cache.host.instance then
-    self.sc_logger:warning("[sc_event:is_valid_poller]: no instance ID found for host ID: " .. tostring(self.event.host_id))
-    return false
   end
 
   -- return false if no poller found in cache


### PR DESCRIPTION
## Description

when you filter your events based on the name of a poller, it will never work  because the `if not self.event.cache.host.instance then` condition will never be true because the instance entry doesn't exist

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- have an apiv2 stream connector 
- put all your poller in the accepted_pollers parameter 
- without the patch, every events are going to be filtered out while they should all be accepted
- with the patch, it will work as intended

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

