### PR TITLE
fix(ci): update get-version to handle specific cloud packages builds

### DIFF
--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -51,7 +51,6 @@ jobs:
           else
             echo "GH CLI is already installed."
           fi
-          gh auth login --with-token ${{ secrets.GITHUB_TOKEN }}
         shell: bash
 
       - id: get_version
@@ -113,3 +112,4 @@ jobs:
           echo "env=$VERSION-$ENV" >> $GITHUB_OUTPUT
           echo "GH_ENV: $VERSION-$ENV"
         shell: bash
+        GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -80,7 +80,8 @@ jobs:
               echo "GITHUB_RELEASE_BRANCH_BASE_REF_NAME is: $GITHUB_RELEASE_BRANCH_BASE_REF_NAME"
               GITHUB_RELEASE_BRANCH_PR_STATE="$(gh pr view $BRANCHNAME -q .state --json headRefName,baseRefName,state)"
               echo "GITHUB_RELEASE_BRANCH_PR_STATE is: $GITHUB_RELEASE_BRANCH_PR_STATE"
-              if [[ "$GITHUB_RELEASE_BRANCH_BASE_REF_NAME" == "master" ]] && [[ "$GITHUB_RELEASE_BRANCH_PR_STATE" == "OPEN" ]]; then                # This case is specific to cloud release
+              if [[ "$GITHUB_RELEASE_BRANCH_BASE_REF_NAME" == "master" ]] && [[ "$GITHUB_RELEASE_BRANCH_PR_STATE" == "OPEN" ]]; then
+                # This case is specific to cloud release
                 echo "release=`date +%s`.`echo ${{ github.sha }} | cut -c -7`" >> $GITHUB_OUTPUT
               else
                 echo "release=1" >> $GITHUB_OUTPUT

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -112,4 +112,5 @@ jobs:
           echo "env=$VERSION-$ENV" >> $GITHUB_OUTPUT
           echo "GH_ENV: $VERSION-$ENV"
         shell: bash
-        GH_TOKEN: ${{ github.token }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -38,6 +38,20 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
+      - name: install gh cli on self-hosted runner
+        run: |
+          if [[ $(gh) -ne 0 ]]; then
+            type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+            sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+            sudo apt update \
+            sudo apt install gh -y
+          else
+            echo "GH CLI is already installed."
+          fi
+        shell: bash
+
       - id: get_version
         run: |
           IMG_VERSION=$( cat `ls .github/docker/Dockerfile.centreon-collect-* | grep -v test` conanfile.txt | md5sum | awk '{print substr($1, 0, 8)}')
@@ -60,8 +74,10 @@ jobs:
               echo "release=1" >> $GITHUB_OUTPUT
               ;;
             release* | hotfix*)
-              if [[ "$GITHUB_BASE_REF" == "master" ]]; then
-                # This case is specific to cloud release
+              # Handle workflow_dispatch run triggers
+              GITHUB_RELEASE_BRANCH_BASE_REF_NAME="$(gh pr view -q .baseRefName --json headRefName,baseRefName,state)"
+              GITHUB_RELEASE_BRANCH_PR_STATE="$(gh pr view -q .state --json headRefName,baseRefName,state)"
+              if [[ "$GITHUB_RELEASE_BRANCH_BASE_REF_NAME" == "master" ]] && [[ "$GITHUB_RELEASE_BRANCH_PR_STATE" == "OPEN" ]]; then                # This case is specific to cloud release
                 echo "release=`date +%s`.`echo ${{ github.sha }} | cut -c -7`" >> $GITHUB_OUTPUT
               else
                 echo "release=1" >> $GITHUB_OUTPUT

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -40,12 +40,13 @@ jobs:
 
       - name: install gh cli on self-hosted runner
         run: |
-          if [[ $(gh) -ne 0 ]]; then
+          if ! command -v gh &> /dev/null; then
+            echo "Installing GH CLI."
             type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-            sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-            sudo apt update \
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt update
             sudo apt install gh -y
           else
             echo "GH CLI is already installed."
@@ -76,8 +77,10 @@ jobs:
               ;;
             release* | hotfix*)
               # Handle workflow_dispatch run triggers
-              GITHUB_RELEASE_BRANCH_BASE_REF_NAME="$(gh pr view -q .baseRefName --json headRefName,baseRefName,state)"
-              GITHUB_RELEASE_BRANCH_PR_STATE="$(gh pr view -q .state --json headRefName,baseRefName,state)"
+              GITHUB_RELEASE_BRANCH_BASE_REF_NAME="$(gh pr view $BRANCHNAME -q .baseRefName --json headRefName,baseRefName,state)"
+              echo "GITHUB_RELEASE_BRANCH_BASE_REF_NAME is: $GITHUB_RELEASE_BRANCH_BASE_REF_NAME"
+              GITHUB_RELEASE_BRANCH_PR_STATE="$(gh pr view $BRANCHNAME -q .state --json headRefName,baseRefName,state)"
+              echo "GITHUB_RELEASE_BRANCH_PR_STATE is: $GITHUB_RELEASE_BRANCH_PR_STATE"
               if [[ "$GITHUB_RELEASE_BRANCH_BASE_REF_NAME" == "master" ]] && [[ "$GITHUB_RELEASE_BRANCH_PR_STATE" == "OPEN" ]]; then                # This case is specific to cloud release
                 echo "release=`date +%s`.`echo ${{ github.sha }} | cut -c -7`" >> $GITHUB_OUTPUT
               else

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -50,6 +50,7 @@ jobs:
           else
             echo "GH CLI is already installed."
           fi
+          gh auth login --with-token ${{ secrets.GITHUB_TOKEN }}
         shell: bash
 
       - id: get_version


### PR DESCRIPTION
## Description

- add a check using “gh pr view” to check if
- release branch as a PR associated
- the PR associated is OPEN
- the BASE_REF is “master
- add gh cli to get-version

Fixes #MON-34379

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)