### PR TITLE
Mon 33712 ccc getba ignored develop

### DIFF
--- a/broker/bam/CMakeLists.txt
+++ b/broker/bam/CMakeLists.txt
@@ -22,7 +22,10 @@ set(SRC_DIR "${PROJECT_SOURCE_DIR}/bam/src")
 set(TEST_DIR "${PROJECT_SOURCE_DIR}/bam/test")
 include_directories(
   ${INC_DIR} ${PROJECT_SOURCE_DIR}/core/inc ${PROJECT_SOURCE_DIR}/core/sql/inc
-  ${PROJECT_SOURCE_DIR}/neb/inc)
+  ${PROJECT_SOURCE_DIR}/neb/inc
+  ${PROJECT_SOURCE_DIR}/core/src
+)
+
 set(INC_DIR "${INC_DIR}/com/centreon/broker/bam")
 
 # BAM module.

--- a/broker/bam/inc/com/centreon/broker/bam/internal.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/internal.hh
@@ -1,25 +1,26 @@
-/*
-** Copyright 2022 Centreon
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-**
-** For more information : contact@centreon.com
-*/
+/**
+ * Copyright 2022-2023 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #ifndef CCB_BAM_INTERNAL_HH
 #define CCB_BAM_INTERNAL_HH
 
 #include "bbdo/bam.pb.h"
+#include "broker.pb.h"
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/io/protobuf.hh"
 
@@ -77,6 +78,15 @@ using pb_dimension_truncate_table_signal =
 
 }  // namespace bam
 
-}
+/* We have to declare the pb_ba_info also here because we don't control the
+ * order things are created. If the bam stream is created before brokerrpc, its
+ * muxer will be declared with known events (so without pb_ba_info) and if we
+ * want pb_ba_info to be known, thenwe have to force its declaration. */
+namespace extcmd {
+using pb_ba_info =
+    io::protobuf<BaInfo, make_type(io::extcmd, extcmd::de_ba_info)>;
+}  // namespace extcmd
+
+}  // namespace com::centreon::broker
 
 #endif

--- a/broker/bam/src/main.cc
+++ b/broker/bam/src/main.cc
@@ -1,20 +1,21 @@
 /**
-* Copyright 2011-2015, 2020-2021 Centreon
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* For more information : contact@centreon.com
-*/
+ * Copyright 2011-2015, 2020-2023 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
+
 #include "bbdo/bam/ba_duration_event.hh"
 #include "bbdo/bam/ba_status.hh"
 #include "bbdo/bam/dimension_ba_bv_relation_event.hh"
@@ -169,6 +170,10 @@ void broker_module_init(void const* arg) {
       e.register_event(bam::pb_dimension_truncate_table_signal::static_type(),
                        "DimensionTruncateTableSignal",
                        &bam::pb_dimension_truncate_table_signal::operations);
+      /* Let's register the ba_info event to be sure it is declared in case
+       * brokerrpc is not already instanciated. */
+      e.register_event(make_type(io::extcmd, extcmd::de_ba_info), "ba_info",
+                       &extcmd::pb_ba_info::operations);
     }
   }
 }

--- a/broker/core/inc/com/centreon/broker/broker_impl.hh
+++ b/broker/core/inc/com/centreon/broker/broker_impl.hh
@@ -37,6 +37,9 @@ using pb_remove_graphs =
 using pb_remove_poller =
     io::protobuf<GenericNameOrIndex,
                  make_type(io::bbdo, bbdo::de_remove_poller)>;
