### PR TITLE
fix(broker/lua): new cache function get_check_command(host_id,service…

### DIFF
--- a/broker/lua/inc/com/centreon/broker/lua/macro_cache.hh
+++ b/broker/lua/inc/com/centreon/broker/lua/macro_cache.hh
@@ -87,6 +87,8 @@ class macro_cache {
   const std::string& get_action_url(uint64_t host_id,
                                     uint64_t service_id) const;
   int32_t get_severity(uint64_t host_id, uint64_t service_id) const;
+  absl::string_view get_check_command(uint64_t host_id,
+                                      uint64_t service_id = 0) const;
   const std::string& get_host_group_name(uint64_t id) const;
   absl::btree_map<std::pair<uint64_t, uint64_t>,
                   std::shared_ptr<neb::host_group_member>> const&

--- a/broker/lua/src/broker_cache.cc
+++ b/broker/lua/src/broker_cache.cc
@@ -616,6 +616,25 @@ static int32_t l_broker_cache_get_severity(lua_State* L) {
   return 1;
 }
 
+static int32_t l_broker_cache_get_check_command(lua_State* L) {
+  macro_cache const* cache(
+      *static_cast<macro_cache**>(luaL_checkudata(L, 1, "lua_broker_cache")));
+  int host_id = luaL_checkinteger(L, 2);
+  int service_id = 0;
+  if (lua_gettop(L) >= 3)
+    service_id = luaL_checkinteger(L, 3);
+
+  try {
+    absl::string_view check_command =
+        cache->get_check_command(host_id, service_id);
+    lua_pushlstring(L, check_command.data(), check_command.size());
+  } catch (std::exception const& e) {
+    (void)e;
+    lua_pushnil(L);
+  }
+  return 1;
+}
+
 /**
  *  Load the Lua interpreter with the standard libraries
  *  and the broker lua sdk.
@@ -652,6 +671,7 @@ void broker_cache::broker_cache_reg(lua_State* L,
       {"get_notes", l_broker_cache_get_notes},
       {"get_action_url", l_broker_cache_get_action_url},
       {"get_severity", l_broker_cache_get_severity},
+      {"get_check_command", l_broker_cache_get_check_command},
       {nullptr, nullptr}};
 
   if (api_version == 2) {


### PR DESCRIPTION
## Description

new streamconnector function broker_cache:get_check_command()

REFS: MON-19604

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x
- [ ] 23.10.x (master)
