### PR TITLE
fix(broker/unified_sql): bulk_bind row filling must be protected

### DIFF
--- a/broker/core/test/mysql/mysql.cc
+++ b/broker/core/test/mysql/mysql.cc
@@ -1959,3 +1959,91 @@ TEST_F(DatabaseStorageTest, BulkStatementsWithNullValues) {
   }
   ASSERT_TRUE(inside);
 }
+
+TEST_F(DatabaseStorageTest, RepeatStatementsWithBooleanValues) {
+  database_config db_cfg("MySQL", "127.0.0.1", MYSQL_SOCKET, 3306, "root",
+                         "centreon", "centreon_storage", 5, true, 5);
+  auto ms{std::make_unique<mysql>(db_cfg)};
+  std::string query1{"DROP TABLE IF EXISTS ut_test"};
+  std::string query2{
+      "CREATE TABLE ut_test (id BIGINT NOT NULL AUTO_INCREMENT "
+      "PRIMARY KEY, name VARCHAR(1000), value DOUBLE, t TINYINT, e enum('a', "
+      "'b', 'c') DEFAULT 'a', b TINYINT)"};
+  ms->run_query(query1);
+  ms->commit();
+  ms->run_query(query2);
+  ms->commit();
+
+  std::string query("INSERT INTO ut_test (name,b, t) VALUES (?,?,?)");
+  mysql_stmt stmt(ms->prepare_query(query));
+
+  constexpr int TOTAL = 200;
+
+  for (int i = 0; i < TOTAL; i++) {
+    stmt.bind_value_as_str(0, fmt::format("foo{}", i));
+    stmt.bind_value_as_bool(1, (i % 2) == 0);
+    stmt.bind_value_as_bool(2, (i % 2) == 1);
+    ms->run_statement(stmt);
+  }
+  ms->commit();
+
+  std::string query4("SELECT name, b, t FROM ut_test LIMIT 5");
+  std::promise<mysql_result> promise;
+  std::future<mysql_result> future = promise.get_future();
+  ms->run_query_and_get_result(query4, std::move(promise));
+  mysql_result res = future.get();
+  bool inside = false;
+  while (ms->fetch_row(res)) {
+    inside = true;
+    ASSERT_TRUE(res.value_as_bool(1) != res.value_as_bool(2));
+  }
+  ASSERT_TRUE(inside);
+}
+
+TEST_F(DatabaseStorageTest, BulkStatementsWithBooleanValues) {
+  database_config db_cfg("MySQL", "127.0.0.1", MYSQL_SOCKET, 3306, "root",
+                         "centreon", "centreon_storage", 5, true, 5);
+  auto ms{std::make_unique<mysql>(db_cfg)};
+  std::string query1{"DROP TABLE IF EXISTS ut_test"};
+  std::string query2{
+      "CREATE TABLE ut_test (id BIGINT NOT NULL AUTO_INCREMENT "
+      "PRIMARY KEY, name VARCHAR(1000), value DOUBLE, t TINYINT, e enum('a', "
+      "'b', 'c') DEFAULT 'a', b TINYINT, i INT, u INT UNSIGNED)"};
+  ms->run_query(query1);
+  ms->commit();
+  ms->run_query(query2);
+  ms->commit();
+
+  std::string query("INSERT INTO ut_test (name,b, t) VALUES (?,?, ?)");
+  mysql_bulk_stmt stmt(query);
+  ms->prepare_statement(stmt);
+
+  auto bb = stmt.create_bind();
+  bb->reserve(200);
+  constexpr int TOTAL = 200;
+
+  for (int i = 0; i < TOTAL; i++) {
+    ASSERT_EQ(bb->current_row(), i);
+    bb->set_value_as_str(0, fmt::format("foo{}", i));
+    bb->set_value_as_bool(1, (i % 2) == 0);
+    bb->set_value_as_bool(2, (i % 2) == 1);
+    bb->next_row();
+  }
+  stmt.set_bind(std::move(bb));
+  ms->run_statement(stmt);
+  ms->commit();
+
+  std::string query4("SELECT id, value, b, t FROM ut_test LIMIT 5");
+  std::promise<mysql_result> promise;
+  std::future<mysql_result> future = promise.get_future();
+  ms->run_query_and_get_result(query4, std::move(promise));
+  mysql_result res = future.get();
+  bool inside1 = false;
+  while (ms->fetch_row(res)) {
+    inside1 = true;
+    ASSERT_TRUE(res.value_as_int(2) <= 1);
+    ASSERT_TRUE(res.value_as_int(3) <= 1);
+    ASSERT_NE(res.value_as_bool(2), res.value_as_bool(3));
+  }
+  ASSERT_TRUE(inside1);
+}

