### PR TITLE
fix(broker/mysql): new tests added and a little fix in mysql on stats

### DIFF
--- a/broker/bam/test/monitoring_stream.cc
+++ b/broker/bam/test/monitoring_stream.cc
@@ -38,9 +38,9 @@ class BamMonitoringStream : public testing::Test {
 };
 
 TEST_F(BamMonitoringStream, WriteKpi) {
-  database_config cfg("MySQL", "127.0.0.1", "", 3306, "centreon", "centreon",
+  database_config cfg("MySQL", "127.0.0.1", "", 3306, "root", "centreon",
                       "centreon");
-  database_config storage("MySQL", "127.0.0.1", "", 3306, "centreon",
+  database_config storage("MySQL", "127.0.0.1", "", 3306, "root",
                           "centreon", "centreon_storage");
 
   std::shared_ptr<persistent_cache> cache;
@@ -55,9 +55,9 @@ TEST_F(BamMonitoringStream, WriteKpi) {
 }
 
 TEST_F(BamMonitoringStream, WriteBA) {
-  database_config cfg("MySQL", "127.0.0.1", "", 3306, "centreon", "centreon",
+  database_config cfg("MySQL", "127.0.0.1", "", 3306, "root", "centreon",
                       "centreon");
-  database_config storage("MySQL", "127.0.0.1", "", 3306, "centreon",
+  database_config storage("MySQL", "127.0.0.1", "", 3306, "root",
                           "centreon", "centreon_storage");
   ;
   std::shared_ptr<persistent_cache> cache;

--- a/broker/core/inc/com/centreon/broker/database/mysql_bind.hh
+++ b/broker/core/inc/com/centreon/broker/database/mysql_bind.hh
@@ -56,7 +56,6 @@ class mysql_bind : public mysql_bind_base {
    */
   mysql_bind(int size, int length = 0);
   ~mysql_bind() noexcept = default;
-  void set_size(int size);
 
   /**
    * @brief getter to the int32 value at index range. The type of the column
@@ -283,7 +282,6 @@ class mysql_bind : public mysql_bind_base {
    */
   void set_null_tiny(size_t range);
 
-  int get_size() const;
   bool value_is_null(size_t range) const;
   size_t rows_count() const;
 

--- a/broker/core/inc/com/centreon/broker/mysql.hh
+++ b/broker/core/inc/com/centreon/broker/mysql.hh
@@ -78,7 +78,6 @@ class mysql {
   bool fetch_row(database::mysql_result& res);
   int get_last_insert_id(int thread_id);
   int connections_count() const;
-  bool commit_if_needed();
   int choose_connection_by_name(std::string const& name);
   int choose_connection_by_instance(int instance_id) const;
   int choose_best_connection(int32_t type);

--- a/broker/core/src/database/mysql_bind.cc
+++ b/broker/core/src/database/mysql_bind.cc
@@ -41,18 +41,6 @@ mysql_bind::mysql_bind(int size, int length)
   }
 }
 
-/**
- * @brief Set the size of the bind, that is to say the number of columns.
- *
- * @param size An integer.
- */
-void mysql_bind::set_size(int size) {
-  _bind.resize(size);
-  _buffer.resize(size);
-  for (int i = 0; i < size; ++i)
-    _bind[i].buffer = get_value_pointer(i);
-}
-
 void* mysql_bind::get_value_pointer(size_t range) {
   switch (_bind[range].buffer_type) {
     case MYSQL_TYPE_LONG:
@@ -142,7 +130,6 @@ VALUE(f64, double, MYSQL_TYPE_DOUBLE)
 VALUE(str, const char*, MYSQL_TYPE_STRING)
 SET_VALUE(tiny, char, MYSQL_TYPE_TINY, false)
 VALUE(tiny, char, MYSQL_TYPE_TINY)
-// SET_VALUE(bool, bool, MYSQL_TYPE_TINY, false)
 VALUE(bool, bool, MYSQL_TYPE_TINY)
 
 #undef SET_VALUE
@@ -172,95 +159,4 @@ void mysql_bind::set_null_str(size_t range) {
  */
 bool mysql_bind::value_is_null(size_t range) const {
   return _bind[range].buffer_type == MYSQL_TYPE_NULL;
-}
-
-/**
- * @brief A debug function to display the content of this bind.
- */
-// void mysql_bind::debug() {
-//   std::cout << "DEBUG BIND " << this << std::endl;
-//   int size = _bind.size();
-//     for (int i = 0; i < size; ++i) {
-//       switch (_bind[i].buffer_type) {
-//         case MYSQL_TYPE_LONGLONG: {
-//           std::cout << "LONGLONG : "
-//                     << "BL: " << _bind[i].buffer_length << " NULL: "
-//                     << (_bind[i].buffer_type == MYSQL_TYPE_NULL ? "1" : "0")
-//                     << " : "
-//                     << get_value_pointer(i)
-//                     << std::endl;
-//         } break;
-//         case MYSQL_TYPE_LONG: {
-//           std::cout << "LONG : "
-//                     << "BL: " << _bind[i].buffer_length << " NULL: "
-//                     << (_bind[i].buffer_type == MYSQL_TYPE_NULL ? "1" : "0")
-//                     << " : "
-//                     << get_value_pointer(i)
-//                     << std::endl;
-//         } break;
-//         case MYSQL_TYPE_TINY: {
-//           std::cout << "TINY : "
-//                     << "BL: " << _bind[i].buffer_length << " NULL: "
-//                     << (_bind[i].buffer_type == MYSQL_TYPE_NULL ? "1" : "0")
-//                     << " : "
-//                     << get_value_pointer(i)
-//                     << std::endl;
-//         } break;
-//         case MYSQL_TYPE_NULL:
-//           std::cout << "NULL : "
-//                     << "BL: " << _bind[i].buffer_length;
-//           break;
-//         case MYSQL_TYPE_ENUM:
-//           std::cout << "ENUM : "
-//                     << "BL: " << _bind[i].buffer_length << " : "
-//                     << static_cast<char**>(_column[i].get_buffer())[j]
-//                     << std::endl;
-//           break;
-//         case MYSQL_TYPE_STRING:
-//           std::cout << "STRING : "
-//                     << "BL: " << _bind[i].buffer_length << " NULL: "
-//                     << (_bind[i].u.indicator[j] == STMT_INDICATOR_NULL ? "1"
-//                                                                        : "0")
-//                     << " : " <<
-//                     static_cast<char**>(_column[i].get_buffer())[j]
-//                     << std::endl;
-//           break;
-//         case MYSQL_TYPE_DOUBLE: {
-//           std::cout << "DOUBLE : "
-//                        "BL: "
-//                     << _bind[i].buffer_length << " NULL: "
-//                     << (_bind[i].u.indicator[j] == STMT_INDICATOR_NULL ? "1"
-//                                                                        : "0")
-//                     << " : " <<
-//                     static_cast<double*>(_column[i].get_buffer())[j]
-//                     << std::endl;
-//         } break;
-//         case MYSQL_TYPE_FLOAT: {
-//           std::cout << "FLOAT : "
-//                        "BL: "
-//                     << _bind[i].buffer_length << " NULL: "
-//                     << (_bind[i].u.indicator[j] == STMT_INDICATOR_NULL ? "1"
-//                                                                        : "0")
-//                     << " : " <<
-//                     static_cast<float*>(_column[i].get_buffer())[j]
-//                     << std::endl;
-//         } break;
-//         default:
-//           std::cout << _bind[i].buffer_type
-//                     << " : BL: " << _bind[i].buffer_length << " : "
-//                     << "TYPE NOT MANAGED...\n";
-//           assert(1 == 0);  // Should not arrive...
-//           break;
-//       }
-//       std::cout << std::endl;
-//     }
-// }
-
-/**
- * @brief Accessor to the number of columns in this bind.
- *
- * @return An integer.
- */
-int mysql_bind::get_size() const {
-  return _bind.size();
 }

--- a/broker/core/src/database/mysql_stmt.cc
+++ b/broker/core/src/database/mysql_stmt.cc
@@ -64,7 +64,7 @@ mysql_stmt::mysql_stmt(const std::string& query,
  */
 std::unique_ptr<mysql_bind> mysql_stmt::create_bind() {
   log_v2::sql()->trace("new mysql bind of stmt {}", get_id());
-  auto retval = std::make_unique<mysql_bind>(get_param_count(), 0);
+  auto retval = std::make_unique<mysql_bind>(get_param_count());
   return retval;
 }
 

--- a/broker/core/src/mysql.cc
+++ b/broker/core/src/mysql.cc
@@ -99,23 +99,6 @@ bool mysql::fetch_row(mysql_result& res) {
   return res.get_connection()->fetch_row(res);
 }
 
-/**
- *  This method commits only if the max queries per transaction is reached.
- *
- * @return true if a commit has been done, false otherwise.
- */
-bool mysql::commit_if_needed() {
-  bool retval(false);
-  int qpt(_db_cfg.get_queries_per_transaction());
-  if (qpt > 1) {
-    ++_pending_queries;
-    if (_pending_queries >= qpt) {
-      commit();
-      retval = true;
-    }
-  }
-  return retval;
-}
 
 /**
  *  Checks for previous errors. As queries are made asynchronously, errors

--- a/broker/core/src/mysql_connection.cc
+++ b/broker/core/src/mysql_connection.cc
@@ -880,7 +880,7 @@ void mysql_connection::_process_while_empty_task(
 /*                    Methods executed by the main thread                     */
 /******************************************************************************/
 
-mysql_connection::mysql_connection(database_config const& db_cfg,
+mysql_connection::mysql_connection(const database_config& db_cfg,
                                    SqlConnectionStats* stats)
     : _conn(nullptr),
       _finish_asked(false),


### PR DESCRIPTION
## Description

Memory corruption fixed in mysql_connection destructor.

REFS: MON-17453

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
