### PR TITLE
fix(tests): robot test on ccc fixed on get_version

### DIFF
--- a/tests/ccc/ccc.robot
+++ b/tests/ccc/ccc.robot
@@ -207,10 +207,18 @@ BECCC6
     ${vers}=    Split String    ${version}    .
     ${mm}=    Evaluate    """${vers}[0]""".lstrip("0")
     ${m}=    Evaluate    """${vers}[1]""".lstrip("0")
-    Should Contain
-    ...    ${content}
-    ...    {\n \"major\": ${mm},\n \"minor\": ${m}\n}
-    ...    msg=A version as json string should be returned
+    ${p}=    Evaluate    """${vers}[2]""".lstrip("0")
+    IF    "${p}" == 0 or "${p}" == ""
+        Should Contain
+        ...    ${content}
+        ...    {\n \"major\": ${mm},\n \"minor\": ${m}\n}
+        ...    msg=A version as json string should be returned
+    ELSE
+        Should Contain
+        ...    ${content}
+        ...    {\n \"major\": ${mm},\n \"minor\": ${m},\n \"patch\": ${p}\n}
+        ...    msg=A version as json string should be returned
+    END
     Stop Engine
     Kindly Stop Broker
     Remove File    /tmp/output.txt


### PR DESCRIPTION
## Description

A fix on ccc tests with get_version...

REFS: MON-20394

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x (master)
