### PR TITLE
MON-19273 - Fix centreon-engine logrotate on Debian

### DIFF
--- a/packaging/debian/centreon-engine.logrotate
+++ b/packaging/debian/centreon-engine.logrotate
@@ -5,10 +5,12 @@
   delaycompress
   missingok
   olddir /var/log/centreon-engine/archives
+  createolddir 755 centreon-engine centreon-engine
   rotate 365
   postrotate
     systemctl reload centengine
   endscript
+  su centreon-engine centreon-engine
 }
 
 /var/log/centreon-engine/centengine.debug {
@@ -17,9 +19,11 @@
   delaycompress
   missingok
   olddir /var/log/centreon-engine/archives
+  createolddir 755 centreon-engine centreon-engine
   rotate 5
   size   1G
   postrotate
     systemctl reload centengine
   endscript
+  su centreon-engine centreon-engine
 }


### PR DESCRIPTION
## Description

Fix centreon-engine logrotate on Debian
Add createolddir option and "su centreon-engine centreon-engine"

**Fixes** MON-19273

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)


