### PR TITLE
Update centreon-engine.logrotate - Add createolddir

### DIFF
--- a/ci/debian-collect/centreon-engine.logrotate
+++ b/ci/debian-collect/centreon-engine.logrotate
@@ -5,10 +5,12 @@
   delaycompress
   missingok
   olddir /var/log/centreon-engine/archives
+  createolddir 755 centreon-engine centreon-engine
   rotate 365
   postrotate
     systemctl reload centengine
   endscript
+  su centreon-engine centreon-engine
 }
 
 /var/log/centreon-engine/centengine.debug {
@@ -17,9 +19,11 @@
   delaycompress
   missingok
   olddir /var/log/centreon-engine/archives
+  createolddir 755 centreon-engine centreon-engine
   rotate 5
   size   1G
   postrotate
     systemctl reload centengine
   endscript
+  su centreon-engine centreon-engine
 }


### PR DESCRIPTION
Description
Fix centreon-engine logrotate on Debian
Add createolddir option and "su centreon-engine centreon-engine"

REFS: MON-19330