### PR TITLE
Mon 19656 backup script broker retention 22.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,10 +39,11 @@ build/*
 ### node ###
 node_modules/
 
-### vscode ###
+### ide ###
 **/.vscode/
 **/.idea
 .scannerwork
+**/.cache
 
 ### temp build files ###
 logs/*

--- a/broker/core/src/mysql_connection.cc
+++ b/broker/core/src/mysql_connection.cc
@@ -986,11 +986,13 @@ void mysql_connection::_process_tasks(
                           static_cast<const void*>(this));
     }
 
-    if (!_error.is_active()) {
-      tasks_list.pop_front();
-    } else {
+    /* We must pop the task from the list once it has been handled in all cases:
+     * success or failure. Otherwise at the call of
+     * _send_exceptions_to_task_futures() the future could be set a second time
+     * on case of error. */
+    tasks_list.pop_front();
+    if (_error.is_active())
       return;
-    }
   }
 }
 

--- a/broker/unified_sql/src/stream_storage.cc
+++ b/broker/unified_sql/src/stream_storage.cc
@@ -812,114 +812,189 @@ void stream::_check_queues(asio::error_code ec) {
       sz_metrics = _metrics.size();
     }
 
-    bool perfdata_done = false;
+    try {
+      bool perfdata_done = false;
 
-    bool resources_done = false;
-    if (_bulk_prepared_statement) {
-      for (uint32_t conn = 0; conn < _perfdata_b->connections_count(); conn++) {
-        if (_perfdata_b->ready(conn)) {
-          log_v2::sql()->debug("Sending {} perfdata on connection {}",
-                               _perfdata_b->size(conn), conn);
-          // Setting the good bind to the stmt
-          _perfdata_b->apply_to_stmt(conn);
-          // Executing the stmt
-          _mysql.run_statement(*_perfdata_stmt,
-                               database::mysql_error::insert_data);
-          perfdata_done = true;
+      bool resources_done = false;
+      if (_bulk_prepared_statement) {
+        for (uint32_t conn = 0; conn < _perfdata_b->connections_count();
+             conn++) {
+          if (_perfdata_b->ready(conn)) {
+            log_v2::sql()->debug("Sending {} perfdata on connection {}",
+                                 _perfdata_b->size(conn), conn);
+            // Setting the good bind to the stmt
+            _perfdata_b->apply_to_stmt(conn);
+            // Executing the stmt
+            _mysql.run_statement(*_perfdata_stmt,
+                                 database::mysql_error::insert_data);
+            perfdata_done = true;
+          }
         }
-      }
-      _finish_action(-1, actions::host_parents | actions::comments |
-                             actions::downtimes | actions::host_dependencies |
-                             actions::service_dependencies);
-      if (_store_in_hosts_services) {
-        if (_hscr_bind) {
-          log_v2::sql()->trace(
-              "Check if some statements are ready,  hscr_bind connections "
-              "count "
-              "= {}",
-              _hscr_bind->connections_count());
-          for (uint32_t conn = 0; conn < _hscr_bind->connections_count();
-               conn++) {
-            if (_hscr_bind->ready(conn)) {
-              log_v2::sql()->debug(
-                  "Sending {} hosts rows of host status on connection {}",
-                  _hscr_bind->size(conn), conn);
-              // Setting the good bind to the stmt
-              _hscr_bind->apply_to_stmt(conn);
-              // Executing the stmt
-              _mysql.run_statement(*_hscr_update,
-                                   database::mysql_error::store_host_status,
-                                   conn);
-              _add_action(conn, actions::hosts);
+        _finish_action(-1, actions::host_parents | actions::comments |
+                               actions::downtimes | actions::host_dependencies |
+                               actions::service_dependencies);
+        if (_store_in_hosts_services) {
+          if (_hscr_bind) {
+            log_v2::sql()->trace(
+                "Check if some statements are ready,  hscr_bind connections "
+                "count "
+                "= {}",
+                _hscr_bind->connections_count());
+            for (uint32_t conn = 0; conn < _hscr_bind->connections_count();
+                 conn++) {
+              if (_hscr_bind->ready(conn)) {
+                log_v2::sql()->debug(
+                    "Sending {} hosts rows of host status on connection {}",
+                    _hscr_bind->size(conn), conn);
+                // Setting the good bind to the stmt
+                _hscr_bind->apply_to_stmt(conn);
+                // Executing the stmt
+                _mysql.run_statement(*_hscr_update,
+                                     database::mysql_error::store_host_status,
+                                     conn);
+                _add_action(conn, actions::hosts);
+              }
+            }
+          }
+          if (_sscr_bind) {
+            log_v2::sql()->trace(
+                "Check if some statements are ready,  sscr_bind connections "
+                "count "
+                "= {}",
+                _sscr_bind->connections_count());
+            for (uint32_t conn = 0; conn < _sscr_bind->connections_count();
+                 conn++) {
+              if (_sscr_bind->ready(conn)) {
+                log_v2::sql()->debug(
+                    "Sending {} services rows of service status on connection "
+                    "{}",
+                    _sscr_bind->size(conn), conn);
+                // Setting the good bind to the stmt
+                _sscr_bind->apply_to_stmt(conn);
+                // Executing the stmt
+                _mysql.run_statement(
+                    *_sscr_update, database::mysql_error::store_service_status,
+                    conn);
+                _add_action(conn, actions::services);
+              }
             }
           }
         }
-        if (_sscr_bind) {
-          log_v2::sql()->trace(
-              "Check if some statements are ready,  sscr_bind connections "
-              "count "
-              "= {}",
-              _sscr_bind->connections_count());
-          for (uint32_t conn = 0; conn < _sscr_bind->connections_count();
-               conn++) {
-            if (_sscr_bind->ready(conn)) {
-              log_v2::sql()->debug(
-                  "Sending {} services rows of service status on connection {}",
-                  _sscr_bind->size(conn), conn);
-              // Setting the good bind to the stmt
-              _sscr_bind->apply_to_stmt(conn);
-              // Executing the stmt
-              _mysql.run_statement(*_sscr_update,
-                                   database::mysql_error::store_service_status,
-                                   conn);
-              _add_action(conn, actions::services);
+        if (_store_in_resources) {
+          if (_hscr_resources_bind) {
+            for (uint32_t conn = 0;
+                 conn < _hscr_resources_bind->connections_count(); conn++) {
+              if (_hscr_resources_bind->ready(conn)) {
+                log_v2::sql()->debug(
+                    "Sending {} host rows of resource status on connection {}",
+                    _hscr_resources_bind->size(conn), conn);
+                // Setting the good bind to the stmt
+                _hscr_resources_bind->apply_to_stmt(conn);
+                // Executing the stmt
+                _mysql.run_statement(*_hscr_resources_update,
+                                     database::mysql_error::store_host_status,
+                                     conn);
+                _add_action(conn, actions::resources);
+              }
+            }
+          }
+          if (_sscr_resources_bind) {
+            for (uint32_t conn = 0;
+                 conn < _sscr_resources_bind->connections_count(); conn++) {
+              if (_sscr_resources_bind->ready(conn)) {
+                log_v2::sql()->debug(
+                    "Sending {} service rows of resource status on connection "
+                    "{}",
+                    _sscr_resources_bind->size(conn), conn);
+                // Setting the good bind to the stmt
+                _sscr_resources_bind->apply_to_stmt(conn);
+                // Executing the stmt
+                _mysql.run_statement(
+                    *_sscr_resources_update,
+                    database::mysql_error::store_service_status, conn);
+                _add_action(conn, actions::resources);
+              }
             }
           }
         }
-      }
-      if (_store_in_resources) {
-        if (_hscr_resources_bind) {
-          for (uint32_t conn = 0;
-               conn < _hscr_resources_bind->connections_count(); conn++) {
-            if (_hscr_resources_bind->ready(conn)) {
-              log_v2::sql()->debug(
-                  "Sending {} host rows of resource status on connection {}",
-                  _hscr_resources_bind->size(conn), conn);
-              // Setting the good bind to the stmt
-              _hscr_resources_bind->apply_to_stmt(conn);
-              // Executing the stmt
-              _mysql.run_statement(*_hscr_resources_update,
-                                   database::mysql_error::store_host_status,
-                                   conn);
-              _add_action(conn, actions::resources);
-            }
-          }
-        }
-        if (_sscr_resources_bind) {
-          for (uint32_t conn = 0;
-               conn < _sscr_resources_bind->connections_count(); conn++) {
-            if (_sscr_resources_bind->ready(conn)) {
-              log_v2::sql()->debug(
-                  "Sending {} service rows of resource status on connection {}",
-                  _sscr_resources_bind->size(conn), conn);
-              // Setting the good bind to the stmt
-              _sscr_resources_bind->apply_to_stmt(conn);
-              // Executing the stmt
-              _mysql.run_statement(*_sscr_resources_update,
-                                   database::mysql_error::store_service_status,
-                                   conn);
-              _add_action(conn, actions::resources);
-            }
-          }
-        }
-      }
-      resources_done = true;
-    } else if (_perfdata_q->ready()) {
-      std::string query = _perfdata_q->get_query();
-      // Execute query.
-      _mysql.run_query(query, database::mysql_error::insert_data);
+        resources_done = true;
+      } else if (_perfdata_q->ready()) {
+        std::string query = _perfdata_q->get_query();
+        // Execute query.
+        _mysql.run_query(query, database::mysql_error::insert_data);
 
-      perfdata_done = true;
+        perfdata_done = true;
+      }
+
+      bool metrics_done = false;
+      if (now >= _next_update_metrics || sz_metrics >= _max_metrics_queries) {
+        _next_update_metrics = now + queue_timer_duration;
+        _update_metrics();
+        metrics_done = true;
+      }
+
+      bool customvar_done = false;
+      if (_cv.ready()) {
+        log_v2::sql()->debug("{} new custom variables inserted", _cv.size());
+        std::string query = _cv.get_query();
+        int32_t conn =
+            special_conn::custom_variable % _mysql.connections_count();
+        _mysql.run_query(query, database::mysql_error::update_customvariables,
+                         false, conn);
+        _add_action(conn, actions::custom_variables);
+        customvar_done = true;
+      }
+
+      if (_cvs.ready()) {
+        log_v2::sql()->debug("{} new custom variable status inserted",
+                             _cvs.size());
+        std::string query = _cvs.get_query();
+        int32_t conn =
+            special_conn::custom_variable % _mysql.connections_count();
+        _mysql.run_query(query, database::mysql_error::update_customvariables,
+                         false, conn);
+        _add_action(conn, actions::custom_variables);
+        customvar_done = true;
+      }
+
+      bool downtimes_done = false;
+      if (_downtimes.ready()) {
+        log_v2::sql()->debug("{} new downtimes inserted", _downtimes.size());
+        std::string query = _downtimes.get_query();
+        _finish_action(-1, actions::hosts | actions::instances |
+                               actions::downtimes | actions::host_parents |
+                               actions::host_dependencies |
+                               actions::service_dependencies);
+        int32_t conn = special_conn::downtime % _mysql.connections_count();
+        _mysql.run_query(query, database::mysql_error::update_customvariables,
+                         false, conn);
+        _add_action(conn, actions::downtimes);
+        downtimes_done = true;
+      }
+
+      bool logs_done = false;
+      if (_logs.ready()) {
+        log_v2::sql()->debug("{} new logs inserted", _logs.size());
+        std::string query = _logs.get_query();
+        // Execute query.
+        int32_t conn = special_conn::log % _mysql.connections_count();
+        _mysql.run_query(query, database::mysql_error::update_logs, false,
+                         conn);
+        logs_done = true;
+      }
+
+      // End.
+      log_v2::perfdata()->debug(
+          "unified_sql: end check_queue - resources: {}, "
+          "perfdata: {}, metrics: {}, customvar: "
+          "{}, logs: {}, downtimes: {}",
+          resources_done, perfdata_done, metrics_done, customvar_done,
+          logs_done, downtimes_done);
+    } catch (const std::exception& e) {
+      log_v2::sql()->critical(
+          "sql: Error encountered during bulk dispatch of services, hosts, "
+          "metrics, etc.: {}",
+          e.what());
     }
 
     bool metrics_done = false;

--- a/broker/unified_sql/src/stream_storage.cc
+++ b/broker/unified_sql/src/stream_storage.cc
@@ -812,8 +812,6 @@ void stream::_check_queues(asio::error_code ec) {
       sz_metrics = _metrics.size();
     }
 
-    // This try/catch is needed by mysql methods that can throw exceptions in
-    // case of error.
     try {
       bool perfdata_done = false;
 
@@ -942,7 +940,7 @@ void stream::_check_queues(asio::error_code ec) {
         int32_t conn =
             special_conn::custom_variable % _mysql.connections_count();
         _mysql.run_query(query, database::mysql_error::update_customvariables,
-                         false, conn);
+                         conn);
         _add_action(conn, actions::custom_variables);
         customvar_done = true;
       }
@@ -954,7 +952,7 @@ void stream::_check_queues(asio::error_code ec) {
         int32_t conn =
             special_conn::custom_variable % _mysql.connections_count();
         _mysql.run_query(query, database::mysql_error::update_customvariables,
-                         false, conn);
+                         conn);
         _add_action(conn, actions::custom_variables);
         customvar_done = true;
       }
@@ -969,7 +967,7 @@ void stream::_check_queues(asio::error_code ec) {
                                actions::service_dependencies);
         int32_t conn = special_conn::downtime % _mysql.connections_count();
         _mysql.run_query(query, database::mysql_error::update_customvariables,
-                         false, conn);
+                         conn);
         _add_action(conn, actions::downtimes);
         downtimes_done = true;
       }
@@ -980,8 +978,7 @@ void stream::_check_queues(asio::error_code ec) {
         std::string query = _logs.get_query();
         // Execute query.
         int32_t conn = special_conn::log % _mysql.connections_count();
-        _mysql.run_query(query, database::mysql_error::update_logs, false,
-                         conn);
+        _mysql.run_query(query, database::mysql_error::update_logs, conn);
         logs_done = true;
       }
 
@@ -993,73 +990,9 @@ void stream::_check_queues(asio::error_code ec) {
           resources_done, perfdata_done, metrics_done, customvar_done,
           logs_done, downtimes_done);
     } catch (const std::exception& e) {
-      log_v2::sql()->critical(
-          "sql: Error encountered during bulk dispatch of services, hosts, "
-          "metrics, etc.: {}",
-          e.what());
+      log_v2::sql()->critical("sql: Error while dispatching bulk queries: {}",
+                              e.what());
     }
-
-    bool metrics_done = false;
-    if (now >= _next_update_metrics || sz_metrics >= _max_metrics_queries) {
-      _next_update_metrics = now + queue_timer_duration;
-      _update_metrics();
-      metrics_done = true;
-    }
-
-    bool customvar_done = false;
-    if (_cv.ready()) {
-      log_v2::sql()->debug("{} new custom variables inserted", _cv.size());
-      std::string query = _cv.get_query();
-      int32_t conn = special_conn::custom_variable % _mysql.connections_count();
-      _mysql.run_query(query, database::mysql_error::update_customvariables,
-                       conn);
-      _add_action(conn, actions::custom_variables);
-      customvar_done = true;
-    }
-
-    if (_cvs.ready()) {
-      log_v2::sql()->debug("{} new custom variable status inserted",
-                           _cvs.size());
-      std::string query = _cvs.get_query();
-      int32_t conn = special_conn::custom_variable % _mysql.connections_count();
-      _mysql.run_query(query, database::mysql_error::update_customvariables,
-                       conn);
-      _add_action(conn, actions::custom_variables);
-      customvar_done = true;
-    }
-
-    bool downtimes_done = false;
-    if (_downtimes.ready()) {
-      log_v2::sql()->debug("{} new downtimes inserted", _downtimes.size());
-      std::string query = _downtimes.get_query();
-      _finish_action(-1, actions::hosts | actions::instances |
-                             actions::downtimes | actions::host_parents |
-                             actions::host_dependencies |
-                             actions::service_dependencies);
-      int32_t conn = special_conn::downtime % _mysql.connections_count();
-      _mysql.run_query(query, database::mysql_error::update_customvariables,
-                       conn);
-      _add_action(conn, actions::downtimes);
-      downtimes_done = true;
-    }
-
-    bool logs_done = false;
-    if (_logs.ready()) {
-      log_v2::sql()->debug("{} new logs inserted", _logs.size());
-      std::string query = _logs.get_query();
-      // Execute query.
-      int32_t conn = special_conn::log % _mysql.connections_count();
-      _mysql.run_query(query, database::mysql_error::update_logs, conn);
-      logs_done = true;
-    }
-
-    // End.
-    log_v2::perfdata()->debug(
-        "unified_sql: end check_queue - resources: {}, "
-        "perfdata: {}, metrics: {}, customvar: "
-        "{}, logs: {}, downtimes: {}",
-        resources_done, perfdata_done, metrics_done, customvar_done, logs_done,
-        downtimes_done);
 
     if (!_stop_check_queues) {
       _queues_timer.expires_after(std::chrono::seconds(5));

--- a/broker/unified_sql/src/stream_storage.cc
+++ b/broker/unified_sql/src/stream_storage.cc
@@ -812,6 +812,8 @@ void stream::_check_queues(asio::error_code ec) {
       sz_metrics = _metrics.size();
     }
 
+    // This try/catch is needed by mysql methods that can throw exceptions in
+    // case of error.
     try {
       bool perfdata_done = false;
 

--- a/tests/broker-engine/services-and-bulk-stmt.robot
+++ b/tests/broker-engine/services-and-bulk-stmt.robot
@@ -243,8 +243,8 @@ EBPS2
     Start Broker    ${True}
     Start Engine
     # Let's wait for the external command check start
-    ${content}= Create List     check_for_external_commands()
-    ${result}=  Find In Log with Timeout        ${engineLog0}   ${start}        ${content}      60
+    ${content}=    Create List     check_for_external_commands()
+    ${result}=  Find In Log with Timeout        ${logEngine0}   ${start}        ${content}      60
     Should Be True      ${result}       msg=A message telling check_for_external_commands() should be available.
 
     # Let's wait for one "INSERT INTO data_bin" to appear in stats.
@@ -255,7 +255,7 @@ EBPS2
     ${content}=     create list     Check if some statements are ready,  sscr_bind connections
     ${result}=  Find In Log with Timeout        ${centralLog}   ${start}        ${content}      60
     Should Be True  ${result}       msg=A message telling that statements are available should be displayed
-    Stop mysql
+    Kill Mysql
     Stop Engine
     Start mysql
     Kindly Stop Broker   ${True}

--- a/tests/broker-engine/services-and-bulk-stmt.robot
+++ b/tests/broker-engine/services-and-bulk-stmt.robot
@@ -208,16 +208,17 @@ EBMSSM
     ${duration}=    Broker Get Sql Manager Stats    51001    INSERT INTO data_bin    300
     Should Be True    ${duration} > 0
 
-	# Let's wait for all force checks to be in the storage database.
-	Connect To Database	pymysql	${DBName}	${DBUser}	${DBPass}	${DBHost}	${DBPort}
-	FOR	${i}	IN RANGE	${500}
-	  ${output}=	Query	SELECT COUNT(s.last_check) FROM metrics m LEFT JOIN index_data i ON m.index_id = i.id LEFT JOIN services s ON s.host_id = i.host_id AND s.service_id = i.service_id WHERE metric_name LIKE "metric_%" AND s.last_check >= ${start}
-	  Exit For Loop If	${output[0][0]} >= 100000
-          Sleep	1s
-	END
-	Should Be True	${output[0][0]} >= 100000
-	Stop Engine
-	Kindly Stop Broker	True
+    # Let's wait for all force checks to be in the storage database.
+    Connect To Database    pymysql    ${DBName}    ${DBUser}    ${DBPass}    ${DBHost}    ${DBPort}
+    FOR    ${i}    IN RANGE    ${500}
+        ${output}=    Query
+        ...    SELECT COUNT(s.last_check) FROM metrics m LEFT JOIN index_data i ON m.index_id = i.id LEFT JOIN services s ON s.host_id = i.host_id AND s.service_id = i.service_id WHERE metric_name LIKE "metric_%" AND s.last_check >= ${start}
+        IF    ${output[0][0]} >= 100000    BREAK
+        Sleep    1s
+    END
+    Should Be True    ${output[0][0]} >= 100000
+    Stop Engine
+    Kindly Stop Broker    True
 
 EBPS2
     [Documentation]    1000 services are configured with 20 metrics each. The rrd output is removed from
@@ -230,7 +231,7 @@ EBPS2
     Config Broker    module    ${1}
     Broker Config Add Item    module0    bbdo_version    3.0.1
     Broker Config Add Item    central    bbdo_version    3.0.1
-    Broker Config Flush Log     central     0
+    Broker Config Flush Log    central    0
     Broker Config Log    central    core    error
     Broker Config Log    central    tcp    error
     Broker Config Log    central    sql    trace
@@ -243,19 +244,21 @@ EBPS2
     Start Broker    ${True}
     Start Engine
     # Let's wait for the external command check start
-    ${content}=    Create List     check_for_external_commands()
-    ${result}=  Find In Log with Timeout        ${logEngine0}   ${start}        ${content}      60
-    Should Be True      ${result}       msg=A message telling check_for_external_commands() should be available.
+    ${content}=    Create List    check_for_external_commands()
+    ${result}=    Find In Log with Timeout    ${logEngine0}    ${start}    ${content}    60
+    Should Be True    ${result}    msg=A message telling check_for_external_commands() should be available.
 
-    # Let's wait for one "INSERT INTO data_bin" to appear in stats.
+    # We send 3000 service status and during the 1500th, we kill the database. This crashed cbd before
+    # the new patch.
+    FOR    ${i}    IN RANGE    ${3000}
+        IF    ${i} == 1500    Kill Mysql
+        Process Service Check result with metrics    host_1    service_${${i}%1000+1}    1    warning${i}    20
+    END
+
     FOR    ${i}    IN RANGE    ${1000}
         Process Service Check result with metrics    host_1    service_${i+1}    1    warning${i}    20
     END
-    ${start}=    Get Current Date
-    ${content}=     create list     Check if some statements are ready,  sscr_bind connections
-    ${result}=  Find In Log with Timeout        ${centralLog}   ${start}        ${content}      60
-    Should Be True  ${result}       msg=A message telling that statements are available should be displayed
-    Kill Mysql
+
     Stop Engine
     Start mysql
-    Kindly Stop Broker   ${True}
+    Kindly Stop Broker    ${True}

--- a/tests/broker-engine/services-and-bulk-stmt.robot
+++ b/tests/broker-engine/services-and-bulk-stmt.robot
@@ -245,7 +245,7 @@ EBPS2
     Start Engine
     # Let's wait for the external command check start
     ${content}=    Create List    check_for_external_commands()
-    ${result}=    Find In Log with Timeout    ${logEngine0}    ${start}    ${content}    60
+    ${result}=    Find In Log with Timeout    ${engineLog0}    ${start}    ${content}    60
     Should Be True    ${result}    msg=A message telling check_for_external_commands() should be available.
 
     # We send 3000 service status and during the 1500th, we kill the database. This crashed cbd before

--- a/tests/broker-engine/services-and-bulk-stmt.robot
+++ b/tests/broker-engine/services-and-bulk-stmt.robot
@@ -208,14 +208,54 @@ EBMSSM
     ${duration}=    Broker Get Sql Manager Stats    51001    INSERT INTO data_bin    300
     Should Be True    ${duration} > 0
 
-    # Let's wait for all force checks to be in the storage database.
-    Connect To Database    pymysql    ${DBName}    ${DBUser}    ${DBPass}    ${DBHost}    ${DBPort}
-    FOR    ${i}    IN RANGE    ${500}
-        ${output}=    Query
-        ...    SELECT COUNT(s.last_check) FROM metrics m LEFT JOIN index_data i ON m.index_id = i.id LEFT JOIN services s ON s.host_id = i.host_id AND s.service_id = i.service_id WHERE metric_name LIKE "metric_%" AND s.last_check >= ${start}
-        IF    ${output[0][0]} >= 100000    BREAK
-        Sleep    1s
+	# Let's wait for all force checks to be in the storage database.
+	Connect To Database	pymysql	${DBName}	${DBUser}	${DBPass}	${DBHost}	${DBPort}
+	FOR	${i}	IN RANGE	${500}
+	  ${output}=	Query	SELECT COUNT(s.last_check) FROM metrics m LEFT JOIN index_data i ON m.index_id = i.id LEFT JOIN services s ON s.host_id = i.host_id AND s.service_id = i.service_id WHERE metric_name LIKE "metric_%" AND s.last_check >= ${start}
+	  Exit For Loop If	${output[0][0]} >= 100000
+          Sleep	1s
+	END
+	Should Be True	${output[0][0]} >= 100000
+	Stop Engine
+	Kindly Stop Broker	True
+
+EBPS2
+    [Documentation]    1000 services are configured with 20 metrics each. The rrd output is removed from
+    [Tags]    broker    engine    services    unified_sql    benchmark
+    Clear Metrics
+    Config Engine    ${1}    ${1}    ${1000}
+    # We want all the services to be passive to avoid parasite checks during our test.
+    Set Services passive    ${0}    service_.*
+    Config Broker    central
+    Config Broker    module    ${1}
+    Broker Config Add Item    module0    bbdo_version    3.0.1
+    Broker Config Add Item    central    bbdo_version    3.0.1
+    Broker Config Flush Log     central     0
+    Broker Config Log    central    core    error
+    Broker Config Log    central    tcp    error
+    Broker Config Log    central    sql    trace
+    Broker Config Log    central    perfdata    debug
+    Config Broker Sql Output    central    unified_sql
+    Config Broker Remove Rrd Output    central
+    Clear Retention
+
+    ${start}=    Get Current Date
+    Start Broker    ${True}
+    Start Engine
+    # Let's wait for the external command check start
+    ${content}= Create List     check_for_external_commands()
+    ${result}=  Find In Log with Timeout        ${engineLog0}   ${start}        ${content}      60
+    Should Be True      ${result}       msg=A message telling check_for_external_commands() should be available.
+
+    # Let's wait for one "INSERT INTO data_bin" to appear in stats.
+    FOR    ${i}    IN RANGE    ${1000}
+        Process Service Check result with metrics    host_1    service_${i+1}    1    warning${i}    20
     END
-    Should Be True    ${output[0][0]} >= 100000
+    ${start}=    Get Current Date
+    ${content}=     create list     Check if some statements are ready,  sscr_bind connections
+    ${result}=  Find In Log with Timeout        ${centralLog}   ${start}        ${content}      60
+    Should Be True  ${result}       msg=A message telling that statements are available should be displayed
+    Stop mysql
     Stop Engine
-    Kindly Stop Broker    True
+    Start mysql
+    Kindly Stop Broker   ${True}

--- a/tests/resources/Common.py
+++ b/tests/resources/Common.py
@@ -205,6 +205,16 @@ def start_mysql():
         logger.console("Mariadb directly started")
 
 
+def kill_mysql():
+    logger.console("Killing directly MariaDB")
+    for proc in psutil.process_iter():
+        if ('mariadbd' in proc.name()):
+            logger.console(
+                f"process '{proc.name()}' containing mariadbd found: stopping it")
+            proc.kill()
+    logger.console("Mariadb killed")
+
+
 def stop_mysql():
     if not run_env():
         logger.console("Stopping Mariadb with systemd")


### PR DESCRIPTION
## Description

Exceptions thrown by mysql::check_errors() not catched by the check_queue() method in unified_sql.

REFS: MON-10656

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [X] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)
