### PR TITLE
MON-17759 AD uses subservice macros fix tags and severities unit tests

### DIFF
--- a/engine/inc/com/centreon/engine/service.hh
+++ b/engine/inc/com/centreon/engine/service.hh
@@ -55,6 +55,15 @@ typedef std::unordered_map<std::pair<uint64_t, uint64_t>,
 CCE_BEGIN()
 
 class service : public notifier {
+ protected:
+  int run_async_check_local(int check_options,
+                            double latency,
+                            bool scheduled_check,
+                            bool reschedule_check,
+                            bool* time_is_valid,
+                            time_t* preferred_time,
+                            service* svc) noexcept;
+
  public:
   static std::array<std::pair<uint32_t, std::string>, 4> const
       tab_service_states;

--- a/engine/tests/configuration/severity.cc
+++ b/engine/tests/configuration/severity.cc
@@ -67,7 +67,7 @@ TEST_F(ConfigSeverity, NewSeverityWellFilled) {
   sv.parse("type", "service");
   ASSERT_EQ(sv.key().first, 1);
   ASSERT_EQ(sv.level(), 2);
-  ASSERT_EQ(sv.name(), "foobar");
+  ASSERT_EQ(sv.severity_name(), "foobar");
   ASSERT_EQ(sv.type(), configuration::severity::service);
   ASSERT_NO_THROW(sv.check_validity());
 }

--- a/engine/tests/configuration/tag.cc
+++ b/engine/tests/configuration/tag.cc
@@ -66,7 +66,7 @@ TEST_F(ConfigTag, NewTagWellFilled) {
   tg.parse("tag_name", "foobar");
   ASSERT_EQ(tg.key().first, 1);
   ASSERT_EQ(tg.key().second, engine::configuration::tag::servicegroup);
-  ASSERT_EQ(tg.name(), "foobar");
+  ASSERT_EQ(tg.tag_name(), "foobar");
   ASSERT_NO_THROW(tg.check_validity());
 }
 


### PR DESCRIPTION
## Description

**Fixes** # (issue)

AD must use subservice's macros in her checks

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [X] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

