### PR TITLE
Mon 20044 bam boolean rules

### DIFF
--- a/broker/bam/inc/com/centreon/broker/bam/bool_and.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_and.hh
@@ -40,6 +40,7 @@ class bool_and : public bool_binary_operator {
   bool_and& operator=(const bool_and&) = delete;
   double value_hard() override;
   double value_soft() override;
+  bool state_known() const;
 };
 }  // namespace bam
 

--- a/broker/bam/inc/com/centreon/broker/bam/bool_binary_operator.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_binary_operator.hh
@@ -59,9 +59,6 @@ class bool_binary_operator : public bool_value {
   void set_right(std::shared_ptr<bool_value> const& right);
   bool state_known() const override;
   bool in_downtime() const override;
-
- private:
-  void _internal_copy(bool_binary_operator const& right);
 };
 }  // namespace bam
 

--- a/broker/bam/inc/com/centreon/broker/bam/bool_call.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_call.hh
@@ -38,9 +38,9 @@ class bool_call : public bool_value {
   typedef std::shared_ptr<bool_call> ptr;
 
   bool_call(std::string const& name);
-  bool_call(bool_call const& right);
   ~bool_call() noexcept override = default;
-  bool_call& operator=(bool_call const& right);
+  bool_call(const bool_call&) = delete;
+  bool_call& operator=(const bool_call&) = delete;
   double value_hard() override;
   double value_soft() override;
   bool state_known() const override;

--- a/broker/bam/inc/com/centreon/broker/bam/bool_constant.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_constant.hh
@@ -33,13 +33,13 @@ namespace bam {
  *  value (i.e '42').
  */
 class bool_constant : public bool_value {
-  double _value;
+  const double _value;
 
  public:
   bool_constant(double value);
-  bool_constant(bool_constant const& right);
   ~bool_constant() noexcept override = default;
-  bool_constant& operator=(bool_constant const& right);
+  bool_constant(const bool_constant&) = delete;
+  bool_constant& operator=(const bool_constant&) = delete;
   bool child_has_update(computable* child, io::stream* visitor) override;
   double value_hard() override;
   double value_soft() override;

--- a/broker/bam/inc/com/centreon/broker/bam/bool_equal.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_equal.hh
@@ -36,8 +36,8 @@ class bool_equal : public bool_binary_operator {
  public:
   bool_equal() = default;
   ~bool_equal() noexcept override = default;
-  bool_equal(bool_equal const&) = delete;
-  bool_equal& operator=(bool_equal const&) = delete;
+  bool_equal(const bool_equal&) = delete;
+  bool_equal& operator=(const bool_equal&) = delete;
   double value_hard() override;
   double value_soft() override;
 };

--- a/broker/bam/inc/com/centreon/broker/bam/bool_expression.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_expression.hh
@@ -45,19 +45,18 @@ class bool_expression : public computable {
   bool _impact_if;
 
  public:
-  bool_expression();
-  bool_expression(bool_expression const& other) = delete;
+  bool_expression(uint32_t id, bool impact_if);
+  bool_expression(const bool_expression&) = delete;
   ~bool_expression() noexcept override = default;
-  bool_expression& operator=(bool_expression const& other) = delete;
+  bool_expression& operator=(const bool_expression&) = delete;
   bool child_has_update(computable* child,
                         io::stream* visitor = nullptr) override;
   state get_state() const;
   bool state_known() const;
   void set_expression(std::shared_ptr<bool_value> const& expression);
   std::shared_ptr<bool_value> get_expression() const;
-  void set_id(uint32_t id);
-  void set_impact_if(bool impact_if);
   bool in_downtime() const;
+  uint32_t get_id() const;
 };
 }  // namespace bam
 

--- a/broker/bam/inc/com/centreon/broker/bam/bool_less_than.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_less_than.hh
@@ -39,8 +39,8 @@ class bool_less_than : public bool_binary_operator {
  public:
   bool_less_than(bool strict = false);
   ~bool_less_than() noexcept = default;
-  bool_less_than(bool_less_than const&) = delete;
-  bool_less_than& operator=(bool_less_than const&) = delete;
+  bool_less_than(const bool_less_than&) = delete;
+  bool_less_than& operator=(const bool_less_than&) = delete;
   double value_hard();
   double value_soft();
 };

--- a/broker/bam/inc/com/centreon/broker/bam/bool_more_than.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_more_than.hh
@@ -37,9 +37,9 @@ class bool_more_than : public bool_binary_operator {
 
  public:
   bool_more_than(bool strict = false);
-  bool_more_than(bool_more_than const& right) = delete;
+  bool_more_than(const bool_more_than&) = delete;
   ~bool_more_than() noexcept = default;
-  bool_more_than& operator=(bool_more_than const&) = delete;
+  bool_more_than& operator=(const bool_more_than&) = delete;
   double value_hard();
   double value_soft();
 };

--- a/broker/bam/inc/com/centreon/broker/bam/bool_not.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_not.hh
@@ -37,22 +37,19 @@ class bool_value;
  *  NOT on a bool_value.
  */
 class bool_not : public bool_value {
+  bool_value::ptr _value;
+
  public:
   bool_not(bool_value::ptr val = bool_value::ptr());
-  bool_not(const bool_not&);
+  bool_not(const bool_not&) = delete;
   ~bool_not();
-  bool_not& operator=(const bool_not&);
+  bool_not& operator=(const bool_not&) = delete;
   bool child_has_update(computable* child, io::stream* visitor = NULL);
   void set_value(std::shared_ptr<bool_value>& value);
   double value_hard();
   double value_soft();
   bool state_known() const;
   bool in_downtime() const;
-
- private:
-  void _internal_copy(bool_not const& right);
-
-  bool_value::ptr _value;
 };
 }  // namespace bam
 

--- a/broker/bam/inc/com/centreon/broker/bam/bool_not.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_not.hh
@@ -39,9 +39,9 @@ class bool_value;
 class bool_not : public bool_value {
  public:
   bool_not(bool_value::ptr val = bool_value::ptr());
-  bool_not(bool_not const& right);
+  bool_not(const bool_not&);
   ~bool_not();
-  bool_not& operator=(bool_not const& right);
+  bool_not& operator=(const bool_not&);
   bool child_has_update(computable* child, io::stream* visitor = NULL);
   void set_value(std::shared_ptr<bool_value>& value);
   double value_hard();

--- a/broker/bam/inc/com/centreon/broker/bam/bool_not_equal.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_not_equal.hh
@@ -36,9 +36,9 @@ namespace bam {
 class bool_not_equal : public bool_binary_operator {
  public:
   bool_not_equal() = default;
-  bool_not_equal(bool_not_equal const&) = delete;
+  bool_not_equal(const bool_not_equal&) = delete;
   ~bool_not_equal() noexcept override = default;
-  bool_not_equal& operator=(bool_not_equal const&) = delete;
+  bool_not_equal& operator=(const bool_not_equal&) = delete;
   double value_hard() override;
   double value_soft() override;
 };

--- a/broker/bam/inc/com/centreon/broker/bam/bool_operation.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_operation.hh
@@ -46,8 +46,8 @@ class bool_operation : public bool_binary_operator {
  public:
   bool_operation(std::string const& op);
   ~bool_operation() noexcept override = default;
-  bool_operation(bool_operation const&) = delete;
-  bool_operation& operator=(bool_operation const&) = delete;
+  bool_operation(const bool_operation&) = delete;
+  bool_operation& operator=(const bool_operation&) = delete;
   double value_hard() override;
   double value_soft() override;
   bool state_known() const override;

--- a/broker/bam/inc/com/centreon/broker/bam/bool_or.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_or.hh
@@ -40,6 +40,7 @@ class bool_or : public bool_binary_operator {
   bool_or& operator=(const bool_or&) = delete;
   double value_hard() override;
   double value_soft() override;
+  bool state_known() const;
 };
 }  // namespace bam
 

--- a/broker/bam/inc/com/centreon/broker/bam/bool_value.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_value.hh
@@ -35,7 +35,7 @@ class bool_value : public computable {
  public:
   typedef std::shared_ptr<bool_value> ptr;
 
-  bool_value();
+  bool_value() = default;
   ~bool_value() noexcept override = default;
   bool_value(const bool_value&) = delete;
   bool_value& operator=(const bool_value&) = delete;

--- a/broker/bam/inc/com/centreon/broker/bam/bool_value.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_value.hh
@@ -36,9 +36,9 @@ class bool_value : public computable {
   typedef std::shared_ptr<bool_value> ptr;
 
   bool_value();
-  bool_value(bool_value const& right);
   ~bool_value() noexcept override = default;
-  bool_value& operator=(bool_value const& right);
+  bool_value(const bool_value&) = delete;
+  bool_value& operator=(const bool_value&) = delete;
   virtual double value_hard() = 0;
   virtual double value_soft() = 0;
   virtual bool state_known() const = 0;

--- a/broker/bam/inc/com/centreon/broker/bam/exp_parser.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/exp_parser.hh
@@ -37,22 +37,21 @@ namespace bam {
  */
 class exp_parser {
  public:
-  typedef std::list<std::string> notation;
+  using notation = std::list<std::string>;
 
+ private:
+  std::string _exp;
+  absl::flat_hash_map<std::string, int> _precedence;
+  notation _postfix;
+
+ public:
   exp_parser(std::string const& expression);
-  exp_parser(exp_parser const& other);
-  ~exp_parser();
-  exp_parser& operator=(exp_parser const& other);
+  exp_parser(exp_parser const&) = delete;
+  ~exp_parser() noexcept = default;
+  exp_parser& operator=(const exp_parser&) = delete;
   notation const& get_postfix();
   static bool is_function(std::string const& token);
   static bool is_operator(std::string const& token);
-
- private:
-  void _internal_copy(exp_parser const& other);
-
-  std::string _exp;
-  std::map<std::string, int> _precedence;
-  notation _postfix;
 };
 }  // namespace bam
 

--- a/broker/bam/inc/com/centreon/broker/bam/kpi_boolexp.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/kpi_boolexp.hh
@@ -40,11 +40,10 @@ class computable;
  *  bool_expression) as a KPI for a BA.
  */
 class kpi_boolexp : public kpi {
- private:
-  state _get_state() const;
   std::shared_ptr<bool_expression> _boolexp;
   double _impact;
 
+  state _get_state() const;
   void _fill_impact(impact_values& impact);
   void _open_new_event(io::stream* visitor, int impact, state state);
 

--- a/broker/bam/inc/com/centreon/broker/bam/service_listener.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/service_listener.hh
@@ -43,10 +43,10 @@ namespace bam {
  */
 class service_listener {
  public:
-  service_listener();
-  service_listener(service_listener const& other);
-  virtual ~service_listener();
-  service_listener& operator=(service_listener const& other);
+  service_listener() = default;
+  service_listener(const service_listener&) = delete;
+  virtual ~service_listener() noexcept = default;
+  service_listener& operator=(const service_listener&) = delete;
   virtual void service_update(std::shared_ptr<neb::pb_service> const& status,
                               io::stream* visitor = nullptr);
   virtual void service_update(

--- a/broker/bam/src/ba.cc
+++ b/broker/bam/src/ba.cc
@@ -97,8 +97,8 @@ void ba::add_impact(std::shared_ptr<kpi> const& impact) {
  *  @return True if the value of this ba was modified.
  */
 bool ba::child_has_update(computable* child, io::stream* visitor) {
-  std::unordered_map<kpi*, impact_info>::iterator it(
-      _impacts.find(static_cast<kpi*>(child)));
+  std::unordered_map<kpi*, impact_info>::iterator it =
+      _impacts.find(static_cast<kpi*>(child));
   if (it != _impacts.end()) {
     // Get impact.
     impact_values new_hard_impact;
@@ -119,8 +119,13 @@ bool ba::child_has_update(computable* child, io::stream* visitor) {
     if (it->second.hard_impact == new_hard_impact &&
         it->second.soft_impact == new_soft_impact &&
         it->second.in_downtime == kpi_in_downtime) {
-      SPDLOG_LOGGER_DEBUG(log_v2::bam(),
-                          "BAM: BA {} has no changes since last update", _id);
+      SPDLOG_LOGGER_DEBUG(
+          log_v2::bam(),
+          "BAM: BA {} has no changes since last update: hard impact: (ack: {}, "
+          "dwnt: {}, nominal: {}), downtime: {}",
+          _id, new_hard_impact.get_acknowledgement(),
+          new_hard_impact.get_nominal(), new_hard_impact.get_downtime(),
+          kpi_in_downtime);
       return false;
     }
     timestamp last_state_change(it->second.kpi_ptr->get_last_state_change());

--- a/broker/bam/src/bool_and.cc
+++ b/broker/bam/src/bool_and.cc
@@ -16,6 +16,7 @@
 ** For more information : contact@centreon.com
 */
 
+#include "com/centreon/broker/log_v2.hh"
 #include "com/centreon/broker/bam/bool_and.hh"
 
 using namespace com::centreon::broker::bam;
@@ -38,4 +39,12 @@ double bool_and::value_hard() {
  */
 double bool_and::value_soft() {
   return std::abs(_left_soft) > ::eps && std::abs(_right_soft) > ::eps;
+}
+
+bool bool_and::state_known() const {
+  bool left_exists = _left && _left->state_known();
+  bool right_exists = _right && _right->state_known();
+  bool retval = (right_exists && right_exists) || (left_exists && std::abs(_left_hard) < ::eps) || (right_exists && std::abs(_right_hard) >= ::eps);
+  log_v2::bam()->debug("BAM: bool and: state known {}", retval);
+  return retval;
 }

--- a/broker/bam/src/bool_and.cc
+++ b/broker/bam/src/bool_and.cc
@@ -16,8 +16,8 @@
 ** For more information : contact@centreon.com
 */
 
-#include "com/centreon/broker/log_v2.hh"
 #include "com/centreon/broker/bam/bool_and.hh"
+#include "com/centreon/broker/log_v2.hh"
 
 using namespace com::centreon::broker::bam;
 
@@ -44,7 +44,9 @@ double bool_and::value_soft() {
 bool bool_and::state_known() const {
   bool left_exists = _left && _left->state_known();
   bool right_exists = _right && _right->state_known();
-  bool retval = (right_exists && right_exists) || (left_exists && std::abs(_left_hard) < ::eps) || (right_exists && std::abs(_right_hard) >= ::eps);
+  bool retval = (right_exists && right_exists) ||
+                (left_exists && std::abs(_left_hard) < ::eps) ||
+                (right_exists && std::abs(_right_hard) >= ::eps);
   log_v2::bam()->debug("BAM: bool and: state known {}", retval);
   return retval;
 }

--- a/broker/bam/src/bool_and.cc
+++ b/broker/bam/src/bool_and.cc
@@ -51,7 +51,7 @@ double bool_and::value_soft() {
 bool bool_and::state_known() const {
   bool left_exists = _left && _left->state_known();
   bool right_exists = _right && _right->state_known();
-  bool retval = (right_exists && right_exists) ||
+  bool retval = (left_exists && right_exists) ||
                 (left_exists && std::abs(_left_hard) < ::eps) ||
                 (right_exists && std::abs(_right_hard) < ::eps);
   log_v2::bam()->debug("BAM: bool and: state known {}", retval);

--- a/broker/bam/src/bool_and.cc
+++ b/broker/bam/src/bool_and.cc
@@ -41,12 +41,19 @@ double bool_and::value_soft() {
   return std::abs(_left_soft) > ::eps && std::abs(_right_soft) > ::eps;
 }
 
+/**
+ * @brief Tell if this boolean value has a known state. Since it is a logical
+ * and, if one operand is known to be false, we can consider the state to be
+ * known because the result will be false.
+ *
+ * @return a boolean.
+ */
 bool bool_and::state_known() const {
   bool left_exists = _left && _left->state_known();
   bool right_exists = _right && _right->state_known();
   bool retval = (right_exists && right_exists) ||
                 (left_exists && std::abs(_left_hard) < ::eps) ||
-                (right_exists && std::abs(_right_hard) >= ::eps);
+                (right_exists && std::abs(_right_hard) < ::eps);
   log_v2::bam()->debug("BAM: bool and: state known {}", retval);
   return retval;
 }

--- a/broker/bam/src/bool_binary_operator.cc
+++ b/broker/bam/src/bool_binary_operator.cc
@@ -45,22 +45,6 @@ bool_binary_operator::bool_binary_operator(bool_binary_operator const& right)
 }
 
 /**
- *  Assignment operator.
- *
- *  @param[in] right Object to copy.
- *
- *  @return This object.
- */
-// bool_binary_operator& bool_binary_operator::operator=(
-//    bool_binary_operator const& right) {
-//  if (this != &right) {
-//    bool_value::operator=(right);
-//    _internal_copy(right);
-//  }
-//  return (*this);
-//}
-
-/**
  *  Notification of child update.
  *
  *  @param[in] child     Child that got updated.
@@ -71,7 +55,7 @@ bool_binary_operator::bool_binary_operator(bool_binary_operator const& right)
 bool bool_binary_operator::child_has_update(computable* child,
                                             io::stream* visitor) {
   (void)visitor;
-  bool retval(true);
+  bool retval = false;
 
   // Check operation members values.
   if (child) {
@@ -110,20 +94,20 @@ bool bool_binary_operator::child_has_update(computable* child,
   }
 
   // Check known flag.
-  bool known(state_known());
+  bool known = state_known();
   if (_state_known != known) {
     _state_known = known;
     retval = true;
   }
 
   // Check downtime flag.
-  bool in_dt(in_downtime());
+  bool in_dt = in_downtime();
   if (_in_downtime != in_dt) {
     _in_downtime = in_dt;
     retval = true;
   }
 
-  return (retval);
+  return retval;
 }
 
 /**
@@ -137,7 +121,6 @@ void bool_binary_operator::set_left(std::shared_ptr<bool_value> const& left) {
   _left_soft = _left->value_soft();
   _state_known = state_known();
   _in_downtime = in_downtime();
-  return;
 }
 
 /**
@@ -151,7 +134,6 @@ void bool_binary_operator::set_right(std::shared_ptr<bool_value> const& right) {
   _right_soft = _right->value_soft();
   _state_known = state_known();
   _in_downtime = in_downtime();
-  return;
 }
 
 /**
@@ -168,7 +150,6 @@ void bool_binary_operator::_internal_copy(bool_binary_operator const& right) {
   _right_soft = right._right_soft;
   _state_known = right._state_known;
   _in_downtime = right._in_downtime;
-  return;
 }
 
 /**
@@ -177,7 +158,10 @@ void bool_binary_operator::_internal_copy(bool_binary_operator const& right) {
  *  @return  True if the state is known.
  */
 bool bool_binary_operator::state_known() const {
-  return (_left && _right && _left->state_known() && _right->state_known());
+  bool retval =
+      _left && _right && _left->state_known() && _right->state_known();
+  log_v2::bam()->debug("BAM: bool binary operator: state known {}", retval);
+  return retval;
 }
 
 /**
@@ -186,5 +170,5 @@ bool bool_binary_operator::state_known() const {
  *  @return  True if this expression is in downtime.
  */
 bool bool_binary_operator::in_downtime() const {
-  return ((_left && _left->in_downtime()) || (_right && _right->in_downtime()));
+  return (_left && _left->in_downtime()) || (_right && _right->in_downtime());
 }

--- a/broker/bam/src/bool_binary_operator.cc
+++ b/broker/bam/src/bool_binary_operator.cc
@@ -35,16 +35,6 @@ bool_binary_operator::bool_binary_operator()
       _in_downtime(false) {}
 
 /**
- *  Copy constructor.
- *
- *  @param[in] right Object to copy.
- */
-bool_binary_operator::bool_binary_operator(bool_binary_operator const& right)
-    : bool_value(right) {
-  _internal_copy(right);
-}
-
-/**
  *  Notification of child update.
  *
  *  @param[in] child     Child that got updated.

--- a/broker/bam/src/bool_binary_operator.cc
+++ b/broker/bam/src/bool_binary_operator.cc
@@ -127,22 +127,6 @@ void bool_binary_operator::set_right(std::shared_ptr<bool_value> const& right) {
 }
 
 /**
- *  Copy internal data members.
- *
- *  @param[in] right Object to copy.
- */
-void bool_binary_operator::_internal_copy(bool_binary_operator const& right) {
-  _left = right._left;
-  _left_hard = right._left_hard;
-  _left_soft = right._left_soft;
-  _right = right._right;
-  _right_hard = right._right_hard;
-  _right_soft = right._right_soft;
-  _state_known = right._state_known;
-  _in_downtime = right._in_downtime;
-}
-
-/**
  *  Get if the state is known, i.e has been computed at least once.
  *
  *  @return  True if the state is known.

--- a/broker/bam/src/bool_call.cc
+++ b/broker/bam/src/bool_call.cc
@@ -28,32 +28,6 @@ using namespace com::centreon::broker::bam;
 bool_call::bool_call(std::string const& name) : _name(name) {}
 
 /**
- *  Copy constructor.
- *
- *  @param[in] right Object to copy.
- */
-// bool_call::bool_call(bool_call const& right) : bool_value(right) {
-//   _name = right._name;
-//   _expression = right._expression;
-// }
-
-/**
- *  Assignment operator.
- *
- *  @param[in] right Object to copy.
- *
- *  @return This object.
- */
-// bool_call& bool_call::operator=(bool_call const& right) {
-//   bool_value::operator=(right);
-//   if (this != &right) {
-//     _name = right._name;
-//     _expression = right._expression;
-//   }
-//   return (*this);
-// }
-
-/**
  *  Get the hard value.
  *
  *  @return Evaluation of the expression with hard values.
@@ -95,7 +69,7 @@ bool bool_call::state_known() const {
  *  @return  The name of this boolean expression.
  */
 std::string const& bool_call::get_name() const {
-  return (_name);
+  return _name;
 }
 
 /**

--- a/broker/bam/src/bool_call.cc
+++ b/broker/bam/src/bool_call.cc
@@ -32,10 +32,10 @@ bool_call::bool_call(std::string const& name) : _name(name) {}
  *
  *  @param[in] right Object to copy.
  */
-bool_call::bool_call(bool_call const& right) : bool_value(right) {
-  _name = right._name;
-  _expression = right._expression;
-}
+// bool_call::bool_call(bool_call const& right) : bool_value(right) {
+//   _name = right._name;
+//   _expression = right._expression;
+// }
 
 /**
  *  Assignment operator.
@@ -44,14 +44,14 @@ bool_call::bool_call(bool_call const& right) : bool_value(right) {
  *
  *  @return This object.
  */
-bool_call& bool_call::operator=(bool_call const& right) {
-  bool_value::operator=(right);
-  if (this != &right) {
-    _name = right._name;
-    _expression = right._expression;
-  }
-  return (*this);
-}
+// bool_call& bool_call::operator=(bool_call const& right) {
+//   bool_value::operator=(right);
+//   if (this != &right) {
+//     _name = right._name;
+//     _expression = right._expression;
+//   }
+//   return (*this);
+// }
 
 /**
  *  Get the hard value.

--- a/broker/bam/src/bool_constant.cc
+++ b/broker/bam/src/bool_constant.cc
@@ -28,31 +28,6 @@ using namespace com::centreon::broker::bam;
 bool_constant::bool_constant(double val) : _value(val) {}
 
 /**
- *  Copy constructor.
- *
- *  @param[in] right Object to copy.
- */
-// bool_constant::bool_constant(const bool_constant& right) : bool_value(right)
-// {
-//   _value = right._value;
-// }
-
-/**
- *  Assignment operator.
- *
- *  @param[in] right Object to copy.
- *
- *  @return This object.
- */
-// bool_constant& bool_constant::operator=(bool_constant const& right) {
-//   bool_value::operator=(right);
-//   if (this != &right) {
-//     _value = right._value;
-//   }
-//   return *this;
-// }
-
-/**
  *  Get notified of child update.
  *
  *  @param[in] child    The child.

--- a/broker/bam/src/bool_constant.cc
+++ b/broker/bam/src/bool_constant.cc
@@ -32,9 +32,10 @@ bool_constant::bool_constant(double val) : _value(val) {}
  *
  *  @param[in] right Object to copy.
  */
-bool_constant::bool_constant(const bool_constant& right) : bool_value(right) {
-  _value = right._value;
-}
+// bool_constant::bool_constant(const bool_constant& right) : bool_value(right)
+// {
+//   _value = right._value;
+// }
 
 /**
  *  Assignment operator.
@@ -43,13 +44,13 @@ bool_constant::bool_constant(const bool_constant& right) : bool_value(right) {
  *
  *  @return This object.
  */
-bool_constant& bool_constant::operator=(bool_constant const& right) {
-  bool_value::operator=(right);
-  if (this != &right) {
-    _value = right._value;
-  }
-  return *this;
-}
+// bool_constant& bool_constant::operator=(bool_constant const& right) {
+//   bool_value::operator=(right);
+//   if (this != &right) {
+//     _value = right._value;
+//   }
+//   return *this;
+// }
 
 /**
  *  Get notified of child update.

--- a/broker/bam/src/bool_constant.cc
+++ b/broker/bam/src/bool_constant.cc
@@ -32,7 +32,7 @@ bool_constant::bool_constant(double val) : _value(val) {}
  *
  *  @param[in] right Object to copy.
  */
-bool_constant::bool_constant(bool_constant const& right) : bool_value(right) {
+bool_constant::bool_constant(const bool_constant& right) : bool_value(right) {
   _value = right._value;
 }
 
@@ -48,7 +48,7 @@ bool_constant& bool_constant::operator=(bool_constant const& right) {
   if (this != &right) {
     _value = right._value;
   }
-  return (*this);
+  return *this;
 }
 
 /**
@@ -62,7 +62,7 @@ bool_constant& bool_constant::operator=(bool_constant const& right) {
 bool bool_constant::child_has_update(computable* child, io::stream* visitor) {
   (void)child;
   (void)visitor;
-  return (true);
+  return true;
 }
 
 /**
@@ -71,7 +71,7 @@ bool bool_constant::child_has_update(computable* child, io::stream* visitor) {
  *  @return Evaluation of the expression with hard values.
  */
 double bool_constant::value_hard() {
-  return (_value);
+  return _value;
 }
 
 /**
@@ -80,7 +80,7 @@ double bool_constant::value_hard() {
  *  @return Evaluation of the expression with soft values.
  */
 double bool_constant::value_soft() {
-  return (_value);
+  return _value;
 }
 
 /**
@@ -89,5 +89,5 @@ double bool_constant::value_soft() {
  *  @return  True if the state is known.
  */
 bool bool_constant::state_known() const {
-  return (true);
+  return true;
 }

--- a/broker/bam/src/bool_equal.cc
+++ b/broker/bam/src/bool_equal.cc
@@ -40,5 +40,7 @@ double bool_equal::value_hard() {
  *  @return Evaluation of the expression with soft values.
  */
 double bool_equal::value_soft() {
-  return std::fabs(_left_soft - _right_soft) < COMPARE_EPSILON ? 1.0 : 0.0;
+  bool retval = std::fabs(_left_soft - _right_soft) < COMPARE_EPSILON;
+  log_v2::bam()->trace("BAM: soft bool_equal: {}", retval);
+  return retval;
 }

--- a/broker/bam/src/bool_equal.cc
+++ b/broker/bam/src/bool_equal.cc
@@ -17,6 +17,7 @@
 */
 
 #include "com/centreon/broker/bam/bool_equal.hh"
+#include "com/centreon/broker/log_v2.hh"
 
 #include <cmath>
 
@@ -28,7 +29,9 @@ using namespace com::centreon::broker::bam;
  *  @return Evaluation of the expression with hard values.
  */
 double bool_equal::value_hard() {
-  return (std::fabs(_left_hard - _right_hard) < COMPARE_EPSILON) ? 1.0 : 0.0;
+  bool retval = std::fabs(_left_hard - _right_hard) < COMPARE_EPSILON;
+  log_v2::bam()->debug("BAM: bool_equal: {}", retval);
+  return retval;
 }
 
 /**
@@ -37,5 +40,5 @@ double bool_equal::value_hard() {
  *  @return Evaluation of the expression with soft values.
  */
 double bool_equal::value_soft() {
-  return (std::fabs(_left_soft - _right_soft) < COMPARE_EPSILON) ? 1.0 : 0.0;
+  return std::fabs(_left_soft - _right_soft) < COMPARE_EPSILON ? 1.0 : 0.0;
 }

--- a/broker/bam/src/bool_equal.cc
+++ b/broker/bam/src/bool_equal.cc
@@ -30,7 +30,7 @@ using namespace com::centreon::broker::bam;
  */
 double bool_equal::value_hard() {
   bool retval = std::fabs(_left_hard - _right_hard) < COMPARE_EPSILON;
-  log_v2::bam()->debug("BAM: bool_equal: {}", retval);
+  log_v2::bam()->trace("BAM: bool_equal: {}", retval);
   return retval;
 }
 

--- a/broker/bam/src/bool_expression.cc
+++ b/broker/bam/src/bool_expression.cc
@@ -61,7 +61,6 @@ bool bool_expression::child_has_update(computable* child, io::stream* visitor) {
  *  @return Either OK (0) or CRITICAL (2).
  */
 state bool_expression::get_state() const {
-  log_v2::bam()->debug("BAM: bool_expression::get_state()");
   bool v = _expression->value_hard() > 0.5;
   state retval = v == _impact_if ? state_critical : state_ok;
   log_v2::bam()->debug(

--- a/broker/bam/src/bool_expression.cc
+++ b/broker/bam/src/bool_expression.cc
@@ -26,9 +26,14 @@ using namespace com::centreon::broker::bam;
 using namespace com::centreon::broker;
 
 /**
- *  Default constructor.
+ * @brief Constructor of a boolean expression.
+ *
+ * @param id Id of the boolean expression
+ * @param impact_if True if impact is applied if the expression is true.False
+ * otherwise.
  */
-bool_expression::bool_expression() : _id(0), _impact_if(true) {}
+bool_expression::bool_expression(uint32_t id, bool impact_if)
+    : _id(id), _impact_if(impact_if) {}
 
 /**
  *  Base boolean expression got updated.
@@ -56,8 +61,13 @@ bool bool_expression::child_has_update(computable* child, io::stream* visitor) {
  *  @return Either OK (0) or CRITICAL (2).
  */
 state bool_expression::get_state() const {
+  log_v2::bam()->debug("BAM: bool_expression::get_state()");
   bool v = _expression->value_hard() > 0.5;
-  return v == _impact_if ? state_critical : state_ok;
+  state retval = v == _impact_if ? state_critical : state_ok;
+  log_v2::bam()->debug(
+      "BAM: boolean expression {} - impact if: {} - value: {} - state: {}", _id,
+      _impact_if, v, retval);
+  return retval;
 }
 
 /**
@@ -93,25 +103,10 @@ std::shared_ptr<bool_value> bool_expression::get_expression() const {
  *  @param[in] expression Boolean expression.
  */
 void bool_expression::set_expression(
-    std::shared_ptr<bool_value> const& expression) {
+    const std::shared_ptr<bool_value>& expression) {
   _expression = expression;
 }
 
-/**
- *  Set boolean expression ID.
- *
- *  @param[in] id  Boolean expression ID.
- */
-void bool_expression::set_id(uint32_t id) {
-  _id = id;
-}
-
-/**
- *  Set whether we should impact if the expression is true or false.
- *
- *  @param[in] impact_if True if impact is applied if the expression is
- *                       true. False otherwise.
- */
-void bool_expression::set_impact_if(bool impact_if) {
-  _impact_if = impact_if;
+uint32_t bool_expression::get_id() const {
+  return _id;
 }

--- a/broker/bam/src/bool_more_than.cc
+++ b/broker/bam/src/bool_more_than.cc
@@ -28,22 +28,12 @@ using namespace com::centreon::broker::bam;
 bool_more_than::bool_more_than(bool strict) : _strict(strict) {}
 
 /**
- *  Copy constructor.
- *
- *  @param[in] right Object to copy.
- */
-// bool_more_than::bool_more_than(bool_more_than const& right)
-//    : bool_binary_operator(right) {
-//  _strict = right._strict;
-//}
-
-/**
  *  Get the hard value.
  *
  *  @return Evaluation of the expression with hard values.
  */
 double bool_more_than::value_hard() {
-  return (_strict ? _left_hard > _right_hard : _left_hard >= _right_hard);
+  return _strict ? _left_hard > _right_hard : _left_hard >= _right_hard;
 }
 
 /**
@@ -52,5 +42,5 @@ double bool_more_than::value_hard() {
  *  @return Evaluation of the expression with soft values.
  */
 double bool_more_than::value_soft() {
-  return (_strict ? _left_soft > _right_soft : _left_soft >= _right_soft);
+  return _strict ? _left_soft > _right_soft : _left_soft >= _right_soft;
 }

--- a/broker/bam/src/bool_not.cc
+++ b/broker/bam/src/bool_not.cc
@@ -35,9 +35,9 @@ bool_not::bool_not(bool_value::ptr val) : _value(std::move(val)) {}
  *
  *  @param[in] right Object to copy.
  */
-bool_not::bool_not(bool_not const& right) : bool_value(right) {
-  _internal_copy(right);
-}
+// bool_not::bool_not(bool_not const& right) : bool_value(right) {
+//   _internal_copy(right);
+// }
 
 /**
  *  Destructor.
@@ -51,13 +51,13 @@ bool_not::~bool_not() {}
  *
  *  @return This object.
  */
-bool_not& bool_not::operator=(bool_not const& right) {
-  if (this != &right) {
-    bool_value::operator=(right);
-    _internal_copy(right);
-  }
-  return (*this);
-}
+// bool_not& bool_not::operator=(bool_not const& right) {
+//   if (this != &right) {
+//     bool_value::operator=(right);
+//     _internal_copy(right);
+//   }
+//   return (*this);
+// }
 
 /**
  *  @brief Notify of the change of value of the child.

--- a/broker/bam/src/bool_not.cc
+++ b/broker/bam/src/bool_not.cc
@@ -31,33 +31,9 @@ constexpr double eps = 0.000001;
 bool_not::bool_not(bool_value::ptr val) : _value(std::move(val)) {}
 
 /**
- *  Copy constructor.
- *
- *  @param[in] right Object to copy.
- */
-// bool_not::bool_not(bool_not const& right) : bool_value(right) {
-//   _internal_copy(right);
-// }
-
-/**
  *  Destructor.
  */
 bool_not::~bool_not() {}
-
-/**
- *  Assignment operator.
- *
- *  @param[in] right Object to copy.
- *
- *  @return This object.
- */
-// bool_not& bool_not::operator=(bool_not const& right) {
-//   if (this != &right) {
-//     bool_value::operator=(right);
-//     _internal_copy(right);
-//   }
-//   return (*this);
-// }
 
 /**
  *  @brief Notify of the change of value of the child.
@@ -101,15 +77,6 @@ double bool_not::value_hard() {
  */
 double bool_not::value_soft() {
   return std::abs(_value->value_soft()) < ::eps;
-}
-
-/**
- *  Copy the internal data members.
- *
- *  @param[in] right Object to copy.
- */
-void bool_not::_internal_copy(bool_not const& right) {
-  _value = right._value;
 }
 
 /**

--- a/broker/bam/src/bool_operation.cc
+++ b/broker/bam/src/bool_operation.cc
@@ -99,7 +99,7 @@ double bool_operation::value_soft() {
 bool bool_operation::state_known() const {
   bool known = bool_binary_operator::state_known();
   if (known && (_type == division || _type == modulo) &&
-      ((std::fabs(_right_hard) < COMPARE_EPSILON) ||
+      (std::fabs(_right_hard) < COMPARE_EPSILON ||
        std::fabs(_right_soft) < COMPARE_EPSILON))
     return false;
   else

--- a/broker/bam/src/bool_or.cc
+++ b/broker/bam/src/bool_or.cc
@@ -63,7 +63,7 @@ double bool_or::value_soft() {
 bool bool_or::state_known() const {
   bool left_exists = _left && _left->state_known();
   bool right_exists = _right && _right->state_known();
-  bool retval = (right_exists && right_exists) ||
+  bool retval = (left_exists && right_exists) ||
                 (left_exists && std::abs(_left_hard) >= ::eps) ||
                 (right_exists && std::abs(_right_hard) >= ::eps);
   log_v2::bam()->debug("BAM: bool or: state known {}", retval);

--- a/broker/bam/src/bool_or.cc
+++ b/broker/bam/src/bool_or.cc
@@ -53,6 +53,13 @@ double bool_or::value_soft() {
   return retval;
 }
 
+/**
+ * @brief Tell if this boolean value has a known state. Since it is a logical
+ * or, if one operand is known to be true, we can consider the state to be
+ * known because the result will be true.
+ *
+ * @return a boolean.
+ */
 bool bool_or::state_known() const {
   bool left_exists = _left && _left->state_known();
   bool right_exists = _right && _right->state_known();

--- a/broker/bam/src/bool_or.cc
+++ b/broker/bam/src/bool_or.cc
@@ -52,3 +52,11 @@ double bool_or::value_soft() {
       right, retval);
   return retval;
 }
+
+bool bool_or::state_known() const {
+  bool left_exists = _left && _left->state_known();
+  bool right_exists = _right && _right->state_known();
+  bool retval = (right_exists && right_exists) || (left_exists && std::abs(_left_hard) >= ::eps) || (right_exists && std::abs(_right_hard) >= ::eps);
+  log_v2::bam()->debug("BAM: bool or: state known {}", retval);
+  return retval;
+}

--- a/broker/bam/src/bool_or.cc
+++ b/broker/bam/src/bool_or.cc
@@ -56,7 +56,9 @@ double bool_or::value_soft() {
 bool bool_or::state_known() const {
   bool left_exists = _left && _left->state_known();
   bool right_exists = _right && _right->state_known();
-  bool retval = (right_exists && right_exists) || (left_exists && std::abs(_left_hard) >= ::eps) || (right_exists && std::abs(_right_hard) >= ::eps);
+  bool retval = (right_exists && right_exists) ||
+                (left_exists && std::abs(_left_hard) >= ::eps) ||
+                (right_exists && std::abs(_right_hard) >= ::eps);
   log_v2::bam()->debug("BAM: bool or: state known {}", retval);
   return retval;
 }

--- a/broker/bam/src/bool_or.cc
+++ b/broker/bam/src/bool_or.cc
@@ -17,6 +17,7 @@
 */
 
 #include "com/centreon/broker/bam/bool_or.hh"
+#include "com/centreon/broker/log_v2.hh"
 
 using namespace com::centreon::broker::bam;
 
@@ -28,7 +29,13 @@ constexpr double eps = 0.000001;
  *  @return Evaluation of the expression with hard values.
  */
 double bool_or::value_hard() {
-  return std::abs(_left_hard) >= ::eps || std::abs(_right_hard) >= ::eps;
+  bool left = std::abs(_left_hard) >= ::eps;
+  bool right = std::abs(_right_hard) >= ::eps;
+  double retval = left || right;
+  log_v2::bam()->debug(
+      "bool_or: (hard) left: {} | (hard) right: {} = (hard) result: {}", left,
+      right, retval);
+  return retval;
 }
 
 /**
@@ -37,5 +44,11 @@ double bool_or::value_hard() {
  *  @return Evaluation of the expression with soft values.
  */
 double bool_or::value_soft() {
-  return std::abs(_left_soft) >= ::eps || std::abs(_right_soft) >= ::eps;
+  bool left = std::abs(_left_soft) >= ::eps;
+  bool right = std::abs(_right_soft) >= ::eps;
+  double retval = left || right;
+  log_v2::bam()->debug(
+      "bool_or: (soft) left: {} | (soft) right: {} = (soft) result: {}", left,
+      right, retval);
+  return retval;
 }

--- a/broker/bam/src/bool_service.cc
+++ b/broker/bam/src/bool_service.cc
@@ -35,9 +35,7 @@ bool_service::bool_service(uint32_t host_id, uint32_t service_id)
       _state_hard(0),
       _state_soft(0),
       _state_known(false),
-      _in_downtime(false) {
-  assert(_host_id);
-}
+      _in_downtime(false) {}
 
 /**
  *  @brief Notification of child update.

--- a/broker/bam/src/bool_service.cc
+++ b/broker/bam/src/bool_service.cc
@@ -141,7 +141,7 @@ double bool_service::value_soft() {
  *  @return  True if the state is known.
  */
 bool bool_service::state_known() const {
-  log_v2::bam()->debug("BAM: bool_service::state_known: {}", _state_known);
+  log_v2::bam()->trace("BAM: bool_service::state_known: {}", _state_known);
   return _state_known;
 }
 

--- a/broker/bam/src/bool_service.cc
+++ b/broker/bam/src/bool_service.cc
@@ -104,10 +104,12 @@ void bool_service::service_update(
 void bool_service::service_update(
     const std::shared_ptr<neb::pb_service_status>& status,
     io::stream* visitor) {
-  SPDLOG_LOGGER_TRACE(
-      log_v2::bam(),
-      "bool_service: service update with neb::pb_service_status");
   auto& o = status->obj();
+  SPDLOG_LOGGER_TRACE(log_v2::bam(),
+                      "bool_service: service ({},{}) updated with "
+                      "neb::pb_service_status hard state: {}, downtime: {}",
+                      o.host_id(), o.service_id(), o.last_hard_state(),
+                      o.scheduled_downtime_depth());
   if (o.host_id() == _host_id && o.service_id() == _service_id) {
     _state_hard = o.last_hard_state();
     _state_soft = o.state();
@@ -141,6 +143,7 @@ double bool_service::value_soft() {
  *  @return  True if the state is known.
  */
 bool bool_service::state_known() const {
+  log_v2::bam()->debug("BAM: bool_service::state_known: {}", _state_known);
   return _state_known;
 }
 

--- a/broker/bam/src/bool_value.cc
+++ b/broker/bam/src/bool_value.cc
@@ -26,26 +26,6 @@ using namespace com::centreon::broker::bam;
 bool_value::bool_value() {}
 
 /**
- *  Copy constructor.
- *
- *  @param[in] right Object to copy.
- */
-bool_value::bool_value(bool_value const& right) : computable(right) {}
-
-/**
- *  Assignment operator.
- *
- *  @param[in] right Object to copy.
- *
- *  @return This object.
- */
-bool_value& bool_value::operator=(const bool_value& right) {
-  if (this != &right)
-    computable::operator=(right);
-  return *this;
-}
-
-/**
  *  Is this boolean value in downtime?
  *
  *  @return  True if this boolean value is in downtime.

--- a/broker/bam/src/bool_value.cc
+++ b/broker/bam/src/bool_value.cc
@@ -21,11 +21,6 @@
 using namespace com::centreon::broker::bam;
 
 /**
- *  Default constructor.
- */
-bool_value::bool_value() {}
-
-/**
  *  Is this boolean value in downtime?
  *
  *  @return  True if this boolean value is in downtime.

--- a/broker/bam/src/computable.cc
+++ b/broker/bam/src/computable.cc
@@ -72,8 +72,8 @@ void computable::add_parent(std::shared_ptr<computable> const& parent) {
 void computable::propagate_update(io::stream* visitor) {
   std::vector<bool> filter(_parents.size());
   uint32_t i = 0;
-  for (std::list<std::weak_ptr<computable> >::iterator it(_parents.begin()),
-       end(_parents.end());
+  for (std::list<std::weak_ptr<computable> >::iterator it = _parents.begin(),
+                                                       end = _parents.end();
        it != end; ++it) {
     std::shared_ptr<computable> ptr = it->lock();
     if (ptr)
@@ -82,8 +82,8 @@ void computable::propagate_update(io::stream* visitor) {
       ++i;
   }
   i = 0;
-  for (std::list<std::weak_ptr<computable> >::iterator it(_parents.begin()),
-       end(_parents.end());
+  for (std::list<std::weak_ptr<computable> >::iterator it = _parents.begin(),
+                                                       end = _parents.end();
        it != end; ++it)
     if (filter[i++]) {
       std::shared_ptr<computable> ptr = it->lock();

--- a/broker/bam/src/configuration/applier/bool_expression.cc
+++ b/broker/bam/src/configuration/applier/bool_expression.cc
@@ -98,12 +98,12 @@ void applier::bool_expression::apply(
   to_delete.clear();
 
   // Create new objects.
-  for (bam::configuration::state::bool_exps::iterator it(to_create.begin()),
-       end(to_create.end());
+  for (bam::configuration::state::bool_exps::iterator it = to_create.begin(),
+                                                      end = to_create.end();
        it != end; ++it) {
     log_v2::bam()->info("BAM: creating new boolean expression {}", it->first);
-    std::shared_ptr<bam::bool_expression> new_bool_exp(
-        new bam::bool_expression);
+    auto new_bool_exp = std::make_shared<bam::bool_expression>(
+        it->first, it->second.get_impact_if());
     try {
       bam::exp_parser p(it->second.get_expression());
       bam::exp_builder b(p.get_postfix(), mapping);
@@ -119,8 +119,8 @@ void applier::bool_expression::apply(
       content.call = b.get_calls();
       // Resolve boolean service.
       for (std::list<bool_service::ptr>::const_iterator
-               it2(content.svc.begin()),
-           end2(content.svc.end());
+               it2 = content.svc.begin(),
+               end2 = content.svc.end();
            it2 != end2; ++it2)
         book.listen((*it2)->get_host_id(), (*it2)->get_service_id(),
                     it2->get());
@@ -130,8 +130,6 @@ void applier::bool_expression::apply(
           "discarded: {}",
           it->first, e.what());
     }
-    new_bool_exp->set_id(it->first);
-    new_bool_exp->set_impact_if(it->second.get_impact_if());
   }
 
   _resolve_expression_calls();

--- a/broker/bam/src/configuration/bool_expression.cc
+++ b/broker/bam/src/configuration/bool_expression.cc
@@ -65,7 +65,7 @@ bool_expression& bool_expression::operator=(bool_expression const& other) {
     _expression = other._expression;
     _impact_if = other._impact_if;
   }
-  return (*this);
+  return *this;
 }
 
 /**
@@ -76,9 +76,8 @@ bool_expression& bool_expression::operator=(bool_expression const& other) {
  *  @return True if this and other objects are equal.
  */
 bool bool_expression::operator==(bool_expression const& other) const {
-  return ((_id == other._id) && (_name == other._name) &&
-          (_expression == other._expression) &&
-          (_impact_if == other._impact_if));
+  return _id == other._id && _name == other._name &&
+         _expression == other._expression && _impact_if == other._impact_if;
 }
 
 /**
@@ -89,7 +88,7 @@ bool bool_expression::operator==(bool_expression const& other) const {
  *  @return True if this and other objects are equal.
  */
 bool bool_expression::operator!=(bool_expression const& other) const {
-  return (!operator==(other));
+  return !operator==(other);
 }
 
 /**
@@ -98,7 +97,7 @@ bool bool_expression::operator!=(bool_expression const& other) const {
  *  @return The id.
  */
 uint32_t bool_expression::get_id() const {
-  return (_id);
+  return _id;
 }
 
 /**
@@ -107,7 +106,7 @@ uint32_t bool_expression::get_id() const {
  *  @return The name of this expression..
  */
 std::string const& bool_expression::get_name() const {
-  return (_name);
+  return _name;
 }
 
 /**
@@ -116,7 +115,7 @@ std::string const& bool_expression::get_name() const {
  *  @return The textual representation of the expression.
  */
 std::string const& bool_expression::get_expression() const {
-  return (_expression);
+  return _expression;
 }
 
 /**
@@ -126,7 +125,7 @@ std::string const& bool_expression::get_expression() const {
  *          for a true or false statement.
  */
 bool bool_expression::get_impact_if() const {
-  return (_impact_if);
+  return _impact_if;
 }
 
 /**
@@ -154,7 +153,6 @@ void bool_expression::set_expression(std::string const& expr) {
  */
 void bool_expression::set_id(uint32_t id) {
   _id = id;
-  return;
 }
 
 /**

--- a/broker/bam/src/exp_builder.cc
+++ b/broker/bam/src/exp_builder.cc
@@ -107,9 +107,8 @@ exp_builder::exp_builder(exp_parser::notation const& postfix,
       std::string func(*it);
       if (++it == end)
         throw msg_fmt(
-            "internal expression parsing "
-            "error: no arity placed after function name in "
-            "postfix notation");
+            "internal expression parsing error: no arity placed after function "
+            "name in postfix notation");
       int arity(std::strtol(it->c_str(), nullptr, 0));
 
       // Host status.
@@ -130,10 +129,8 @@ exp_builder::exp_builder(exp_parser::notation const& postfix,
         // Find host and service IDs.
         std::pair<uint32_t, uint32_t> ids(_mapping.get_service_id(hst, svc));
         if (!ids.first || !ids.second)
-          throw msg_fmt(
-              "could not find ID of service '{}"
-              "' and/or of host '{}'",
-              svc, hst);
+          throw msg_fmt("could not find ID of service '{}' and/or of host '{}'",
+                        svc, hst);
 
         // Build object.
         bool_service::ptr obj{

--- a/broker/bam/src/exp_parser.cc
+++ b/broker/bam/src/exp_parser.cc
@@ -122,7 +122,7 @@ exp_parser::notation const& exp_parser::get_postfix() {
         while (!stack.empty() &&
                is_operator(stack.top())
                // And o1's precedence is less than or equal to that of o2
-               && (_precedence[token] <= (_precedence[stack.top()]))) {
+               && _precedence[token] <= _precedence[stack.top()]) {
           // Pop o2 off the operator stack, onto the output queue.
           _postfix.push_back(stack.top());
           stack.pop();

--- a/broker/bam/src/exp_parser.cc
+++ b/broker/bam/src/exp_parser.cc
@@ -31,57 +31,15 @@ using namespace com::centreon::broker::bam;
  *
  *  @param[in] expression  Expression to parse.
  */
-exp_parser::exp_parser(std::string const& expression) : _exp(expression) {
-  _precedence["&&"] = 2;
-  _precedence["AND"] = 2;
-  _precedence["||"] = 2;
-  _precedence["OR"] = 2;
-  _precedence["IS"] = 3;
-  _precedence["^"] = 2;
-  _precedence["XOR"] = 2;
-  _precedence["NOT"] = 3;
-  _precedence[">"] = 3;
-  _precedence[">="] = 3;
-  _precedence["<"] = 3;
-  _precedence["<="] = 3;
-  _precedence["=="] = 3;
-  _precedence["!="] = 3;
-  _precedence["+"] = 4;
-  _precedence["-"] = 4;
-  _precedence["*"] = 5;
-  _precedence["/"] = 5;
-  _precedence["%"] = 5;
-  _precedence["-u"] = 6;
-  _precedence["!"] = 6;
-
+exp_parser::exp_parser(const std::string& expression)
+    : _exp(expression), _precedence{{"&&", 2},  {"AND", 2}, {"||", 2},
+                                    {"OR", 2},  {"IS", 3},  {"^", 2},
+                                    {"XOR", 2}, {"NOT", 3}, {">", 3},
+                                    {">=", 3},  {"<", 3},   {"<=", 3},
+                                    {"==", 3},  {"!=", 3},  {"+", 4},
+                                    {"-", 4},   {"*", 5},   {"/", 5},
+                                    {"%", 5},   {"-u", 6},  {"!", 6}} {
   log_v2::bam()->trace("exp_parser constructor '{}'", expression);
-}
-
-/**
- *  Copy constructor.
- *
- *  @param[in] other  Object to copy.
- */
-exp_parser::exp_parser(exp_parser const& other) {
-  _internal_copy(other);
-}
-
-/**
- *  Destructor.
- */
-exp_parser::~exp_parser() {}
-
-/**
- *  Assignment operator.
- *
- *  @param[in] other  Object to copy.
- *
- *  @return This object.
- */
-exp_parser& exp_parser::operator=(exp_parser const& other) {
-  if (this != &other)
-    _internal_copy(other);
-  return (*this);
 }
 
 /**
@@ -225,15 +183,15 @@ exp_parser::notation const& exp_parser::get_postfix() {
     stack.pop();
     if (token == "(") {
       throw msg_fmt(
-          "mismatched parentheses found while parsing "
-          "the following expression: {}",
+          "mismatched parentheses found while parsing the following "
+          "expression: {}",
           _exp);
     }
     // Or pop the operator onto the output queue.
     _postfix.push_back(token);
   }
 
-  return (_postfix);
+  return _postfix;
 }
 
 /**
@@ -242,10 +200,10 @@ exp_parser::notation const& exp_parser::get_postfix() {
  *  @return True if token is a valid function name.
  */
 bool exp_parser::is_function(std::string const& token) {
-  return ((token == "HOSTSTATUS") || (token == "SERVICESTATUS") ||
-          (token == "METRICS") || (token == "METRIC") || (token == "AVERAGE") ||
-          (token == "COUNT") || (token == "MAX") || (token == "MIN") ||
-          (token == "SUM") || (token == "CALL"));
+  return token == "HOSTSTATUS" || token == "SERVICESTATUS" ||
+         token == "METRICS" || token == "METRIC" || token == "AVERAGE" ||
+         token == "COUNT" || token == "MAX" || token == "MIN" ||
+         token == "SUM" || token == "CALL";
 }
 
 /**
@@ -254,23 +212,10 @@ bool exp_parser::is_function(std::string const& token) {
  *  @return True if token is a valid operator.
  */
 bool exp_parser::is_operator(std::string const& token) {
-  return ((token == "+") || (token == "-") || (token == "-u") ||
-          (token == "*") || (token == "/") || (token == "%") ||
-          (token == ">") || (token == ">=") || (token == "<") ||
-          (token == "<=") || (token == "==") || (token == "IS") ||
-          (token == "NOT") || (token == "!=") || (token == "!") ||
-          (token == "AND") || (token == "^") || (token == "XOR") ||
-          (token == "&&") || (token == "OR") || (token == "||"));
-}
-
-/**
- *  Copy internal data members.
- *
- *  @param[in] other  Object to copy.
- */
-void exp_parser::_internal_copy(exp_parser const& other) {
-  _exp = other._exp;
-  _postfix = other._postfix;
-  _precedence = other._precedence;
-  return;
+  return token == "+" || token == "-" || token == "-u" || token == "*" ||
+         token == "/" || token == "%" || token == ">" || token == ">=" ||
+         token == "<" || token == "<=" || token == "==" || token == "IS" ||
+         token == "NOT" || token == "!=" || token == "!" || token == "AND" ||
+         token == "^" || token == "XOR" || token == "&&" || token == "OR" ||
+         token == "||";
 }

--- a/broker/bam/src/exp_tokenizer.cc
+++ b/broker/bam/src/exp_tokenizer.cc
@@ -83,14 +83,14 @@ std::string exp_tokenizer::next() {
     if (_current < _size) {
       // Special char. Most of them are single-charaters token.
       if (_is_special_char()) {
-        if ((_current + 1 < _size)
+        if (_current + 1 < _size
             // Double character exceptions: ==, !=, >=, <=.
-            && ((((_text[_current] == '=') || (_text[_current] == '!') ||
-                  (_text[_current] == '<') || (_text[_current] == '>')) &&
-                 (_text[_current + 1] == '='))
+            && (((_text[_current] == '=' || _text[_current] == '!' ||
+                  _text[_current] == '<' || _text[_current] == '>') &&
+                 _text[_current + 1] == '=')
                 // Double character exceptions: ||, &&.
-                || (((_text[_current] == '|') || (_text[_current] == '&')) &&
-                    (_text[_current] == _text[_current + 1])))) {
+                || ((_text[_current] == '|' || _text[_current] == '&') &&
+                    _text[_current] == _text[_current + 1]))) {
           retval.push_back(_text[_current]);
           retval.push_back(_text[_current + 1]);
           _next = _current + 2;
@@ -105,7 +105,7 @@ std::string exp_tokenizer::next() {
       }
     }
   }
-  return (retval);
+  return retval;
 }
 
 /**
@@ -159,20 +159,18 @@ std::string exp_tokenizer::_extract_token() {
     }
 
     // Assert that ending brace was found.
-    if ((_next < _size) && (_text[_next] == '}')) {
+    if (_next < _size && _text[_next] == '}') {
       ++_next;
     } else
-      throw msg_fmt(
-          "opening brace at position {}"
-          " has no ending brace ",
-          _current);
+      throw msg_fmt("opening brace at position {} has no ending brace ",
+                    _current);
   }
   // Extract classical token.
   else {
     retval = _extract_until(&exp_tokenizer::_is_delimiter);
   }
 
-  return (retval);
+  return retval;
 }
 
 /**
@@ -234,7 +232,6 @@ void exp_tokenizer::_internal_copy(exp_tokenizer const& other) {
   _queue = other._queue;
   _size = other._size;
   _text = other._text;
-  return;
 }
 
 /**

--- a/broker/bam/src/kpi_boolexp.cc
+++ b/broker/bam/src/kpi_boolexp.cc
@@ -224,20 +224,19 @@ state kpi_boolexp::_get_state() const {
   state retval;
   if (_boolexp->state_known()) {
     state retval = _boolexp->get_state();
-    log_v2::bam()->debug(
+    log_v2::bam()->trace(
         "BAM: kpi {} boolean expression: state (known) value: {}", id, retval);
     return retval;
   } else {
-    log_v2::bam()->debug("BAM: kpi {} boolean expression: state unknown", id);
     if (_event) {
       retval = static_cast<state>(_event->status());
-      log_v2::bam()->debug(
+      log_v2::bam()->trace(
           "BAM: kpi {} boolean expression: state from internal event: {}", id,
           retval);
       return retval;
     } else {
       retval = _boolexp->get_state();
-      log_v2::bam()->debug(
+      log_v2::bam()->trace(
           "BAM: kpi {} boolean expression: state value still taken from "
           "boolexp: {}",
           id, retval);

--- a/broker/bam/src/kpi_boolexp.cc
+++ b/broker/bam/src/kpi_boolexp.cc
@@ -220,13 +220,29 @@ void kpi_boolexp::_open_new_event(io::stream* visitor,
  *  @return  The current state of the boolexp.
  */
 state kpi_boolexp::_get_state() const {
-  if (_boolexp->state_known())
-    return _boolexp->get_state();
-  else {
-    if (_event)
-      return static_cast<state>(_event->status());
-    else
-      return _boolexp->get_state();
+  uint32_t id = _boolexp->get_id();
+  state retval;
+  if (_boolexp->state_known()) {
+    state retval = _boolexp->get_state();
+    log_v2::bam()->debug(
+        "BAM: kpi {} boolean expression: state (known) value: {}", id, retval);
+    return retval;
+  } else {
+    log_v2::bam()->debug("BAM: kpi {} boolean expression: state unknown", id);
+    if (_event) {
+      retval = static_cast<state>(_event->status());
+      log_v2::bam()->debug(
+          "BAM: kpi {} boolean expression: state from internal event: {}", id,
+          retval);
+      return retval;
+    } else {
+      retval = _boolexp->get_state();
+      log_v2::bam()->debug(
+          "BAM: kpi {} boolean expression: state value still taken from "
+          "boolexp: {}",
+          id, retval);
+      return retval;
+    }
   }
 }
 

--- a/broker/bam/src/kpi_service.cc
+++ b/broker/bam/src/kpi_service.cc
@@ -192,8 +192,9 @@ void kpi_service::service_update(
     // Log message.
     log_v2::bam()->debug(
         "BAM: KPI {} is getting notified of service ({}, {}) update (state: "
-        "{})",
-        _id, _host_id, _service_id, status->current_state);
+        "{} hard state: {})",
+        _id, _host_id, _service_id, status->current_state,
+        status->last_hard_state);
 
     // Update information.
     if (status->last_check.is_null()) {

--- a/broker/bam/src/monitoring_stream.cc
+++ b/broker/bam/src/monitoring_stream.cc
@@ -709,7 +709,7 @@ void monitoring_stream::_explicitly_send_forced_svc_checks(
       std::lock_guard<std::mutex> lock(_ext_cmd_file_m);
       log_v2::bam()->info("opening {}", _ext_cmd_file);
       misc::fifo_client fc(_ext_cmd_file);
-      SPDLOG_LOGGER_TRACE(log_v2::bam(), "BAM: {} forced checks to schedule",
+      SPDLOG_LOGGER_DEBUG(log_v2::bam(), "BAM: {} forced checks to schedule",
                           _timer_forced_svc_checks.size());
       for (auto& p : _timer_forced_svc_checks) {
         time_t now = time(nullptr);

--- a/broker/bam/src/service_book.cc
+++ b/broker/bam/src/service_book.cc
@@ -148,7 +148,7 @@ void service_book::update(const std::shared_ptr<neb::service_status>& t,
     range.first->second->service_update(t, visitor);
     ++range.first;
   }
-  log_v2::bam()->debug(
+  log_v2::bam()->trace(
       "service_book: {} listeners notified of service ({},{}) status", count,
       t->host_id, t->service_id);
 }

--- a/broker/bam/src/service_book.cc
+++ b/broker/bam/src/service_book.cc
@@ -170,7 +170,7 @@ void service_book::update(const std::shared_ptr<neb::pb_service>& t,
     range.first->second->service_update(t, visitor);
     ++range.first;
   }
-  log_v2::bam()->debug(
+  log_v2::bam()->trace(
       "service_book: {} listeners notified of pb service ({},{})", count,
       t->obj().host_id(), t->obj().service_id());
 }

--- a/broker/bam/src/service_book.cc
+++ b/broker/bam/src/service_book.cc
@@ -142,10 +142,15 @@ void service_book::update(const std::shared_ptr<neb::service_status>& t,
                           io::stream* visitor) {
   std::pair<multimap::iterator, multimap::iterator> range{
       _book.equal_range(std::make_pair(t->host_id, t->service_id))};
+  size_t count = 0;
   while (range.first != range.second) {
+    count++;
     range.first->second->service_update(t, visitor);
     ++range.first;
   }
+  log_v2::bam()->debug(
+      "service_book: {} listeners notified of service ({},{}) status", count,
+      t->host_id, t->service_id);
 }
 
 /**
@@ -159,10 +164,15 @@ void service_book::update(const std::shared_ptr<neb::pb_service>& t,
                           io::stream* visitor) {
   std::pair<multimap::iterator, multimap::iterator> range{_book.equal_range(
       std::make_pair(t->obj().host_id(), t->obj().service_id()))};
+  size_t count = 0;
   while (range.first != range.second) {
+    ++count;
     range.first->second->service_update(t, visitor);
     ++range.first;
   }
+  log_v2::bam()->debug(
+      "service_book: {} listeners notified of pb service ({},{})", count,
+      t->obj().host_id(), t->obj().service_id());
 }
 
 /**
@@ -176,8 +186,13 @@ void service_book::update(const std::shared_ptr<neb::pb_service_status>& t,
                           io::stream* visitor) {
   std::pair<multimap::iterator, multimap::iterator> range{_book.equal_range(
       std::make_pair(t->obj().host_id(), t->obj().service_id()))};
+  size_t count = 0;
   while (range.first != range.second) {
+    ++count;
     range.first->second->service_update(t, visitor);
     ++range.first;
   }
+  log_v2::bam()->debug(
+      "service_book: {} listeners notified of pb service ({},{}) status", count,
+      t->obj().host_id(), t->obj().service_id());
 }

--- a/broker/bam/src/service_book.cc
+++ b/broker/bam/src/service_book.cc
@@ -192,7 +192,7 @@ void service_book::update(const std::shared_ptr<neb::pb_service_status>& t,
     range.first->second->service_update(t, visitor);
     ++range.first;
   }
-  log_v2::bam()->debug(
+  log_v2::bam()->trace(
       "service_book: {} listeners notified of pb service ({},{}) status", count,
       t->obj().host_id(), t->obj().service_id());
 }

--- a/broker/bam/src/service_listener.cc
+++ b/broker/bam/src/service_listener.cc
@@ -21,37 +21,6 @@
 using namespace com::centreon::broker::bam;
 
 /**
- *  Default constructor.
- */
-service_listener::service_listener() {}
-
-/**
- *  Copy constructor.
- *
- *  @param[in] other  Object to copy.
- */
-service_listener::service_listener(service_listener const& other) {
-  (void)other;
-}
-
-/**
- *  Destructor.
- */
-service_listener::~service_listener() {}
-
-/**
- *  Assignment operator.
- *
- *  @param[in] other  Object to copy.
- *
- *  @return This object.
- */
-service_listener& service_listener::operator=(service_listener const& other) {
-  (void)other;
-  return (*this);
-}
-
-/**
  *  Notify of a service status update.
  *
  *  @param[in]  status   Service status.

--- a/broker/bam/test/exp_parser/get_postfix.cc
+++ b/broker/bam/test/exp_parser/get_postfix.cc
@@ -157,21 +157,6 @@ TEST(BamExpParserGetPostfix, UnaryMinus) {
 }
 
 // Given an exp_parser object
-// When it is constructed with a valid expression
-// Then get_postfix() return its postfix notation
-// Here we test copy constructor and operator=
-TEST(BamExpParserGetPostfix, Copy) {
-  bam::exp_parser p("HOSTSTATUS(Host, Service) IS OK");
-  bam::exp_parser p_copy(p);
-  bam::exp_parser p_assign("");
-  p_assign = p_copy;
-  char const* expected[] = {"Host", "Service", "HOSTSTATUS", "2",
-                            "OK",   "IS",      nullptr};
-  ASSERT_EQ(p_copy.get_postfix(), array_to_list(expected));
-  ASSERT_EQ(p_assign.get_postfix(), array_to_list(expected));
-}
-
-// Given an exp_parser object
 // When a parenthesis is missing
 // Then get_postfix() throw an exception
 TEST(BamExpParserGetPostfix, MissingParenthesis1) {

--- a/broker/lua/src/luabinding.cc
+++ b/broker/lua/src/luabinding.cc
@@ -277,9 +277,13 @@ void luabinding::_init_script(
         assert(1 == 0);
     }
   }
-  if (lua_pcall(_L, 1, 0, 0) != 0)
-    throw msg_fmt("lua: error running function `init' {}",
-                  lua_tostring(_L, -1));
+  if (lua_pcall(_L, 1, 0, 0) != 0) {
+    const char* ret = lua_tostring(_L, -1);
+    if (ret)
+      throw msg_fmt("lua: error running function `init' {}", ret);
+    else
+      throw msg_fmt("lua: unknown error running function `init'");
+  }
 }
 
 /**
@@ -317,9 +321,15 @@ int luabinding::write(std::shared_ptr<io::data> const& data) noexcept {
     lua_pushinteger(_L, elem);
 
     if (lua_pcall(_L, 2, 1, 0) != 0) {
-      SPDLOG_LOGGER_ERROR(log_v2::lua(),
-                          "lua: error while running function `filter()': {}",
-                          lua_tostring(_L, -1));
+      const char* ret = lua_tostring(_L, -1);
+      if (ret)
+        spdlog_logger_error(log_v2::lua(),
+                            "lua: error while running function `filter()': {}",
+                            ret);
+      else
+        spdlog_logger_error(
+            log_v2::lua(),
+            "lua: unknown error while running function `filter()'");
       return 0;
     }
 
@@ -354,8 +364,13 @@ int luabinding::write(std::shared_ptr<io::data> const& data) noexcept {
   }
 
   if (lua_pcall(_L, 1, 1, 0) != 0) {
-    SPDLOG_LOGGER_ERROR(log_v2::lua(), "lua: error running function `write' {}",
-                        lua_tostring(_L, -1));
+    const char* ret = lua_tostring(_L, -1);
+    if (ret)
+      SPDLOG_LOGGER_ERROR(log_v2::lua(),
+                          "lua: error running function `write' {}", ret);
+    else
+      SPDLOG_LOGGER_ERROR(log_v2::lua(),
+                          "lua: unknown error running function `write'");
     return 0;
   }
 
@@ -395,8 +410,13 @@ int32_t luabinding::flush() noexcept {
   // Let's get the function to call
   lua_getglobal(_L, "flush");
   if (lua_pcall(_L, 0, 1, 0) != 0) {
-    SPDLOG_LOGGER_ERROR(log_v2::lua(), "lua: error running function `flush' {}",
-                        lua_tostring(_L, -1));
+    const char* ret = lua_tostring(_L, -1);
+    if (ret)
+      SPDLOG_LOGGER_ERROR(log_v2::lua(),
+                          "lua: error running function `flush' {}", ret);
+    else
+      SPDLOG_LOGGER_ERROR(log_v2::lua(),
+                          "lua: unknown error running function `flush'");
     return 0;
   }
   if (!lua_isboolean(_L, -1)) {

--- a/broker/lua/src/luabinding.cc
+++ b/broker/lua/src/luabinding.cc
@@ -323,11 +323,11 @@ int luabinding::write(std::shared_ptr<io::data> const& data) noexcept {
     if (lua_pcall(_L, 2, 1, 0) != 0) {
       const char* ret = lua_tostring(_L, -1);
       if (ret)
-        spdlog_logger_error(log_v2::lua(),
+        SPDLOG_LOGGER_ERROR(log_v2::lua(),
                             "lua: error while running function `filter()': {}",
                             ret);
       else
-        spdlog_logger_error(
+        SPDLOG_LOGGER_ERROR(
             log_v2::lua(),
             "lua: unknown error while running function `filter()'");
       return 0;

--- a/tests/bam/bam_pb.robot
+++ b/tests/bam/bam_pb.robot
@@ -469,6 +469,7 @@ BA_BOOL_KPI
     add_boolean_kpi
     ...    ${id_ba__sid[0]}
     ...    {host_16 service_302} {IS} {OK} {OR} ( {host_16 service_303} {IS} {OK} {AND} {host_16 service_314} {NOT} {UNKNOWN} )
+    ...    False
     ...    100
 
     Start Broker
@@ -704,7 +705,7 @@ BEPB_DIMENSION_KPI_EVENT
     @{svc}=    Set Variable    ${{ [("host_16", "service_314")] }}
     ${baid_svcid}=    create_ba_with_services    test    worst    ${svc}
 
-    add_boolean_kpi    ${baid_svcid[0]}    {host_16 service_302} {IS} {OK}    100
+    add_boolean_kpi    ${baid_svcid[0]}    {host_16 service_302} {IS} {OK}    False    100
 
     Start Broker    True
     Start Engine

--- a/tests/bam/boolean_rules.robot
+++ b/tests/bam/boolean_rules.robot
@@ -1,0 +1,101 @@
+*** Settings ***
+Documentation       Centreon Broker and BAM with bbdo version 3.0.1 on boolean rules
+
+Resource            ../resources/resources.robot
+Library             Process
+Library             DatabaseLibrary
+Library             DateTime
+Library             OperatingSystem
+Library             String
+Library             ../resources/Broker.py
+Library             ../resources/Engine.py
+
+Suite Setup         Clean Before Suite
+Suite Teardown      Clean After Suite
+Test Setup          BAM Setup
+Test Teardown       Save logs If Failed
+
+
+*** Test Cases ***
+BABOO
+    [Documentation]    With bbdo version 3.0.1, a BA of type 'worst' with 2 child services and another BA of type impact with a boolean rule returning if one of its two services are critical are created. These two BA are built from the same services and should have a similar behavior
+    [Tags]    broker    engine    bam    boolean_expression
+    Clear Commands Status
+    Clear Retention
+    Config Broker    module
+    Config Broker    central
+    Config Broker    rrd
+    Broker Config Log    central    core    error
+    Broker Config Log    central    bam    trace
+    Broker Config Log    central    sql    error
+    Broker Config Flush Log    central    0
+    Broker Config Source Log    central    1
+    Config BBDO3    ${1}
+    Config Engine    ${1}
+
+    Clone Engine Config To DB
+    Add Bam Config To Engine
+    Add Bam Config To Broker    central
+    Set Services Passive    ${0}    service_302
+    Set Services Passive    ${0}    service_303
+
+    ${id_ba__sid}=    create_ba    ba-worst    worst    70    80
+    Add Service KPI    host_16    service_302    ${id_ba__sid[0]}    40    30    20
+    Add Service KPI    host_16    service_303    ${id_ba__sid[0]}    40    30    20
+
+    ${id_ba__sid}=    create_ba    boolean-ba    impact    70    80
+    add_boolean_kpi
+    ...    ${id_ba__sid[0]}
+    ...    {host_16 service_302} {IS} {CRITICAL} {OR} {host_16 service_303} {IS} {CRITICAL}
+    ...    True
+    ...    100
+
+    Start Broker
+    ${start}=    Get Current Date
+    Start Engine
+    # Let's wait for the external command check start
+    ${content}=    Create List    check_for_external_commands()
+    ${result}=    Find In Log with Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    msg=A message telling check_for_external_commands() should be available.
+
+    # 393 is set to ok.
+    Process Service Check Result    host_16    service_303    0    output ok for service_303
+
+    FOR    ${i}    IN RANGE    10
+        Log To Console    @@@@@@@@@@@@@@ Step ${i} @@@@@@@@@@@@@@
+        # 302 is set to critical => the two ba become critical
+        Repeat Keyword
+        ...    3 times
+        ...    Process Service Check Result
+        ...    host_16
+        ...    service_302
+        ...    2
+        ...    output critical for service_302
+
+        ${result}=    check_ba_status_with_timeout    ba-worst    2    30
+        Should Be True    ${result}    msg=The 'ba-worst' BA is not CRITICAL as expected
+        ${result}=    check_ba_status_with_timeout    boolean-ba    2    30
+        Should Be True    ${result}    msg=The 'boolean-ba' BA is not CRITICAL as expected
+
+        Process Service Check Result    host_16    service_302    0    output ok for service_302
+        ${result}=    check_ba_status_with_timeout    ba-worst    0    30
+        Should Be True    ${result}    msg=The 'ba-worst' BA is not OK as expected
+        ${result}=    check_ba_status_with_timeout    boolean-ba    0    30
+        Should Be True    ${result}    msg=The 'boolean-ba' BA is not OK as expected
+    END
+
+    Stop Engine
+    Kindly Stop Broker
+
+
+*** Keywords ***
+BAM Setup
+    Stop Processes
+    Connect To Database    pymysql    ${DBName}    ${DBUserRoot}    ${DBPassRoot}    ${DBHost}    ${DBPort}
+    Execute SQL String    SET GLOBAL FOREIGN_KEY_CHECKS=0
+    Execute SQL String    DELETE FROM mod_bam_reporting_kpi
+    Execute SQL String    DELETE FROM mod_bam_reporting_timeperiods
+    Execute SQL String    DELETE FROM mod_bam_reporting_relations_ba_timeperiods
+    Execute SQL String    DELETE FROM mod_bam_reporting_ba_events
+    Execute SQL String    ALTER TABLE mod_bam_reporting_ba_events AUTO_INCREMENT = 1
+    Execute SQL String    SET GLOBAL FOREIGN_KEY_CHECKS=1

--- a/tests/resources/Engine.py
+++ b/tests/resources/Engine.py
@@ -598,6 +598,8 @@ def engine_config_set_value(idx: int, key: str, value: str, force: bool = False)
 # @param key the key to change the value.
 # @param value the new value to set to the key variable.
 #
+
+
 def engine_config_add_value(idx: int, key: str, value: str):
     filename = ETC_ROOT + \
         "/centreon-engine/config{}/centengine.cfg".format(idx)
@@ -921,8 +923,8 @@ def create_ba(name: str, typ: str, critical_impact: int, warning_impact: int, dt
     return dbconf.create_ba(name, typ, critical_impact, warning_impact, dt_policy)
 
 
-def add_boolean_kpi(id_ba: int, expression: str, critical_impact: int):
-    dbconf.add_boolean_kpi(id_ba, expression, critical_impact)
+def add_boolean_kpi(id_ba: int, expression: str, impact_if: bool, critical_impact: int):
+    dbconf.add_boolean_kpi(id_ba, expression, impact_if, critical_impact)
 
 
 def add_ba_kpi(id_ba_src: int, id_ba_dest: int, critical_impact: int, warning_impact: int, unknown_impact: int):

--- a/tests/resources/db_conf.py
+++ b/tests/resources/db_conf.py
@@ -285,7 +285,7 @@ class DbConf:
 
             connection.commit()
 
-    def add_boolean_kpi(self, id_ba: int, expression: str, critical_impact: int):
+    def add_boolean_kpi(self, id_ba: int, expression: str, impact_if: bool, critical_impact: int):
         connection = pymysql.connect(host=DB_HOST,
                                      user=DB_USER,
                                      password=DB_PASS,
@@ -296,10 +296,10 @@ class DbConf:
         with connection:
             with connection.cursor() as cursor:
                 cursor.execute(
-                    "INSERT INTO mod_bam_boolean (name, expression, bool_state, activate) VALUES('bool test','{}', 0, 1)".format(expression))
+                    f"INSERT INTO mod_bam_boolean (name, expression, bool_state, activate) VALUES('bool test','{expression}', {int(impact_if)}, 1)")
                 boolean_id = cursor.lastrowid
-                cursor.execute("INSERT INTO mod_bam_kpi (boolean_id,id_ba,drop_warning,drop_critical,drop_unknown,config_type) VALUES ({},{},50,{},75,'1')".format(
-                    boolean_id, id_ba, critical_impact))
+                cursor.execute(
+                    f"INSERT INTO mod_bam_kpi (boolean_id,id_ba,drop_warning,drop_critical,drop_unknown,config_type) VALUES ({boolean_id},{id_ba},50,{critical_impact},75,'1')")
 
             connection.commit()
 

--- a/tests/resources/db_variables.robot
+++ b/tests/resources/db_variables.robot
@@ -7,5 +7,5 @@ ${DBHost}           localhost
 ${DBUser}           centreon
 ${DBPass}           centreon
 ${DBPort}           3306
-${DBUserRoot}       root_centreon
+${DBUserRoot}       root
 ${DBPassRoot}       centreon

--- a/tests/resources/db_variables.robot
+++ b/tests/resources/db_variables.robot
@@ -7,5 +7,5 @@ ${DBHost}           localhost
 ${DBUser}           centreon
 ${DBPass}           centreon
 ${DBPort}           3306
-${DBUserRoot}       root
+${DBUserRoot}       root_centreon
 ${DBPassRoot}       centreon


### PR DESCRIPTION
## Description

AND and OR do not need anymore that all their children are known to be computed.
If a child is known and FALSE, we already know that the AND will be FALSE.
If a child is known and TRUE, we already know that the OR will be TRUE.

REFS: MON-20044

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
