### PR TITLE
fix(broker/lua): functions in error could keep data on the stack

### DIFF
--- a/.github/workflows/package-collect.yml
+++ b/.github/workflows/package-collect.yml
@@ -138,7 +138,7 @@ jobs:
         run: rm -rf *-debuginfo*.${{ matrix.package_extension }}
 
       # set condition to true if artifacts are needed
-      - if: ${{ false }}
+      - if: ${{ true }}
         name: Upload package artifacts
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:

--- a/.github/workflows/package-collect.yml
+++ b/.github/workflows/package-collect.yml
@@ -138,7 +138,7 @@ jobs:
         run: rm -rf *-debuginfo*.${{ matrix.package_extension }}
 
       # set condition to true if artifacts are needed
-      - if: ${{ true }}
+      - if: ${{ false }}
         name: Upload package artifacts
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:

--- a/broker/lua/inc/com/centreon/broker/lua/luabinding.hh
+++ b/broker/lua/inc/com/centreon/broker/lua/luabinding.hh
@@ -1,20 +1,20 @@
-/*
-** Copyright 2018 Centreon
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-**
-** For more information : contact@centreon.com
-*/
+/**
+ * Copyright 2018-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #ifndef CCB_LUA_LUABINDING_HH
 #define CCB_LUA_LUABINDING_HH
@@ -112,7 +112,7 @@ class luabinding {
              macro_cache& cache);
   luabinding(luabinding const&) = delete;
   luabinding& operator=(luabinding const&) = delete;
-  ~luabinding() noexcept = default;
+  ~luabinding() noexcept;
   bool has_filter() const noexcept;
   int32_t write(std::shared_ptr<io::data> const& data) noexcept;
   bool has_flush() const noexcept;
@@ -125,6 +125,6 @@ void push_event_as_table(lua_State* L, io::data const& d);
 
 }  // namespace lua
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_LUA_LUA_HH


### PR DESCRIPTION
## Description

data on the lua Stack could be kept if the write() function failed. This lead to a memory leak.

REFS: MON-33334

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)
