### PR TITLE
MON-33121 allow bypass the notification inhibitions for recovery notifications

### DIFF
--- a/engine/doc/engine-doc.md
+++ b/engine/doc/engine-doc.md
@@ -31,12 +31,18 @@ This class is a singleton witch is replace by another instance each time conf is
 
 Checkable class inherited by service and host classes keeps the last result of whitelist's check in cache in order to reduce CPU whitelist usage.
 
-## extended configuration
+## Extended configuration
 Users can pass an additional configuration file to engine. Gorgone is not aware of this file, so users can override centengine.cfg configuration.
-Each entry found in additional json configuration file override his twin in centengine.cfg
+Each entry found in additional json configuration file overrides its twin in `centengine.cfg`.
 
-### example of command line
+### examples of command line
+```sh
 /usr/sbin/centengine --config-file=/tmp/centengine_extend.json /etc/centreon-engine/centengine.cfg
+
+/usr/sbin/centengine --c /tmp/file1.json  --c /tmp/file2.json /etc/centreon-engine/centengine.cfg
+```
+
+In the second case, values of file1.json will override values of centengine.cfg and values of file2.json will override values of file1.json
 
 ### file format
 ```json
@@ -46,4 +52,8 @@ Each entry found in additional json configuration file override his twin in cent
 ```
 
 ### implementation detail
-In state.cc all setters have two methods, apply_from_cfg and apply_from_json. On configuration update, we first parse centengine.cfg and other, and then we parse additional configuration files.
+In `state.cc` all setters have two methods:
+* `apply_from_cfg`
+* `apply_from_json`.
+
+On configuration update, we first parse the `centengine.cfg` and all the `*.cfg` files, and then we parse additional configuration files.

--- a/engine/doc/engine-doc.md
+++ b/engine/doc/engine-doc.md
@@ -30,3 +30,20 @@ The main main job is done by whitelist class, it parses file and compares final 
 This class is a singleton witch is replace by another instance each time conf is reloaded.
 
 Checkable class inherited by service and host classes keeps the last result of whitelist's check in cache in order to reduce CPU whitelist usage.
+
+## extended configuration
+Users can pass an additional configuration file to engine. Gorgone is not aware of this file, so users can override centengine.cfg configuration.
+Each entry found in additional json configuration file override his twin in centengine.cfg
+
+### example of command line
+/usr/sbin/centengine --config-file=/tmp/centengine_extend.json /etc/centreon-engine/centengine.cfg
+
+### file format
+```json
+{   
+    "send_recovery_notifications_anyways": true
+}
+```
+
+### implementation detail
+In state.cc all setters have two methods, apply_from_cfg and apply_from_json. On configuration update, we first parse centengine.cfg and other, and then we parse additional configuration files.

--- a/engine/inc/com/centreon/engine/configuration/extended_conf.hh
+++ b/engine/inc/com/centreon/engine/configuration/extended_conf.hh
@@ -62,7 +62,10 @@ template <class file_path_iterator>
 void extended_conf::load_all(file_path_iterator begin, file_path_iterator end) {
   _confs.clear();
   for (; begin != end; ++begin) {
-    _confs.emplace_back(std::make_unique<extended_conf>(*begin));
+    try {
+      _confs.emplace_back(std::make_unique<extended_conf>(*begin));
+    } catch (const std::exception&) {
+    }
   }
 }
 

--- a/engine/inc/com/centreon/engine/configuration/state.hh
+++ b/engine/inc/com/centreon/engine/configuration/state.hh
@@ -447,6 +447,8 @@ class state {
   void use_timezone(std::string const& value);
   bool use_true_regexp_matching() const noexcept;
   void use_true_regexp_matching(bool value);
+  bool use_send_recovery_notifications_anyways() const;
+  void use_send_recovery_notifications_anyways(bool value);
 
   using setter_map =
       absl::flat_hash_map<std::string_view, std::unique_ptr<setter_base>>;
@@ -650,6 +652,7 @@ class state {
   std::string _log_level_runtime;
   std::string _use_timezone;
   bool _use_true_regexp_matching;
+  bool _send_recovery_notifications_anyways;
 };
 
 }  // namespace com::centreon::engine::configuration

