### PR TITLE
enh(ci): delivery to internal repo on release

### DIFF
--- a/.github/actions/promote-to-stable/action.yml
+++ b/.github/actions/promote-to-stable/action.yml
@@ -53,10 +53,15 @@ runs:
           echo "[DEBUG] - Build $ARCH artifactory target path."
           TARGET_PATH="rpm-standard/${{ inputs.major_version }}/${{ inputs.distrib }}/${{ inputs.stability }}/$ARCH/RPMS/"
           echo "[DEBUG] - Target path: $TARGET_PATH"
+          echo "[INFO] - Build INTERNAL $ARCH target path."
+          TARGET_PATH_INTERNAL="rpm-standard-internal/${{ inputs.major_version }}/${{ inputs.distrib }}/${{ inputs.stability }}/$ARCH/RPMS/"
+          echo "[INFO] - Target internal path: $TARGET_PATH_INTERNAL"
           echo "[DEBUG] - Promoting $ARCH testing artifacts to stable."
           for ARTIFACT in ${SRC_PATHS[@]}; do
             echo "[DEBUG] - Promoting $ARTIFACT to stable on artifactory."
             jf rt cp $ARTIFACT $TARGET_PATH --flat=true
+            echo "[DEBUG] - Promoting $ARTIFACT to stable internal."
+            jf rt cp $ARTIFACT $TARGET_PATH_INTERNAL --flat=true
           done
         done
       shell: bash


### PR DESCRIPTION
## Description

Add promote delivery to internal on stable release event.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

