### PR TITLE
Mon 33636 ba status not updated develop

### DIFF
--- a/broker/bam/inc/com/centreon/broker/bam/ba.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/ba.hh
@@ -102,8 +102,12 @@ class ba : public computable, public service_listener {
   int _recompute_count{0};
 
   static double _normalize(double d);
-  virtual bool _apply_impact(kpi* kpi_ptr, impact_info& impact) = 0;
+  virtual void _apply_impact(kpi* kpi_ptr, impact_info& impact) = 0;
   virtual void _unapply_impact(kpi* kpi_ptr, impact_info& impact) = 0;
+  virtual bool _apply_changes(kpi* child,
+                              const impact_values& new_hard_impact,
+                              const impact_values& new_soft_impact,
+                              bool in_downtime) = 0;
   std::shared_ptr<pb_ba_status> _generate_ba_status(bool state_changed) const;
   std::shared_ptr<io::data> _generate_virtual_service_status() const;
 

--- a/broker/bam/inc/com/centreon/broker/bam/ba.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/ba.hh
@@ -129,7 +129,7 @@ class ba : public computable, public service_listener {
   uint32_t get_id() const;
   uint32_t get_host_id() const;
   uint32_t get_service_id() const;
-  bool get_in_downtime() const;
+  bool in_downtime() const;
   timestamp get_last_kpi_update() const;
   std::string const& get_name() const;
   virtual std::string get_output() const = 0;

--- a/broker/bam/inc/com/centreon/broker/bam/ba.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/ba.hh
@@ -104,7 +104,6 @@ class ba : public computable, public service_listener {
   static double _normalize(double d);
   virtual bool _apply_impact(kpi* kpi_ptr, impact_info& impact) = 0;
   virtual void _unapply_impact(kpi* kpi_ptr, impact_info& impact) = 0;
-  virtual void _recompute();
   std::shared_ptr<pb_ba_status> _generate_ba_status(bool state_changed) const;
   std::shared_ptr<io::data> _generate_virtual_service_status() const;
 
@@ -157,6 +156,6 @@ class ba : public computable, public service_listener {
 };
 }  // namespace bam
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_BAM_BA_HH

--- a/broker/bam/inc/com/centreon/broker/bam/ba_best.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/ba_best.hh
@@ -44,8 +44,12 @@ class ba_best : public ba {
   void _commit_initial_events(io::stream* visitor);
 
  protected:
-  bool _apply_impact(kpi* kpi_ptr, impact_info& impact) override;
+  void _apply_impact(kpi* kpi_ptr, impact_info& impact) override;
   void _unapply_impact(kpi* kpi_ptr, impact_info& impact) override;
+  bool _apply_changes(kpi* child,
+                      const impact_values& new_hard_impact,
+                      const impact_values& new_soft_impact,
+                      bool in_downtime) override;
 
  public:
   ba_best(uint32_t id,

--- a/broker/bam/inc/com/centreon/broker/bam/ba_best.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/ba_best.hh
@@ -1,20 +1,20 @@
-/*
-** Copyright 2022 Centreon
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-**
-** For more information : contact@centreon.com
-*/
+/**
+ * Copyright 2022-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #ifndef CCB_BAM_BA_BEST_HH
 #define CCB_BAM_BA_BEST_HH
@@ -46,7 +46,6 @@ class ba_best : public ba {
  protected:
   bool _apply_impact(kpi* kpi_ptr, impact_info& impact) override;
   void _unapply_impact(kpi* kpi_ptr, impact_info& impact) override;
-  void _recompute() override;
 
  public:
   ba_best(uint32_t id,
@@ -60,6 +59,6 @@ class ba_best : public ba {
 };
 }  // namespace bam
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_BAM_BA_BEST_HH

--- a/broker/bam/inc/com/centreon/broker/bam/ba_impact.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/ba_impact.hh
@@ -38,8 +38,12 @@ class ba_impact : public ba {
   void _recompute();
 
  protected:
-  bool _apply_impact(kpi* kpi_ptr, impact_info& impact) override;
+  void _apply_impact(kpi* kpi_ptr, impact_info& impact) override;
   void _unapply_impact(kpi* kpi_ptr, impact_info& impact) override;
+  bool _apply_changes(kpi* child,
+                      const impact_values& new_hard_impact,
+                      const impact_values& new_soft_impact,
+                      bool in_downtime) override;
 
  public:
   ba_impact(uint32_t id,

--- a/broker/bam/inc/com/centreon/broker/bam/ba_impact.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/ba_impact.hh
@@ -1,20 +1,20 @@
-/*
-** Copyright 2022 Centreon
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-**
-** For more information : contact@centreon.com
-*/
+/**
+ * Copyright 2022-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #ifndef CCB_BAM_BA_IMPACT_HH
 #define CCB_BAM_BA_IMPACT_HH
@@ -35,6 +35,8 @@ class kpi;
  *  of value.
  */
 class ba_impact : public ba {
+  void _recompute();
+
  protected:
   bool _apply_impact(kpi* kpi_ptr, impact_info& impact) override;
   void _unapply_impact(kpi* kpi_ptr, impact_info& impact) override;
@@ -53,6 +55,6 @@ class ba_impact : public ba {
 };
 }  // namespace bam
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_BAM_BA_IMPACT_HH

--- a/broker/bam/inc/com/centreon/broker/bam/ba_ratio_number.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/ba_ratio_number.hh
@@ -1,20 +1,20 @@
-/*
-** Copyright 2022 Centreon
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-**
-** For more information : contact@centreon.com
-*/
+/**
+ * Copyright 2022-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #ifndef CCB_BAM_BA_RATIO_NUMBER_HH
 #define CCB_BAM_BA_RATIO_NUMBER_HH
@@ -37,7 +37,6 @@ class kpi;
 class ba_ratio_number : public ba {
   bool _apply_impact(kpi* kpi_ptr, impact_info& impact) override;
   void _unapply_impact(kpi* kpi_ptr, impact_info& impact) override;
-  void _recompute() override;
 
  public:
   ba_ratio_number(uint32_t id,
@@ -51,6 +50,6 @@ class ba_ratio_number : public ba {
 };
 }  // namespace bam
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_BAM_BA_RATIO_NUMBER_HH

--- a/broker/bam/inc/com/centreon/broker/bam/ba_ratio_number.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/ba_ratio_number.hh
@@ -35,8 +35,12 @@ class kpi;
  *  of value.
  */
 class ba_ratio_number : public ba {
-  bool _apply_impact(kpi* kpi_ptr, impact_info& impact) override;
+  void _apply_impact(kpi* kpi_ptr, impact_info& impact) override;
   void _unapply_impact(kpi* kpi_ptr, impact_info& impact) override;
+  bool _apply_changes(kpi* child,
+                      const impact_values& new_hard_impact,
+                      const impact_values& new_soft_impact,
+                      bool in_downtime) override;
 
  public:
   ba_ratio_number(uint32_t id,

--- a/broker/bam/inc/com/centreon/broker/bam/ba_ratio_percent.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/ba_ratio_percent.hh
@@ -35,8 +35,12 @@ class kpi;
  *  of value.
  */
 class ba_ratio_percent : public ba {
-  bool _apply_impact(kpi* kpi_ptr, ba::impact_info& impact) override;
+  void _apply_impact(kpi* kpi_ptr, ba::impact_info& impact) override;
   void _unapply_impact(kpi* kpi_ptr, ba::impact_info& impact) override;
+  bool _apply_changes(kpi* child,
+                      const impact_values& new_hard_impact,
+                      const impact_values& new_soft_impact,
+                      bool in_downtime) override;
 
  public:
   ba_ratio_percent(uint32_t id,

--- a/broker/bam/inc/com/centreon/broker/bam/ba_ratio_percent.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/ba_ratio_percent.hh
@@ -1,20 +1,20 @@
-/*
-** Copyright 2022 Centreon
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-**
-** For more information : contact@centreon.com
-*/
+/**
+ * Copyright 2022-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #ifndef CCB_BAM_BA_RATIO_PERCENT_HH
 #define CCB_BAM_BA_RATIO_PERCENT_HH
@@ -37,7 +37,6 @@ class kpi;
 class ba_ratio_percent : public ba {
   bool _apply_impact(kpi* kpi_ptr, ba::impact_info& impact) override;
   void _unapply_impact(kpi* kpi_ptr, ba::impact_info& impact) override;
-  void _recompute() override;
 
  public:
   ba_ratio_percent(uint32_t id,
@@ -51,6 +50,6 @@ class ba_ratio_percent : public ba {
 };
 }  // namespace bam
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_BAM_BA_RATIO_PERCENT_HH

--- a/broker/bam/inc/com/centreon/broker/bam/ba_worst.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/ba_worst.hh
@@ -44,8 +44,12 @@ class ba_worst : public ba {
   void _commit_initial_events(io::stream* visitor);
 
  protected:
-  bool _apply_impact(kpi* kpi_ptr, impact_info& impact) override;
+  void _apply_impact(kpi* kpi_ptr, impact_info& impact) override;
   void _unapply_impact(kpi* kpi_ptr, impact_info& impact) override;
+  bool _apply_changes(kpi* child,
+                      const impact_values& new_hard_impact,
+                      const impact_values& new_soft_impact,
+                      bool in_downtime) override;
 
  public:
   ba_worst(uint32_t id,

--- a/broker/bam/inc/com/centreon/broker/bam/ba_worst.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/ba_worst.hh
@@ -1,20 +1,20 @@
-/*
-** Copyright 2022 Centreon
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-**
-** For more information : contact@centreon.com
-*/
+/**
+ * Copyright 2022-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #ifndef CCB_BAM_BA_WORST_HH
 #define CCB_BAM_BA_WORST_HH
@@ -46,7 +46,6 @@ class ba_worst : public ba {
  protected:
   bool _apply_impact(kpi* kpi_ptr, impact_info& impact) override;
   void _unapply_impact(kpi* kpi_ptr, impact_info& impact) override;
-  void _recompute() override;
 
  public:
   ba_worst(uint32_t id,
@@ -60,6 +59,6 @@ class ba_worst : public ba {
 };
 }  // namespace bam
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_BAM_BA_WORST_HH

--- a/broker/bam/inc/com/centreon/broker/bam/computable.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/computable.hh
@@ -1,5 +1,5 @@
-/*
- * Copyright 2014, 2023 Centreon
+/**
+ * Copyright 2014, 2023-2024 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,6 @@ class computable {
 };
 }  // namespace bam
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_BAM_COMPUTABLE_HH

--- a/broker/bam/inc/com/centreon/broker/bam/impact_values.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/impact_values.hh
@@ -1,20 +1,20 @@
-/*
-** Copyright 2014 Centreon
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-**
-** For more information : contact@centreon.com
-*/
+/**
+ * Copyright 2014, 2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #ifndef CCB_BAM_IMPACT_VALUES_HH
 #define CCB_BAM_IMPACT_VALUES_HH
@@ -60,6 +60,6 @@ class impact_values {
 };
 }  // namespace bam
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_BAM_IMPACT_VALUES_HH

--- a/broker/bam/inc/com/centreon/broker/bam/kpi_service.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/kpi_service.hh
@@ -104,10 +104,10 @@ class kpi_service : public service_listener, public kpi {
   bool ok_state() const override;
   void update_from(computable* child, io::stream* visitor) override;
   std::string object_info() const override;
-  void dump(std::ofstream& output) const;
+  void dump(std::ofstream& output) const override;
 };
 }  // namespace bam
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_BAM_KPI_SERVICE_HH

--- a/broker/bam/src/ba.cc
+++ b/broker/bam/src/ba.cc
@@ -622,54 +622,41 @@ void ba::set_level_warning(double level) {
 void ba::update_from(computable* child, io::stream* visitor) {
   auto logger = log_v2::bam();
   logger->trace("ba::update_from (BA {})", _id);
-  auto it = _impacts.find(static_cast<kpi*>(child));
-  if (it != _impacts.end()) {
-    // Get impact.
-    impact_values new_hard_impact;
-    impact_values new_soft_impact;
-    kpi* kpi_child = static_cast<kpi*>(child);
-    kpi_child->impact_hard(new_hard_impact);
-    kpi_child->impact_soft(new_soft_impact);
-    bool kpi_in_downtime(kpi_child->in_downtime());
+  // Get impact.
+  impact_values new_hard_impact;
+  impact_values new_soft_impact;
+  kpi* kpi_child = static_cast<kpi*>(child);
+  kpi_child->impact_hard(new_hard_impact);
+  kpi_child->impact_soft(new_soft_impact);
+  bool kpi_in_downtime(kpi_child->in_downtime());
 
-    // Logging.
-    SPDLOG_LOGGER_DEBUG(
-        logger,
-        "BAM: BA {}, '{}' is getting notified of child update (KPI {}, impact "
-        "{}, last state change {}, downtime {})",
-        _id, _name, kpi_child->get_id(), new_hard_impact.get_nominal(),
-        kpi_child->get_last_state_change(), kpi_in_downtime);
+  // Logging.
+  SPDLOG_LOGGER_DEBUG(
+      logger,
+      "BAM: BA {}, '{}' is getting notified of child update (KPI {}, impact "
+      "{}, last state change {}, downtime {})",
+      _id, _name, kpi_child->get_id(), new_hard_impact.get_nominal(),
+      kpi_child->get_last_state_change(), kpi_in_downtime);
 
-    timestamp last_state_change(kpi_child->get_last_state_change());
-    if (!last_state_change.is_null())
-      _last_kpi_update = std::max(_last_kpi_update, last_state_change);
+  timestamp last_state_change(kpi_child->get_last_state_change());
+  if (!last_state_change.is_null())
+    _last_kpi_update = std::max(_last_kpi_update, last_state_change);
 
-    // Discard old data.
-    _unapply_impact(it->first, it->second);
+  // Apply new data.
+  SPDLOG_LOGGER_TRACE(log_v2::bam(), "BAM: BA {} updated from KPI {}", _id,
+                      kpi_child->get_id());
+  bool changed = _apply_changes(kpi_child, new_hard_impact, new_soft_impact,
+                                kpi_in_downtime);
+  SPDLOG_LOGGER_TRACE(log_v2::bam(), "BA has changed: {}", changed);
 
-    // Apply new data.
-    SPDLOG_LOGGER_TRACE(
-        log_v2::bam(),
-        "BAM: BA {} changes: hard impact changed {}, soft impact changed {}, "
-        "downtime {} => {}",
-        _id, it->second.hard_impact != new_hard_impact,
-        it->second.soft_impact != new_soft_impact, it->second.in_downtime,
-        kpi_in_downtime);
-    it->second.hard_impact = new_hard_impact;
-    it->second.soft_impact = new_soft_impact;
-    it->second.in_downtime = kpi_in_downtime;
-    bool changed = _apply_impact(it->first, it->second);
-    SPDLOG_LOGGER_TRACE(log_v2::bam(), "BA has changed: {}", changed);
+  // Check for inherited downtimes.
+  _compute_inherited_downtime(visitor);
 
-    // Check for inherited downtimes.
-    _compute_inherited_downtime(visitor);
+  // Generate status event.
+  visit(visitor);
 
-    // Generate status event.
-    visit(visitor);
-
-    if (changed)
-      notify_parents_of_change(visitor);
-  }
+  if (changed)
+    notify_parents_of_change(visitor);
 }
 
 /**

--- a/broker/bam/src/ba_best.cc
+++ b/broker/bam/src/ba_best.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Centreon
+ * Copyright 2022-2024 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,29 +97,54 @@ state ba_best::get_state_soft() const {
  *
  *  @param[in] impact Impact information.
  */
-bool ba_best::_apply_impact(kpi* kpi_ptr __attribute__((unused)),
+void ba_best::_apply_impact(kpi* kpi_ptr [[maybe_unused]],
                             ba::impact_info& impact) {
-  const std::array<short, 5> order{0, 3, 4, 2, 1};
-
-  auto is_state_better = [&](short current_state, short new_state) -> bool {
+  auto is_state_better = [](short current_state, short new_state) -> bool {
+    const std::array<short, 5> order{0, 3, 4, 2, 1};
     assert((unsigned int)current_state < order.size());
     assert((unsigned int)new_state < order.size());
     return order[new_state] < order[current_state];
   };
 
   if (_dt_behaviour == configuration::ba::dt_ignore_kpi && impact.in_downtime)
-    return false;
+    return;
 
-  bool retval = false;
-  if (is_state_better(_computed_soft_state, impact.soft_impact.get_state())) {
+  if (is_state_better(_computed_soft_state, impact.soft_impact.get_state()))
     _computed_soft_state = impact.soft_impact.get_state();
-    retval = true;
-  }
-  if (is_state_better(_computed_hard_state, impact.hard_impact.get_state())) {
+  if (is_state_better(_computed_hard_state, impact.hard_impact.get_state()))
     _computed_hard_state = impact.hard_impact.get_state();
-    retval = true;
+}
+
+/**
+ *  Apply some impact. This method is more complete than _apply_impact().
+ *  It takes as argument a child kpi and its impact. This child is already
+ *  known, so its previous impact is replaced by the new one.
+ *  In other words, this method makes almost the same work as _unapply_impact()
+ *  and the _apply_impact() ; the difference is that it returns true if the BA
+ *  really changed.
+ *
+ *  @param[in] impact Impact information.
+ *  @return True if the BA changes, False otherwise.
+ */
+bool ba_best::_apply_changes(kpi* child,
+                             const impact_values& new_hard_impact,
+                             const impact_values& new_soft_impact,
+                             bool in_downtime) {
+  state previous_state = _computed_hard_state;
+
+  _computed_soft_state = _computed_hard_state = state_critical;
+
+  // We recompute all impacts...
+  for (auto it = _impacts.begin(), end = _impacts.end(); it != end; ++it) {
+    if (it->first == child) {
+      it->second.hard_impact = new_hard_impact;
+      it->second.soft_impact = new_soft_impact;
+      it->second.in_downtime = in_downtime;
+    }
+    _apply_impact(it->first, it->second);
   }
-  return retval;
+
+  return _computed_hard_state != previous_state;
 }
 
 /**

--- a/broker/bam/src/ba_best.cc
+++ b/broker/bam/src/ba_best.cc
@@ -1,24 +1,25 @@
 /**
-* Copyright 2022 Centreon
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* For more information : contact@centreon.com
-*/
+ * Copyright 2022 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #include "com/centreon/broker/bam/ba_best.hh"
 
 #include <fmt/format.h>
+
 #include <cassert>
 
 #include "bbdo/bam/ba_status.hh"
@@ -173,12 +174,4 @@ std::string ba_best::get_output() const {
  */
 std::string ba_best::get_perfdata() const {
   return {};
-}
-
-void ba_best::_recompute() {
-  _computed_soft_state = state_critical;
-  _computed_hard_state = state_critical;
-  for (auto it = _impacts.begin(), end = _impacts.end(); it != end; ++it)
-    _apply_impact(it->first, it->second);
-  _recompute_count = 0;
 }

--- a/broker/bam/src/ba_impact.cc
+++ b/broker/bam/src/ba_impact.cc
@@ -1,24 +1,25 @@
 /**
-* Copyright 2022 Centreon
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* For more information : contact@centreon.com
-*/
+ * Copyright 2022-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #include "com/centreon/broker/bam/ba_impact.hh"
 
 #include <fmt/format.h>
+
 #include <cassert>
 
 #include "bbdo/bam/ba_status.hh"
@@ -232,4 +233,24 @@ std::string ba_impact::get_perfdata() const {
   return fmt::format(
       "BA_Level={};{};{};0;100", static_cast<int>(_normalize(_level_hard)),
       static_cast<int>(_level_warning), static_cast<int>(_level_critical));
+}
+
+/**
+ *  @brief Recompute all impacts.
+ *
+ *  This method was created to prevent the real values to derive to
+ *  much from their true value due to the caching system.
+ */
+void ba_impact::_recompute() {
+  _acknowledgement_hard = 0.0;
+  _acknowledgement_soft = 0.0;
+  _downtime_hard = 0.0;
+  _downtime_soft = 0.0;
+  _level_hard = 100.0;
+  _level_soft = 100.0;
+  for (std::unordered_map<kpi*, impact_info>::iterator it = _impacts.begin(),
+                                                       end = _impacts.end();
+       it != end; ++it)
+    _apply_impact(it->first, it->second);
+  _recompute_count = 0;
 }

--- a/broker/bam/src/ba_ratio_number.cc
+++ b/broker/bam/src/ba_ratio_number.cc
@@ -33,6 +33,8 @@
 using namespace com::centreon::broker;
 using namespace com::centreon::broker::bam;
 
+static constexpr double eps = 0.000001;
+
 /**
  *  Constructor.
  *
@@ -88,21 +90,15 @@ state ba_ratio_number::get_state_soft() const {
  *
  *  @param[in] impact Impact information.
  */
-bool ba_ratio_number::_apply_impact(kpi* kpi_ptr __attribute__((unused)),
+void ba_ratio_number::_apply_impact(kpi* kpi_ptr [[maybe_unused]],
                                     ba::impact_info& impact) {
   if (_dt_behaviour == configuration::ba::dt_ignore_kpi && impact.in_downtime)
-    return false;
+    return;
 
-  bool retval = false;
-  if (impact.soft_impact.get_state() == state_critical) {
+  if (impact.soft_impact.get_state() == state_critical)
     _level_soft++;
-    retval = true;
-  }
-  if (impact.hard_impact.get_state() == state_critical) {
+  if (impact.hard_impact.get_state() == state_critical)
     _level_hard++;
-    retval = true;
-  }
-  return retval;
 }
 
 /**
@@ -112,7 +108,7 @@ bool ba_ratio_number::_apply_impact(kpi* kpi_ptr __attribute__((unused)),
  */
 void ba_ratio_number::_unapply_impact(kpi* kpi_ptr,
                                       ba::impact_info& impact
-                                      __attribute__((unused))) {
+                                      [[maybe_unused]]) {
   _level_soft = 0.;
   _level_hard = 0.;
 
@@ -122,6 +118,39 @@ void ba_ratio_number::_unapply_impact(kpi* kpi_ptr,
        it != end; ++it)
     if (it->first != kpi_ptr)
       _apply_impact(it->first, it->second);
+}
+
+/**
+ *  Apply some child changes. This method is more complete than _apply_impact().
+ *  It takes as argument a child kpi and its impact. This child is already
+ *  known, so its previous impact is replaced by the new one.
+ *  In other words, this method makes almost the same work as _unapply_impact()
+ *  and the _apply_impact() ; the difference is that it returns true if the BA
+ *  really changed.
+ *
+ *  @param[in] impact Impact information.
+ *  @return True if the BA changes, False otherwise.
+ */
+bool ba_ratio_number::_apply_changes(kpi* child,
+                                     const impact_values& new_hard_impact,
+                                     const impact_values& new_soft_impact,
+                                     bool in_downtime) {
+  double previous_level = _level_hard;
+  _level_soft = 0.;
+  _level_hard = 0.;
+
+  // We recompute all impact, except the one to unapply...
+  for (std::unordered_map<kpi*, impact_info>::iterator it = _impacts.begin(),
+                                                       end = _impacts.end();
+       it != end; ++it) {
+    if (it->first == child) {
+      it->second.hard_impact = new_hard_impact;
+      it->second.soft_impact = new_soft_impact;
+      it->second.in_downtime = in_downtime;
+    }
+    _apply_impact(it->first, it->second);
+  }
+  return std::abs(previous_level - _level_hard) > eps;
 }
 
 /**

--- a/broker/bam/src/ba_ratio_number.cc
+++ b/broker/bam/src/ba_ratio_number.cc
@@ -1,24 +1,25 @@
 /**
-* Copyright 2022 Centreon
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* For more information : contact@centreon.com
-*/
+ * Copyright 2022-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #include "com/centreon/broker/bam/ba_ratio_number.hh"
 
 #include <fmt/format.h>
+
 #include <cassert>
 
 #include "bbdo/bam/ba_status.hh"
@@ -121,16 +122,6 @@ void ba_ratio_number::_unapply_impact(kpi* kpi_ptr,
        it != end; ++it)
     if (it->first != kpi_ptr)
       _apply_impact(it->first, it->second);
-}
-
-void ba_ratio_number::_recompute() {
-  _level_hard = 0.0;
-  _level_soft = 0.0f;
-  for (std::unordered_map<kpi*, impact_info>::iterator it(_impacts.begin()),
-       end(_impacts.end());
-       it != end; ++it)
-    _apply_impact(it->first, it->second);
-  _recompute_count = 0;
 }
 
 /**

--- a/broker/bam/src/ba_ratio_percent.cc
+++ b/broker/bam/src/ba_ratio_percent.cc
@@ -108,18 +108,16 @@ void ba_ratio_percent::_apply_impact(kpi* kpi_ptr [[maybe_unused]],
  *
  *  @param[in] impact Impact information.
  */
-void ba_ratio_percent::_unapply_impact(kpi* kpi_ptr,
+void ba_ratio_percent::_unapply_impact(kpi* kpi_ptr [[maybe_unused]],
                                        ba::impact_info& impact
                                        [[maybe_unused]]) {
-  _level_soft = 0.0;
-  _level_hard = 0.0;
+  if (_dt_behaviour == configuration::ba::dt_ignore_kpi && impact.in_downtime)
+    return;
 
-  // We recompute all impact, except the one to unapply...
-  for (std::unordered_map<kpi*, impact_info>::iterator it = _impacts.begin(),
-                                                       end = _impacts.end();
-       it != end; ++it)
-    if (it->first != kpi_ptr)
-      _apply_impact(it->first, it->second);
+  if (impact.soft_impact.get_state() == state_critical)
+    _level_soft--;
+  if (impact.hard_impact.get_state() == state_critical)
+    _level_hard--;
 }
 
 /**
@@ -138,20 +136,12 @@ bool ba_ratio_percent::_apply_changes(kpi* child,
                                       const impact_values& new_soft_impact,
                                       bool in_downtime) {
   double previous_level = _level_hard;
-  _level_soft = 0.;
-  _level_hard = 0.;
-
-  // We recompute all impact, except the one to unapply...
-  for (std::unordered_map<kpi*, impact_info>::iterator it = _impacts.begin(),
-                                                       end = _impacts.end();
-       it != end; ++it) {
-    if (it->first == child) {
-      it->second.hard_impact = new_hard_impact;
-      it->second.soft_impact = new_soft_impact;
-      it->second.in_downtime = in_downtime;
-    }
-    _apply_impact(it->first, it->second);
-  }
+  auto& child_impact = _impacts[child];
+  _unapply_impact(child, child_impact);
+  child_impact.hard_impact = new_hard_impact;
+  child_impact.soft_impact = new_soft_impact;
+  child_impact.in_downtime = in_downtime;
+  _apply_impact(child, child_impact);
   return std::abs(previous_level - _level_hard) > eps;
 }
 

--- a/broker/bam/src/ba_ratio_percent.cc
+++ b/broker/bam/src/ba_ratio_percent.cc
@@ -33,6 +33,8 @@
 using namespace com::centreon::broker;
 using namespace com::centreon::broker::bam;
 
+static constexpr double eps = 0.000001;
+
 /**
  *  Constructor.
  *
@@ -90,21 +92,15 @@ state ba_ratio_percent::get_state_soft() const {
  *
  *  @param[in] impact Impact information.
  */
-bool ba_ratio_percent::_apply_impact(kpi* kpi_ptr [[maybe_unused]],
+void ba_ratio_percent::_apply_impact(kpi* kpi_ptr [[maybe_unused]],
                                      ba::impact_info& impact) {
   if (_dt_behaviour == configuration::ba::dt_ignore_kpi && impact.in_downtime)
-    return false;
+    return;
 
-  bool retval = false;
-  if (impact.soft_impact.get_state() == state_critical) {
+  if (impact.soft_impact.get_state() == state_critical)
     _level_soft++;
-    retval = true;
-  }
-  if (impact.hard_impact.get_state() == state_critical) {
+  if (impact.hard_impact.get_state() == state_critical)
     _level_hard++;
-    retval = true;
-  }
-  return retval;
 }
 
 /**
@@ -124,6 +120,39 @@ void ba_ratio_percent::_unapply_impact(kpi* kpi_ptr,
        it != end; ++it)
     if (it->first != kpi_ptr)
       _apply_impact(it->first, it->second);
+}
+
+/**
+ *  Apply some child changes. This method is more complete than _apply_impact().
+ *  It takes as argument a child kpi and its impact. This child is already
+ *  known, so its previous impact is replaced by the new one.
+ *  In other words, this method makes almost the same work as _unapply_impact()
+ *  and the _apply_impact() ; the difference is that it returns true if the BA
+ *  really changed.
+ *
+ *  @param[in] impact Impact information.
+ *  @return True if the BA changes, False otherwise.
+ */
+bool ba_ratio_percent::_apply_changes(kpi* child,
+                                      const impact_values& new_hard_impact,
+                                      const impact_values& new_soft_impact,
+                                      bool in_downtime) {
+  double previous_level = _level_hard;
+  _level_soft = 0.;
+  _level_hard = 0.;
+
+  // We recompute all impact, except the one to unapply...
+  for (std::unordered_map<kpi*, impact_info>::iterator it = _impacts.begin(),
+                                                       end = _impacts.end();
+       it != end; ++it) {
+    if (it->first == child) {
+      it->second.hard_impact = new_hard_impact;
+      it->second.soft_impact = new_soft_impact;
+      it->second.in_downtime = in_downtime;
+    }
+    _apply_impact(it->first, it->second);
+  }
+  return std::abs(previous_level - _level_hard) > eps;
 }
 
 /**

--- a/broker/bam/src/ba_ratio_percent.cc
+++ b/broker/bam/src/ba_ratio_percent.cc
@@ -1,24 +1,25 @@
 /**
-* Copyright 2022 Centreon
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* For more information : contact@centreon.com
-*/
+ * Copyright 2022-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #include "com/centreon/broker/bam/ba_ratio_percent.hh"
 
 #include <fmt/format.h>
+
 #include <cassert>
 
 #include "bbdo/bam/ba_status.hh"
@@ -89,7 +90,7 @@ state ba_ratio_percent::get_state_soft() const {
  *
  *  @param[in] impact Impact information.
  */
-bool ba_ratio_percent::_apply_impact(kpi* kpi_ptr __attribute__((unused)),
+bool ba_ratio_percent::_apply_impact(kpi* kpi_ptr [[maybe_unused]],
                                      ba::impact_info& impact) {
   if (_dt_behaviour == configuration::ba::dt_ignore_kpi && impact.in_downtime)
     return false;
@@ -123,16 +124,6 @@ void ba_ratio_percent::_unapply_impact(kpi* kpi_ptr,
        it != end; ++it)
     if (it->first != kpi_ptr)
       _apply_impact(it->first, it->second);
-}
-
-void ba_ratio_percent::_recompute() {
-  _level_hard = 0.0;
-  _level_soft = 0.0;
-  for (std::unordered_map<kpi*, impact_info>::iterator it(_impacts.begin()),
-       end(_impacts.end());
-       it != end; ++it)
-    _apply_impact(it->first, it->second);
-  _recompute_count = 0;
 }
 
 /**

--- a/broker/bam/src/ba_worst.cc
+++ b/broker/bam/src/ba_worst.cc
@@ -116,20 +116,24 @@ void ba_worst::_apply_impact(kpi* kpi_ptr [[maybe_unused]],
 }
 
 /**
- *  Apply some child changes. This method is more complete than _apply_impact().
- *  It takes as argument a child kpi and its impact. This child is already
- *  known, so its previous impact is replaced by the new one.
- *  In other words, this method makes almost the same work as _unapply_impact()
- *  and the _apply_impact() ; the difference is that it returns true if the BA
- *  really changed.
+ *  @brief Apply some child changes. This method is more complete than
+ * _apply_impact(). It takes as argument a child kpi and its impact. This child
+ * is already known, so its previous impact is replaced by the new one. In other
+ * words, this method makes almost the same work as _unapply_impact() and the
+ * _apply_impact() ; the difference is that it returns true if the BA really
+ * changed.
  *
- *  @param[in] impact Impact information.
- *  @return True if the BA changes, False otherwise.
+ * @param child The kpi that changed
+ * @param new_hard_impact The new hard impact for this child.
+ * @param new_soft_impact The new soft impact for this child.
+ * @param child_in_downtime The child is in downtime (or not).
+ *
+ * @return True if the BA changes, False otherwise.
  */
 bool ba_worst::_apply_changes(kpi* child,
                               const impact_values& new_hard_impact,
                               const impact_values& new_soft_impact,
-                              bool in_downtime) {
+                              bool child_in_downtime) {
   state previous_state = _computed_hard_state;
 
   _computed_soft_state = _computed_hard_state = state_ok;
@@ -140,7 +144,7 @@ bool ba_worst::_apply_changes(kpi* child,
     if (it->first == child) {
       it->second.hard_impact = new_hard_impact;
       it->second.soft_impact = new_soft_impact;
-      it->second.in_downtime = in_downtime;
+      it->second.in_downtime = child_in_downtime;
     }
     _apply_impact(it->first, it->second);
   }

--- a/broker/bam/src/ba_worst.cc
+++ b/broker/bam/src/ba_worst.cc
@@ -1,24 +1,25 @@
 /**
-* Copyright 2022 Centreon
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* For more information : contact@centreon.com
-*/
+ * Copyright 2022-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #include "com/centreon/broker/bam/ba_worst.hh"
 
 #include <fmt/format.h>
+
 #include <cassert>
 
 #include "bbdo/bam/ba_status.hh"
@@ -98,9 +99,8 @@ state ba_worst::get_state_soft() const {
  */
 bool ba_worst::_apply_impact(kpi* kpi_ptr [[maybe_unused]],
                              ba::impact_info& impact) {
-  const std::array<short, 5> order{0, 3, 4, 2, 1};
-
-  auto is_state_worse = [&](short current_state, short new_state) -> bool {
+  auto is_state_worse = [](short current_state, short new_state) -> bool {
+    const std::array<short, 5> order{0, 3, 4, 2, 1};
     assert((unsigned int)current_state < order.size());
     assert((unsigned int)new_state < order.size());
     return order[new_state] > order[current_state];
@@ -188,12 +188,4 @@ std::string ba_worst::get_output() const {
  */
 std::string ba_worst::get_perfdata() const {
   return {};
-}
-
-void ba_worst::_recompute() {
-  _computed_soft_state = state_ok;
-  _computed_hard_state = state_ok;
-  for (auto it = _impacts.begin(), end = _impacts.end(); it != end; ++it)
-    _apply_impact(it->first, it->second);
-  _recompute_count = 0;
 }

--- a/broker/bam/src/ba_worst.cc
+++ b/broker/bam/src/ba_worst.cc
@@ -97,7 +97,7 @@ state ba_worst::get_state_soft() const {
  *
  *  @param[in] impact Impact information.
  */
-bool ba_worst::_apply_impact(kpi* kpi_ptr [[maybe_unused]],
+void ba_worst::_apply_impact(kpi* kpi_ptr [[maybe_unused]],
                              ba::impact_info& impact) {
   auto is_state_worse = [](short current_state, short new_state) -> bool {
     const std::array<short, 5> order{0, 3, 4, 2, 1};
@@ -107,18 +107,45 @@ bool ba_worst::_apply_impact(kpi* kpi_ptr [[maybe_unused]],
   };
 
   if (_dt_behaviour == configuration::ba::dt_ignore_kpi && impact.in_downtime)
-    return false;
+    return;
 
-  bool retval = false;
-  if (is_state_worse(_computed_soft_state, impact.soft_impact.get_state())) {
+  if (is_state_worse(_computed_soft_state, impact.soft_impact.get_state()))
     _computed_soft_state = impact.soft_impact.get_state();
-    retval = true;
-  }
-  if (is_state_worse(_computed_hard_state, impact.hard_impact.get_state())) {
+  if (is_state_worse(_computed_hard_state, impact.hard_impact.get_state()))
     _computed_hard_state = impact.hard_impact.get_state();
-    retval = true;
+}
+
+/**
+ *  Apply some child changes. This method is more complete than _apply_impact().
+ *  It takes as argument a child kpi and its impact. This child is already
+ *  known, so its previous impact is replaced by the new one.
+ *  In other words, this method makes almost the same work as _unapply_impact()
+ *  and the _apply_impact() ; the difference is that it returns true if the BA
+ *  really changed.
+ *
+ *  @param[in] impact Impact information.
+ *  @return True if the BA changes, False otherwise.
+ */
+bool ba_worst::_apply_changes(kpi* child,
+                              const impact_values& new_hard_impact,
+                              const impact_values& new_soft_impact,
+                              bool in_downtime) {
+  state previous_state = _computed_hard_state;
+
+  _computed_soft_state = _computed_hard_state = state_ok;
+
+  // We recompute all impacts...
+  for (auto it = _impacts.begin(), end = _impacts.end(); it != end; ++it) {
+    /* The changed child is updated in _impacts */
+    if (it->first == child) {
+      it->second.hard_impact = new_hard_impact;
+      it->second.soft_impact = new_soft_impact;
+      it->second.in_downtime = in_downtime;
+    }
+    _apply_impact(it->first, it->second);
   }
-  return retval;
+
+  return _computed_hard_state != previous_state;
 }
 
 /**

--- a/broker/bam/src/computable.cc
+++ b/broker/bam/src/computable.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2023 Centreon
+ * Copyright 2014-2024 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  */
 
 #include "com/centreon/broker/bam/computable.hh"
+
 #include "com/centreon/broker/log_v2.hh"
 
 using namespace com::centreon::broker::bam;
@@ -27,6 +28,9 @@ using namespace com::centreon::broker::bam;
  *  @param[in] parent Parent node.
  */
 void computable::add_parent(std::shared_ptr<computable> const& parent) {
+  for (auto it = _parents.begin(), end = _parents.end(); it != end; ++it)
+    if (it->lock().get() == parent.get())
+      return;
   _parents.push_back(std::weak_ptr<computable>(parent));
 }
 

--- a/broker/bam/src/kpi_ba.cc
+++ b/broker/bam/src/kpi_ba.cc
@@ -146,7 +146,7 @@ void kpi_ba::visit(io::stream* visitor) {
                           last_ba_update);
       }
       // If state changed, close event and open a new one.
-      else if (_ba->get_in_downtime() != _event->in_downtime() ||
+      else if (_ba->in_downtime() != _event->in_downtime() ||
                ba_state != _event->status()) {
         _event->set_end_time(last_ba_update.get_time_t());
         visitor->write(std::make_shared<pb_kpi_event>(*_event));
@@ -241,7 +241,7 @@ void kpi_ba::_open_new_event(io::stream* visitor,
   _event->set_start_time(event_start_time.get_time_t());
   _event->set_end_time(-1);
   _event->set_impact_level(impact);
-  _event->set_in_downtime(_ba->get_in_downtime());
+  _event->set_in_downtime(_ba->in_downtime());
   _event->set_output(_ba->get_output());
   _event->set_perfdata(_ba->get_perfdata());
   _event->set_status(com::centreon::broker::State(ba_state));
@@ -264,7 +264,7 @@ bool kpi_ba::ok_state() const {
  *  @return  True if this KPI is in downtime.
  */
 bool kpi_ba::in_downtime() const {
-  return _ba->get_in_downtime();
+  return _ba->in_downtime();
 }
 
 /**
@@ -306,7 +306,7 @@ std::string kpi_ba::object_info() const {
  * @param output An output stream.
  */
 void kpi_ba::dump(std::ofstream& output) const {
-  output << fmt::format("\"{}\" -> \"{}\"", object_info(), _ba->get_id());
+  output << fmt::format("\"{}\" -> \"{}\"", object_info(), _ba->object_info());
   _ba->dump(output);
   dump_parents(output);
 }

--- a/broker/bam/src/kpi_ba.cc
+++ b/broker/bam/src/kpi_ba.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014-2015, 2021-2023 Centreon
+ * Copyright 2014-2015, 2021-2024 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/broker/bam/src/kpi_service.cc
+++ b/broker/bam/src/kpi_service.cc
@@ -719,8 +719,9 @@ void kpi_service::update_from(computable* child [[maybe_unused]],
  * @return A multiline strings with various informations.
  */
 std::string kpi_service::object_info() const {
-  return fmt::format("KPI {} with service ({}, {})\nstate: {}", get_id(),
-                     get_host_id(), get_service_id(), get_state_hard());
+  return fmt::format("KPI {} with service ({}, {})\nstate: {}\ndowntime: {}",
+                     get_id(), get_host_id(), get_service_id(),
+                     get_state_hard(), _downtimed);
 }
 
 /**

--- a/broker/bam/test/ba/kpi_ba.cc
+++ b/broker/bam/test/ba/kpi_ba.cc
@@ -290,8 +290,10 @@ TEST_F(KpiBA, KpiBaDt) {
   test_ba_child->set_downtime_behaviour(bam::configuration::ba::dt_inherit);
 
   absl::FixedArray<std::shared_ptr<bam::kpi_service>, 2> kpis{
-      std::make_shared<bam::kpi_service>(1, 2, 3, 1),
-      std::make_shared<bam::kpi_service>(2, 2, 3, 2),
+      std::make_shared<bam::kpi_service>(1, 2, 3, 1,
+                                         fmt::format("service {}", 0)),
+      std::make_shared<bam::kpi_service>(2, 2, 3, 2,
+                                         fmt::format("service {}", 1)),
   };
 
   /* Construction of kpi_services */

--- a/broker/bam/test/ba/kpi_service.cc
+++ b/broker/bam/test/ba/kpi_service.cc
@@ -537,7 +537,7 @@ TEST_F(BamBA, KpiServiceDtInheritAllCritical) {
     kpis[j]->service_update(dt, _visitor.get());
 
     short val = results.top();
-    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    ASSERT_EQ(test_ba->in_downtime(), val);
     results.pop();
   }
 }
@@ -587,7 +587,7 @@ TEST_F(BamBA, KpiServiceDtInheritAllCriticalPb) {
     kpis[j]->service_update(dt, _visitor.get());
 
     short val = results.top();
-    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    ASSERT_EQ(test_ba->in_downtime(), val);
     results.pop();
   }
 }
@@ -639,7 +639,7 @@ TEST_F(BamBA, KpiServiceDtInheritOneOK) {
     kpis[j]->service_update(dt, _visitor.get());
 
     short val = results.top();
-    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    ASSERT_EQ(test_ba->in_downtime(), val);
     results.pop();
   }
 
@@ -697,7 +697,7 @@ TEST_F(BamBA, KpiServiceDtInheritOneOKPb) {
     kpis[j]->service_update(dt, _visitor.get());
 
     short val = results.top();
-    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    ASSERT_EQ(test_ba->in_downtime(), val);
     results.pop();
   }
 
@@ -749,7 +749,7 @@ TEST_F(BamBA, KpiServiceIgnoreDt) {
     kpis[j]->service_update(dt, _visitor.get());
 
     short val = results.top();
-    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    ASSERT_EQ(test_ba->in_downtime(), val);
     results.pop();
   }
 }
@@ -800,7 +800,7 @@ TEST_F(BamBA, KpiServiceIgnoreDtPb) {
     kpis[j]->service_update(dt, _visitor.get());
 
     short val = results.top();
-    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    ASSERT_EQ(test_ba->in_downtime(), val);
     results.pop();
   }
 }
@@ -848,7 +848,7 @@ TEST_F(BamBA, KpiServiceDtIgnoreKpi) {
     kpis[j]->service_update(dt, _visitor.get());
 
     short val = results.top();
-    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    ASSERT_EQ(test_ba->in_downtime(), val);
     results.pop();
   }
 }
@@ -899,7 +899,7 @@ TEST_F(BamBA, KpiServiceDtIgnoreKpiPb) {
     kpis[j]->service_update(dt, _visitor.get());
 
     short val = results.top();
-    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    ASSERT_EQ(test_ba->in_downtime(), val);
     results.pop();
   }
 }
@@ -1401,7 +1401,7 @@ TEST_F(BamBA, KpiServiceDt) {
     kpis[j]->service_update(dt, _visitor.get());
 
     short val = *it;
-    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    ASSERT_EQ(test_ba->in_downtime(), val);
     ++it;
   }
 
@@ -1515,7 +1515,7 @@ TEST_F(BamBA, KpiServiceDt) {
       ++it;
     } while (it->typ != test_visitor::test_event::kpi);
   }
-  ASSERT_FALSE(test_ba->get_in_downtime());
+  ASSERT_FALSE(test_ba->in_downtime());
 }
 
 TEST_F(BamBA, KpiServiceDtPb) {
@@ -1565,7 +1565,7 @@ TEST_F(BamBA, KpiServiceDtPb) {
     kpis[j]->service_update(dt, _visitor.get());
 
     short val = *it;
-    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    ASSERT_EQ(test_ba->in_downtime(), val);
     ++it;
   }
 
@@ -1679,7 +1679,7 @@ TEST_F(BamBA, KpiServiceDtPb) {
       ++it;
     } while (it->typ != test_visitor::test_event::kpi);
   }
-  ASSERT_FALSE(test_ba->get_in_downtime());
+  ASSERT_FALSE(test_ba->in_downtime());
 }
 
 TEST_F(BamBA, KpiServiceDtInherited_set) {
@@ -1726,7 +1726,7 @@ TEST_F(BamBA, KpiServiceDtInherited_set) {
     kpis[j]->service_update(dt, _visitor.get());
 
     short val = *it;
-    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    ASSERT_EQ(test_ba->in_downtime(), val);
     ++it;
   }
 
@@ -1738,7 +1738,7 @@ TEST_F(BamBA, KpiServiceDtInherited_set) {
     dt->was_started = true;
     kpis[0]->service_update(dt, _visitor.get());
   }
-  ASSERT_TRUE(test_ba->get_in_downtime());
+  ASSERT_TRUE(test_ba->in_downtime());
 }
 
 TEST_F(BamBA, KpiServiceDtInherited_setPb) {
@@ -1788,7 +1788,7 @@ TEST_F(BamBA, KpiServiceDtInherited_setPb) {
     kpis[j]->service_update(dt, _visitor.get());
 
     short val = *it;
-    ASSERT_EQ(test_ba->get_in_downtime(), val);
+    ASSERT_EQ(test_ba->in_downtime(), val);
     ++it;
   }
 
@@ -1800,7 +1800,7 @@ TEST_F(BamBA, KpiServiceDtInherited_setPb) {
     dt_obj.set_started(true);
     kpis[0]->service_update(dt, _visitor.get());
   }
-  ASSERT_TRUE(test_ba->get_in_downtime());
+  ASSERT_TRUE(test_ba->in_downtime());
 }
 
 TEST_F(BamBA, KpiServiceDtInherited_unset) {
@@ -1846,7 +1846,7 @@ TEST_F(BamBA, KpiServiceDtInherited_unset) {
     kpis[j]->service_update(dt, _visitor.get());
   }
 
-  ASSERT_FALSE(test_ba->get_in_downtime());
+  ASSERT_FALSE(test_ba->in_downtime());
 }
 
 TEST_F(BamBA, KpiServiceDtInherited_unsetPb) {
@@ -1893,7 +1893,7 @@ TEST_F(BamBA, KpiServiceDtInherited_unsetPb) {
     kpis[j]->service_update(dt, _visitor.get());
   }
 
-  ASSERT_FALSE(test_ba->get_in_downtime());
+  ASSERT_FALSE(test_ba->in_downtime());
 }
 
 TEST_F(BamBA, KpiServiceAcknowledgement) {

--- a/broker/doc/broker-doc.md
+++ b/broker/doc/broker-doc.md
@@ -13,8 +13,9 @@ Before describing these BA, let's try to explain how they lives and how they are
 
 All the BA classes derived from an abstract `ba` class.
 They have to implement the following methods:
-* `bool _apply_impact(kpi*, impact_info&)`: knowing that the `kpi*` given in parameter is a child of the BA, this method applies on the BA the impact of the KPI, knowing its change stored in the `impact_info` object. If this changes the BA, the method must return `true` to be sure impacts are propagated to parents, otherwise it returns `false`.
+* `void _apply_impact(kpi*, impact_info&)`: knowing that the `kpi*` given in parameter is a child of the BA, this method applies on the BA the impact of the KPI, knowing its change stored in the `impact_info` object.
 * `void _unapply_impact(kpi*, impact_info&)`: the method is the reverse of `_apply_impact()`.
+* `bool _apply_changes(kpi*, const impact_values& new_hard_impact, const impact_values& new_soft_impact, bool in_downtime)`: Each time a kpi changes, it calls this method for all its parents. This function unapplies the previous impact of the kpi, stores in the parent's `_impacts` the new changes and also applies this new impact to it. It returns a boolean that is `true` only when the parent has changes to propagate.
 * `std::string get_output() const`: builds the output string of the Engine virtual service relied to this BA.
 * `std::string get_perfdata() const`: builds the performance data for the virtual service relied to this BA.
 * `state get_state_hard() const`: returns the current state of the BA (an enum corresponding to service states, one value among `state_ok`, `state_warning`, `state_critical` or `state_unknown`).
@@ -53,7 +54,7 @@ The amount of a BA points is forced in the range [0;100].
 Technically, an `impact_ba` class is derived from `ba`. The current amount of
 points is in the `_level_hard` attribute.
 
-The BA is considered in WARNING if `_level_critical < _level_hard =< _level_warning`.
+The BA is considered in WARNING if `_level_critical < _level_hard <= _level_warning`.
 
 The BA is considered OK if `_level_warning < _level_hard`.
 
@@ -73,10 +74,10 @@ Technically, its class `ba_worst` is derived from `ba`.
 
 ### Ratio number BA
 
-This BA computes the number of KPIs in state OK. It is possible to configure
+This BA computes the number of KPIs in CRITICAL state. It is possible to configure
 a warning level and a critical level.
 
-If the number of KPIs in state CRITICAL is less than the warning level, the BA is OK.
+If the number of KPIs in CRITICAL state is less than the warning level, the BA is OK.
 If this number is greater than WARNING but not than CRITICAL, the BA is WARNING.
 Otherwise, the BA is CRITICAL.
 

--- a/cmake.sh
+++ b/cmake.sh
@@ -274,8 +274,8 @@ elif [ -r /etc/issue ] ; then
   fi
 fi
 
-if ! pip3 install conan==1.61.0 --upgrade --break-system-packages ; then
-  pip3 install conan==1.61.0 --upgrade
+if ! pip3 install conan==1.62.0 --upgrade --break-system-packages ; then
+  pip3 install conan==1.62.0 --upgrade
 fi
 
 if which conan ; then


### PR DESCRIPTION
## Description

If a worst BA has one child that is also a worst BA, when the child changes to a state, the parent should also change to that state. It wasn't always the case.
Several reasons:
* Since the previous change in bam it is the child that checks if it changes and should notify its parent. But there was still a piece of code in the parent that also made the check. So we could have some changes not detected.
* The change of a kpi in  a BA was done by two function, unapply_impact() and apply_impact(), but only apply_impact() returned a boolean to tell if there was a change. Now we have a new method apply_changes() that returns a boolean and makes directly all the needed changes.

REFS: MON-33636
