### PR TITLE
MON-11761 fix macros init issue

### DIFF
--- a/engine/src/macros/clear_host.cc
+++ b/engine/src/macros/clear_host.cc
@@ -77,7 +77,7 @@ int clear_host_macros_r(nagios_macros* mac) {
                                          MACRO_HOSTID,
                                          MACRO_HOSTTIMEZONE};
   for (unsigned int i = 0; i < sizeof(to_free) / sizeof(*to_free); ++i) {
-    mac->x[i] = "";
+    mac->x[to_free[i]] = "";
   }
 
   // Clear custom host variables.

--- a/engine/src/macros/clear_hostgroup.cc
+++ b/engine/src/macros/clear_hostgroup.cc
@@ -36,7 +36,7 @@ int clear_hostgroup_macros_r(nagios_macros* mac) {
       MACRO_HOSTGROUPNAME,      MACRO_HOSTGROUPALIAS,    MACRO_HOSTGROUPMEMBERS,
       MACRO_HOSTGROUPACTIONURL, MACRO_HOSTGROUPNOTESURL, MACRO_HOSTGROUPNOTES};
   for (unsigned int i = 0; i < sizeof(to_free) / sizeof(*to_free); ++i) {
-    mac->x[i] = "";
+    mac->x[to_free[i]] = "";
   }
 
   // Clear pointers.

--- a/engine/src/macros/clear_service.cc
+++ b/engine/src/macros/clear_service.cc
@@ -69,7 +69,7 @@ int clear_service_macros_r(nagios_macros* mac) {
                                          MACRO_SERVICEID,
                                          MACRO_SERVICETIMEZONE};
   for (unsigned int i = 0; i < sizeof(to_free) / sizeof(*to_free); ++i) {
-    mac->x[i] = "";
+    mac->x[to_free[i]] = "";
   }
 
   // Clear custom service variables.

--- a/engine/src/macros/clear_servicegroup.cc
+++ b/engine/src/macros/clear_servicegroup.cc
@@ -37,7 +37,7 @@ int clear_servicegroup_macros_r(nagios_macros* mac) {
       MACRO_SERVICEGROUPMEMBERS,  MACRO_SERVICEGROUPACTIONURL,
       MACRO_SERVICEGROUPNOTESURL, MACRO_SERVICEGROUPNOTES};
   for (unsigned int i = 0; i < sizeof(to_free) / sizeof(*to_free); ++i) {
-    mac->x[i] = "";
+    mac->x[to_free[i]] = "";
   }
 
   // Clear pointers.

--- a/tests/engine/forced_checks.robot
+++ b/tests/engine/forced_checks.robot
@@ -221,18 +221,57 @@ EMACROS
     ...    msg=An Initial host state on host_1 should be raised before we can start our external commands.
     schedule_forced_svc_check    host_1    service_1
     Sleep    5s
-    ${content}=    Create List
-    ...    EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;
-    ...    HOST ALERT: host_1;DOWN;SOFT;1;
-    ...    EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;
-    ...    HOST ALERT: host_1;DOWN;SOFT;2;
-    ...    EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;
-    ...    HOST ALERT: host_1;DOWN;HARD;3;
 
     ${content}=    Create List
-    ...    ResourceFile: /tmp/etc/centreon-engine/config0/resource.cfg - LogFile: /tmp/var/log/centreon-engine/config0/centengine.log - AdminEmail: titus@bidibule.com - AdminPager
+    ...    ResourceFile: /tmp/etc/centreon-engine/config0/resource.cfg - LogFile: /tmp/var/log/centreon-engine/config0/centengine.log - AdminEmail: titus@bidibule.com - AdminPager: admin
     ${result}=    Find In Log with Timeout    ${engineLog0}    ${start}    ${content}    60
     Should Be True    ${result}    msg=AdminEmail: titus@bidibule.com - AdminPager: admin not found in log.
+
+    Stop Engine
+    Kindly Stop Broker
+
+EMACROS_NOTIF
+    [Documentation]    macros ADMINEMAIL and ADMINPAGER are replaced in notification commands
+    [Tags]    engine    external_cmd    macros
+    Config Engine    ${1}
+    Config Broker    central
+    Config Broker    rrd
+    Config Broker    module    ${1}
+    Engine Config Set Value    ${0}    log_legacy_enabled    ${0}
+    Engine Config Set Value    ${0}    log_v2_enabled    ${1}
+    engine_config_set_value    0    log_level_checks    trace    True
+    engine_config_add_value    0    cfg_file   ${EtcRoot}/centreon-engine/config0/contacts.cfg
+    engine_config_add_command
+    ...    0
+    ...    command_notif
+    ...    /bin/sh -c '/bin/echo "ResourceFile: $RESOURCEFILE$ - LogFile: $LOGFILE$ - AdminEmail: $ADMINEMAIL$ - AdminPager: $ADMINPAGER$" >> /tmp/notif_toto.txt'
+    engine_config_set_value_in_services    0    service_1    contacts    John_Doe
+    engine_config_set_value_in_services    0    service_1    notification_options    w,c,r
+    engine_config_set_value_in_services    0    service_1    notifications_enabled    1
+    engine_config_set_value_in_contacts    0    John_Doe    host_notification_commands    command_notif
+    engine_config_set_value_in_contacts    0    John_Doe    service_notification_commands    command_notif
+
+    Remove File    /tmp/notif_toto.txt
+    Clear Retention
+    ${start}=    Get Current Date
+    Start Engine
+    Start Broker
+
+    ${content}=    Create List    INITIAL HOST STATE: host_1;
+    ${result}=    Find In Log with Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True
+    ...    ${result}
+    ...    msg=An Initial host state on host_1 should be raised before we can start our external commands.
+
+    FOR    ${i}    IN RANGE    3
+        Process Service Check result    host_1    service_1    2    critical
+    END
+
+    Wait Until Created    /tmp/notif_toto.txt    30s
+
+    ${grep_res}=    Grep File
+    ...    /tmp/notif_toto.txt
+    ...    ResourceFile: /tmp/etc/centreon-engine/resource.cfg - LogFile: /tmp/var/log/centreon-engine/centengine.log - AdminEmail: titus@bidibule.com - AdminPager: admin
 
     Stop Engine
     Kindly Stop Broker

