### PR TITLE
enh(ci): exclude non required paths from create jira version workflows

### DIFF
--- a/.github/workflows/release-collect.yml
+++ b/.github/workflows/release-collect.yml
@@ -10,6 +10,8 @@ on:
       - "[2-9][0-9].[0-9][0-9].x"
     paths:
       - "centreon-collect/**"
+      - "!centreon-collect/ci/**"
+      - "!centreon-collect/tests/**"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Description

* exclude paths to prevent any undesired trigger of web create jira version workflow
* remove old unused create jira version workflows for widgets

Fixes #MON-34514

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)
