### PR TITLE
Mon 32736 attempt with open 1.1.1w

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -8,7 +8,7 @@ libcurl/8.2.1
 libssh2/1.11.0
 mariadb-connector-c/3.3.3
 nlohmann_json/3.11.2
-openssl/3.1.2
+openssl/1.1.1t
 opentelemetry-cpp/1.9.1
 rapidyaml/0.5.0
 protobuf/3.21.9


### PR DESCRIPTION
## Description

OpenSSL is forced to v1.1.1t so that we don't have any crash with libcurl.
This patch is just a quick fix. A better one should arrive soon.

REFS: MON-32736

