### PR TITLE
fix(packaging): invert dependency between engine and cbmod

### DIFF
--- a/packaging/centreon-broker-cbmod.yaml
+++ b/packaging/centreon-broker-cbmod.yaml
@@ -34,11 +34,9 @@ overrides:
   rpm:
     depends:
       - centreon-broker-core = ${VERSION}-${RELEASE}${DIST}
-      - centreon-engine-daemon = ${VERSION}-${RELEASE}${DIST}
   deb:
     depends:
       - centreon-broker-core (= ${VERSION}-${RELEASE}${DIST})
-      - centreon-engine-daemon (= ${VERSION}-${RELEASE}${DIST})
 
 rpm:
   summary: Centreon Broker as Centreon Engine 2 module.

--- a/packaging/centreon-engine-daemon.yaml
+++ b/packaging/centreon-engine-daemon.yaml
@@ -126,6 +126,7 @@ overrides:
     depends:
       - centreon-clib = ${VERSION}-${RELEASE}${DIST}
       - centreon-engine = ${VERSION}-${RELEASE}${DIST}
+      - centreon-broker-cbmod = ${VERSION}-${RELEASE}${DIST}
     conflicts:
       - centreon-engine-extcommands
       - centreon-engine-devel
@@ -139,6 +140,7 @@ overrides:
     depends:
       - centreon-clib (= ${VERSION}-${RELEASE}${DIST})
       - centreon-engine (= ${VERSION}-${RELEASE}${DIST})
+      - centreon-broker-cbmod = ${VERSION}-${RELEASE}${DIST}
     conflicts:
       - centreon-engine-extcommands
       - centreon-engine-dev

--- a/packaging/scripts/centreon-broker-preinstall.sh
+++ b/packaging/scripts/centreon-broker-preinstall.sh
@@ -15,7 +15,8 @@ else # rpm
 fi
 
 if [ "$(getent passwd centreon-gorgone)" ]; then
-  usermod -a -G centreon-gorgone centreon-broker
+  usermod centreon-broker -a -G centreon-gorgone
+  usermod centreon-gorgone -a -G centreon-broker
 fi
 
 if [ "$(getent passwd centreon-engine)" ]; then

--- a/packaging/scripts/centreon-engine-daemon-preinstall.sh
+++ b/packaging/scripts/centreon-engine-daemon-preinstall.sh
@@ -9,7 +9,8 @@ if id centreon-broker > /dev/null 2>&1; then
 fi
 
 if id centreon-gorgone > /dev/null 2>&1; then
-  usermod -a -G centreon-gorgone centreon-engine
+  usermod centreon-engine -a -G centreon-gorgone
+  usermod centreon-gorgone -a -G centreon-engine
 fi
 
 if id -g nagios > /dev/null 2>&1; then


### PR DESCRIPTION
## Description

invert dependency between engine and cbmod

**Fixes** MON-20896

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)