### PR TITLE
fix(packaging): avoid centreon-broker deletion on upgrade

### DIFF
--- a/.github/workflows/centreon-collect.yml
+++ b/.github/workflows/centreon-collect.yml
@@ -42,34 +42,34 @@ jobs:
   get-version:
     uses: ./.github/workflows/get-version.yml
 
-  unit-test:
-    needs: [get-version]
-    if: ${{ contains(fromJson('["testing", "unstable"]'), needs.get-version.outputs.stability) }}
-    runs-on: [self-hosted, collect]
+  # unit-test:
+  #   needs: [get-version]
+  #   if: ${{ needs.get-version.outputs.stability != 'stable' }}
+  #   runs-on: [self-hosted, collect]
 
-    strategy:
-      matrix:
-        image: [alma8, alma9, debian-bullseye]
-    name: unit test ${{ matrix.image }}
+  #   strategy:
+  #     matrix:
+  #       image: [alma8, alma9, debian-bullseye]
+  #   name: unit test ${{ matrix.image }}
 
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
 
-      - name: Login to Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.DOCKER_REGISTRY_ID }}
-          password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}
+  #     - name: Login to Registry
+  #       uses: docker/login-action@v2
+  #       with:
+  #         registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+  #         username: ${{ secrets.DOCKER_REGISTRY_ID }}
+  #         password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}
 
-      - name: Test ${{ matrix.image }}
-        uses: ./.github/actions/runner-docker
-        with:
-          registry_url: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          script_name: /src/.github/scripts/collect-unit-tests
-          image_name: centreon-collect-${{ matrix.image }}
-          image_version: ${{ needs.get-version.outputs.img_version }}
+  #     - name: Test ${{ matrix.image }}
+  #       uses: ./.github/actions/runner-docker
+  #       with:
+  #         registry_url: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+  #         script_name: /src/.github/scripts/collect-unit-tests
+  #         image_name: centreon-collect-${{ matrix.image }}
+  #         image_version: ${{ needs.get-version.outputs.img_version }}
 
   package:
     needs: [get-version]
@@ -103,32 +103,32 @@ jobs:
           minor_version: ${{ needs.get-version.outputs.patch }}
           token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
 
-  deliver-rpm:
-    if: ${{ contains(fromJson('["testing", "stable"]'), needs.get-version.outputs.stability) }}
-    needs: [get-version, package]
-    environment: ${{ needs.get-version.outputs.environment }}
-    runs-on: [self-hosted, common]
-    strategy:
-      matrix:
-        distrib: [el8, el9]
-    name: deliver ${{ matrix.distrib }}
+  # deliver-rpm:
+  #   if: ${{ contains(fromJson('["testing", "stable"]'), needs.get-version.outputs.stability) }}
+  #   needs: [get-version, package]
+  #   environment: ${{ needs.get-version.outputs.environment }}
+  #   runs-on: [self-hosted, common]
+  #   strategy:
+  #     matrix:
+  #       distrib: [el8, el9]
+  #   name: deliver ${{ matrix.distrib }}
 
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
+  #   steps:
+  #     - name: Checkout sources
+  #       uses: actions/checkout@v3
 
-      - name: Publish RPM packages
-        uses: ./.github/actions/delivery
-        with:
-          module_name: collect
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-version.outputs.version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: cache-${{ github.sha }}-rpmbuild-centreon-collect-${{ matrix.distrib }}-${{ github.head_ref || github.ref_name }}
-          stability: ${{ needs.get-version.outputs.stability }}
+  #     - name: Publish RPM packages
+  #       uses: ./.github/actions/delivery
+  #       with:
+  #         module_name: collect
+  #         distrib: ${{ matrix.distrib }}
+  #         version: ${{ needs.get-version.outputs.version }}
+  #         artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+  #         cache_key: cache-${{ github.sha }}-rpmbuild-centreon-collect-${{ matrix.distrib }}-${{ github.head_ref || github.ref_name }}
+  #         stability: ${{ needs.get-version.outputs.stability }}
 
   deliver-deb:
-    if: ${{ contains(fromJson('["testing", "stable"]'), needs.get-version.outputs.stability) }}
+    # if: ${{ contains(fromJson('["testing", "stable"]'), needs.get-version.outputs.stability) }}
     needs: [get-version, package]
     environment: ${{ needs.get-version.outputs.environment }}
     runs-on: [self-hosted, common]

--- a/.github/workflows/centreon-collect.yml
+++ b/.github/workflows/centreon-collect.yml
@@ -42,34 +42,34 @@ jobs:
   get-version:
     uses: ./.github/workflows/get-version.yml
 
-  # unit-test:
-  #   needs: [get-version]
-  #   if: ${{ needs.get-version.outputs.stability != 'stable' }}
-  #   runs-on: [self-hosted, collect]
+  unit-test:
+    needs: [get-version]
+    if: ${{ needs.get-version.outputs.stability != 'stable' }}
+    runs-on: [self-hosted, collect]
 
