### PR TITLE
[23.10.x] fix(packaging): add symbolic link from /usr/lib64/nagios/plugins to /usr/lib/nagios/plugins

### DIFF
--- a/packaging/centreon-engine-daemon.yaml
+++ b/packaging/centreon-engine-daemon.yaml
@@ -115,6 +115,11 @@ contents:
       owner: centreon-engine
       group: centreon-engine
 
+  - src: "/usr/lib64/nagios/plugins"
+    dst: "/usr/lib/nagios/plugins"
+    type: symlink
+    packager: deb
+
 scripts:
   preinstall: ./scripts/centreon-engine-daemon-preinstall.sh
   postinstall: ./scripts/centreon-engine-daemon-postinstall.sh


### PR DESCRIPTION
## Description

nagios plugins are not deployed in the same directory depending on the OS. in debian, they are deployed in /usr/lib/nagios/plugins/, whereas macros used by commands points to /usr/lib64/nagios/plugins/ to find them. a symbolic link from /usr/lib64/nagios/plugins to /usr/lib/nagios/plugins should therefore make them available

Fixes # MON-50814

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

