### PR TITLE
Mon 35560 semicolon in cfg files 23.10

### DIFF
--- a/engine/precomp_inc/precomp.hh
+++ b/engine/precomp_inc/precomp.hh
@@ -1,21 +1,21 @@
-/*
-** Copyright 2022 Centreon
-**
-** This file is part of Centreon Engine.
-**
-** Centreon Engine is free software: you can redistribute it and/or
-** modify it under the terms of the GNU General Public License version 2
-** as published by the Free Software Foundation.
-**
-** Centreon Engine is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-** General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with Centreon Engine. If not, see
-** <http://www.gnu.org/licenses/>.
-*/
+/**
+ * Copyright 2022 Centreon
+ *
+ * This file is part of Centreon Engine.
+ *
+ * Centreon Engine is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * Centreon Engine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Centreon Engine. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef CCE_PRECOMP_HH
 #define CCE_PRECOMP_HH
@@ -66,13 +66,12 @@
 #include <re2/re2.h>
 
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/trim.hpp>
 #include <boost/circular_buffer.hpp>
 #include <boost/container/flat_map.hpp>
 #include <boost/optional.hpp>
 
 #include <boost/asio.hpp>
-
-namespace asio = boost::asio;
 
 #include "com/centreon/engine/namespace.hh"
 

--- a/engine/precomp_inc/precomp.hh
+++ b/engine/precomp_inc/precomp.hh
@@ -73,6 +73,8 @@
 
 #include <boost/asio.hpp>
 
+namespace asio = boost::asio;
+
 #include "com/centreon/engine/namespace.hh"
 
 namespace fmt {

--- a/engine/src/configuration/object.cc
+++ b/engine/src/configuration/object.cc
@@ -1,21 +1,21 @@
-/*
-** Copyright 2011-2014 Merethis
-**
-** This file is part of Centreon Engine.
-**
-** Centreon Engine is free software: you can redistribute it and/or
-** modify it under the terms of the GNU General Public License version 2
-** as published by the Free Software Foundation.
-**
-** Centreon Engine is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-** General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with Centreon Engine. If not, see
-** <http://www.gnu.org/licenses/>.
-*/
+/**
+ * Copyright 2011-2014 Merethis
+ *
+ * This file is part of Centreon Engine.
+ *
+ * Centreon Engine is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * Centreon Engine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Centreon Engine. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
 
 #include "com/centreon/engine/configuration/object.hh"
 #include "com/centreon/engine/configuration/anomalydetection.hh"
@@ -204,7 +204,7 @@ bool object::parse(std::string const& line) {
     key.assign(line, 0, pos);
     value.assign(line, pos + 1, std::string::npos);
   }
-  string::trim(value);
+  boost::algorithm::trim(value);
   if (!parse(key.c_str(), value.c_str()))
     return object::parse(key.c_str(), value.c_str());
   return true;

--- a/engine/src/string.cc
+++ b/engine/src/string.cc
@@ -41,7 +41,7 @@ bool string::get_next_line(std::ifstream& stream,
                            unsigned int& pos) {
   while (std::getline(stream, line, '\n')) {
     ++pos;
-    string::trim(line);
+    boost::algorithm::trim(line);
     if (!line.empty()) {
       char c(line[0]);
       if (c != '#' && c != ';' && c != '\x0')

--- a/tests/engine/forced_checks.robot
+++ b/tests/engine/forced_checks.robot
@@ -290,8 +290,8 @@ EMACROS_NOTIF
     Kindly Stop Broker
 
 EMACROS_SEMICOLON
-    [Documentation]    macros with a semicolon are used even after semicolon
-    [Tags]    engine    external_cmd    macros
+    [Documentation]    Macros with a semicolon are used even if they contain a semicolon.
+    [Tags]    engine    external_cmd    macros    MON-35560
     Config Engine    ${1}
     Config Broker    central
     Config Broker    rrd

--- a/tests/engine/forced_checks.robot
+++ b/tests/engine/forced_checks.robot
@@ -288,3 +288,38 @@ EMACROS_NOTIF
 
     Stop Engine
     Kindly Stop Broker
+
+EMACROS_SEMICOLON
+    [Documentation]    macros with a semicolon are used even after semicolon
+    [Tags]    engine    external_cmd    macros
+    Config Engine    ${1}
+    Config Broker    central
+    Config Broker    rrd
+    Config Broker    module    ${1}
+    Engine Config Set Value    ${0}    log_legacy_enabled    ${0}
+    Engine Config Set Value    ${0}    log_v2_enabled    ${1}
+    Engine Config Set Value    0    log_level_checks    trace    True
+    Engine Config Set Value In Hosts    0    host_1    _KEY2    VAL1;val3;
+    Engine Config Change Command
+    ...    0
+    ...    \\d+
+    ...    /bin/echo "KEY2=$_HOSTKEY2$"
+    Clear Retention
+    ${start}    Get Current Date
+    Start Engine
+    Start Broker
+
+    ${content}    Create List    INITIAL HOST STATE: host_1;
+    ${result}    Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True
+    ...    ${result}
+    ...    An Initial host state on host_1 should be raised before we can start our external commands.
+    Schedule Forced Svc Check    host_1    service_1
+    Sleep    5s
+
+    ${content}    Create List    KEY2=VAL1;val3;
+    ${result}    Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    VAL1;val3; not found in log.
+
+    Stop Engine
+    Kindly Stop Broker


### PR DESCRIPTION
## Description

Engine cfg files accept now a semicolon as character.

REFS: MON-35560
