### PR TITLE
MON-34687 retention.dat is not deleted by collect install

### DIFF
--- a/packaging/centreon-collect.yaml
+++ b/packaging/centreon-collect.yaml
@@ -30,12 +30,8 @@ contents:
       owner: centreon-engine
       group: centreon-engine
 
-  - src: "./files/empty_file"
-    dst: "/var/log/centreon-engine/retention.dat"
-    file_info:
-      mode: 0755
-      owner: centreon-engine
-      group: centreon-engine
+  - dst: "/var/log/centreon-engine/retention.dat"
+    type: ghost
 
   - src: "./files/empty_file"
     dst: "/var/log/centreon-engine/status.dat"


### PR DESCRIPTION
REFS:MON-34687
## Description

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

retention.dat is cleared after collect install

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

