### PR TITLE
fix(unfied_sql): service and host states are filled at startup with r…

### DIFF
--- a/broker/unified_sql/src/stream_sql.cc
+++ b/broker/unified_sql/src/stream_sql.cc
@@ -308,11 +308,19 @@ void stream::_update_hosts_and_services_of_instance(uint32_t id,
     _mysql.run_query(query, database::mysql_error::restore_instances, conn);
     _add_action(conn, actions::instances);
     query = fmt::format(
-        "UPDATE hosts AS h LEFT JOIN services AS s ON h.host_id=s.host_id "
-        "SET h.state=h.real_state,s.state=s.real_state WHERE h.instance_id={}",
+        "UPDATE hosts AS h "
+        "SET h.state=h.real_state WHERE h.instance_id={} and h.real_state IS "
+        "NOT NULL",
         id);
     _mysql.run_query(query, database::mysql_error::restore_instances, conn);
     _add_action(conn, actions::hosts);
+    query = fmt::format(
+        "UPDATE services AS s JOIN hosts as h ON h.host_id=s.host_id "
+        "SET s.state=s.real_state WHERE h.instance_id={} and s.real_state IS "
+        "NOT NULL",
+        id);
+    _mysql.run_query(query, database::mysql_error::restore_instances, conn);
+    _add_action(conn, actions::services);
   } else {
     query = fmt::format(
         "UPDATE instances SET outdated=TRUE WHERE instance_id={}", id);

--- a/tests/broker/start-stop.robot
+++ b/tests/broker/start-stop.robot
@@ -4,7 +4,11 @@ Documentation       Centreon Broker only start/stop tests
 Resource            ../resources/resources.robot
 Library             Process
 Library             OperatingSystem
+Library             DatabaseLibrary
+Library             DateTime
 Library             ../resources/Broker.py
+Library             ../resources/Engine.py
+Library             ../resources/Common.py
 
 Suite Setup         Clean Before Suite
 Suite Teardown      Clean After Suite
@@ -83,6 +87,46 @@ BSSU5
     Broker Config Output Remove    central    centreon-broker-master-rrd    host
     Repeat Keyword    5 times    Start Stop Instance    1s
 
+START_STOP_CBD
+    [Documentation]    restart cbd with unified_sql services state must not be null after restart
+    [Tags]    broker    start-stop    unified_sql
+    Config Broker    central
+    Config Broker    rrd
+    Config BBDO3    nbEngine=1
+    Config Engine    ${1}    ${50}    ${20}
+    Config Broker Sql Output    central    unified_sql
+
+    Clear Db    services
+    Clear Db    hosts
+    ${start}    Get Current Date
+
+    Start Engine
+    Start Broker
+
+    # wait engine start
+    ${content}    Create List    INITIAL SERVICE STATE: host_50;service_1000;    check_for_external_commands()
+    ${result}    Find In Log with Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True
+    ...    ${result}
+    ...    An Initial service state on (host_50,service_1000) should be raised before we can start our external commands.
+
+    # restart central broker
+    Stop Broker
+    Start Broker
+
+    Connect To Database    pymysql    ${DBName}    ${DBUser}    ${DBPass}    ${DBHost}    ${DBPort}
+
+    FOR    ${index}    IN RANGE    30
+        Sleep    1
+        ${output}    Query    SELECT state FROM services WHERE enabled=1 AND state IS NULL
+        Should Be Equal    "${output}"    "()"    at least one service state is null
+
+        ${output}    Query    SELECT state FROM hosts WHERE enabled=1 AND state IS NULL
+        Should Be Equal    "${output}"    "()"    at least one host state is null
+    END
+
+    [Teardown]    Run Keywords    Stop Engine    AND    Stop Broker
+
 
 *** Keywords ***
 Start Stop Service
@@ -91,22 +135,22 @@ Start Stop Service
     Start Process    /usr/sbin/cbd    ${EtcRoot}/centreon-broker/central-rrd.json    alias=b2
     Sleep    ${interval}
     Send Signal To Process    SIGTERM    b1
-    ${result}=    Wait For Process    b1    timeout=60s    on_timeout=kill
+    ${result}    Wait For Process    b1    timeout=60s    on_timeout=kill
     Should Be True
     ...    ${result.rc} == -15 or ${result.rc} == 0
-    ...    msg=Broker service badly stopped with code ${result.rc}
+    ...    Broker service badly stopped with code ${result.rc}
     Send Signal To Process    SIGTERM    b2
-    ${result}=    Wait For Process    b2    timeout=60s    on_timeout=kill
+    ${result}    Wait For Process    b2    timeout=60s    on_timeout=kill
     Should Be True
     ...    ${result.rc} == -15 or ${result.rc} == 0
-    ...    msg=Broker service badly stopped with code ${result.rc}
+    ...    Broker service badly stopped with code ${result.rc}
 
 Start Stop Instance
     [Arguments]    ${interval}
     Start Process    /usr/sbin/cbd    ${EtcRoot}/centreon-broker/central-broker.json    alias=b1
     Sleep    ${interval}
     Send Signal To Process    SIGTERM    b1
-    ${result}=    Wait For Process    b1    timeout=60s    on_timeout=kill
+    ${result}    Wait For Process    b1    timeout=60s    on_timeout=kill
     Should Be True
     ...    ${result.rc} == -15 or ${result.rc} == 0
-    ...    msg=Broker instance badly stopped with code ${result.rc}
+    ...    Broker instance badly stopped with code ${result.rc}


### PR DESCRIPTION

## Description

**Fixes** # (issue)

real_state is copied in state in services and hosts tables at restart even if real_state is null

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

