### PR TITLE
Mon 34596 wrong rights on rrd files after a rebuild backport22.10

### DIFF
--- a/tests/broker-engine/rrd.robot
+++ b/tests/broker-engine/rrd.robot
@@ -358,7 +358,10 @@ BRRDRMU1
         ${result}    Compare RRD Average Value    ${m}    ${value}
         Should Be True
         ...    ${result}
-        ...    msg=Data before RRD rebuild contain alternatively the metric ID and 0. The expected average is metric_id / 2.
+        ...    Data before RRD rebuild contain alternatively the metric ID and 0. The expected average is metric_id / 2.
+        # 48 = 60(octal)
+        ${result}    Has File Permissions    ${VarRoot}/lib/centreon/metrics/${m}.rrd    48
+        Should Be True    ${result}    ${VarRoot}/lib/centreon/metrics/${m}.rrd has not RW group permission
     END
 
 Rrd_1

--- a/tests/resources/Common.py
+++ b/tests/resources/Common.py
@@ -1137,3 +1137,17 @@ def wait_until_file_modified(path: str, date: str, timeout: int = TIMEOUT):
 
     logger.console(f"{path} not modified since {date}")
     return False
+
+def has_file_permissions(path: str, permission: int):
+    """! test if file has permission passed in parameter
+    it does a AND with permission parameter
+    @param path path of the file
+    @permission mask to test file permission
+    @return True if the file has the requested permissions
+    """
+    stat_res= os.stat(path)
+    if stat_res is None:
+        logger.console(f"fail to get permission of {path}")
+        return False
+    masked = stat_res.st_mode & permission
+    return masked == permission


### PR DESCRIPTION
MON-34596
## Description

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)
rrd files don't have group rw rights ater rebuils

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [X] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

