### PR TITLE
fix(ci): add distrib name in libzmq deb package - 23.10

### DIFF
--- a/.github/workflows/libzmq.yml
+++ b/.github/workflows/libzmq.yml
@@ -52,6 +52,7 @@ jobs:
           dnf install -y wget rpmdevtools rpmlint epel-release
           if [ "${{ matrix.distrib }}" = "el8" ]; then
             dnf config-manager --set-enabled powertools
+            rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux
           else
             dnf config-manager --set-enabled crb
           fi

--- a/.github/workflows/libzmq.yml
+++ b/.github/workflows/libzmq.yml
@@ -29,10 +29,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: packaging-nfpm-alma8
+          - image: packaging-alma8
             distrib: el8
             arch: amd64
-          - image: packaging-nfpm-alma9
+          - image: packaging-alma9
             distrib: el9
             arch: amd64
 
@@ -56,7 +56,7 @@ jobs:
             dnf config-manager --set-enabled crb
           fi
           dnf install -y asciidoc autoconf automake gcc gcc-c++ glib2-devel libbsd-devel libtool make rpm-build xmlto
-          
+
           cd /github/home
           wget -O - https://github.com/zeromq/libzmq/archive/refs/tags/v4.3.5.tar.gz | tar zxvf -
           mkdir -p /github/home/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
@@ -64,7 +64,7 @@ jobs:
           wget https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz -O  /github/home/rpmbuild/SOURCES/zeromq-4.3.5.tar.gz
           rpmbuild -bb /github/home/rpmbuild/SPECS/zeromq.spec
           cd -
