### PR TITLE
fix(ci): force ubuntu 22.04 runner usage in all (mostly veracode) pipelines

### DIFF
--- a/.github/workflows/veracode-analysis.yml
+++ b/.github/workflows/veracode-analysis.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   routing:
     name: Check before analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       development_stage: ${{ steps.routing-mode.outputs.development_stage }}
 
@@ -142,7 +142,7 @@ jobs:
     name: Sandbox scan
     needs: [routing, build]
     if: needs.routing.outputs.development_stage != 'Development'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Promote latest scan


### PR DESCRIPTION
## Description

fix ubuntu 22.04 runner usage in all (mostly veracode) pipelines to prevent unexpected behaviors using ubuntu latest or 24-04 runners

Fixes # MON-93851

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