--- a/tests/resources/Engine.py
+++ b/tests/resources/Engine.py
@@ -417,7 +417,7 @@ passive_checks_enabled 1
 
             config_dir = "{}/config{}".format(CONF_DIR, inst)
             makedirs(config_dir)
-            f = open(config_dir + "/centengine.cfg", "w+")
+            f = open(config_dir + "/centengine.cfg", "w")
             bb = self.create_centengine(inst, debug_level=debug_level)
             f.write(bb)
             f.close()
@@ -497,6 +497,22 @@ define timeperiod {
             f.close()
             f = open(config_dir + "/hostgroups.cfg", "w")
             f.close()
+            f = open(config_dir + "/contacts.cfg", "w")
+            f.write("""define contact {
+    contact_name                   John_Doe
+    alias                          admin
+    email                          admin@admin.tld
+    host_notification_period       24x7
+    service_notification_period    24x7
+    host_notification_options      n
+    service_notification_options   w,c,r
+    register                       1
+    host_notifications_enabled     1
+    service_notifications_enabled  1
+}
+            """)
+            f.close()
+
             if not exists(ENGINE_HOME):
                 makedirs(ENGINE_HOME)
             for file in ["check.pl", "notif.pl"]:
@@ -575,6 +591,20 @@ def engine_config_set_value(idx: int, key: str, value: str, force: bool = False)
     f.writelines(lines)
     f.close()
 
+##
+# @brief Function to add a value in the centengine.cfg for the config idx.
+#
+# @param idx index of the configuration (from 0)
+# @param key the key to change the value.
+# @param value the new value to set to the key variable.
+#
+def engine_config_add_value(idx: int, key: str, value: str):
+    filename = ETC_ROOT + \
+        "/centreon-engine/config{}/centengine.cfg".format(idx)
+    f = open(filename, "a")
+    f.write(f"{key}={value}")
+    f.close()
+
 
 ##
 # @brief Function to change a value in the services.cfg for the config idx.
@@ -650,6 +680,46 @@ def engine_config_change_command(idx: int, command_index: str, new_command: str)
     f = open(f"{CONF_DIR}/config0/commands.cfg", "w")
     f.writelines(new_lines)
     f.close
+
+
+##
+# @brief Function to add a new command in the commands.cfg for the config idx
+#
+# @param idx index of the configuration (from 0)
+# @param command_name
+# @param new_command
+#
+def engine_config_add_command(idx: int, command_name: str, new_command: str):
+    f = open(f"{CONF_DIR}/config{idx}/commands.cfg", "a")
+    f.write("""define command {{
+    command_name                   {} 
+    command_line                   {}
+}}
+    """.format(command_name, new_command))
+    f.close()
+
+
+#
+# @param idx index of the configuration (from 0)
+# @param desc contact_name
+# @param key the key to change the value.
+# @param value the new value to set to the key variable.
+#
+def engine_config_set_value_in_contacts(idx: int, desc: str, key: str, value: str):
+    filename = f"{ETC_ROOT}/centreon-engine/config{idx}/contacts.cfg"
+    f = open(filename, "r")
+    lines = f.readlines()
+    f.close()
+
+    r = re.compile(r"^\s*contact_name\s+" + desc + "\s*$")
+    for i in range(len(lines)):
+        if r.match(lines[i]):
+            lines.insert(i + 1, f"    {key}              {value}\n")
+            break
+
+    f = open(filename, "w")
+    f.writelines(lines)
+    f.close()
 
 
 def engine_config_remove_service_host(idx: int, host: str):

--- a/tests/resources/Engine.py
+++ b/tests/resources/Engine.py
@@ -624,6 +624,34 @@ def engine_config_set_value_in_hosts(idx: int, desc: str, key: str, value: str):
     f.close()
 
 
+##
+# @brief Function to change a value in the commands.cfg for the config idx.
+#
+# @param idx index of the configuration (from 0)
+# @param command_index  index of the command (may be a regex)
+# @param new_command
+#
+def engine_config_change_command(idx: int, command_index: str, new_command: str):
+    f = open(f"{CONF_DIR}/config{idx}/commands.cfg", "r")
+    lines = f.readlines()
+    f.close
+    new_lines = []
+    r = re.compile(f"^\\s+command_name\\s+command_{command_index}$")
+    found = 0
+    for line in lines:
+        if found == 1:
+            found = 0
+            new_lines.append(
+                f"    command_line                    {new_command}\n")
+        else:
+            new_lines.append(line)
+        if r.match(line) is not None:
+            found = 1
+    f = open(f"{CONF_DIR}/config0/commands.cfg", "w")
+    f.writelines(new_lines)
+    f.close
+
+
 def engine_config_remove_service_host(idx: int, host: str):
     filename = ETC_ROOT + "/centreon-engine/config{}/services.cfg".format(idx)
     f = open(filename, "r")


### PR DESCRIPTION
## Description

**Fixes** # (issue)

admin_email and admin_pager macros are erased

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