--- a/engine/src/configuration/applier/state.cc
+++ b/engine/src/configuration/applier/state.cc
@@ -459,6 +459,8 @@ void applier::state::_apply(configuration::state const& new_cfg) {
   config->log_level_comments(new_cfg.log_level_comments());
   config->log_level_macros(new_cfg.log_level_macros());
   config->use_true_regexp_matching(new_cfg.use_true_regexp_matching());
+  config->use_send_recovery_notifications_anyways(
+      new_cfg.use_send_recovery_notifications_anyways());
   config->user(new_cfg.user());
 
   // Set this variable just the first time.

--- a/engine/src/configuration/applier/state.cc
+++ b/engine/src/configuration/applier/state.cc
@@ -45,7 +45,6 @@
 #include "com/centreon/engine/configuration/applier/tag.hh"
 #include "com/centreon/engine/configuration/applier/timeperiod.hh"
 #include "com/centreon/engine/configuration/command.hh"
-#include "com/centreon/engine/configuration/extended_conf.hh"
 #include "com/centreon/engine/configuration/whitelist.hh"
 #include "com/centreon/engine/exceptions/error.hh"
 #include "com/centreon/engine/globals.hh"
@@ -97,7 +96,6 @@ void applier::state::apply(configuration::state& new_cfg) {
       _processing(save);
     }
   }
