### PR TITLE
fix(broker):muxer::_update_stats is called when _muxex is locked

### DIFF
--- a/broker/core/multiplexing/src/muxer.cc
+++ b/broker/core/multiplexing/src/muxer.cc
@@ -264,9 +264,10 @@ void muxer::publish(const std::deque<std::shared_ptr<io::data>>& event_queue) {
         at_least_one_push_to_queue = true;
         _push_to_queue(*evt);
       }
-    }
-    if (evt == event_queue.end()) {
-      return;
+      if (evt == event_queue.end()) {
+        _update_stats();
+        return;
+      }
     }
     // we have stopped insertion because of full queue => retry
     if (at_least_one_push_to_queue) {
@@ -303,8 +304,8 @@ void muxer::publish(const std::deque<std::shared_ptr<io::data>>& event_queue) {
         _file.reset();
       }
     }
+    _update_stats();
   }
-  _update_stats();
 }
 
 /**


### PR DESCRIPTION
## Description


**Fixes** # (issue)

in muxer::publish, muxer::_update_stats is called without locking _mutex

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

