### PR TITLE
fix(broker/bam): unit test regression

### DIFF
--- a/broker/bam/test/ba/kpi_ba.cc
+++ b/broker/bam/test/ba/kpi_ba.cc
@@ -282,7 +282,10 @@ TEST_F(KpiBA, KpiBaDt) {
   test_ba_child->set_name("test-ba-child");
   test_ba_child->set_downtime_behaviour(bam::configuration::ba::dt_inherit);
 
-  std::vector<std::shared_ptr<bam::kpi_service>> kpis;
+  absl::FixedArray<std::shared_ptr<bam::kpi_service>, 2> kpis{
+      std::make_shared<bam::kpi_service>(1, 2, 3, 1),
+      std::make_shared<bam::kpi_service>(2, 2, 3, 2),
+  };
 
   /* Construction of kpi_services */
   for (int i = 0; i < 2; i++) {

--- a/broker/bam/test/ba/kpi_ba.cc
+++ b/broker/bam/test/ba/kpi_ba.cc
@@ -288,8 +288,7 @@ TEST_F(KpiBA, KpiBaDt) {
   };
 
   /* Construction of kpi_services */
-  for (int i = 0; i < 2; i++) {
-    auto s = std::make_shared<bam::kpi_service>(i + 1, 2, 3, 1 + i);
+  for (auto& s : kpis) {
     s->set_downtimed(false);
     s->set_impact_critical(100);
     s->set_impact_unknown(0);
@@ -299,7 +298,6 @@ TEST_F(KpiBA, KpiBaDt) {
 
     // test_ba_child->add_impact(s);
     // s->add_parent(test_ba_child);
-    kpis.push_back(s);
   }
 
   /* Construction of kpi_ba */


### PR DESCRIPTION
## Description

BA not always updated when a ba daughter is updated.

REFS: MON-34131