-  extended_conf::apply_all_to_state(*config);
 }
 
 /**
@@ -132,7 +130,6 @@ void applier::state::apply(configuration::state& new_cfg,
       _processing(save, &state);
     }
   }
-  extended_conf::apply_all_to_state(*config);
 }
 
 /**

--- a/engine/src/configuration/applier/state.cc
+++ b/engine/src/configuration/applier/state.cc
@@ -45,6 +45,7 @@
 #include "com/centreon/engine/configuration/applier/tag.hh"
 #include "com/centreon/engine/configuration/applier/timeperiod.hh"
 #include "com/centreon/engine/configuration/command.hh"
+#include "com/centreon/engine/configuration/extended_conf.hh"
 #include "com/centreon/engine/configuration/whitelist.hh"
 #include "com/centreon/engine/exceptions/error.hh"
 #include "com/centreon/engine/globals.hh"
@@ -96,6 +97,7 @@ void applier::state::apply(configuration::state& new_cfg) {
       _processing(save);
     }
   }
+  extended_conf::apply_all_to_state(*config);
 }
 
 /**
@@ -130,6 +132,7 @@ void applier::state::apply(configuration::state& new_cfg,
       _processing(save, &state);
     }
   }
+  extended_conf::apply_all_to_state(*config);
 }
 
 /**

--- a/engine/src/configuration/extended_conf.cc
+++ b/engine/src/configuration/extended_conf.cc
@@ -33,6 +33,7 @@ std::list<std::unique_ptr<extended_conf>> extended_conf::_confs;
 extended_conf::extended_conf(const std::string& path) : _path(path) {
   if (::stat(_path.c_str(), &_file_info)) {
     SPDLOG_LOGGER_ERROR(log_v2::config(), "can't access to {}", _path);
+    throw exceptions::msg_fmt("can't access to {}", _path);
   }
   try {
     _content = common::rapidjson_helper::read_from_file(_path);
@@ -42,6 +43,7 @@ extended_conf::extended_conf(const std::string& path) : _path(path) {
         log_v2::config(),
         "extended_conf::extended_conf : fail to read json content from {}: {}",
         _path, e.what());
+    throw;
   }
 }
 

--- a/engine/src/configuration/state.cc
+++ b/engine/src/configuration/state.cc
@@ -307,6 +307,8 @@ void state::_init_setter() {
   SETTER(bool, use_true_regexp_matching, "use_true_regexp_matching");
   SETTER(std::string const&, _set_comment_file, "xcddefault_comment_file");
   SETTER(std::string const&, _set_downtime_file, "xdddefault_downtime_file");
+  SETTER(bool, use_send_recovery_notifications_anyways,
+         "send_recovery_notifications_anyways");
 }
 
 // Default values.
@@ -581,7 +583,8 @@ state::state()
       _log_level_process(default_log_level_process),
       _log_level_runtime(default_log_level_runtime),
       _use_timezone(default_use_timezone),
-      _use_true_regexp_matching(default_use_true_regexp_matching) {
+      _use_true_regexp_matching(default_use_true_regexp_matching),
+      _send_recovery_notifications_anyways(false) {
   static absl::once_flag _init_call_once;
   absl::call_once(_init_call_once, _init_setter);
 }
@@ -764,6 +767,8 @@ state& state::operator=(state const& right) {
     _log_level_runtime = right._log_level_runtime;
     _use_timezone = right._use_timezone;
     _use_true_regexp_matching = right._use_true_regexp_matching;
+    _send_recovery_notifications_anyways =
+        right._send_recovery_notifications_anyways;
   }
   return *this;
 }
@@ -928,7 +933,9 @@ bool state::operator==(state const& right) const noexcept {
       _log_level_process == right._log_level_process &&
       _log_level_runtime == right._log_level_runtime &&
       _use_timezone == right._use_timezone &&
-      _use_true_regexp_matching == right._use_true_regexp_matching);
+      _use_true_regexp_matching == right._use_true_regexp_matching &&
+      _send_recovery_notifications_anyways ==
+          right._send_recovery_notifications_anyways);
 }
 
 /**
@@ -4813,6 +4820,37 @@ bool state::enable_macros_filter() const noexcept {
  */
 void state::enable_macros_filter(bool value) {
   _enable_macros_filter = value;
+}
+
+/**
+ * @brief Get _send_recovery_notifications_anyways
+ *
+ * Having a resource that has entered a non-OK state during a notification
+ * period and goes back to an OK state out of a notification period, then only
+ * if send_recovery_notifications_anyways is set to 1, the recovery notification
+ * must be sent to all users that have previously received the alert
+ * notification.
+ *
+ * @return true
+ * @return false
+ */
+bool state::use_send_recovery_notifications_anyways() const {
+  return _send_recovery_notifications_anyways;
+}
+
+/**
+ * @brief
+ *
+ * Having a resource that has entered a non-OK state during a notification
+ * period and goes back to an OK state out of a notification period, then only
+ * if send_recovery_notifications_anyways is set to 1, the recovery notification
+ * must be sent to all users that have previously received the alert
+ * notification.
+ *
+ * @param value true if have to nitify anyway
+ */
+void state::use_send_recovery_notifications_anyways(bool value) {
+  _send_recovery_notifications_anyways = value;
 }
 
 /**

--- a/engine/src/main.cc
+++ b/engine/src/main.cc
@@ -127,7 +127,7 @@ int main(int argc, char* argv[]) {
     bool display_license(false);
     bool error(false);
     bool diagnose(false);
-    std::set<std::string> extended_conf_file;
+    std::vector<std::string> extended_conf_file;
 
     // Process all command line arguments.
     int c;
@@ -161,7 +161,7 @@ int main(int argc, char* argv[]) {
           break;
         case 'c':
           if (optarg)
-            extended_conf_file.insert(optarg);
+            extended_conf_file.emplace_back(optarg);
           break;
         default:
           error = true;

--- a/engine/src/notifier.cc
+++ b/engine/src/notifier.cc
@@ -463,6 +463,7 @@ bool notifier::_is_notification_viable_recovery(reason_type type
     if (!check_time_against_period_for_notif(now, tp)) {
       if (config->use_send_recovery_notifications_anyways()) {
         SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                            "send_recovery_notifications_anyways flag enabled, "
                             "recovery notification is viable even if we are "
                             "out of timeperiod at this time.");
       } else {

--- a/engine/src/notifier.cc
+++ b/engine/src/notifier.cc
@@ -458,16 +458,26 @@ bool notifier::_is_notification_viable_recovery(reason_type type
     std::time_t now;
     std::time(&now);
 
+    // if use_send_recovery_notifications_anyways flag is set, we don't take
+    // timeperiod into account for recovery
     if (!check_time_against_period_for_notif(now, tp)) {
-      engine_logger(dbg_notifications, more)
-          << "This notifier shouldn't have notifications sent out "
-             "at this time.";
-      SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
-                          "This notifier shouldn't have notifications sent out "
-                          "at this time.");
-      retval = false;
-      send_later = true;
+      if (config->use_send_recovery_notifications_anyways()) {
+        SPDLOG_LOGGER_DEBUG(log_v2::notifications(),
+                            "recovery notification is viable even if we are "
+                            "out of timeperiod at this time.");
+      } else {
+        engine_logger(dbg_notifications, more)
+            << "This notifier shouldn't have notifications sent out "
+               "at this time.";
+        SPDLOG_LOGGER_DEBUG(
+            log_v2::notifications(),
+            "This notifier shouldn't have notifications sent out "
+            "at this time.");
+        retval = false;
+        send_later = true;
+      }
     }
+
     /* if this notifier is currently in a scheduled downtime period, don't send
      * the notification */
     else if (is_in_downtime()) {

--- a/tests/broker-engine/notifications.robot
+++ b/tests/broker-engine/notifications.robot
@@ -1313,7 +1313,7 @@ not20
 
 not_in_timeperiod_without_send_recovery_notifications_anyways
     [Documentation]    This test case configures a single service and verifies that a notification is sent when the service is in a non-OK state and OK is not sent outside timeperiod when _send_recovery_notifications_anyways is not set
-    [Tags]    MON-33121  broker    engine    services    hosts    notification    mon-33121
+    [Tags]    MON-33121  broker    engine    services    hosts    notification
     Ctn Config Engine    ${1}    ${1}    ${1}
     Ctn Config Notifications
     Ctn Engine Config Set Value In Hosts    0    host_1    notifications_enabled    1

--- a/tests/broker-engine/notifications.robot
+++ b/tests/broker-engine/notifications.robot
@@ -1311,6 +1311,99 @@ not20
     Ctn Stop Engine
     Ctn Kindly Stop Broker
 
+not_in_timeperiod_without_send_recovery_notifications_anyways
+    [Documentation]    This test case configures a single service and verifies that a notification is sent when the service is in a non-OK state and OK is not sent outside timeperiod when _send_recovery_notifications_anyways is not set
+    [Tags]    MON-33121  broker    engine    services    hosts    notification    mon-33121
+    Ctn Config Engine    ${1}    ${1}    ${1}
+    Ctn Config Notifications
+    Ctn Engine Config Set Value In Hosts    0    host_1    notifications_enabled    1
+    Ctn Engine Config Set Value In Hosts    0    host_1    notification_options    d,r
+    Ctn Engine Config Set Value In Hosts    0    host_1    contacts    John_Doe
+    Ctn Engine Config Set Value In Services    0    service_1    contacts    John_Doe
+    Ctn Engine Config Set Value In Services    0    service_1    notification_options    w,c,r
+    Ctn Engine Config Set Value In Services    0    service_1    notifications_enabled    1
+    Ctn Engine Config Set Value In Services    0    service_1    notification_period    short_time_period
+    Ctn Engine Config Set Value In Contacts    0    John_Doe    host_notification_commands    command_notif
+    Ctn Engine Config Set Value In Contacts    0    John_Doe    service_notification_commands    command_notif
+    ${cmd_1}    Ctn Get Service Command Id    1
+    Log To Console    service_1 has command id ${cmd_1}
+    Ctn Set Command Status    ${cmd_1}    2
+
+    ${start}    Get Current Date
+    Ctn Create Single Day Time Period    0    short_time_period    ${start}    2
+
+    Ctn Start Broker
+    Ctn Start engine
+
+    # Let's wait for the external command check start
+    Ctn Wait For Engine To Be Ready    ${start}
+
+    ## Time to set the service to CRITICAL HARD.
+    Ctn Process Service Result Hard    host_1    service_1    2    critical
+
+    ${result}    Ctn Check Service Status With Timeout    host_1    service_1    ${2}    60    HARD
+    Should Be True    ${result}    Service (host_1,service_1) should be CRITICAL HARD
+
+    ${content}    Create List    SERVICE NOTIFICATION: John_Doe;host_1;service_1;CRITICAL;command_notif;critical
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    The notification is not sent
+
+    Sleep    3m
+    Ctn Set Command Status    ${cmd_1}    0
+    Ctn Process Service Check Result    host_1    service_1    0    ok
+
+    ${content}    Create List    SERVICE NOTIFICATION: John_Doe;host_1;service_1;RECOVERY (OK);command_notif;ok
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Not Be True    ${result}    The notification is sent out of time period
+
+not_in_timeperiod_with_send_recovery_notifications_anyways
+    [Documentation]    This test case configures a single service and verifies that a notification is sent when the service is in a non-OK state and OK is sent outside timeperiod when _send_recovery_notifications_anyways is set
+    [Tags]    MON-33121   broker    engine    services    hosts    notification    mon-33121
+    Ctn Config Engine    ${1}    ${1}    ${1}
+    Ctn Config Notifications
+    Ctn Engine Config Set Value In Hosts    0    host_1    notifications_enabled    1
+    Ctn Engine Config Set Value In Hosts    0    host_1    notification_options    d,r
+    Ctn Engine Config Set Value In Hosts    0    host_1    contacts    John_Doe
+    Ctn Engine Config Set Value In Services    0    service_1    contacts    John_Doe
+    Ctn Engine Config Set Value In Services    0    service_1    notification_options    w,c,r
+    Ctn Engine Config Set Value In Services    0    service_1    notifications_enabled    1
+    Ctn Engine Config Set Value In Services    0    service_1    notification_period    short_time_period
+    Ctn Engine Config Set Value In Contacts    0    John_Doe    host_notification_commands    command_notif
+    Ctn Engine Config Set Value In Contacts    0    John_Doe    service_notification_commands    command_notif
+    Create File    /tmp/centengine_extend.json    {"send_recovery_notifications_anyways": true}
+
+    ${cmd_1}    Ctn Get Service Command Id    1
+    Log To Console    service_1 has command id ${cmd_1}
+    Ctn Set Command Status    ${cmd_1}    2
+
+    ${start}    Get Current Date
+    Ctn Create Single Day Time Period    0    short_time_period    ${start}    2
+
+    Ctn Start Broker
+    Ctn Start Engine With Extend Conf
+
+    # Let's wait for the external command check start
+    Ctn Wait For Engine To Be Ready    ${start}
+
+    ## Time to set the service to CRITICAL HARD.
+    Ctn Process Service Result Hard    host_1    service_1    2    critical
+
+    ${result}    Ctn Check Service Status With Timeout    host_1    service_1    ${2}    60    HARD
+    Should Be True    ${result}    Service (host_1,service_1) should be CRITICAL HARD
+
+    ${content}    Create List    SERVICE NOTIFICATION: John_Doe;host_1;service_1;CRITICAL;command_notif;critical
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    The notification is not sent
+
+    Sleep    3m
+    Ctn Set Command Status    ${cmd_1}    0
+    Ctn Process Service Check Result    host_1    service_1    0    ok
+
+    ${content}    Create List    SERVICE NOTIFICATION: John_Doe;host_1;service_1;RECOVERY (OK);command_notif;ok
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    The notification is not sent outside time period
+
+
 *** Keywords ***
 Ctn Config Notifications
     [Documentation]    Configuring engine notification settings.

--- a/tests/engine/extended_conf.robot
+++ b/tests/engine/extended_conf.robot
@@ -17,11 +17,7 @@ EXT_CONF1
     Ctn Config Broker    module    ${1}
     Create File    /tmp/centengine_extend.json    {"log_level_checks": "trace", "log_level_comments": "debug"}
     ${start}    Get Current Date
-    Start Process
-    ...    /usr/sbin/centengine
-    ...    --config-file\=/tmp/centengine_extend.json
-    ...    ${EtcRoot}/centreon-engine/config0/centengine.cfg
-    ...    alias=e0
+    Ctn Start Engine With Extend Conf
     Ctn Wait For Engine To Be Ready    ${start}    ${1}
     ${level}    Ctn Get Engine Log Level    50001    checks
     Should Be Equal    ${level}    trace    log_level_checks must be the extended conf value
@@ -35,11 +31,7 @@ EXT_CONF2
     Ctn Config Broker    module    ${1}
     Create File    /tmp/centengine_extend.json    {}
     ${start}    Get Current Date
-    Start Process
-    ...    /usr/sbin/centengine
-    ...    --config-file\=/tmp/centengine_extend.json
-    ...    ${EtcRoot}/centreon-engine/config0/centengine.cfg
-    ...    alias=e0
+    Ctn Start Engine With Extend Conf
     Ctn Wait For Engine To Be Ready    ${start}    ${1}
     Create File    /tmp/centengine_extend.json    {"log_level_checks": "trace", "log_level_comments": "debug"}
 

--- a/tests/resources/resources.resource
+++ b/tests/resources/resources.resource
@@ -142,7 +142,7 @@ Ctn Stop Processes
     Ctn Kill Broker
     Ctn Kill Engine
 
-Ctn Start engine
+Ctn Start Engine
     ${count}    Ctn Get Engines Count
     FOR    ${idx}    IN RANGE    0    ${count}
         ${alias}    Catenate    SEPARATOR=    e    ${idx}
@@ -157,6 +157,27 @@ Ctn Start engine
             Log    can't remove ${lib}/rw/centengine.cmd don't worry
         END
         Start Process    /usr/sbin/centengine    ${conf}    alias=${alias}
+    END
+
+Ctn Start Engine With Extend Conf
+    ${count}    Ctn Get Engines Count
+    FOR    ${idx}    IN RANGE    0    ${count}
+        ${alias}    Catenate    SEPARATOR=    e    ${idx}
+        ${conf}    Catenate    SEPARATOR=    ${EtcRoot}    /centreon-engine/config    ${idx}    /centengine.cfg
+        ${log}    Catenate    SEPARATOR=    ${VarRoot}    /log/centreon-engine/config    ${idx}
+        ${lib}    Catenate    SEPARATOR=    ${VarRoot}    /lib/centreon-engine/config    ${idx}
+        Create Directory    ${log}
+        Create Directory    ${lib}
+        TRY
+            Remove File    ${lib}/rw/centengine.cmd
+        EXCEPT
+            Log    can't remove ${lib}/rw/centengine.cmd don't worry
+        END
+        Start Process
+        ...    /usr/sbin/centengine
+        ...    --config-file\=/tmp/centengine_extend.json
+        ...    ${conf}
+        ...    alias=${alias}
     END
 
 Ctn Restart Engine

--- a/tests/resources/resources.resource
+++ b/tests/resources/resources.resource
@@ -143,7 +143,6 @@ Ctn Stop Processes
     Ctn Kill Engine
 
 Ctn Start engine
-    [Arguments]    ${extended_conf}=
     ${count}    Ctn Get Engines Count
     FOR    ${idx}    IN RANGE    0    ${count}
         ${alias}    Catenate    SEPARATOR=    e    ${idx}
@@ -157,7 +156,7 @@ Ctn Start engine
         EXCEPT
             Log    can't remove ${lib}/rw/centengine.cmd don't worry
         END
-        Start Process    /usr/sbin/centengine    ${conf}    ${extended_conf}    alias=${alias}
+        Start Process    /usr/sbin/centengine    ${conf}    alias=${alias}
     END
 
 Ctn Restart Engine

--- a/tests/resources/resources.resource
+++ b/tests/resources/resources.resource
@@ -143,6 +143,7 @@ Ctn Stop Processes
     Ctn Kill Engine
 
 Ctn Start engine
+    [Arguments]    ${extended_conf}=
     ${count}    Ctn Get Engines Count
     FOR    ${idx}    IN RANGE    0    ${count}
         ${alias}    Catenate    SEPARATOR=    e    ${idx}
@@ -156,7 +157,7 @@ Ctn Start engine
         EXCEPT
             Log    can't remove ${lib}/rw/centengine.cmd don't worry
         END
-        Start Process    /usr/sbin/centengine    ${conf}    alias=${alias}
+        Start Process    /usr/sbin/centengine    ${conf}    ${extended_conf}    alias=${alias}
     END
 
 Ctn Restart Engine


### PR DESCRIPTION
## Description

add send_recovery_notifications_anyways engine configuration parameter.
When it is set to true, recovery notifications are always sent even if outside timeperiod

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

