### PR TITLE
fix(ci): add distrib name in libzmq deb package - 23.04

### DIFF
--- a/.github/workflows/libzmq.yml
+++ b/.github/workflows/libzmq.yml
@@ -56,15 +56,18 @@ jobs:
           else
             dnf config-manager --set-enabled crb
           fi
-          dnf install -y asciidoc autoconf automake gcc gcc-c++ glib2-devel libbsd-devel libtool make xmlto
+          dnf install -y asciidoc autoconf automake gcc gcc-c++ glib2-devel libbsd-devel libtool make rpm-build xmlto
+
           cd /github/home
-          wget -O - https://github.com/zeromq/libzmq/archive/refs/tags/v4.3.5.tar.gz|tar zxvf -
+          wget -O - https://github.com/zeromq/libzmq/archive/refs/tags/v4.3.5.tar.gz | tar zxvf -
           mkdir -p /github/home/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
           cp libzmq-4.3.5/packaging/redhat/zeromq.spec /github/home/rpmbuild/SPECS/
           wget https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz -O  /github/home/rpmbuild/SOURCES/zeromq-4.3.5.tar.gz
           rpmbuild -bb /github/home/rpmbuild/SPECS/zeromq.spec
           cd -
+
           mv /github/home/rpmbuild/RPMS/x86_64/*.rpm ./
+          rm -f zeromq-debugsource-*.rpm libzmq5-debuginfo-*.rpm
         shell: bash
 
       - name: cache rpm
@@ -99,20 +102,23 @@ jobs:
       - name: package deb
         run: |
           apt-get update
-          apt-get install -y dpkg-dev wget
-          apt-get install -y debhelper dh-autoreconf libkrb5-dev libnorm-dev libpgm-dev libsodium-dev libunwind8-dev libnss3-dev libgnutls28-dev libbsd-dev pkg-config asciidoc xmlto
-          wget -O - https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz|tar zxvf -
+          apt-get install -y debhelper dh-autoreconf dpkg-dev libkrb5-dev libnorm-dev libpgm-dev libsodium-dev libunwind8-dev libnss3-dev libgnutls28-dev libbsd-dev pkg-config asciidoc wget xmlto
+          wget -O - https://github.com/zeromq/libzmq/releases/download/v4.3.5/zeromq-4.3.5.tar.gz | tar zxvf -
+
           cd zeromq-4.3.5
           ./configure
           make
           make install
           cd ..
+
           wget -O - https://github.com/zeromq/libzmq/archive/refs/tags/v4.3.5.tar.gz|tar zxvf -
           cd libzmq-4.3.5
           apt-get install -y debhelper dh-autoreconf libkrb5-dev libnorm-dev libpgm-dev libsodium-dev libunwind8-dev libnss3-dev libgnutls28-dev libbsd-dev pkg-config asciidoc xmlto
           ln -s packaging/debian
           dpkg-buildpackage -us -uc -nc
           cd ..
+
+          rm -f libzmq5-dbg_*.deb
         shell: bash
 
       - name: cache deb
@@ -161,7 +167,7 @@ jobs:
           - distrib: bullseye
             arch: amd64
 
-    name: deliver ${{ matrix.distrib }}
+    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }}
 
     steps:
       - name: Checkout sources

--- a/.github/workflows/libzmq.yml
+++ b/.github/workflows/libzmq.yml
@@ -111,10 +111,11 @@ jobs:
           make install
           cd ..
 
-          wget -O - https://github.com/zeromq/libzmq/archive/refs/tags/v4.3.5.tar.gz|tar zxvf -
+          wget -O - https://github.com/zeromq/libzmq/archive/refs/tags/v4.3.5.tar.gz | tar zxvf -
           cd libzmq-4.3.5
-          apt-get install -y debhelper dh-autoreconf libkrb5-dev libnorm-dev libpgm-dev libsodium-dev libunwind8-dev libnss3-dev libgnutls28-dev libbsd-dev pkg-config asciidoc xmlto
           ln -s packaging/debian
+          sed -Ei 's/([0-9]+.[0-9]+.[0-9]+-[0-9]+.[0-9]+)/\1~${{ matrix.distrib }}/' debian/changelog
+          sed -Ei 's/UNRELEASED/${{ matrix.distrib }}/' debian/changelog
           dpkg-buildpackage -us -uc -nc
           cd ..
 


### PR DESCRIPTION
## Description

fix(ci): add distrib name in libzmq deb package

Backport #1133 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)