--- a/broker/unified_sql/inc/com/centreon/broker/unified_sql/bulk_bind.hh
+++ b/broker/unified_sql/inc/com/centreon/broker/unified_sql/bulk_bind.hh
@@ -78,6 +78,8 @@ class bulk_bind {
   std::time_t next_time() const;
   std::size_t connections_count() const;
   void init_from_stmt(int32_t conn);
+  void lock();
+  void unlock();
 };
 }  // namespace unified_sql
 CCB_END()

--- a/broker/unified_sql/src/bulk_bind.cc
+++ b/broker/unified_sql/src/bulk_bind.cc
@@ -114,8 +114,13 @@ void bulk_bind::apply_to_stmt(int32_t conn) {
   _next_time[conn] = std::time(nullptr) + _interval;
 }
 
+/**
+ * @brief Initialize the bind at the given connection from the associated
+ * statement.
+ *
+ * @param conn
+ */
 void bulk_bind::init_from_stmt(int32_t conn) {
-  std::lock_guard<std::mutex> lck(_queue_m);
   _bind[conn] = _stmt.create_bind();
 }
 
@@ -128,6 +133,22 @@ std::size_t bulk_bind::connections_count() const {
   return _bind.size();
 }
 
+/**
+ * @brief accessor to the bind corresponding to a connection. This function
+ * call must be protected.
+ *
+ * @param conn
+ *
+ * @return An unique_ptr to a mysql_bulk_bind.
+ */
 std::unique_ptr<database::mysql_bulk_bind>& bulk_bind::bind(int32_t conn) {
   return _bind[conn];
+}
+
+void bulk_bind::lock() {
+  _queue_m.lock();
+}
+
+void bulk_bind::unlock() {
+  _queue_m.unlock();
 }

--- a/broker/unified_sql/src/stream_sql.cc
+++ b/broker/unified_sql/src/stream_sql.cc
@@ -1613,6 +1613,7 @@ void stream::_process_pb_host_status(const std::shared_ptr<io::data>& d) {
       int32_t conn = _mysql.choose_connection_by_instance(
           _cache_host_instance[static_cast<uint32_t>(hscr.host_id())]);
       if (_bulk_prepared_statement) {
+        std::lock_guard<bulk_bind> lck(*_hscr_bind);
         if (!_hscr_bind->bind(conn))
           _hscr_bind->init_from_stmt(conn);
         auto* b = _hscr_bind->bind(conn).get();
@@ -1707,6 +1708,7 @@ void stream::_process_pb_host_status(const std::shared_ptr<io::data>& d) {
       int32_t conn = _mysql.choose_connection_by_instance(
           _cache_host_instance[static_cast<uint32_t>(hscr.host_id())]);
       if (_bulk_prepared_statement) {
+        std::lock_guard<bulk_bind> lck(*_hscr_resources_bind);
         if (!_hscr_resources_bind->bind(conn))
           _hscr_resources_bind->init_from_stmt(conn);
         auto* b = _hscr_resources_bind->bind(conn).get();
@@ -3036,6 +3038,7 @@ void stream::_process_pb_service_status(const std::shared_ptr<io::data>& d) {
       int32_t conn = _mysql.choose_connection_by_instance(
           _cache_host_instance[static_cast<uint32_t>(sscr.host_id())]);
       if (_bulk_prepared_statement) {
+        std::lock_guard<bulk_bind> lck(*_sscr_bind);
         if (!_sscr_bind->bind(conn))
           _sscr_bind->init_from_stmt(conn);
         auto* b = _sscr_bind->bind(conn).get();
@@ -3137,6 +3140,7 @@ void stream::_process_pb_service_status(const std::shared_ptr<io::data>& d) {
       size_t output_size = misc::string::adjust_size_utf8(
           sscr.output(), get_resources_col_size(resources_output));
       if (_bulk_prepared_statement) {
+        std::lock_guard<bulk_bind> lck(*_sscr_resources_bind);
         if (!_sscr_resources_bind->bind(conn))
           _sscr_resources_bind->init_from_stmt(conn);
         auto* b = _sscr_resources_bind->bind(conn).get();


### PR DESCRIPTION
## Description

When the bulk_bind is filled, we must protect the row because of others threads that can change it.

REFS: MON-16986

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie
