### PR TITLE
retention.dat is now a ghost in centreon-collect.spec

### DIFF
--- a/packaging/rpm/centreon-collect.spec
+++ b/packaging/rpm/centreon-collect.spec
@@ -491,9 +491,10 @@ fi
 %{_exec_prefix}/lib/systemd/system/centengine.service
 %{_localstatedir}/log/centreon-engine/centengine.debug
 %{_localstatedir}/log/centreon-engine/centengine.log
-%{_localstatedir}/log/centreon-engine/retention.dat
 %{_localstatedir}/log/centreon-engine/status.dat
 
+%ghost
+%{_localstatedir}/log/centreon-engine/retention.dat
 
 %changelog
 * Fri Dec 3 2021 David Boucher <dboucher@centreon.com> 22.04.0-1


### PR DESCRIPTION
## Description

**Fixes** # (issue)
retention0dat is cleared on upgrade

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [X] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

