### PR TITLE
MON 20564 : add test case to check non existing indexes

### DIFF
--- a/broker/unified_sql/src/rebuilder.cc
+++ b/broker/unified_sql/src/rebuilder.cc
@@ -129,6 +129,12 @@ void rebuilder::rebuild_graphs(const std::shared_ptr<io::data>& d) {
             v.check_interval = 5 * 60;
         }
 
+        if (mids.empty()) {
+          log_v2::sql()->error("Metrics rebuild: metrics don't exist: {}",
+                               ids_str);
+          return;
+        }
+
         std::string mids_str{fmt::format("{}", fmt::join(mids, ","))};
         multiplexing::publisher().write(start_rebuild);
 

--- a/tests/broker-engine/rrd.robot
+++ b/tests/broker-engine/rrd.robot
@@ -14,7 +14,7 @@ Library             ../resources/Common.py
 Suite Setup         Clean Before Suite
 Suite Teardown      Clean After Suite
 Test Setup          Stop Processes
-Test Teardown       Test Clean
+Test Teardown       Stop Engine Broker And Save Logs
 
 
 *** Test Cases ***
@@ -429,17 +429,10 @@ Rrd_1
     Log To Console    Indexes to rebuild: ${index}
     ${metrics}    Get Metrics Matching Indexes    ${index}
     Log To Console    Metrics to rebuild: ${metrics}
-    ${content}    Create List    Metrics rebuild: metrics doesn't exist
+    ${content}    Create List    Metrics rebuild: metrics don't exist
     ${result}    Find In Log With Timeout    ${centralLog}    ${start}    ${content}    30
     Should Be True    ${result}    Central did not send metrics to rebuild
 
     ${content1}    Create List    mysql_connection: You have an error in your SQL syntax
     ${result}    Find In Log With Timeout    ${rrdLog}    ${start}    ${content1}    45
     Should Not Be True    ${result}    Database did not receive command to rebuild metrics
-
-
-*** Keywords ***
-Test Clean
-    Stop Engine
-    Kindly Stop Broker
-    Save logs If Failed


### PR DESCRIPTION
## Description
If we choose index IDs from services that have no metric IDs, then the query is badly built and this leads to errors in broker

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