+using pb_ba_info =
+    io::protobuf<BaInfo,
+                 make_type(io::extcmd, extcmd::de_ba_info)>;
 }  // namespace bbdo
 
 namespace extcmd {

--- a/broker/core/inc/com/centreon/broker/broker_impl.hh
+++ b/broker/core/inc/com/centreon/broker/broker_impl.hh
@@ -37,9 +37,6 @@ using pb_remove_graphs =
 using pb_remove_poller =
     io::protobuf<GenericNameOrIndex,
                  make_type(io::bbdo, bbdo::de_remove_poller)>;
-using pb_ba_info =
-    io::protobuf<BaInfo,
-                 make_type(io::extcmd, extcmd::de_ba_info)>;
 }  // namespace bbdo
 
 namespace extcmd {
@@ -72,7 +69,8 @@ class broker_impl final : public Broker::Service {
                                const GenericNameOrIndex* request,
                                GenericString* response) override;
 
-  grpc::Status GetMuxerStats(grpc::ServerContext*, const GenericString*,
+  grpc::Status GetMuxerStats(grpc::ServerContext*,
+                             const GenericString*,
                              MuxerStats*) override;
 
   grpc::Status GetNumEndpoint(grpc::ServerContext* context,
@@ -91,7 +89,8 @@ class broker_impl final : public Broker::Service {
                             const ToRemove* request,
                             ::google::protobuf::Empty* response) override;
 
-  grpc::Status GetBa(grpc::ServerContext* context, const BaInfo* request,
+  grpc::Status GetBa(grpc::ServerContext* context,
+                     const BaInfo* request,
                      ::google::protobuf::Empty* response) override;
 
   grpc::Status GetProcessingStats(grpc::ServerContext* context
@@ -117,7 +116,8 @@ class broker_impl final : public Broker::Service {
                                   const SqlManagerStatsOptions* request,
                                   ::google::protobuf::Empty*) override;
   ::grpc::Status GetProcessStats(
-      ::grpc::ServerContext* context, const ::google::protobuf::Empty* request,
+      ::grpc::ServerContext* context,
+      const ::google::protobuf::Empty* request,
       ::com::centreon::common::pb_process_stat* response) override;
 
  public:

--- a/broker/core/src/brokerrpc.cc
+++ b/broker/core/src/brokerrpc.cc
@@ -50,6 +50,10 @@ brokerrpc::brokerrpc(const std::string& address,
   e.register_event(make_type(io::bbdo, bbdo::de_remove_poller), "remove_poller",
                    &bbdo::pb_remove_poller::operations);
 
+  /* Let's register the ba_info event. */
+  e.register_event(make_type(io::extcmd, extcmd::de_ba_info), "ba_info",
+                   &extcmd::pb_ba_info::operations);
+
   _service.set_broker_name(broker_name);
   std::string server_address{fmt::format("{}:{}", address, port)};
   grpc::ServerBuilder builder;

--- a/broker/core/src/io/events.cc
+++ b/broker/core/src/io/events.cc
@@ -1,20 +1,20 @@
 /**
-* Copyright 2013, 2020-2021 Centreon
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* For more information : contact@centreon.com
-*/
+ * Copyright 2013, 2020-2023 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #include "com/centreon/broker/io/events.hh"
 

--- a/tests/bam/bam_pb.robot
+++ b/tests/bam/bam_pb.robot
@@ -86,6 +86,12 @@ BAWORST
     ...    SELECT current_level, acknowledged, downtime, in_downtime, current_status FROM mod_bam WHERE name='test'
     Should Be Equal As Strings    ${output}    ((100.0, 0.0, 0.0, 0, 2),)
 
+    # Little check of the GetBa keyword
+    Broker Get Ba    51001    1    /tmp/output
+    File Should Exist    /tmp/output
+    ${result}    Grep File    /tmp/output    digraph
+    Should Be True    ${result}    /tmp/output does not contain the word 'digraph'
+
     ${result}    Check Ba Output With Timeout
     ...    test
     ...    Status is CRITICAL - At least one KPI is in a CRITICAL state: KPI Service host_16/service_303 is in WARNING state, KPI Service host_16/service_314 is in CRITICAL state

--- a/tests/bam/bam_pb.robot
+++ b/tests/bam/bam_pb.robot
@@ -86,17 +86,19 @@ BAWORST
     ...    SELECT current_level, acknowledged, downtime, in_downtime, current_status FROM mod_bam WHERE name='test'
     Should Be Equal As Strings    ${output}    ((100.0, 0.0, 0.0, 0, 2),)
 
-    # Little check of the GetBa keyword
-    Broker Get Ba    51001    1    /tmp/output
-    File Should Exist    /tmp/output
-    ${result}    Grep File    /tmp/output    digraph
-    Should Be True    ${result}    /tmp/output does not contain the word 'digraph'
-
     ${result}    Check Ba Output With Timeout
     ...    test
     ...    Status is CRITICAL - At least one KPI is in a CRITICAL state: KPI Service host_16/service_303 is in WARNING state, KPI Service host_16/service_314 is in CRITICAL state
     ...    60
     Should Be True    ${result}    The BA test has not the expected output
+
+    # Little check of the GetBa keyword
+    ${result}    Run Keyword And Return Status    File Should Exist    /tmp/output
+    Run Keyword If    ${result} is True    Remove File    /tmp/output
+    Broker Get Ba    51001    1    /tmp/output
+    Wait Until Created    /tmp/output
+    ${result}    Grep File    /tmp/output    digraph
+    Should Not Be Empty    ${result}    /tmp/output does not contain the word 'digraph'
 
     [Teardown]    Run Keywords    Stop Engine    AND    Kindly Stop Broker
 

--- a/tests/bam/bam_pb.robot
+++ b/tests/bam/bam_pb.robot
@@ -92,7 +92,7 @@ BAWORST
     ...    60
     Should Be True    ${result}    The BA test has not the expected output
 
-    # Little check of the GetBa keyword
+    # Little check of the GetBa gRPC command
     ${result}    Run Keyword And Return Status    File Should Exist    /tmp/output
     Run Keyword If    ${result} is True    Remove File    /tmp/output
     Broker Get Ba    51001    1    /tmp/output

--- a/tests/resources/Broker.py
+++ b/tests/resources/Broker.py
@@ -2108,7 +2108,7 @@ def dump_ba(port, index: int, filename: str):
             logger.console("gRPC server not ready")
 
 
-def broker_get_ba(port, ba_id, output_file, timeout=TIMEOUT):
+def broker_get_ba(port: int, ba_id: int, output_file: str, timeout=TIMEOUT):
     """
     broker_get_ba calls the gRPC GetBa function.
 
@@ -2128,7 +2128,7 @@ def broker_get_ba(port, ba_id, output_file, timeout=TIMEOUT):
         with grpc.insecure_channel(f"127.0.0.1:{port}") as channel:
             stub = broker_pb2_grpc.BrokerStub(channel)
             ref = broker_pb2.BaInfo()
-            ref.id = ba_id
+            ref.id = int(ba_id)
             ref.output_file = output_file
 
             try:

--- a/tests/resources/Broker.py
+++ b/tests/resources/Broker.py
@@ -1352,7 +1352,7 @@ def create_metrics(count: int):
 
 def run_reverse_bam(duration, interval):
     pro = subp.Popen("broker/map_client.py {:f}".format(interval),
-               shell=True, stdout=subp.PIPE, stdin=subp.PIPE, preexec_fn=setsid)
+                     shell=True, stdout=subp.PIPE, stdin=subp.PIPE, preexec_fn=setsid)
     time.sleep(duration)
     os.killpg(os.getpgid(pro.pid), signal.SIGKILL)
 
@@ -2106,3 +2106,38 @@ def dump_ba(port, index: int, filename: str):
             logger.console(f"BA {index} dump to {filename}")
         except:
             logger.console("gRPC server not ready")
+
+
+def broker_get_ba(port, ba_id, output_file, timeout=TIMEOUT):
+    """
+    broker_get_ba calls the gRPC GetBa function.
+
+    Args:
+        port: the gRPC port to use.
+        ba_id: the BA's ID we want to get.
+        output_file: The full path of the file to generate.
+        timeout: A timeout in seconds (default value 30s).
+
+    Returns:
+        An empty Protobuf object.
+    """
+    limit = time.time() + timeout
+    while time.time() < limit:
+        logger.console("Try to call GetBa")
+        time.sleep(1)
+        with grpc.insecure_channel(f"127.0.0.1:{port}") as channel:
+            stub = broker_pb2_grpc.BrokerStub(channel)
+            ref = broker_pb2.BaInfo()
+            ref.id = ba_id
+            ref.output_file = output_file
+
+            try:
+                res = stub.GetBa(ref)
+                break
+            except grpc.RpcError as rpc_error:
+                if rpc_error.code() == grpc.StatusCode.INVALID_ARGUMENT:
+                    res = rpc_error.details()
+                break
+            except:
+                logger.console("gRPC server not ready")
+    return res


### PR DESCRIPTION
## Description

Issue with the GetBa grpc command fixed. It could be ignored because of objects instanciations order.

REFS: MON-33712

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
