### PR TITLE
fix(packaging): fix dependency declaration on debian

### DIFF
--- a/.github/scripts/collect-test-robot.sh
+++ b/.github/scripts/collect-test-robot.sh
@@ -90,9 +90,11 @@ echo "########################## Install centreon collect ######################
 cd ..
 echo "Installation..."
 if [ "$distrib" = "ALMALINUX" ]; then
-  /usr/bin/rpm -Uvvh --force --nodeps *.rpm
+  dnf clean all
+  dnf install -y ./*.rpm
 else
-  dpkg --force-all -i ./*.deb
+  apt-get update
+  apt-get install -y ./*.deb
 fi
 
 ulimit -c unlimited

--- a/packaging/centreon-engine-daemon.yaml
+++ b/packaging/centreon-engine-daemon.yaml
@@ -140,7 +140,7 @@ overrides:
     depends:
       - centreon-clib (= ${VERSION}-${RELEASE}${DIST})
       - centreon-engine (= ${VERSION}-${RELEASE}${DIST})
-      - centreon-broker-cbmod = ${VERSION}-${RELEASE}${DIST}
+      - centreon-broker-cbmod (= ${VERSION}-${RELEASE}${DIST})
     conflicts:
       - centreon-engine-extcommands
       - centreon-engine-dev


### PR DESCRIPTION
## Description

* fix dependency declaration on debian
* do not force installation of packages for robot tests since `centreon-common` is not required anymore

**Fixes** MON-20896

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)