-  #   strategy:
-  #     matrix:
-  #       image: [alma8, alma9, debian-bullseye]
-  #   name: unit test ${{ matrix.image }}
+    strategy:
+      matrix:
+        image: [alma8, alma9, debian-bullseye]
+    name: unit test ${{ matrix.image }}
 
-  #   steps:
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Login to Registry
-  #       uses: docker/login-action@v2
-  #       with:
-  #         registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-  #         username: ${{ secrets.DOCKER_REGISTRY_ID }}
-  #         password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}
+      - name: Login to Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+          username: ${{ secrets.DOCKER_REGISTRY_ID }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}
 
-  #     - name: Test ${{ matrix.image }}
-  #       uses: ./.github/actions/runner-docker
-  #       with:
-  #         registry_url: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-  #         script_name: /src/.github/scripts/collect-unit-tests
-  #         image_name: centreon-collect-${{ matrix.image }}
-  #         image_version: ${{ needs.get-version.outputs.img_version }}
+      - name: Test ${{ matrix.image }}
+        uses: ./.github/actions/runner-docker
+        with:
+          registry_url: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+          script_name: /src/.github/scripts/collect-unit-tests
+          image_name: centreon-collect-${{ matrix.image }}
+          image_version: ${{ needs.get-version.outputs.img_version }}
 
   package:
     needs: [get-version]
@@ -103,32 +103,32 @@ jobs:
           minor_version: ${{ needs.get-version.outputs.patch }}
           token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
 
-  # deliver-rpm:
-  #   if: ${{ contains(fromJson('["testing", "stable"]'), needs.get-version.outputs.stability) }}
-  #   needs: [get-version, package]
-  #   environment: ${{ needs.get-version.outputs.environment }}
-  #   runs-on: [self-hosted, common]
-  #   strategy:
-  #     matrix:
-  #       distrib: [el8, el9]
-  #   name: deliver ${{ matrix.distrib }}
+  deliver-rpm:
+    if: ${{ contains(fromJson('["testing", "stable"]'), needs.get-version.outputs.stability) }}
+    needs: [get-version, package]
+    environment: ${{ needs.get-version.outputs.environment }}
+    runs-on: [self-hosted, common]
+    strategy:
+      matrix:
+        distrib: [el8, el9]
+    name: deliver ${{ matrix.distrib }}
 
-  #   steps:
-  #     - name: Checkout sources
-  #       uses: actions/checkout@v3
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
 
-  #     - name: Publish RPM packages
-  #       uses: ./.github/actions/delivery
-  #       with:
-  #         module_name: collect
-  #         distrib: ${{ matrix.distrib }}
-  #         version: ${{ needs.get-version.outputs.version }}
-  #         artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-  #         cache_key: cache-${{ github.sha }}-rpmbuild-centreon-collect-${{ matrix.distrib }}-${{ github.head_ref || github.ref_name }}
-  #         stability: ${{ needs.get-version.outputs.stability }}
+      - name: Publish RPM packages
+        uses: ./.github/actions/delivery
+        with:
+          module_name: collect
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-version.outputs.version }}
+          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+          cache_key: cache-${{ github.sha }}-rpmbuild-centreon-collect-${{ matrix.distrib }}-${{ github.head_ref || github.ref_name }}
+          stability: ${{ needs.get-version.outputs.stability }}
 
   deliver-deb:
-    # if: ${{ contains(fromJson('["testing", "stable"]'), needs.get-version.outputs.stability) }}
+    if: ${{ contains(fromJson('["testing", "stable"]'), needs.get-version.outputs.stability) }}
     needs: [get-version, package]
     environment: ${{ needs.get-version.outputs.environment }}
     runs-on: [self-hosted, common]

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -71,7 +71,7 @@ jobs:
               ENV="production"
               ;;
             *)
-              STABILITY="canary"
+              STABILITY="unstable"
               ENV="development"
               ;;
           esac

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -71,7 +71,7 @@ jobs:
               ENV="production"
               ;;
             *)
-              STABILITY="unstable"
+              STABILITY="canary"
               ENV="development"
               ;;
           esac

--- a/packaging/debian/centreon-broker.postinst
+++ b/packaging/debian/centreon-broker.postinst
@@ -8,6 +8,9 @@ if [ "$1" = "configure" ] ; then
     usermod -a -G centreon-broker centreon
     usermod -a -G centreon centreon-broker
   fi
+  if [ "$(getent passwd www-data)" ]; then
+    usermod -a -G centreon-broker www-data
+  fi
   chown -vR centreon-broker:centreon-broker \
     /etc/centreon-broker \
     /var/lib/centreon-broker \

--- a/packaging/debian/centreon-broker.postrm
+++ b/packaging/debian/centreon-broker.postrm
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-deluser centreon centreon-broker || true
-deluser centreon-broker || true
-delgroup centreon-broker || true
-
-#DEBHELPER#
+case "$1" in
+  purge)
+    deluser centreon-broker || :
+    delgroup centreon-broker || :
+  ;;
+esac


### PR DESCRIPTION
## Description

* avoid centreon-broker deletion on upgrade
* reset group of www-data user

**Fixes** MON-20769

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)