### PR TITLE
enh(ci): use upload instead of copy for promote (#1039)

### DIFF
--- a/.github/actions/promote-to-stable/action.yml
+++ b/.github/actions/promote-to-stable/action.yml
@@ -55,9 +55,14 @@ runs:
           echo "[DEBUG] - Target path: $TARGET_PATH"
           echo "[DEBUG] - Promoting $ARCH testing artifacts to stable."
           for ARTIFACT in ${SRC_PATHS[@]}; do
-            echo "[DEBUG] - Promoting $ARTIFACT to stable on artifactory."
-            jf rt cp $ARTIFACT $TARGET_PATH --flat=true
+            echo "[DEBUG] - Downloading $ARTIFACT from TESTING."
+            jf rt download $ARTIFACT --flat
           done
+          for ARTIFACT_DL in $(dir|grep -E "*.rpm"); do
+            echo "[DEBUG] - Promoting (upload) $ARTIFACT_DL to stable $TARGET_PATH."
+            jf rt upload "$ARTIFACT_DL" "$TARGET_PATH" --flat
+          done
+          rm -f *.rpm
         done
       shell: bash
 
@@ -86,7 +91,15 @@ runs:
 
         echo "[DEBUG] - Promoting DEB testing artifacts to stable."
         for ARTIFACT in ${SRC_PATHS[@]}; do
-          echo "[DEBUG] - Promoting $ARTIFACT to stable."
-          jf rt cp $ARTIFACT $TARGET_PATH --flat=true
+          echo "[DEBUG] - Downloading $ARTIFACT from TESTING."
+          jf rt download $ARTIFACT --flat
         done
+
+        for ARTIFACT_DL in $(dir|grep -E "*.deb"); do
+          ARCH=$(echo $ARTIFACT_DL | cut -d '_' -f3 | cut -d '.' -f1)
+          echo "[DEBUG] - Promoting (upload) $ARTIFACT_DL to stable $TARGET_PATH."
+          jf rt upload "$ARTIFACT_DL" "$TARGET_PATH" --deb "${{ inputs.distrib }}/main/$ARCH"
+        done
+
+        rm -f *.deb
       shell: bash


### PR DESCRIPTION
## Description

Use upload instead of copy for promote, as it is more reliable even if generating a bit more traffic.
This should mitigate the metadata issue encountered during promotion of packages (rpm or deb)

Fixes #MON-21835 #MON-32880

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

