### PR TITLE
enh(promote): handle debian package promotion for multiple distributions

### DIFF
--- a/.github/actions/promote-to-stable/action.yml
+++ b/.github/actions/promote-to-stable/action.yml
@@ -113,12 +113,14 @@ runs:
     - name: Promote DEB packages to stable
       if: ${{ contains(fromJSON('["bullseye", "bookworm"]'), inputs.distrib) }}
       run: |
+        set -eux
+
         echo "[DEBUG] - Major version: ${{ inputs.major_version }}"
         echo "[DEBUG] - Minor version: ${{ inputs.minor_version }}"
         echo "[DEBUG] - Distrib: ${{ inputs.distrib }}"
 
         echo "[DEBUG] - Get path of testing DEB packages to promote to stable."
-        SRC_PATHS=$(jf rt s --include-dirs apt-standard-${{ inputs.major_version }}-testing/pool/${{ inputs.module_name }}/*.deb | jq -r '.[].path')
+        SRC_PATHS=$(jf rt search --include-dirs apt-standard-${{ inputs.major_version }}-testing/pool/${{ inputs.module_name }}/*${{ inputs.major_version }}.${{ inputs.minor_version }}*${{ inputs.distrib }}*.deb | jq -r '.[].path')
 
         if [[ ${SRC_PATHS[@]} ]]; then
           for SRC_PATH in ${SRC_PATHS[@]}; do
@@ -141,6 +143,11 @@ runs:
 
         for ARTIFACT_DL in $(dir|grep -E "*.deb"); do
           ARCH=$(echo $ARTIFACT_DL | cut -d '_' -f3 | cut -d '.' -f1)
+          DISTRIB=$(echo $ARTIFACT_DL | cut -d '_' -f2 | cut -d '-' -f2)
+          if [[ "${{ inputs.distrib }}" != "$DISTRIB" ]]; then
+            echo "[ERROR] - Distrib [$DISTRIB] from package does not match distrib [${{ inputs.distrib }}] from input, abort promotion."
+            exit 1
+          fi
           echo "[DEBUG] - Promoting (upload) $ARTIFACT_DL to stable $TARGET_PATH."
           jf rt upload "$ARTIFACT_DL" "$TARGET_PATH" --deb "${{ inputs.distrib }}/main/$ARCH" --flat
         done

--- a/.github/actions/promote-to-stable/action.yml
+++ b/.github/actions/promote-to-stable/action.yml
@@ -145,7 +145,7 @@ runs:
           ARCH=$(echo $ARTIFACT_DL | cut -d '_' -f3 | cut -d '.' -f1)
           DISTRIB=$(echo $ARTIFACT_DL | cut -d '_' -f2 | cut -d '-' -f2)
           if [[ "${{ inputs.distrib }}" != "$DISTRIB" ]]; then
-            echo "[ERROR] - Distrib [$DISTRIB] from package does not match distrib [${{ inputs.distrib }}] from input, abort promotion."
+            echo "::error::Distrib [$DISTRIB] from package does not match distrib [${{ inputs.distrib }}] from input, abort promotion."
             exit 1
           fi
           echo "[DEBUG] - Promoting (upload) $ARTIFACT_DL to stable $TARGET_PATH."


### PR DESCRIPTION
## Description

minor fixes
add support for multiple debian distributions to promote action

Fixes #MON-51089

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)
