### PR TITLE
MON-36709 fix multi-insert issue that occurs when run_query thows an exception

### DIFF
--- a/broker/core/sql/src/mysql_multi_insert.cc
+++ b/broker/core/sql/src/mysql_multi_insert.cc
@@ -1,20 +1,20 @@
 /**
-* Copyright 2023 Centreon
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* For more information : contact@centreon.com
-*/
+ * Copyright 2023 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #include "com/centreon/broker/sql/mysql_multi_insert.hh"
 
@@ -42,8 +42,8 @@ unsigned mysql_multi_insert::execute_queries(mysql& pool,
                                              my_error::code ec,
                                              int thread_id) {
   for (std::string& query_data : _queries) {
-    query_data.append(_on_duplicate_key_part);
-    thread_id = pool.run_query(query_data, ec, thread_id);
+    thread_id =
+        pool.run_query(query_data + _on_duplicate_key_part, ec, thread_id);
   }
   return _queries.size();
 }


### PR DESCRIPTION
REFS:MON-36709
## Description

**Fixes** # (issue)

In mysql_multi_insert::execute_queries, pool.run_query may throw an exception. If it occurs and we retry to execute this, _on_duplicate_key_part is append twice.



## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

