### PR TITLE
MON-71657 exception is cached in _check_queues (#1330)

### DIFF
--- a/tests/broker-database/networkFailure.robot
+++ b/tests/broker-database/networkFailure.robot
@@ -163,6 +163,43 @@ NetworkDBFailU7
     Ctn Stop Engine
     Ctn Kindly Stop Broker
 
+NetworkDBFailU8
+    [Documentation]    network failure test between broker and database: we wait for the connection to be established and then we shutdown the connection until _check_queues failure
+    [Tags]    MON-71277 broker    database    network    unified_sql    unstable
+    Ctn Reset Eth Connection
+    Ctn Config Engine    ${1}
+    Ctn Config Broker    central
+    Ctn Config Broker Sql Output    central    unified_sql
+    Ctn Broker Config Output Set    central    central-broker-unified-sql    db_host    127.0.0.1
+    Ctn Broker Config Output Set    central    central-broker-unified-sql    connections_count    3
+    Ctn Broker Config Log    central    sql    trace
+    Ctn Config Broker    rrd
+    Ctn Config Broker    module
+    ${start}    Get Current Date
+    Ctn Start Broker
+    Ctn Start engine
+    ${result}    Ctn Check Connections
+    Should Be True    ${result}    Broker and Engine are not connected
+    ${content}    Create List    run query: SELECT
+    ${result}    Ctn Find In Log With Timeout    ${centralLog}    ${start}    ${content}    40
+    Should Be True    ${result}    No SELECT done by broker in the DB
+
+    Log To Console    Connection failure.
+    ${start}    Get Current Date
+    Ctn Disable Eth Connection On Port    port=3306
+    ${content}    Create List    fail to store queued data in database
+    ${result}    Ctn Find In Log With Timeout    ${centralLog}    ${start}    ${content}    40
+    Should Be True    ${result}    No failure found in log
+
+    ${start}    Get Current Date
+    Log To Console    Reestablishing the connection and test last steps.
+    Ctn Reset Eth Connection
+    ${content}    Create List    unified_sql:_check_queues
+    ${result}    Ctn Find In Log With Timeout    ${centralLog}    ${start}    ${content}    40
+    Ctn Stop engine
+    Ctn Kindly Stop Broker
+
+
 
 *** Keywords ***
 Ctn Disable Sleep Enable


### PR DESCRIPTION
REFS:MON-71657
## Description

**Fixes** # (issue)
When database is down, _check_error throw an exception that is not catched by _check_queues witch is catched by pool

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