-          
+
           mv /github/home/rpmbuild/RPMS/x86_64/*.rpm ./
           rm -f zeromq-debugsource-*.rpm libzmq5-debuginfo-*.rpm
         shell: bash
@@ -82,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: packaging-nfpm-bullseye
+          - image: packaging-bullseye
             distrib: bullseye
             runner: ubuntu-22.04
             arch: amd64
@@ -107,20 +107,20 @@ jobs:
           apt-get update
           apt-get install -y debhelper dh-autoreconf dpkg-dev libkrb5-dev libnorm-dev libpgm-dev libsodium-dev libunwind8-dev libnss3-dev libgnutls28-dev libbsd-dev pkg-config asciidoc wget xmlto
           wget -O - https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz | tar zxvf -
-          
+
           cd zeromq-4.3.5
           ./configure
           make
           make install
           cd ..
-          
+
           wget -O - https://github.com/zeromq/libzmq/archive/refs/tags/v4.3.5.tar.gz|tar zxvf -
           cd libzmq-4.3.5
           apt-get install -y debhelper dh-autoreconf libkrb5-dev libnorm-dev libpgm-dev libsodium-dev libunwind8-dev libnss3-dev libgnutls28-dev libbsd-dev pkg-config asciidoc xmlto
           ln -s packaging/debian
           dpkg-buildpackage -us -uc -nc
           cd ..
-          
+
           rm -f libzmq5-dbg_*.deb
         shell: bash
 

--- a/.github/workflows/libzmq.yml
+++ b/.github/workflows/libzmq.yml
@@ -115,10 +115,11 @@ jobs:
           make install
           cd ..
 
-          wget -O - https://github.com/zeromq/libzmq/archive/refs/tags/v4.3.5.tar.gz|tar zxvf -
+          wget -O - https://github.com/zeromq/libzmq/archive/refs/tags/v4.3.5.tar.gz | tar zxvf -
           cd libzmq-4.3.5
-          apt-get install -y debhelper dh-autoreconf libkrb5-dev libnorm-dev libpgm-dev libsodium-dev libunwind8-dev libnss3-dev libgnutls28-dev libbsd-dev pkg-config asciidoc xmlto
           ln -s packaging/debian
+          sed -Ei 's/([0-9]+.[0-9]+.[0-9]+-[0-9]+.[0-9]+)/\1~${{ matrix.distrib }}/' debian/changelog
+          sed -Ei 's/UNRELEASED/${{ matrix.distrib }}/' debian/changelog
           dpkg-buildpackage -us -uc -nc
           cd ..
 

--- a/.github/workflows/libzmq.yml
+++ b/.github/workflows/libzmq.yml
@@ -29,10 +29,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: packaging-alma8
+          - image: packaging-nfpm-alma8
             distrib: el8
             arch: amd64
-          - image: packaging-alma9
+          - image: packaging-nfpm-alma9
             distrib: el9
             arch: amd64
 
@@ -52,19 +52,21 @@ jobs:
           dnf install -y wget rpmdevtools rpmlint epel-release
           if [ "${{ matrix.distrib }}" = "el8" ]; then
             dnf config-manager --set-enabled powertools
-            rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux
           else
             dnf config-manager --set-enabled crb
           fi
-          dnf install -y asciidoc autoconf automake gcc gcc-c++ glib2-devel libbsd-devel libtool make xmlto
+          dnf install -y asciidoc autoconf automake gcc gcc-c++ glib2-devel libbsd-devel libtool make rpm-build xmlto
+          
           cd /github/home
-          wget -O - https://github.com/zeromq/libzmq/archive/refs/tags/v4.3.5.tar.gz|tar zxvf -
+          wget -O - https://github.com/zeromq/libzmq/archive/refs/tags/v4.3.5.tar.gz | tar zxvf -
           mkdir -p /github/home/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
           cp libzmq-4.3.5/packaging/redhat/zeromq.spec /github/home/rpmbuild/SPECS/
           wget https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz -O  /github/home/rpmbuild/SOURCES/zeromq-4.3.5.tar.gz
           rpmbuild -bb /github/home/rpmbuild/SPECS/zeromq.spec
           cd -
+          
           mv /github/home/rpmbuild/RPMS/x86_64/*.rpm ./
+          rm -f zeromq-debugsource-*.rpm libzmq5-debuginfo-*.rpm
         shell: bash
 
       - name: cache rpm
@@ -80,7 +82,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: packaging-bullseye
+          - image: packaging-nfpm-bullseye
             distrib: bullseye
             runner: ubuntu-22.04
             arch: amd64
@@ -103,20 +105,23 @@ jobs:
       - name: package deb
         run: |
           apt-get update
-          apt-get install -y dpkg-dev wget
-          apt-get install -y debhelper dh-autoreconf libkrb5-dev libnorm-dev libpgm-dev libsodium-dev libunwind8-dev libnss3-dev libgnutls28-dev libbsd-dev pkg-config asciidoc xmlto
-          wget -O - https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz|tar zxvf -
+          apt-get install -y debhelper dh-autoreconf dpkg-dev libkrb5-dev libnorm-dev libpgm-dev libsodium-dev libunwind8-dev libnss3-dev libgnutls28-dev libbsd-dev pkg-config asciidoc wget xmlto
+          wget -O - https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz | tar zxvf -
+          
           cd zeromq-4.3.5
           ./configure
           make
           make install
           cd ..
+          
           wget -O - https://github.com/zeromq/libzmq/archive/refs/tags/v4.3.5.tar.gz|tar zxvf -
           cd libzmq-4.3.5
           apt-get install -y debhelper dh-autoreconf libkrb5-dev libnorm-dev libpgm-dev libsodium-dev libunwind8-dev libnss3-dev libgnutls28-dev libbsd-dev pkg-config asciidoc xmlto
           ln -s packaging/debian
           dpkg-buildpackage -us -uc -nc
           cd ..
+          
+          rm -f libzmq5-dbg_*.deb
         shell: bash
 
       - name: cache deb
@@ -167,7 +172,7 @@ jobs:
           - distrib: bullseye
             arch: arm64
 
-    name: deliver ${{ matrix.distrib }}
+    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }}
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
## Description

fix(ci): add distrib name in libzmq deb package

Backport #1133 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)