### PR TITLE
enh(ci): deliver develop packages to cloud internal repositories

### DIFF
--- a/.github/actions/delivery/action.yml
+++ b/.github/actions/delivery/action.yml
@@ -99,13 +99,13 @@ runs:
         # if non-cloud, delivery to onprem testing or unstable
 
         # CLOUD + HOTFIX + REPO STANDARD INTERNAL OR CLOUD + RELEASE + REPO STANDARD INTERNAL
-        if [[ ${{ inputs.release_cloud }} -eq 1 && ${{ inputs.release_type }} == "hotfix" ]] || [[ ${{ inputs.release_cloud }} -eq 1 && ${{ inputs.release_type }} == "release" ]]; then
+        if [[ ${{ inputs.release_cloud }} -eq 1 && ( ${{ inputs.release_type }} == "hotfix" || ${{ inputs.release_type }} == "release" ) ]]; then
           echo "[DEBUG] : Release cloud + ${{ inputs.release_type }}, using rpm-standard-internal."
           ROOT_REPO_PATHS="rpm-standard-internal"
           UPLOAD_REPO_PATH="${{ inputs.version }}/${{ inputs.distrib }}/${{ inputs.stability }}-${{ inputs.release_type }}/$ARCH/RPMS/${{ inputs.module_name }}/"
 
         # CLOUD + NOT HOTFIX OR CLOUD + NOT RELEASE + REPO STANDARD INTERNAL
-        elif [[ ${{ inputs.release_cloud }} -eq 1 && ${{ inputs.release_type }} != "hotfix" ]] || [[ ${{ inputs.release_cloud }} -eq 1 && ${{ inputs.release_type }} != "release" ]]; then
+        elif [[ ${{ inputs.release_cloud }} -eq 1 && ( ${{ inputs.release_type }} != "hotfix" && ${{ inputs.release_type }} != "release" ) ]]; then
           echo "[DEBUG] : Release cloud + NOT ${{ inputs.release_type }}, using rpm-standard-internal."
           ROOT_REPO_PATHS="rpm-standard-internal"
           UPLOAD_REPO_PATH="${{ inputs.version }}/${{ inputs.distrib }}/${{ inputs.stability }}-${{ inputs.release_type }}/$ARCH/${{ inputs.module_name }}/"

--- a/.github/actions/delivery/action.yml
+++ b/.github/actions/delivery/action.yml
@@ -94,16 +94,29 @@ runs:
         done
 
         # Build upload target path based on release_cloud and release_type values
-        # if cloud, deliver to testing-<release_type>
-        # if non-cloud, delivery to testing as usual
+        # if cloud + hotfix or cloud + release, deliver to internal testing-<release_type>
+        # if cloud + develop, delivery to internal unstable
+        # if non-cloud, delivery to onprem testing or unstable
+
         # CLOUD + HOTFIX + REPO STANDARD INTERNAL OR CLOUD + RELEASE + REPO STANDARD INTERNAL
         if [[ ${{ inputs.release_cloud }} -eq 1 && ${{ inputs.release_type }} == "hotfix" ]] || [[ ${{ inputs.release_cloud }} -eq 1 && ${{ inputs.release_type }} == "release" ]]; then
+          echo "[DEBUG] : Release cloud + ${{ inputs.release_type }}, using rpm-standard-internal."
           ROOT_REPO_PATHS="rpm-standard-internal"
           UPLOAD_REPO_PATH="${{ inputs.version }}/${{ inputs.distrib }}/${{ inputs.stability }}-${{ inputs.release_type }}/$ARCH/RPMS/${{ inputs.module_name }}/"
+
+        # CLOUD + NOT HOTFIX OR CLOUD + NOT RELEASE + REPO STANDARD INTERNAL
+        elif [[ ${{ inputs.release_cloud }} -eq 1 && ${{ inputs.release_type }} != "hotfix" ]] || [[ ${{ inputs.release_cloud }} -eq 1 && ${{ inputs.release_type }} != "release" ]]; then
+          echo "[DEBUG] : Release cloud + NOT ${{ inputs.release_type }}, using rpm-standard-internal."
+          ROOT_REPO_PATHS="rpm-standard-internal"
+          UPLOAD_REPO_PATH="${{ inputs.version }}/${{ inputs.distrib }}/${{ inputs.stability }}-${{ inputs.release_type }}/$ARCH/${{ inputs.module_name }}/"
+
         # NON-CLOUD + (HOTFIX OR RELEASE) + REPO STANDARD
         elif [[ ${{ inputs.release_cloud }} -eq 0 ]]; then
+          echo "[DEBUG] : NOT Release cloud + ${{ inputs.release_type }}, using rpm-standard."
           ROOT_REPO_PATHS="rpm-standard"
           UPLOAD_REPO_PATH="${{ inputs.version }}/${{ inputs.distrib }}/${{ inputs.stability }}/$ARCH/${{ inputs.module_name }}/"
+
+        #  NOT VALID, DO NOT DELIVER
         else
           echo "Invalid combination of release_type and release_cloud"
           exit 1

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -96,6 +96,11 @@ jobs:
               echo "release_cloud=$GITHUB_RELEASE_CLOUD" >> $GITHUB_OUTPUT
               echo "release_type=$GITHUB_RELEASE_TYPE" >> $GITHUB_OUTPUT
               ;;
+            develop)
+              echo "release=`date +%s`.`echo ${{ github.sha }} | cut -c -7`" >> $GITHUB_OUTPUT
+              echo "release_cloud=1" >> $GITHUB_OUTPUT
+              echo "release_type=$GITHUB_RELEASE_TYPE" >> $GITHUB_OUTPUT
+              ;;
             release* | hotfix*)
             # Handle workflow_dispatch run triggers and run a dispatch ONLY for cloud release
               GITHUB_RELEASE_BRANCH_BASE_REF_NAME="$(gh pr view $BRANCHNAME -q .baseRefName --json headRefName,baseRefName,state)"


### PR DESCRIPTION
## Description

depending on get-versions release_cloud output

deliver testing packages to internal repositories (release or hotfix) or to onprem repositories (testing)
deliver unstable packages to internal repositories or to onprem repositories

Fixes #MON-52724

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Improved release delivery process to handle various scenarios including hotfixes and development changes.
    - Enhanced versioning system to automatically set release information for the `develop` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->