### PR TITLE
fix(test): do not install selinux packages for nightly robot

### DIFF
--- a/.github/scripts/collect-test-robot.sh
+++ b/.github/scripts/collect-test-robot.sh
@@ -91,6 +91,7 @@ cd ..
 echo "Installation..."
 if [ "$distrib" = "ALMALINUX" ]; then
   dnf clean all
+  rm -f ./*-selinux-*.rpm # avoid to install selinux packages which are dependent to centreon-common-selinux
   dnf install -y ./*.rpm
 else
   apt-get update


### PR DESCRIPTION
## Description

do not install selinux packages for nightly robot

**Fixes** MON-20157

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Check nightly robot workflow
