### PR TITLE
fix(promote): add missing el7 distrib in promote

### DIFF
--- a/.github/workflows/centreon-collect.yml
+++ b/.github/workflows/centreon-collect.yml
@@ -302,7 +302,7 @@ jobs:
     runs-on: [self-hosted, common]
     strategy:
       matrix:
-        distrib: [el8, bullseye]
+        distrib: [el7, el8, bullseye]
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
## Description

Add missing EL7 in promote matrix.

**Fixes** #MON-35261

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

