### PR TITLE
MON-33334 fix stats muxer memory-leak

### DIFF
--- a/.github/workflows/package-collect.yml
+++ b/.github/workflows/package-collect.yml
@@ -182,7 +182,7 @@ jobs:
         run: rm -rf *-debuginfo*.${{ matrix.package_extension }}
 
       # set condition to true if artifacts are needed
-      - if: ${{ false }}
+      - if: ${{ true }}
         name: Upload package artifacts
         uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6 # v4.2.0
         with:

--- a/.github/workflows/package-collect.yml
+++ b/.github/workflows/package-collect.yml
@@ -182,7 +182,7 @@ jobs:
         run: rm -rf *-debuginfo*.${{ matrix.package_extension }}
 
       # set condition to true if artifacts are needed
-      - if: ${{ true }}
+      - if: ${{ false }}
         name: Upload package artifacts
         uses: actions/upload-artifact@694cdabd8bdb0f10b2cea11669e1bf5453eed0a6 # v4.2.0
         with:

--- a/broker/core/multiplexing/src/muxer.cc
+++ b/broker/core/multiplexing/src/muxer.cc
@@ -1,20 +1,20 @@
 /**
-* Copyright 2009-2013,2015-2017,2019-2021 Centreon
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* For more information : contact@centreon.com
-*/
+ * Copyright 2009-2013,2015-2017,2019-2021 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #include "com/centreon/broker/multiplexing/muxer.hh"
 
@@ -195,15 +195,19 @@ std::shared_ptr<muxer> muxer::create(std::string name,
  *  Destructor.
  */
 muxer::~muxer() noexcept {
-  stats::center::instance().unregister_muxer(_name);
   unsubscribe();
-  std::lock_guard<std::mutex> lock(_mutex);
-  SPDLOG_LOGGER_INFO(log_v2::core(),
-                     "Destroying muxer {}: number of events in the queue: {}",
-                     _name, _events_size);
-  _clean();
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    SPDLOG_LOGGER_INFO(log_v2::core(),
+                       "Destroying muxer {}: number of events in the queue: {}",
+                       _name, _events_size);
+    _clean();
+  }
   DEBUG(
       fmt::format("DESTRUCTOR muxer {:p} {}", static_cast<void*>(this), _name));
+  // caution, unregister_muxer must be the last center method called at muxer
+  // destruction to avoid re create a muxer stat entry
+  stats::center::instance().unregister_muxer(_name);
 }
 
 /**


### PR DESCRIPTION
## Description

**Fixes** # (issue)
center::unregister_muxer is called before center::update_muxer at muxer destruction


## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

