### PR TITLE
fix(packaging): tweak nagios plugins symlink to avoid file conflicts with monitoring plugins

### DIFF
--- a/packaging/centreon-engine-daemon.yaml
+++ b/packaging/centreon-engine-daemon.yaml
@@ -114,8 +114,8 @@ contents:
       owner: centreon-engine
       group: centreon-engine
 
-  - src: "/usr/lib64/nagios/plugins"
-    dst: "/usr/lib/nagios/plugins"
+  - src: "/usr/lib/nagios/plugins"
+    dst: "/usr/lib64/nagios/plugins"
     type: symlink
     packager: deb
 


### PR DESCRIPTION
## Description

the latest fix on usr/lib/nagios/plugins caused a file claim conflict with the monitoring-plugins-common external package (which is a dependency for monitoring-plugins-basic) due to the source and the destination being "inverted" on npfm. this PR solves this issue 

**Fixes** # MON-58186

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).