### PR TITLE
fix(packaging): fix permission rights on systemd files packaged on centreon-collect

### DIFF
--- a/packaging/centreon-broker-cbd.yaml
+++ b/packaging/centreon-broker-cbd.yaml
@@ -49,13 +49,12 @@ contents:
   - src: "../broker/script/cbd.service"
     dst: "/usr/lib/systemd/system/cbd.service"
     file_info:
-      mode: 644
+      mode: 0644
     packager: rpm
-
   - src: "../broker/script/cbd.service"
     dst: "/lib/systemd/system/cbd.service"
     file_info:
-      mode: 644
+      mode: 0644
     packager: deb
 
 scripts:

--- a/packaging/centreon-engine-daemon.yaml
+++ b/packaging/centreon-engine-daemon.yaml
@@ -55,13 +55,12 @@ contents:
   - src: "../engine/scripts/centengine.service"
     dst: "/usr/lib/systemd/system/centengine.service"
     file_info:
-      mode: 644
+      mode: 0644
     packager: rpm
-
   - src: "../engine/scripts/centengine.service"
     dst: "/lib/systemd/system/centengine.service"
     file_info:
-      mode: 644
+      mode: 0644
     packager: deb
 
   - src: "../build/engine/centengine"


### PR DESCRIPTION
## Description

fixes errors that appeared in journalctl and noted that several systemd config file were "world-inaccessible" or "noted as executable"

also has a centreon counterpart (https://github.com/centreon/centreon/pull/3878) since several files of the issue are packaged there

Fixes # MON-37082

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated file permission settings for `cbd.service` in RPM and DEB packaging configurations.
	- Modified file permissions for systemd service files in various packaging paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->