### PR TITLE
fix(broker/bam): regression due to backport fixed

### DIFF
--- a/broker/bam/src/bool_binary_operator.cc
+++ b/broker/bam/src/bool_binary_operator.cc
@@ -16,6 +16,7 @@
 ** For more information : contact@centreon.com
 */
 
+#include "com/centreon/broker/log_v2.hh"
 #include "com/centreon/broker/bam/bool_binary_operator.hh"
 
 using namespace com::centreon::broker::bam;

--- a/broker/bam/src/kpi_boolexp.cc
+++ b/broker/bam/src/kpi_boolexp.cc
@@ -225,7 +225,7 @@ state kpi_boolexp::_get_state() const {
     return retval;
   } else {
     if (_event) {
-      retval = static_cast<state>(_event->status());
+      retval = static_cast<state>(_event->status);
       log_v2::bam()->trace(
           "BAM: kpi {} boolean expression: state from internal event: {}", id,
           retval);


### PR DESCRIPTION
## Description

A missing include and a method called instead of an attribute.

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [X] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)
