### PR TITLE
enh(broker): logs and data_bin use dedicated auto commit connections

### DIFF
--- a/broker/core/sql/inc/com/centreon/broker/sql/database_config.hh
+++ b/broker/core/sql/inc/com/centreon/broker/sql/database_config.hh
@@ -34,6 +34,13 @@ class endpoint;
  *  @brief Database configuration.
  *
  *  Hold the database information.
+ * a spot on _category attribute:
+ * mysql_manager try to factorise mysql connections and share the same
+ * connection between clients that have the same configuration
+ * (mysql_connection::match_config method)
+ * category must be used if you don't want to use this sharing
+ * only client that have the same config host, port, user, password, socket,
+ * queries_per_transaction and category can share the same connection
  */
 class database_config {
  public:
@@ -67,6 +74,7 @@ class database_config {
   bool get_check_replication() const;
   int get_connections_count() const;
   unsigned get_max_commit_delay() const;
+  unsigned get_category() const;
 
   void set_type(std::string const& type);
   void set_host(std::string const& host);
@@ -78,6 +86,7 @@ class database_config {
   void set_connections_count(int count);
   void set_queries_per_transaction(int qpt);
   void set_check_replication(bool check_replication);
+  void set_category(unsigned category);
 
   database_config auto_commit_conf() const;
 
@@ -95,6 +104,7 @@ class database_config {
   bool _check_replication;
   int _connections_count;
   unsigned _max_commit_delay;
+  unsigned _category;
 };
 
 std::ostream& operator<<(std::ostream& s, const database_config cfg);

--- a/broker/core/sql/inc/com/centreon/broker/sql/database_config.hh
+++ b/broker/core/sql/inc/com/centreon/broker/sql/database_config.hh
@@ -44,6 +44,8 @@ class endpoint;
  */
 class database_config {
  public:
+  enum category { SHARED = 0, DATA_BIN_LOGS = 1 };
+
   database_config();
   database_config(std::string const& type,
                   std::string const& host,

--- a/broker/core/sql/inc/com/centreon/broker/sql/mysql_connection.hh
+++ b/broker/core/sql/inc/com/centreon/broker/sql/mysql_connection.hh
@@ -101,6 +101,7 @@ class mysql_connection {
   SqlConnectionStats* _proto_stats;
   std::time_t _last_stats;
   uint32_t _qps;
+  unsigned _category;
 
   sql::stats _stats;
 

--- a/broker/core/sql/src/database_config.cc
+++ b/broker/core/sql/src/database_config.cc
@@ -48,7 +48,7 @@ database_config::database_config()
     : _queries_per_transaction(1),
       _check_replication(true),
       _connections_count(1),
-      _category(0) {}
+      _category(SHARED) {}
 
 /**
  *  Constructor.
@@ -89,7 +89,7 @@ database_config::database_config(const std::string& type,
       _check_replication(check_replication),
       _connections_count(connections_count),
       _max_commit_delay(max_commit_delay),
-      _category(0) {}
+      _category(SHARED) {}
 
 /**
  *  Build a database configuration from a configuration set.

--- a/broker/core/sql/src/database_config.cc
+++ b/broker/core/sql/src/database_config.cc
@@ -47,7 +47,8 @@ CCB_END()
 database_config::database_config()
     : _queries_per_transaction(1),
       _check_replication(true),
-      _connections_count(1) {}
+      _connections_count(1),
+      _category(0) {}
 
 /**
  *  Constructor.
@@ -87,7 +88,8 @@ database_config::database_config(const std::string& type,
       _queries_per_transaction(queries_per_transaction),
       _check_replication(check_replication),
       _connections_count(connections_count),
-      _max_commit_delay(max_commit_delay) {}
+      _max_commit_delay(max_commit_delay),
+      _category(0) {}
 
 /**
  *  Build a database configuration from a configuration set.
@@ -419,6 +421,21 @@ unsigned database_config::get_max_commit_delay() const {
 }
 
 /**
+ * @brief get_category
+ * mysql_manager try to factorise mysql connections and share the same
+ * connection between clients that have the same configuration
+ * (mysql_connection::match_config method)
+ * category must be used if you don't want to use this sharing
+ * only client that have the same config host, port, user, password, socket,
+ * queries_per_transaction and category can share the same connection
+ *
+ * @return unsigned _category field
+ */
+unsigned database_config::get_category() const {
+  return _category;
+}
+
+/**
  *  Set type.
  *
  *  @param[in] type  The database type.
@@ -506,6 +523,16 @@ void database_config::set_connections_count(int count) {
  */
 void database_config::set_check_replication(bool check_replication) {
   _check_replication = check_replication;
+}
+
+/**
+ *  Set the category of the connections (connections in mysql_manager aren't
+ * shared if cfg have different category).
+ *
+ *  @param[in] category  Replication check flag.
+ */
+void database_config::set_category(unsigned category) {
+  _category = category;
 }
 
 /**

--- a/broker/core/sql/src/mysql_connection.cc
+++ b/broker/core/sql/src/mysql_connection.cc
@@ -1085,7 +1085,8 @@ mysql_connection::mysql_connection(const database_config& db_cfg,
       _switch_point{std::time(nullptr)},
       _proto_stats{stats},
       _last_stats{std::time(nullptr)},
-      _qps(db_cfg.get_queries_per_transaction()) {
+      _qps(db_cfg.get_queries_per_transaction()),
+      _category(db_cfg.get_category()) {
   std::unique_lock<std::mutex> lck(_start_m);
   SPDLOG_LOGGER_INFO(log_v2::sql(),
                      "mysql_connection: starting connection {:p} to {}",
@@ -1202,7 +1203,9 @@ bool mysql_connection::match_config(database_config const& db_cfg) const {
   return db_cfg.get_host() == _host && db_cfg.get_socket() == _socket &&
          db_cfg.get_user() == _user && db_cfg.get_password() == _pwd &&
          db_cfg.get_name() == _name && db_cfg.get_port() == _port &&
-         db_cfg.get_queries_per_transaction() == _qps;
+         db_cfg.get_queries_per_transaction() == _qps &&
+         db_cfg.get_category() == _category;
+  ;
 }
 
 int mysql_connection::get_tasks_count() const {

--- a/broker/unified_sql/inc/com/centreon/broker/unified_sql/stream.hh
+++ b/broker/unified_sql/inc/com/centreon/broker/unified_sql/stream.hh
@@ -255,6 +255,7 @@ class stream : public io::stream {
   uint32_t _max_pending_queries;
   database_config _dbcfg;
   mysql _mysql;
+  std::unique_ptr<mysql> _dedicated_connections;
   uint32_t _instance_timeout;
   rebuilder _rebuilder;
   bool _store_in_db = true;

--- a/broker/unified_sql/src/stream.cc
+++ b/broker/unified_sql/src/stream.cc
@@ -116,7 +116,7 @@ constexpr size_t neb_processing_table_size =
 
 /**
  * @brief this function return a database_config equal to the parameter dbcfg
- * except the connections_count witch is equal to 1
+ * except that the connections_count is equal to 1
  *
  * @param dbcfg  config to copy to the return object
  * @return database_config  copy of the parameter with connections_count = 1
@@ -183,29 +183,29 @@ stream::stream(const database_config& dbcfg,
   SPDLOG_LOGGER_DEBUG(log_v2::sql(), "unified sql: stream class instanciation");
 
   // dedicated connections for data_bin and logs?
-  unsigned nb_dedicated_connexion = 0;
+  unsigned nb_dedicated_connection = 0;
   switch (dbcfg.get_connections_count()) {
-    case 1:  // only one connexion =>data_bin and logs are filled with the only
+    case 1:  // only one connection =>data_bin and logs are filled with the only
              // connection
       break;
     case 2:
-      nb_dedicated_connexion = 1;
+      nb_dedicated_connection = 1;
       break;
-    case 3:
     default:
-      nb_dedicated_connexion = store_in_data_bin ? 2 : 1;
+      nb_dedicated_connection = store_in_data_bin ? 2 : 1;
       break;
   }
 
-  if (nb_dedicated_connexion > 0) {
+  if (nb_dedicated_connection > 0) {
     SPDLOG_LOGGER_INFO(
         log_v2::sql(),
         "use of {} dedicated connection for logs and data_bin tables",
-        nb_dedicated_connexion);
+        nb_dedicated_connection);
     database_config dedicated_cfg(dbcfg);
-    dedicated_cfg.set_category(1);  // no shared with bam connection
+    dedicated_cfg.set_category(
+        database_config::DATA_BIN_LOGS);  // no shared with bam connection
     dedicated_cfg.set_queries_per_transaction(1);
-    dedicated_cfg.set_connections_count(nb_dedicated_connexion);
+    dedicated_cfg.set_connections_count(nb_dedicated_connection);
     _dedicated_connections = std::make_unique<mysql>(dedicated_cfg);
   }
 

--- a/tests/broker-database/dedicated-connection.robot
+++ b/tests/broker-database/dedicated-connection.robot
@@ -1,0 +1,49 @@
+*** Settings ***
+Documentation       Centreon Broker data_bin and logs dedicated connections
+
+Resource            ../resources/resources.robot
+Library             DateTime
+Library             Examples
+Library             ../resources/Broker.py
+Library             ../resources/Common.py
+
+Suite Setup         Clean Before Suite
+Suite Teardown      Clean After Suite
+Test Setup          Stop Processes
+Test Teardown       Save logs If Failed
+
+
+*** Test Cases ***
+DEDICATED_DB_CONNECTION_${nb_conn}_${store_in_data_bin}
+    [Documentation]    count database connection
+    [Tags]    broker    database
+    Config Broker    central
+    Broker Config Log    central    sql    debug
+    Config Broker Sql Output    central    unified_sql
+
+    Broker Config Output Set    central    central-broker-unified-sql    db_host    127.0.0.1
+    Broker Config Output Set    central    central-broker-unified-sql    connections_count    ${nb_conn}
+    Broker Config Output Set    central    central-broker-unified-sql    store_in_data_bin    ${store_in_data_bin}
+
+    ${start}    Get Current Date
+    Start Broker    only_central=${True}
+    ${content}    Create List    unified sql: stream class instanciation
+    ${result}    Find In Log with Timeout    ${centralLog}    ${start}    ${content}    60
+    Should Be True    ${result}    No unified sql instanciation
+
+    IF    ${nb_conn} > 1
+        ${nb_dedicated}    Evaluate    ${nb_conn_expected} - 1
+        ${content}    Create List    use of ${nb_dedicated} dedicated connection for logs and data_bin tables
+        ${result}    Find In Log with Timeout    ${centralLog}    ${start}    ${content}    5
+        Should Be True    ${result}    No dedicated message
+    END
+
+    ${connected}    Wait For Connections    3306    ${nb_conn_expected}
+    Should Be True    ${connected}    no ${nb_conn_expected} connections found
+
+    Examples:    nb_conn    nb_conn_expected    store_in_data_bin    --
+    ...    1    1    yes
+    ...    2    2    yes
+    ...    3    3    yes
+    ...    3    2    no
+    [Teardown]    Stop Broker    only_central=${True}

--- a/tests/broker-engine/bench.robot
+++ b/tests/broker-engine/bench.robot
@@ -86,7 +86,7 @@ BENCH_${nb_check}STATUS
     ...    10000
     [Teardown]    Run Keywords    Stop Engine    AND    Kindly Stop Broker
 
-BENCH_1000STATUS_100ENGINE
+BENCH_1000STATUS_100${suffixe}
     [Documentation]    external command CHECK_SERVICE_RESULT 100 times    with 100 pollers with 20 services
     [Tags]    broker    engine    bench
     Config Engine    ${100}    ${100}    ${20}
@@ -102,6 +102,7 @@ BENCH_1000STATUS_100ENGINE
     Broker Config Log    central    processing    error
     Config BBDO3    ${100}
     Config Broker Sql Output    central    unified_sql
+    Broker Config Output Set    central    central-broker-unified-sql    connections_count    ${nb_conn}
     ${start}    Get Current Date
     Start Broker
     Start Engine
@@ -152,12 +153,12 @@ BENCH_1000STATUS_100ENGINE
 
     ${success}    Store Result In Unqlite
     ...    bench.unqlite
-    ...    BENCH_1000STATUS_100POLLER
+    ...    BENCH_1000STATUS_100POLLER${suffixe}
     ...    broker
     ...    ${diff_broker}
     ...    ${broker_stat_after}
     ...    ${bench_data}
-    ...    central-broker-master-input-\\d+
+    ...    central-broker-master-input-[0-9]+
     ...    write
     ...    central-rrd-master-output
     ...    publish
@@ -166,7 +167,7 @@ BENCH_1000STATUS_100ENGINE
 
     ${success}    Store Result In Unqlite
     ...    bench.unqlite
-    ...    BENCH_1000STATUS_100POLLER
+    ...    BENCH_1000STATUS_100POLLER${suffixe}
     ...    engine
     ...    ${diff_engine}
     ...    ${engine_stat_after}
@@ -179,5 +180,10 @@ BENCH_1000STATUS_100ENGINE
     Should Be True    ${success}    "fail to save engine bench to database"
 
     Upload Database To S3    bench.unqlite
+
+    Examples:    suffixe    nb_conn    --
+    ...    ENGINE    1
+    ...    ENGINE_2    2
+    ...    ENGINE_3    3
 
     [Teardown]    Run Keywords    Stop Engine    AND    Kindly Stop Broker


### PR DESCRIPTION
## Description

New rules for database connections:
if connections_count conf parameter == 1, all queries use a single database connection
if 2, data_bin and logs share a private autocommit database connection, the others (config) use another one
if more, data_bin and logs share 2 connections (if store_in_databin is activated), the others use another one


**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

