### PR TITLE
fix(unfied_sql): service and host states are filled at startup with r…

### DIFF
--- a/broker/unified_sql/src/stream_sql.cc
+++ b/broker/unified_sql/src/stream_sql.cc
@@ -310,11 +310,19 @@ void stream::_update_hosts_and_services_of_instance(uint32_t id,
     _mysql.run_query(query, database::mysql_error::restore_instances, conn);
     _add_action(conn, actions::instances);
     query = fmt::format(
-        "UPDATE hosts AS h LEFT JOIN services AS s ON h.host_id=s.host_id "
-        "SET h.state=h.real_state,s.state=s.real_state WHERE h.instance_id={}",
+        "UPDATE hosts AS h "
+        "SET h.state=h.real_state WHERE h.instance_id={} and h.real_state IS "
+        "NOT NULL",
         id);
     _mysql.run_query(query, database::mysql_error::restore_instances, conn);
     _add_action(conn, actions::hosts);
+    query = fmt::format(
+        "UPDATE services AS s JOIN hosts as h ON h.host_id=s.host_id "
+        "SET s.state=s.real_state WHERE h.instance_id={} and s.real_state IS "
+        "NOT NULL",
+        id);
+    _mysql.run_query(query, database::mysql_error::restore_instances, conn);
+    _add_action(conn, actions::services);
   } else {
     query = fmt::format(
         "UPDATE instances SET outdated=TRUE WHERE instance_id={}", id);

--- a/tests/broker/start-stop.robot
+++ b/tests/broker/start-stop.robot
@@ -1,104 +1,159 @@
 *** Settings ***
-Resource	../resources/resources.robot
-Suite Setup	Clean Before Suite
-Suite Teardown	Clean After Suite
-Test Setup	Stop Processes
+Resource            ../resources/resources.robot
+Resource            ../resources/resources.robot
+Library             Process
+Library             OperatingSystem
+Library             DatabaseLibrary
+Library             DateTime
+Library             ../resources/Broker.py
+Library             ../resources/Engine.py
+Library             ../resources/Common.py
 
-Documentation	Centreon Broker only start/stop tests
-Library	Process
-Library	OperatingSystem
-Library	../resources/Broker.py
+Suite Setup         Clean Before Suite
+Suite Teardown      Clean After Suite
+Test Setup          Stop Processes
+
+Suite Setup         Clean Before Suite
+Suite Teardown      Clean After Suite
+Test Setup          Stop Processes
 
 
 *** Test Cases ***
 BSS1
-	[Documentation]	Start-Stop two instances of broker and no coredump
-	[Tags]	Broker	start-stop
-	Config Broker	central
-	Config Broker	rrd
-	Repeat Keyword	5 times	Start Stop Service	0
+    [Documentation]    Start-Stop two instances of broker and no coredump
+    [Tags]    broker    start-stop
+    Config Broker    central
+    Config Broker    rrd
+    Repeat Keyword    5 times    Start Stop Service    0
 
 BSS2
-	[Documentation]	Start/Stop 10 times broker with 300ms interval and no coredump
-	[Tags]	Broker	start-stop
-	Config Broker	central
-	Repeat Keyword	10 times	Start Stop Instance	300ms
+    [Documentation]    Start/Stop 10 times broker with 300ms interval and no coredump
+    [Tags]    broker    start-stop
+    Config Broker    central
+    Repeat Keyword    10 times    Start Stop Instance    300ms
 
 BSS3
-	[Documentation]	Start-Stop one instance of broker and no coredump
-	[Tags]	Broker	start-stop
-	Config Broker	central
-	Repeat Keyword	5 times	Start Stop Instance	0
+    [Documentation]    Start-Stop one instance of broker and no coredump
+    [Tags]    broker    start-stop
+    Config Broker    central
+    Repeat Keyword    5 times    Start Stop Instance    0
 
 BSS4
-	[Documentation]	Start/Stop 10 times broker with 1sec interval and no coredump
-	[Tags]	Broker	start-stop
-	Config Broker	central
-	Repeat Keyword	10 times	Start Stop Instance	1s
+    [Documentation]    Start/Stop 10 times broker with 1sec interval and no coredump
+    [Tags]    broker    start-stop
+    Config Broker    central
+    Repeat Keyword    10 times    Start Stop Instance    1s
 
 BSS5
-	[Documentation]	Start-Stop with reversed connection on TCP acceptor with only one instance and no deadlock
-	[Tags]	Broker	start-stop
-	Config Broker	central
-	Broker Config Output Set	central	centreon-broker-master-rrd	one_peer_retention_mode	yes
-	Broker Config Output Remove	central	centreon-broker-master-rrd	host
-	Repeat Keyword	5 times	Start Stop Instance	1s
+    [Documentation]    Start-Stop with reversed connection on TCP acceptor with only one instance and no deadlock
+    [Tags]    broker    start-stop
+    Config Broker    central
+    Broker Config Output Set    central    centreon-broker-master-rrd    one_peer_retention_mode    yes
+    Broker Config Output Remove    central    centreon-broker-master-rrd    host
+    Repeat Keyword    5 times    Start Stop Instance    1s
 
 BSSU1
-	[Documentation]	Start-Stop with unified_sql two instances of broker and no coredump
-	[Tags]	Broker	start-stop	unified_sql
-	Config Broker	central
-	Config Broker	rrd
-	Config Broker Sql Output	central	unified_sql
-	Repeat Keyword	5 times	Start Stop Service	0
+    [Documentation]    Start-Stop with unified_sql two instances of broker and no coredump
+    [Tags]    broker    start-stop    unified_sql
+    Config Broker    central
+    Config Broker    rrd
+    Config Broker Sql Output    central    unified_sql
+    Repeat Keyword    5 times    Start Stop Service    0
 
 BSSU2
-	[Documentation]	Start/Stop with unified_sql 10 times broker with 300ms interval and no coredump
-	[Tags]	Broker	start-stop	unified_sql
-	Config Broker	central
-	Config Broker Sql Output	central	unified_sql
-	Repeat Keyword	10 times	Start Stop Instance	300ms
+    [Documentation]    Start/Stop with unified_sql 10 times broker with 300ms interval and no coredump
+    [Tags]    broker    start-stop    unified_sql
+    Config Broker    central
+    Config Broker Sql Output    central    unified_sql
+    Repeat Keyword    10 times    Start Stop Instance    300ms
 
 BSSU3
-	[Documentation]	Start-Stop with unified_sql one instance of broker and no coredump
-	[Tags]	Broker	start-stop	unified_sql
-	Config Broker	central
-	Config Broker Sql Output	central	unified_sql
-	Repeat Keyword	5 times	Start Stop Instance	0
+    [Documentation]    Start-Stop with unified_sql one instance of broker and no coredump
+    [Tags]    broker    start-stop    unified_sql
+    Config Broker    central
+    Config Broker Sql Output    central    unified_sql
+    Repeat Keyword    5 times    Start Stop Instance    0
 
 BSSU4
-	[Documentation]	Start/Stop with unified_sql 10 times broker with 1sec interval and no coredump
-	[Tags]	Broker	start-stop	unified_sql
-	Config Broker	central
-	Config Broker Sql Output	central	unified_sql
-	Repeat Keyword	10 times	Start Stop Instance	1s
+    [Documentation]    Start/Stop with unified_sql 10 times broker with 1sec interval and no coredump
+    [Tags]    broker    start-stop    unified_sql
+    Config Broker    central
+    Config Broker Sql Output    central    unified_sql
+    Repeat Keyword    10 times    Start Stop Instance    1s
 
 BSSU5
-	[Documentation]	Start-Stop with unified_sql with reversed connection on TCP acceptor with only one instance and no deadlock
-	[Tags]	Broker	start-stop	unified_sql
-	Config Broker	central
-	Config Broker Sql Output	central	unified_sql
-	Broker Config Output Set	central	centreon-broker-master-rrd	one_peer_retention_mode	yes
-	Broker Config Output Remove	central	centreon-broker-master-rrd	host
-	Repeat Keyword	5 times	Start Stop Instance	1s
+    [Documentation]    Start-Stop with unified_sql with reversed connection on TCP acceptor with only one instance and no deadlock
+    [Tags]    broker    start-stop    unified_sql
+    Config Broker    central
+    Config Broker Sql Output    central    unified_sql
+    Broker Config Output Set    central    centreon-broker-master-rrd    one_peer_retention_mode    yes
+    Broker Config Output Remove    central    centreon-broker-master-rrd    host
+    Repeat Keyword    5 times    Start Stop Instance    1s
+
+START_STOP_CBD
+    [Documentation]    restart cbd with unified_sql services state must not be null after restart
+    [Tags]    broker    start-stop    unified_sql
+    Config Broker    central
+    Config Broker    rrd
+    Config BBDO3    nbEngine=1
+    Config Engine    ${1}    ${50}    ${20}
+    Config Broker Sql Output    central    unified_sql
+
+    Clear Db    services
+    Clear Db    hosts
+    ${start}    Get Current Date
+
+    Start Engine
+    Start Broker
+
+    # wait engine start
+    ${content}    Create List    INITIAL SERVICE STATE: host_50;service_1000;    check_for_external_commands()
+    ${result}    Find In Log with Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True
+    ...    ${result}
+    ...    An Initial service state on (host_50,service_1000) should be raised before we can start our external commands.
+
+    # restart central broker
+    Stop Broker
+    Start Broker
+
+    Connect To Database    pymysql    ${DBName}    ${DBUser}    ${DBPass}    ${DBHost}    ${DBPort}
+
+    FOR    ${index}    IN RANGE    30
+        Sleep    1
+        ${output}    Query    SELECT state FROM services WHERE enabled=1 AND state IS NULL
+        Should Be Equal    "${output}"    "()"    at least one service state is null
+
+        ${output}    Query    SELECT state FROM hosts WHERE enabled=1 AND state IS NULL
+        Should Be Equal    "${output}"    "()"    at least one host state is null
+    END
+
+    [Teardown]    Run Keywords    Stop Engine    AND    Stop Broker
+
 
 *** Keywords ***
 Start Stop Service
-	[Arguments]	${interval}
-	Start Process	/usr/sbin/cbd	${EtcRoot}/centreon-broker/central-broker.json	alias=b1
-	Start Process	/usr/sbin/cbd	${EtcRoot}/centreon-broker/central-rrd.json	alias=b2
-	Sleep	${interval}
-	Send Signal To Process	SIGTERM	b1
-	${result}=	Wait For Process	b1	timeout=60s	on_timeout=kill
-	Should Be True	${result.rc} == -15 or ${result.rc} == 0	msg=Broker service badly stopped with code ${result.rc}
-	Send Signal To Process	SIGTERM	b2
-	${result}=	Wait For Process	b2	timeout=60s	on_timeout=kill
-	Should Be True	${result.rc} == -15 or ${result.rc} == 0	msg=Broker service badly stopped with code ${result.rc}
+    [Arguments]    ${interval}
+    Start Process    /usr/sbin/cbd    ${EtcRoot}/centreon-broker/central-broker.json    alias=b1
+    Start Process    /usr/sbin/cbd    ${EtcRoot}/centreon-broker/central-rrd.json    alias=b2
+    Sleep    ${interval}
+    Send Signal To Process    SIGTERM    b1
+    ${result}    Wait For Process    b1    timeout=60s    on_timeout=kill
+    Should Be True
+    ...    ${result.rc} == -15 or ${result.rc} == 0
+    ...    Broker service badly stopped with code ${result.rc}
+    Send Signal To Process    SIGTERM    b2
+    ${result}    Wait For Process    b2    timeout=60s    on_timeout=kill
+    Should Be True
+    ...    ${result.rc} == -15 or ${result.rc} == 0
+    ...    Broker service badly stopped with code ${result.rc}
 
 Start Stop Instance
-	[Arguments]	${interval}
-	Start Process	/usr/sbin/cbd	${EtcRoot}/centreon-broker/central-broker.json	alias=b1
-	Sleep	${interval}
-	Send Signal To Process	SIGTERM	b1
-	${result}=	Wait For Process	b1	timeout=60s	on_timeout=kill
-	Should Be True	${result.rc} == -15 or ${result.rc} == 0	msg=Broker instance badly stopped with code ${result.rc}
+    [Arguments]    ${interval}
+    Start Process    /usr/sbin/cbd    ${EtcRoot}/centreon-broker/central-broker.json    alias=b1
+    Sleep    ${interval}
+    Send Signal To Process    SIGTERM    b1
+    ${result}    Wait For Process    b1    timeout=60s    on_timeout=kill
+    Should Be True
+    ...    ${result.rc} == -15 or ${result.rc} == 0
+    ...    Broker instance badly stopped with code ${result.rc}


### PR DESCRIPTION
…eal_state only if real_state is not null (#853)

REFS:MON-20271

## Description

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)
real_state is copied in state in services and hosts tables at restart even if real_state is null

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

