### PR TITLE
fix(engine): configuration module has its own logger

### DIFF
--- a/broker/core/src/main.cc
+++ b/broker/core/src/main.cc
@@ -274,6 +274,8 @@ int main(int argc, char* argv[]) {
         config::parser parsr;
         config::state conf{parsr.parse(gl_mainconfigfiles.front())};
         auto& log_conf = conf.log_conf();
+        /* It is important to apply the log conf before broker threads start.
+         * Otherwise we will have issues with concurrent accesses. */
         try {
           log_v2::instance().apply(log_conf);
         } catch (const std::exception& e) {

--- a/engine/inc/com/centreon/engine/configuration/connector.hh
+++ b/engine/inc/com/centreon/engine/configuration/connector.hh
@@ -1,22 +1,21 @@
-/*
-** Copyright 2011-2013,2017 Centreon
-**
-** This file is part of Centreon Engine.
-**
-** Centreon Engine is free software: you can redistribute it and/or
-** modify it under the terms of the GNU General Public License version 2
-** as published by the Free Software Foundation.
-**
-** Centreon Engine is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-** General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with Centreon Engine. If not, see
-** <http://www.gnu.org/licenses/>.
-*/
-
+/**
+ * Copyright 2011-2013,2017-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
 #ifndef CCE_CONFIGURATION_CONNECTOR_HH
 #define CCE_CONFIGURATION_CONNECTOR_HH
 

--- a/engine/inc/com/centreon/engine/configuration/extended_conf.hh
+++ b/engine/inc/com/centreon/engine/configuration/extended_conf.hh
@@ -31,6 +31,7 @@ class state;
  *
  */
 class extended_conf {
+  std::shared_ptr<spdlog::logger> _logger;
   std::string _path;
   struct stat _file_info;
   rapidjson::Document _content;

--- a/engine/inc/com/centreon/engine/configuration/object.hh
+++ b/engine/inc/com/centreon/engine/configuration/object.hh
@@ -119,6 +119,7 @@ class object {
   bool _should_register;
   list_string _templates;
   object_type _type;
+  std::shared_ptr<spdlog::logger> _logger;
 };
 
 typedef std::shared_ptr<object> object_ptr;

--- a/engine/inc/com/centreon/engine/configuration/parser.hh
+++ b/engine/inc/com/centreon/engine/configuration/parser.hh
@@ -1,22 +1,21 @@
-/*
-** Copyright 2011-2013,2017 Centreon
-**
-** This file is part of Centreon Engine.
-**
-** Centreon Engine is free software: you can redistribute it and/or
-** modify it under the terms of the GNU General Public License version 2
-** as published by the Free Software Foundation.
-**
-** Centreon Engine is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-** General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with Centreon Engine. If not, see
-** <http://www.gnu.org/licenses/>.
-*/
-
+/**
+ * Copyright 2011-2013,2017-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
 #ifndef CCE_CONFIGURATION_PARSER_HH
 #define CCE_CONFIGURATION_PARSER_HH
 
@@ -39,6 +38,8 @@ namespace com::centreon::engine {
 
 namespace configuration {
 class parser {
+  std::shared_ptr<spdlog::logger> _logger;
+
  public:
   enum read_options {
     read_commands = (1 << 0),
@@ -61,7 +62,7 @@ class parser {
   };
 
   parser(unsigned int read_options = read_all);
-  ~parser() throw();
+  ~parser() noexcept = default;
   void parse(std::string const& path, state& config);
 
  private:

--- a/engine/inc/com/centreon/engine/configuration/state.hh
+++ b/engine/inc/com/centreon/engine/configuration/state.hh
@@ -61,6 +61,8 @@ class setter_base {
  *  to manage configuration data.
  */
 class state {
+  std::shared_ptr<spdlog::logger> _logger;
+
  public:
   /**
    *  @enum state::date_format
@@ -101,7 +103,7 @@ class state {
 
   state();
   state(state const& right);
-  ~state() noexcept;
+  ~state() noexcept = default;
   state& operator=(state const& right);
   bool operator==(state const& right) const noexcept;
   bool operator!=(state const& right) const noexcept;

--- a/engine/inc/com/centreon/engine/configuration/whitelist.hh
+++ b/engine/inc/com/centreon/engine/configuration/whitelist.hh
@@ -20,8 +20,10 @@
 #define CCE_CONFIGURATION_WHITELIST_HH
 
 #include "com/centreon/engine/globals.hh"
+#include "common/log_v2/log_v2.hh"
 
 namespace com::centreon::engine::configuration {
+using com::centreon::common::log_v2::log_v2;
 
 extern const std::string command_blacklist_output;
 
@@ -40,6 +42,8 @@ string
  *
  */
 class whitelist {
+  std::shared_ptr<spdlog::logger> _logger;
+
   // don't reorder values
   enum e_refresh_result { no_directory, empty_directory, no_rule, rules };
 
@@ -82,7 +86,8 @@ class whitelist {
 };
 
 template <typename string_iter>
-whitelist::whitelist(string_iter dir_path_begin, string_iter dir_path_end) {
+whitelist::whitelist(string_iter dir_path_begin, string_iter dir_path_end)
+    : _logger{log_v2::instance().get(log_v2::CONFIG)} {
   init_ryml_error_handler();
   e_refresh_result res = e_refresh_result::no_directory;
   for (; dir_path_begin != dir_path_end; ++dir_path_begin) {
@@ -93,12 +98,11 @@ whitelist::whitelist(string_iter dir_path_begin, string_iter dir_path_end) {
   switch (res) {
     case e_refresh_result::no_directory:
       SPDLOG_LOGGER_INFO(
-          config_logger,
-          "no whitelist directory found, all commands are accepted");
+          _logger, "no whitelist directory found, all commands are accepted");
       break;
     case e_refresh_result::empty_directory:
     case e_refresh_result::no_rule:
-      SPDLOG_LOGGER_INFO(config_logger,
+      SPDLOG_LOGGER_INFO(_logger,
                          "whitelist directory found, but no restrictions, "
                          "all commands are accepted");
       break;

--- a/engine/src/configuration/anomalydetection.cc
+++ b/engine/src/configuration/anomalydetection.cc
@@ -21,18 +21,15 @@
 #include <absl/strings/numbers.h>
 #include <absl/strings/str_split.h>
 #include <absl/strings/string_view.h>
-#include "com/centreon/engine/customvariable.hh"
 #include "com/centreon/engine/exceptions/error.hh"
 #include "com/centreon/engine/globals.hh"
 #include "com/centreon/engine/host.hh"
-#include "com/centreon/engine/logging/logger.hh"
 
 extern int config_warnings;
 extern int config_errors;
 
 using namespace com::centreon;
 using namespace com::centreon::engine::configuration;
-using namespace com::centreon::engine::logging;
 
 #define SETTER(type, method) \
   &object::setter<anomalydetection, type, &anomalydetection::method>::generic
@@ -323,442 +320,312 @@ anomalydetection& anomalydetection::operator=(anomalydetection const& other) {
 bool anomalydetection::operator==(
     anomalydetection const& other) const noexcept {
   if (!object::operator==(other)) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => object don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => object don't match");
     return false;
   }
   if (_acknowledgement_timeout != other._acknowledgement_timeout) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "acknowledgement_timeout don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "acknowledgement_timeout don't match");
     return false;
   }
   if (_action_url != other._action_url) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => action_url don't match";
-    config_logger->debug(
-        "configuration::anomalydetection::"
-        "equality => action_url don't match");
+    _logger->debug(
+        "configuration::anomalydetection::equality => action_url don't match");
     return false;
   }
   if (_status_change != other._status_change) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => status_change don't match";
-    config_logger->debug(
-        "configuration::anomalydetection::"
-        "equality => status_change don't match");
+    _logger->debug(
+        "configuration::anomalydetection::equality => status_change don't "
+        "match");
     return false;
   }
   if (_checks_active != other._checks_active) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => checks_active don't match";
-    config_logger->debug(
-        "configuration::anomalydetection::"
-        "equality => checks_active don't match");
+    _logger->debug(
+        "configuration::anomalydetection::equality => checks_active don't "
+        "match");
     return false;
   }
   if (_checks_passive != other._checks_passive) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => checks_passive don't match";
-    config_logger->debug(
-        "configuration::anomalydetection::"
-        "equality => checks_passive don't match");
+    _logger->debug(
+        "configuration::anomalydetection::equality => checks_passive don't "
+        "match");
     return false;
   }
   if (_metric_name != other._metric_name) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => metric_name don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::"
         "equality => metric_name don't match");
     return false;
   }
   if (_thresholds_file != other._thresholds_file) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => thresholds_file don't "
-           "match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => thresholds_file don't "
         "match");
     return false;
   }
   if (_check_freshness != other._check_freshness) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => check_freshness don't "
-           "match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => check_freshness don't "
         "match");
     return false;
   }
   if (_check_interval != other._check_interval) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => check_interval don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::"
         "equality => check_interval don't match");
     return false;
   }
   if (_contactgroups != other._contactgroups) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => contactgroups don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::"
         "equality => contactgroups don't match");
     return false;
   }
   if (_contacts != other._contacts) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => contacts don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => contacts don't match");
     return false;
   }
   if (std::operator!=(_customvariables, other._customvariables)) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => customvariables don't "
-           "match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => customvariables don't "
         "match");
     return false;
   }
   if (_display_name != other._display_name) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => display_name don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::"
         "equality => display_name don't match");
     return false;
   }
   if (_event_handler != other._event_handler) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => event_handler don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::"
         "equality => event_handler don't match");
     return false;
   }
   if (_event_handler_enabled != other._event_handler_enabled) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => event_handler don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::"
         "equality => event_handler don't match");
     return false;
   }
   if (_first_notification_delay != other._first_notification_delay) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "first_notification_delay don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "first_notification_delay don't match");
     return false;
   }
   if (_flap_detection_enabled != other._flap_detection_enabled) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "flap_detection_enabled don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "flap_detection_enabled don't match");
     return false;
   }
   if (_flap_detection_options != other._flap_detection_options) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "flap_detection_options don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "flap_detection_options don't match");
     return false;
   }
   if (_freshness_threshold != other._freshness_threshold) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "freshness_threshold don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "freshness_threshold don't match");
     return false;
   }
   if (_high_flap_threshold != other._high_flap_threshold) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "high_flap_threshold don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "high_flap_threshold don't match");
     return false;
   }
   if (_host_name != other._host_name) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => _host_name don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::"
         "equality => _host_name don't match");
     return false;
   }
   if (_icon_image != other._icon_image) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => icon_image don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::"
         "equality => icon_image don't match");
     return false;
   }
   if (_icon_image_alt != other._icon_image_alt) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => icon_image_alt don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::"
         "equality => icon_image_alt don't match");
     return false;
   }
   if (_initial_state != other._initial_state) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => initial_state don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::"
         "equality => initial_state don't match");
     return false;
   }
   if (_is_volatile != other._is_volatile) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => is_volatile don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::"
         "equality => is_volatile don't match");
     return false;
   }
   if (_low_flap_threshold != other._low_flap_threshold) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => low_flap_threshold "
-           "don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => low_flap_threshold "
         "don't match");
     return false;
   }
   if (_max_check_attempts != other._max_check_attempts) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => max_check_attempts "
-           "don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => max_check_attempts "
         "don't match");
     return false;
   }
   if (_notes != other._notes) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => notes don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => notes don't match");
     return false;
   }
   if (_notes_url != other._notes_url) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => notes_url don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => notes_url don't match");
     return false;
   }
   if (_notifications_enabled != other._notifications_enabled) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "notifications_enabled don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "notifications_enabled don't match");
     return false;
   }
   if (_notification_interval != other._notification_interval) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "notification_interval don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "notification_interval don't match");
     return false;
   }
   if (_notification_options != other._notification_options) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "notification_options don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "notification_options don't match");
     return false;
   }
   if (_notification_period != other._notification_period) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "notification_period don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "notification_period don't match");
     return false;
   }
   if (_obsess_over_service != other._obsess_over_service) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "obsess_over_service don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "obsess_over_service don't match");
     return false;
   }
   if (_process_perf_data != other._process_perf_data) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => process_perf_data "
-           "don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => process_perf_data "
         "don't match");
     return false;
   }
   if (_retain_nonstatus_information != other._retain_nonstatus_information) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "retain_nonstatus_information don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "retain_nonstatus_information don't match");
     return false;
   }
   if (_retain_status_information != other._retain_status_information) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "retain_status_information don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "retain_status_information don't match");
     return false;
   }
   if (_retry_interval != other._retry_interval) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => retry_interval don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::"
         "equality => retry_interval don't match");
     return false;
   }
   if (_recovery_notification_delay != other._recovery_notification_delay) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "recovery_notification_delay don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "recovery_notification_delay don't match");
     return false;
   }
   if (_servicegroups != other._servicegroups) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => servicegroups don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::"
         "equality => servicegroups don't match");
     return false;
   }
   if (_service_description != other._service_description) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => "
-           "service_description don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => "
         "service_description don't match");
     return false;
   }
   if (_host_id != other._host_id) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => host_id don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => host_id don't match");
     return false;
   }
   if (_host_id != other._host_id) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => host_id don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => host_id don't match");
     return false;
   }
   if (_service_id != other._service_id) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => service_id don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::"
         "equality => service_id don't match");
     return false;
   }
   if (_internal_id != other._internal_id) {
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => internal_id "
         "don't match");
     return false;
   }
   if (_dependent_service_id != other._dependent_service_id) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => dependent_service_id "
-           "don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => dependent_service_id "
         "don't match");
     return false;
   }
   if (_stalking_options != other._stalking_options) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => stalking_options "
-           "don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => stalking_options "
         "don't match");
     return false;
   }
   if (_timezone != other._timezone) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => timezone don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => timezone don't match");
     return false;
   }
   if (_severity_id != other._severity_id) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => severity id don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => severity id don't match");
     return false;
   }
   if (_icon_id != other._icon_id) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => icon id don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => icon id don't match");
     return false;
   }
   if (_tags != other._tags) {
-    engine_logger(dbg_config, more)
-        << "configuration::anomalydetection::equality => tags don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => tags don't match");
     return false;
   }
   if (_sensitivity != other._sensitivity) {
-    engine_logger(dbg_config, more) << "configuration::anomalydetection::"
-                                       "equality => sensitivity don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::anomalydetection::equality => sensitivity don't match");
     return false;
   }
-  engine_logger(dbg_config, more)
-      << "configuration::anomalydetection::equality => OK";
-  config_logger->debug("configuration::anomalydetection::equality => OK");
+  _logger->debug("configuration::anomalydetection::equality => OK");
   return true;
 }
 
@@ -1748,10 +1615,7 @@ bool anomalydetection::_set_event_handler_enabled(bool value) {
  */
 bool anomalydetection::_set_failure_prediction_enabled(bool value) {
   (void)value;
-  engine_logger(log_verification_error, basic)
-      << "Warning: anomalydetection failure_prediction_enabled is deprecated."
-      << " This option will not be supported in 20.04.";
-  config_logger->warn(
+  _logger->warn(
       "Warning: anomalydetection failure_prediction_enabled is deprecated. "
       "This option will not be supported in 20.04.");
   ++config_warnings;
@@ -1768,10 +1632,7 @@ bool anomalydetection::_set_failure_prediction_enabled(bool value) {
 bool anomalydetection::_set_failure_prediction_options(
     std::string const& value) {
   (void)value;
-  engine_logger(log_verification_error, basic)
-      << "Warning: anomalydetection failure_prediction_options is deprecated."
-      << " This option will not be supported in 20.04.";
-  config_logger->warn(
+  _logger->warn(
       "Warning: anomalydetection failure_prediction_options is deprecated. "
       "This option will not be supported in 20.04.");
   ++config_warnings;
@@ -2070,10 +1931,7 @@ bool anomalydetection::_set_obsess_over_service(bool value) {
  */
 bool anomalydetection::_set_parallelize_check(bool value) {
   (void)value;
-  engine_logger(log_verification_error, basic)
-      << "Warning: anomalydetection parallelize_check is deprecated"
-      << " This option will not be supported in 20.04.";
-  config_logger->warn(
+  _logger->warn(
       "Warning: anomalydetection parallelize_check is deprecated This option "
       "will not be supported in 20.04.");
   ++config_warnings;
@@ -2271,7 +2129,7 @@ bool anomalydetection::_set_category_tags(const std::string& value) {
     if (parse_ok) {
       _tags.emplace(id, tag::servicecategory);
     } else {
-      config_logger->warn(
+      _logger->warn(
           "Warning: anomalydetection ({}, {}) error for parsing tag {}",
           _host_id, _service_id, value);
       ret = false;
@@ -2306,7 +2164,7 @@ bool anomalydetection::_set_group_tags(const std::string& value) {
     if (parse_ok) {
       _tags.emplace(id, tag::servicegroup);
     } else {
-      config_logger->warn(
+      _logger->warn(
           "Warning: anomalydetection ({}, {}) error for parsing tag {}",
           _host_id, _service_id, value);
       ret = false;

--- a/engine/src/configuration/command.cc
+++ b/engine/src/configuration/command.cc
@@ -118,7 +118,6 @@ void command::check_validity() const {
   if (_command_line.empty())
     throw(engine_error() << "Command '" << _command_name
                          << "' has no command line (property 'command_line')");
-  return;
 }
 
 /**
@@ -127,7 +126,7 @@ void command::check_validity() const {
  *  @return The command name.
  */
 command::key_type const& command::key() const throw() {
-  return (_command_name);
+  return _command_name;
 }
 
 /**

--- a/engine/src/configuration/connector.cc
+++ b/engine/src/configuration/connector.cc
@@ -120,7 +120,6 @@ void connector::check_validity() const {
     throw(
         engine_error() << "Connector '" << _connector_name
                        << "' has no command line (property 'connector_line')");
-  return;
 }
 
 /**

--- a/engine/src/configuration/contactgroup.cc
+++ b/engine/src/configuration/contactgroup.cc
@@ -53,7 +53,7 @@ contactgroup::contactgroup(contactgroup const& right) : object(right) {
 /**
  *  Destructor.
  */
-contactgroup::~contactgroup() throw() {}
+contactgroup::~contactgroup() noexcept {}
 
 /**
  *  Copy constructor.
@@ -70,7 +70,7 @@ contactgroup& contactgroup::operator=(contactgroup const& right) {
     _contactgroup_name = right._contactgroup_name;
     _members = right._members;
   }
-  return (*this);
+  return *this;
 }
 
 /**
@@ -124,7 +124,6 @@ void contactgroup::check_validity() const {
   if (_contactgroup_name.empty())
     throw(engine_error() << "Contact group has no name "
                             "(property 'contactgroup_name')");
-  return;
 }
 
 /**
@@ -133,7 +132,7 @@ void contactgroup::check_validity() const {
  *  @return The contact group name.
  */
 contactgroup::key_type const& contactgroup::key() const throw() {
-  return (_contactgroup_name);
+  return _contactgroup_name;
 }
 
 /**
@@ -175,7 +174,7 @@ bool contactgroup::parse(char const* key, char const* value) {
  *  @return The alias.
  */
 std::string const& contactgroup::alias() const throw() {
-  return (_alias);
+  return _alias;
 }
 
 /**
@@ -232,7 +231,7 @@ set_string const& contactgroup::members() const throw() {
  */
 bool contactgroup::_set_alias(std::string const& value) {
   _alias = value;
-  return (true);
+  return true;
 }
 
 /**
@@ -244,7 +243,7 @@ bool contactgroup::_set_alias(std::string const& value) {
  */
 bool contactgroup::_set_contactgroup_members(std::string const& value) {
   _contactgroup_members = value;
-  return (true);
+  return true;
 }
 
 /**
@@ -256,7 +255,7 @@ bool contactgroup::_set_contactgroup_members(std::string const& value) {
  */
 bool contactgroup::_set_contactgroup_name(std::string const& value) {
   _contactgroup_name = value;
-  return (true);
+  return true;
 }
 
 /**

--- a/engine/src/configuration/host.cc
+++ b/engine/src/configuration/host.cc
@@ -1267,12 +1267,8 @@ bool host::_set_event_handler_enabled(bool value) {
  *
  *  @return True on success, otherwise false.
  */
-bool host::_set_failure_prediction_enabled(bool value) {
-  (void)value;
-  engine_logger(log_verification_error, basic)
-      << "Warning: host failure_prediction_enabled is deprecated"
-      << " This option will not be supported in 20.04.";
-  config_logger->warn(
+bool host::_set_failure_prediction_enabled(bool value [[maybe_unused]]) {
+  _logger->warn(
       "Warning: host failure_prediction_enabled is deprecated This option will "
       "not be supported in 20.04.");
   ++config_warnings;
@@ -1286,12 +1282,9 @@ bool host::_set_failure_prediction_enabled(bool value) {
  *
  *  @return True on success, otherwise false.
  */
-bool host::_set_failure_prediction_options(std::string const& value) {
-  (void)value;
-  engine_logger(log_verification_error, basic)
-      << "Warning: service failure_prediction_options is deprecated"
-      << " This option will not be supported in 20.04.";
-  config_logger->warn(
+bool host::_set_failure_prediction_options(const std::string& value
+                                           [[maybe_unused]]) {
+  _logger->warn(
       "Warning: service failure_prediction_options is deprecated This option "
       "will not be supported in 20.04.");
   ++config_warnings;
@@ -1738,8 +1731,8 @@ bool host::_set_category_tags(const std::string& value) {
     if (parse_ok) {
       _tags.emplace(id, tag::hostcategory);
     } else {
-      config_logger->warn("Warning: host ({}) error for parsing tag {}",
-                          _host_id, value);
+      _logger->warn("Warning: host ({}) error for parsing tag {}", _host_id,
+                    value);
       ret = false;
     }
   }
@@ -1772,8 +1765,8 @@ bool host::_set_group_tags(const std::string& value) {
     if (parse_ok) {
       _tags.emplace(id, tag::hostgroup);
     } else {
-      config_logger->warn("Warning: host ({}) error for parsing tag {}",
-                          _host_id, value);
+      _logger->warn("Warning: host ({}) error for parsing tag {}", _host_id,
+                    value);
       ret = false;
     }
   }

--- a/engine/src/configuration/hostdependency.cc
+++ b/engine/src/configuration/hostdependency.cc
@@ -90,7 +90,7 @@ hostdependency::hostdependency(hostdependency const& right) : object(right) {
 /**
  *  Destructor.
  */
-hostdependency::~hostdependency() throw() {}
+hostdependency::~hostdependency() noexcept {}
 
 /**
  *  Copy constructor.
@@ -122,7 +122,7 @@ hostdependency& hostdependency::operator=(hostdependency const& right) {
  *
  *  @return True if is the same hostdependency, otherwise false.
  */
-bool hostdependency::operator==(hostdependency const& right) const throw() {
+bool hostdependency::operator==(hostdependency const& right) const noexcept {
   return (object::operator==(right) &&
           _dependency_period == right._dependency_period &&
           _dependency_type == right._dependency_type &&
@@ -141,7 +141,7 @@ bool hostdependency::operator==(hostdependency const& right) const throw() {
  *
  *  @return True if is not the same hostdependency, otherwise false.
  */
-bool hostdependency::operator!=(hostdependency const& right) const throw() {
+bool hostdependency::operator!=(hostdependency const& right) const noexcept {
   return !operator==(right);
 }
 
@@ -196,10 +196,7 @@ void hostdependency::check_validity() const {
     std::string dependend_host_name(!_dependent_hosts->empty()
                                         ? *_dependent_hosts->begin()
                                         : *_dependent_hostgroups->begin());
-    engine_logger(log_config_warning, basic)
-        << "Warning: Ignoring lame host dependency of '" << dependend_host_name
-        << "' on host/hostgroups '" << host_name << "'.";
-    config_logger->warn(
+    _logger->warn(
         "Warning: Ignoring lame host dependency of '{}' on host/hostgroups "
         "'{}'.",
         dependend_host_name, host_name);
@@ -404,7 +401,7 @@ bool hostdependency::inherits_parent() const noexcept {
  *  @param[in] options New options.
  */
 void hostdependency::notification_failure_options(
-    unsigned int options) throw() {
+    unsigned int options) noexcept {
   _notification_failure_options.set(options);
 }
 
@@ -413,7 +410,7 @@ void hostdependency::notification_failure_options(
  *
  *  @return The notification_failure_options.
  */
-unsigned int hostdependency::notification_failure_options() const throw() {
+unsigned int hostdependency::notification_failure_options() const noexcept {
   return _notification_failure_options;
 }
 

--- a/engine/src/configuration/hostgroup.cc
+++ b/engine/src/configuration/hostgroup.cc
@@ -91,58 +91,38 @@ hostgroup& hostgroup::operator=(hostgroup const& right) {
  */
 bool hostgroup::operator==(hostgroup const& right) const throw() {
   if (!object::operator==(right)) {
-    engine_logger(dbg_config, more)
-        << "configuration::hostgroup::equality => object don't match";
-    config_logger->debug(
-        "configuration::hostgroup::equality => object don't match");
+    _logger->debug("configuration::hostgroup::equality => object don't match");
     return false;
   }
   if (_action_url != right._action_url) {
-    engine_logger(dbg_config, more)
-        << "configuration::hostgroup::equality => action url don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::hostgroup::equality => action url don't match");
     return false;
   }
   if (_alias != right._alias) {
-    engine_logger(dbg_config, more)
-        << "configuration::hostgroup::equality => alias don't match";
-    config_logger->debug(
-        "configuration::hostgroup::equality => alias don't match");
+    _logger->debug("configuration::hostgroup::equality => alias don't match");
     return false;
   }
   if (_hostgroup_id != right._hostgroup_id) {
-    engine_logger(dbg_config, more)
-        << "configuration::hostgroup::equality => hostgroup id don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::hostgroup::equality => hostgroup id don't match");
     return false;
   }
   if (_hostgroup_name != right._hostgroup_name) {
-    engine_logger(dbg_config, more)
-        << "configuration::hostgroup::equality => hostgroup name don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::hostgroup::equality => hostgroup name don't match");
     return false;
   }
   if (_members != right._members) {
-    engine_logger(dbg_config, more)
-        << "configuration::hostgroup::equality => members don't match";
-    config_logger->debug(
-        "configuration::hostgroup::equality => members don't match");
+    _logger->debug("configuration::hostgroup::equality => members don't match");
     return false;
   }
   if (_notes != right._notes) {
-    engine_logger(dbg_config, more)
-        << "configuration::hostgroup::equality => notes don't match";
-    config_logger->debug(
-        "configuration::hostgroup::equality => notes don't match");
+    _logger->debug("configuration::hostgroup::equality => notes don't match");
     return false;
   }
   if (_notes_url != right._notes_url) {
-    engine_logger(dbg_config, more)
-        << "configuration::hostgroup::equality => notes url don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::hostgroup::equality => notes url don't match");
     return false;
   }

--- a/engine/src/configuration/object.cc
+++ b/engine/src/configuration/object.cc
@@ -35,9 +35,11 @@
 #include "com/centreon/engine/configuration/tag.hh"
 #include "com/centreon/engine/configuration/timeperiod.hh"
 #include "com/centreon/engine/exceptions/error.hh"
+#include "common/log_v2/log_v2.hh"
 
 using namespace com::centreon;
 using namespace com::centreon::engine::configuration;
+using com::centreon::common::log_v2::log_v2;
 
 #define SETTER(type, method) \
   &object::setter<object, type, &object::method>::generic
@@ -53,7 +55,10 @@ object::setters const object::_setters[] = {
  *  @param[in] type      The object type.
  */
 object::object(object::object_type type)
-    : _is_resolve(false), _should_register(true), _type(type) {}
+    : _is_resolve(false),
+      _should_register(true),
+      _type(type),
+      _logger{log_v2::instance().get(log_v2::CONFIG)} {}
 
 /**
  *  Copy constructor.
@@ -83,6 +88,7 @@ object& object::operator=(object const& right) {
     _should_register = right._should_register;
     _templates = right._templates;
     _type = right._type;
+    _logger = right._logger;
   }
   return *this;
 }
@@ -261,7 +267,9 @@ std::string const& object::type_name() const noexcept {
                                     "serviceextinfo",
                                     "servicegroup",
                                     "timeperiod",
-                                    "anomalydetection"};
+                                    "anomalydetection",
+                                    "severity",
+                                    "tag"};
   return tab[_type];
 }
 

--- a/engine/src/configuration/parser.cc
+++ b/engine/src/configuration/parser.cc
@@ -16,15 +16,16 @@
  * For more information : contact@centreon.com
  *
  */
-
 #include "com/centreon/engine/configuration/parser.hh"
 #include "com/centreon/engine/exceptions/error.hh"
 #include "com/centreon/engine/globals.hh"
 #include "com/centreon/io/directory_entry.hh"
+#include "common/log_v2/log_v2.hh"
 
 using namespace com::centreon;
 using namespace com::centreon::engine::configuration;
 using namespace com::centreon::io;
+using com::centreon::common::log_v2::log_v2;
 
 parser::store parser::_store[] = {
     &parser::_store_into_map<command, &command::command_name>,
@@ -77,12 +78,9 @@ static bool get_next_line(std::ifstream& stream,
  *             (use to skip some object type).
  */
 parser::parser(unsigned int read_options)
-    : _config(NULL), _read_options(read_options) {}
-
-/**
- *  Destructor.
- */
-parser::~parser() throw() {}
+    : _logger{log_v2::instance().get(log_v2::CONFIG)},
+      _config(nullptr),
+      _read_options(read_options) {}
 
 /**
  *  Parse configuration file.
@@ -309,9 +307,7 @@ void parser::_parse_directory_configuration(std::string const& path) {
  *  @param[in] path The configuration path.
  */
 void parser::_parse_global_configuration(const std::string& path) {
-  engine_logger(logging::log_info_message, logging::most)
-      << "Reading main configuration file '" << path << "'.";
-  config_logger->info("Reading main configuration file '{}'.", path);
+  _logger->info("Reading main configuration file '{}'.", path);
 
   std::ifstream stream(path.c_str(), std::ios::binary);
   if (!stream.is_open())
@@ -348,9 +344,7 @@ void parser::_parse_global_configuration(const std::string& path) {
  *  @param[in] path The object definitions path.
  */
 void parser::_parse_object_definitions(std::string const& path) {
-  engine_logger(logging::log_info_message, logging::basic)
-      << "Processing object config file '" << path << "'";
-  config_logger->info("Processing object config file '{}'", path);
+  _logger->info("Processing object config file '{}'", path);
 
   std::ifstream stream(path, std::ios::binary);
   if (!stream.is_open())
@@ -427,9 +421,7 @@ void parser::_parse_object_definitions(std::string const& path) {
  *  @param[in] path The resource file path.
  */
 void parser::_parse_resource_file(std::string const& path) {
-  engine_logger(logging::log_info_message, logging::most)
-      << "Reading resource file '" << path << "'";
-  config_logger->info("Reading resource file '{}'", path);
+  _logger->info("Reading resource file '{}'", path);
 
   std::ifstream stream(path.c_str(), std::ios::binary);
   if (!stream.is_open())

--- a/engine/src/configuration/service.cc
+++ b/engine/src/configuration/service.cc
@@ -307,14 +307,13 @@ bool service::operator==(service const& other) const noexcept {
   if (!object::operator==(other)) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => object don't match";
-    config_logger->debug(
-        "configuration::service::equality => object don't match");
+    _logger->debug("configuration::service::equality => object don't match");
     return false;
   }
   if (_acknowledgement_timeout != other._acknowledgement_timeout) {
     engine_logger(dbg_config, more) << "configuration::service::equality => "
                                        "acknowledgement_timeout don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "acknowledgement_timeout don't match");
     return false;
@@ -322,105 +321,104 @@ bool service::operator==(service const& other) const noexcept {
   if (_action_url != other._action_url) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => action_url don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => action_url don't match");
     return false;
   }
   if (_checks_active != other._checks_active) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => checks_active don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => checks_active don't match");
     return false;
   }
   if (_checks_passive != other._checks_passive) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => checks_passive don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => checks_passive don't match");
     return false;
   }
   if (_check_command != other._check_command) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => checks_passive don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => checks_passive don't match");
     return false;
   }
   if (_check_command_is_important != other._check_command_is_important) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => check_command don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => check_command don't match");
     return false;
   }
   if (_check_freshness != other._check_freshness) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => check_freshness don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => check_freshness don't match");
     return false;
   }
   if (_check_interval != other._check_interval) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => check_interval don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => check_interval don't match");
     return false;
   }
   if (_check_period != other._check_period) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => check_period don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => check_period don't match");
     return false;
   }
   if (_contactgroups != other._contactgroups) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => contactgroups don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => contactgroups don't match");
     return false;
   }
   if (_contacts != other._contacts) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => contacts don't match";
-    config_logger->debug(
-        "configuration::service::equality => contacts don't match");
+    _logger->debug("configuration::service::equality => contacts don't match");
     return false;
   }
   if (std::operator!=(_customvariables, other._customvariables)) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => customvariables don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => customvariables don't match");
     return false;
   }
   if (_display_name != other._display_name) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => display_name don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => display_name don't match");
     return false;
   }
   if (_event_handler != other._event_handler) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => event_handler don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => event_handler don't match");
     return false;
   }
   if (_event_handler_enabled != other._event_handler_enabled) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => event_handler don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => event_handler don't match");
     return false;
   }
   if (_first_notification_delay != other._first_notification_delay) {
     engine_logger(dbg_config, more) << "configuration::service::equality => "
                                        "first_notification_delay don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "first_notification_delay don't match");
     return false;
@@ -428,7 +426,7 @@ bool service::operator==(service const& other) const noexcept {
   if (_flap_detection_enabled != other._flap_detection_enabled) {
     engine_logger(dbg_config, more) << "configuration::service::equality => "
                                        "flap_detection_enabled don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "flap_detection_enabled don't match");
     return false;
@@ -436,7 +434,7 @@ bool service::operator==(service const& other) const noexcept {
   if (_flap_detection_options != other._flap_detection_options) {
     engine_logger(dbg_config, more) << "configuration::service::equality => "
                                        "flap_detection_options don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "flap_detection_options don't match");
     return false;
@@ -444,7 +442,7 @@ bool service::operator==(service const& other) const noexcept {
   if (_freshness_threshold != other._freshness_threshold) {
     engine_logger(dbg_config, more) << "configuration::service::equality => "
                                        "freshness_threshold don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "freshness_threshold don't match");
     return false;
@@ -452,7 +450,7 @@ bool service::operator==(service const& other) const noexcept {
   if (_high_flap_threshold != other._high_flap_threshold) {
     engine_logger(dbg_config, more) << "configuration::service::equality => "
                                        "high_flap_threshold don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "high_flap_threshold don't match");
     return false;
@@ -460,77 +458,74 @@ bool service::operator==(service const& other) const noexcept {
   if (_hostgroups != other._hostgroups) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => hostgroups don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => hostgroups don't match");
     return false;
   }
   if (_hosts != other._hosts) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => _hosts don't match";
-    config_logger->debug(
-        "configuration::service::equality => _hosts don't match");
+    _logger->debug("configuration::service::equality => _hosts don't match");
     return false;
   }
   if (_icon_image != other._icon_image) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => icon_image don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => icon_image don't match");
     return false;
   }
   if (_icon_image_alt != other._icon_image_alt) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => icon_image_alt don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => icon_image_alt don't match");
     return false;
   }
   if (_initial_state != other._initial_state) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => initial_state don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => initial_state don't match");
     return false;
   }
   if (_is_volatile != other._is_volatile) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => is_volatile don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => is_volatile don't match");
     return false;
   }
   if (_low_flap_threshold != other._low_flap_threshold) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => low_flap_threshold don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => low_flap_threshold don't match");
     return false;
   }
   if (_max_check_attempts != other._max_check_attempts) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => max_check_attempts don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => max_check_attempts don't match");
     return false;
   }
   if (_notes != other._notes) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => notes don't match";
-    config_logger->debug(
-        "configuration::service::equality => notes don't match");
+    _logger->debug("configuration::service::equality => notes don't match");
     return false;
   }
   if (_notes_url != other._notes_url) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => notes_url don't match";
-    config_logger->debug(
-        "configuration::service::equality => notes_url don't match");
+    _logger->debug("configuration::service::equality => notes_url don't match");
     return false;
   }
   if (_notifications_enabled != other._notifications_enabled) {
     engine_logger(dbg_config, more) << "configuration::service::equality => "
                                        "notifications_enabled don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "notifications_enabled don't match");
     return false;
@@ -538,7 +533,7 @@ bool service::operator==(service const& other) const noexcept {
   if (_notification_interval != other._notification_interval) {
     engine_logger(dbg_config, more) << "configuration::service::equality => "
                                        "notification_interval don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "notification_interval don't match");
     return false;
@@ -546,7 +541,7 @@ bool service::operator==(service const& other) const noexcept {
   if (_notification_options != other._notification_options) {
     engine_logger(dbg_config, more) << "configuration::service::equality => "
                                        "notification_options don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "notification_options don't match");
     return false;
@@ -554,7 +549,7 @@ bool service::operator==(service const& other) const noexcept {
   if (_notification_period != other._notification_period) {
     engine_logger(dbg_config, more) << "configuration::service::equality => "
                                        "notification_period don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "notification_period don't match");
     return false;
@@ -562,7 +557,7 @@ bool service::operator==(service const& other) const noexcept {
   if (_obsess_over_service != other._obsess_over_service) {
     engine_logger(dbg_config, more) << "configuration::service::equality => "
                                        "obsess_over_service don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "obsess_over_service don't match");
     return false;
@@ -570,7 +565,7 @@ bool service::operator==(service const& other) const noexcept {
   if (_process_perf_data != other._process_perf_data) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => process_perf_data don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => process_perf_data don't match");
     return false;
   }
@@ -578,7 +573,7 @@ bool service::operator==(service const& other) const noexcept {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => "
            "retain_nonstatus_information don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "retain_nonstatus_information don't match");
     return false;
@@ -586,7 +581,7 @@ bool service::operator==(service const& other) const noexcept {
   if (_retain_status_information != other._retain_status_information) {
     engine_logger(dbg_config, more) << "configuration::service::equality => "
                                        "retain_status_information don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "retain_status_information don't match");
     return false;
@@ -594,7 +589,7 @@ bool service::operator==(service const& other) const noexcept {
   if (_retry_interval != other._retry_interval) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => retry_interval don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => retry_interval don't match");
     return false;
   }
@@ -602,7 +597,7 @@ bool service::operator==(service const& other) const noexcept {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => "
            "recovery_notification_delay don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "recovery_notification_delay don't match");
     return false;
@@ -610,14 +605,14 @@ bool service::operator==(service const& other) const noexcept {
   if (_servicegroups != other._servicegroups) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => servicegroups don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => servicegroups don't match");
     return false;
   }
   if (_service_description != other._service_description) {
     engine_logger(dbg_config, more) << "configuration::service::equality => "
                                        "service_description don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => "
         "service_description don't match");
     return false;
@@ -625,54 +620,50 @@ bool service::operator==(service const& other) const noexcept {
   if (_host_id != other._host_id) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => host_id don't match";
-    config_logger->debug(
-        "configuration::service::equality => host_id don't match");
+    _logger->debug("configuration::service::equality => host_id don't match");
     return false;
   }
   if (_service_id != other._service_id) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => service_id don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => service_id don't match");
     return false;
   }
   if (_stalking_options != other._stalking_options) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => stalking_options don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => stalking_options don't match");
     return false;
   }
   if (_timezone != other._timezone) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => timezone don't match";
-    config_logger->debug(
-        "configuration::service::equality => timezone don't match");
+    _logger->debug("configuration::service::equality => timezone don't match");
     return false;
   }
   if (_severity_id != other._severity_id) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => severity id don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::service::equality => severity id don't match");
     return false;
   }
   if (_icon_id != other._icon_id) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => icon id don't match";
-    config_logger->debug(
-        "configuration::service::equality => icon id don't match");
+    _logger->debug("configuration::service::equality => icon id don't match");
     return false;
   }
   if (_tags != other._tags) {
     engine_logger(dbg_config, more)
         << "configuration::service::equality => tags don't match";
-    config_logger->debug(
-        "configuration::service::equality => tags don't match");
+    _logger->debug("configuration::service::equality => tags don't match");
     return false;
   }
   engine_logger(dbg_config, more) << "configuration::service::equality => OK";
-  config_logger->debug("configuration::service::equality => OK");
+  _logger->debug("configuration::service::equality => OK");
   return true;
 }
 
@@ -1645,7 +1636,7 @@ bool service::_set_failure_prediction_enabled(bool value) {
   engine_logger(log_verification_error, basic)
       << "Warning: service failure_prediction_enabled is deprecated."
       << " This option will not be supported in 20.04.";
-  config_logger->warn(
+  _logger->warn(
       "Warning: service failure_prediction_enabled is deprecated. This option "
       "will not be supported in 20.04.");
   ++config_warnings;
@@ -1664,7 +1655,7 @@ bool service::_set_failure_prediction_options(std::string const& value) {
   engine_logger(log_verification_error, basic)
       << "Warning: service failure_prediction_options is deprecated."
       << " This option will not be supported in 20.04.";
-  config_logger->warn(
+  _logger->warn(
       "Warning: service failure_prediction_options is deprecated. This option "
       "will not be supported in 20.04.");
   ++config_warnings;
@@ -1978,7 +1969,7 @@ bool service::_set_parallelize_check(bool value) {
   engine_logger(log_verification_error, basic)
       << "Warning: service parallelize_check is deprecated"
       << " This option will not be supported in 20.04.";
-  config_logger->warn(
+  _logger->warn(
       "Warning: service parallelize_check is deprecated This option will not "
       "be supported in 20.04.");
   ++config_warnings;
@@ -2152,8 +2143,8 @@ bool service::_set_category_tags(const std::string& value) {
     if (parse_ok) {
       _tags.emplace(id, tag::servicecategory);
     } else {
-      config_logger->warn("Warning: service ({}, {}) error for parsing tag {}",
-                          _host_id, _service_id, value);
+      _logger->warn("Warning: service ({}, {}) error for parsing tag {}",
+                    _host_id, _service_id, value);
       ret = false;
     }
   }
@@ -2186,8 +2177,8 @@ bool service::_set_group_tags(const std::string& value) {
     if (parse_ok) {
       _tags.emplace(id, tag::servicegroup);
     } else {
-      config_logger->warn("Warning: service ({}, {}) error for parsing tag {}",
-                          _host_id, _service_id, value);
+      _logger->warn("Warning: service ({}, {}) error for parsing tag {}",
+                    _host_id, _service_id, value);
       ret = false;
     }
   }

--- a/engine/src/configuration/servicedependency.cc
+++ b/engine/src/configuration/servicedependency.cc
@@ -277,8 +277,7 @@ void servicedependency::check_validity() const {
       else
         msg << "host '" << _hosts->front() << "'";
     }
-    engine_logger(log_config_warning, basic) << msg.str();
-    config_logger->warn(msg.str());
+    _logger->warn(msg.str());
   }
 }
 

--- a/engine/src/configuration/serviceescalation.cc
+++ b/engine/src/configuration/serviceescalation.cc
@@ -123,100 +123,70 @@ bool serviceescalation::operator==(serviceescalation const& right) const
    * constructor in almost all cases, we can have two equal escalations
    * with different uuid.*/
   if (!object::operator==(right)) {
-    engine_logger(dbg_config, more)
-        << "configuration::serviceescalation::equality => object don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::serviceescalation::equality => object don't match");
     return false;
   }
   if (_contactgroups != right._contactgroups) {
-    engine_logger(dbg_config, more) << "configuration::serviceescalation::"
-                                       "equality => contact groups don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::serviceescalation::"
         "equality => contact groups don't match");
     return false;
   }
   if (_escalation_options != right._escalation_options) {
-    engine_logger(dbg_config, more)
-        << "configuration::serviceescalation::equality => escalation options "
-           "don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::serviceescalation::equality => escalation options "
         "don't match");
     return false;
   }
   if (_escalation_period != right._escalation_period) {
-    engine_logger(dbg_config, more)
-        << "configuration::serviceescalation::equality => escalation periods "
-           "don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::serviceescalation::equality => escalation periods "
         "don't match");
     return false;
   }
   if (_first_notification != right._first_notification) {
-    engine_logger(dbg_config, more)
-        << "configuration::serviceescalation::equality => first notifications "
-           "don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::serviceescalation::equality => first notifications "
         "don't match");
     return false;
   }
   if (_hostgroups != right._hostgroups) {
-    engine_logger(dbg_config, more) << "configuration::serviceescalation::"
-                                       "equality => host groups don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::serviceescalation::"
         "equality => host groups don't match");
     return false;
   }
   if (_hosts != right._hosts) {
-    engine_logger(dbg_config, more)
-        << "configuration::serviceescalation::equality => hosts don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::serviceescalation::equality => hosts don't match");
     return false;
   }
   if (_last_notification != right._last_notification) {
-    engine_logger(dbg_config, more)
-        << "configuration::serviceescalation::equality => last notification "
-           "don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::serviceescalation::equality => last notification "
         "don't match");
     return false;
   }
   if (_notification_interval != right._notification_interval) {
-    engine_logger(dbg_config, more)
-        << "configuration::serviceescalation::equality => notification "
-           "interval don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::serviceescalation::equality => notification "
         "interval don't match");
     return false;
   }
   if (_servicegroups != right._servicegroups) {
-    engine_logger(dbg_config, more) << "configuration::serviceescalation::"
-                                       "equality => service groups don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::serviceescalation::"
         "equality => service groups don't match");
     return false;
   }
   if (_service_description != right._service_description) {
-    engine_logger(dbg_config, more)
-        << "configuration::serviceescalation::equality => service descriptions "
-           "don't match";
-    config_logger->debug(
+    _logger->debug(
         "configuration::serviceescalation::equality => service descriptions "
         "don't match");
     return false;
   }
-  engine_logger(dbg_config, more)
-      << "configuration::serviceescalation::equality => OK";
-  config_logger->debug("configuration::serviceescalation::equality => OK");
+  _logger->debug("configuration::serviceescalation::equality => OK");
   return true;
 }
 

--- a/engine/src/configuration/whitelist.cc
+++ b/engine/src/configuration/whitelist.cc
@@ -17,6 +17,7 @@
  *
  */
 
+#include "common/log_v2/log_v2.hh"
 #define C4_NO_DEBUG_BREAK 1
 
 #include "com/centreon/engine/configuration/whitelist.hh"
@@ -32,11 +33,13 @@
 #include "absl/base/call_once.h"
 #include "com/centreon/engine/globals.hh"
 #include "com/centreon/exceptions/msg_fmt.hh"
+#include "common/log_v2/log_v2.hh"
 
 using namespace com::centreon;
 using namespace com::centreon::exceptions;
 using namespace com::centreon::engine;
 using namespace com::centreon::engine::configuration;
+using com::centreon::common::log_v2::log_v2;
 
 namespace com::centreon::engine::configuration {
 
@@ -84,7 +87,8 @@ static std::atomic_uint _instance_gen(1);
  * @param file_path
  */
 whitelist::whitelist(const std::string_view& file_path)
-    : _instance_id(_instance_gen.fetch_add(1)) {
+    : _logger{log_v2::instance().get(log_v2::CONFIG)},
+      _instance_id(_instance_gen.fetch_add(1)) {
   init_ryml_error_handler();
   _parse_file(file_path);
 }
@@ -98,15 +102,15 @@ bool whitelist::_parse_file(const std::string_view& file_path) {
   // check file
   struct stat infos;
   if (::stat(file_path.data(), &infos)) {
-    SPDLOG_LOGGER_ERROR(config_logger, "{} doesn't exist", file_path);
+    SPDLOG_LOGGER_ERROR(_logger, "{} doesn't exist", file_path);
     return false;
   }
   if ((infos.st_mode & S_IFMT) != S_IFREG) {
-    SPDLOG_LOGGER_ERROR(config_logger, "{} is not a regular file", file_path);
+    SPDLOG_LOGGER_ERROR(_logger, "{} is not a regular file", file_path);
     return false;
   }
   if (!infos.st_size) {
-    SPDLOG_LOGGER_ERROR(config_logger, "{} is an empty file", file_path);
+    SPDLOG_LOGGER_ERROR(_logger, "{} is an empty file", file_path);
     return false;
   }
 
@@ -114,13 +118,12 @@ bool whitelist::_parse_file(const std::string_view& file_path) {
 
   if (centengine_group) {
     if (infos.st_uid || infos.st_gid != centengine_group->gr_gid) {
-      SPDLOG_LOGGER_ERROR(config_logger,
-                          "file {} must be owned by root@centreon-engine",
-                          file_path);
+      SPDLOG_LOGGER_ERROR(
+          _logger, "file {} must be owned by root@centreon-engine", file_path);
     }
   }
   if (infos.st_mode & S_IRWXO || (infos.st_mode & S_IRWXG) != S_IRGRP) {
-    SPDLOG_LOGGER_ERROR(config_logger, "file {} must have x40 right access",
+    SPDLOG_LOGGER_ERROR(_logger, "file {} must have x40 right access",
                         file_path);
   }
 
@@ -134,14 +137,13 @@ bool whitelist::_parse_file(const std::string_view& file_path) {
       std::streamsize some_read =
           f.readsome(buff.get() + read, file_size - read);
       if (some_read < 0) {
-        SPDLOG_LOGGER_ERROR(config_logger, "fail to read {}: {}");
+        SPDLOG_LOGGER_ERROR(_logger, "fail to read {}: {}");
         return false;
       }
       read += some_read;
     }
   } catch (const std::exception& e) {
-    SPDLOG_LOGGER_ERROR(config_logger, "fail to read {}: {}", file_path,
-                        e.what());
+    SPDLOG_LOGGER_ERROR(_logger, "fail to read {}: {}", file_path, e.what());
     return false;
   }
   // parse file content
@@ -150,8 +152,7 @@ bool whitelist::_parse_file(const std::string_view& file_path) {
     ryml::Tree tree = ryml::parse_in_place(ryml::substr(buff.get(), file_size));
     return _read_file_content(tree);
   } catch (const std::exception& e) {
-    SPDLOG_LOGGER_ERROR(config_logger, "fail to parse {}: {}", file_path,
-                        e.what());
+    SPDLOG_LOGGER_ERROR(_logger, "fail to parse {}: {}", file_path, e.what());
     return false;
   }
 }
@@ -170,12 +171,12 @@ bool whitelist::_read_file_content(const ryml_tree& file_content) {
   bool ret = false;
   if (wildcards.valid() && !wildcards.empty()) {
     if (!wildcards.is_seq()) {  // not an array => error
-      SPDLOG_LOGGER_ERROR(config_logger, "{}: wildcard is not a sequence");
+      SPDLOG_LOGGER_ERROR(_logger, "{}: wildcard is not a sequence");
     } else {
       for (auto wildcard : wildcards) {
         auto value = wildcard.val();
         std::string_view str_value(value.data(), value.size());
-        SPDLOG_LOGGER_INFO(config_logger, "wildcard '{}' added to whitelist",
+        SPDLOG_LOGGER_INFO(_logger, "wildcard '{}' added to whitelist",
                            str_value);
         _wildcards.emplace_back(str_value);
         ret = true;
@@ -184,7 +185,7 @@ bool whitelist::_read_file_content(const ryml_tree& file_content) {
   }
   if (regexps.valid() && !regexps.empty()) {
     if (!regexps.is_seq()) {  // not an array => error
-      SPDLOG_LOGGER_ERROR(config_logger, "{}: regex is not a sequence");
+      SPDLOG_LOGGER_ERROR(_logger, "{}: regex is not a sequence");
     } else {
       for (auto re : regexps) {
         auto value = re.val();
@@ -193,14 +194,14 @@ bool whitelist::_read_file_content(const ryml_tree& file_content) {
             std::make_unique<re2::RE2>(str_value);
         if (to_push_back->error_code() ==
             re2::RE2::ErrorCode::NoError) {  // success compile regex
-          SPDLOG_LOGGER_INFO(config_logger, "regexp '{}' added to whitelist",
+          SPDLOG_LOGGER_INFO(_logger, "regexp '{}' added to whitelist",
                              str_value);
           _regex.push_back(std::move(to_push_back));
           ret = true;
         } else {  // bad regex
           SPDLOG_LOGGER_ERROR(
-              config_logger, "fail to parse regex {}: error: {} at {} ",
-              str_value, to_push_back->error(), to_push_back->error_arg());
+              _logger, "fail to parse regex {}: error: {} at {} ", str_value,
+              to_push_back->error(), to_push_back->error_arg());
         }
       }
     }
@@ -258,7 +259,7 @@ whitelist::e_refresh_result whitelist::parse_dir(
     return e_refresh_result::no_directory;
   }
   if ((dir_infos.st_mode & S_IFMT) != S_IFDIR) {
-    SPDLOG_LOGGER_ERROR(config_logger, "{} is not a directory: {}", directory,
+    SPDLOG_LOGGER_ERROR(_logger, "{} is not a directory: {}", directory,
                         dir_infos.st_mode);
     return e_refresh_result::no_directory;
   }
@@ -267,7 +268,7 @@ whitelist::e_refresh_result whitelist::parse_dir(
 
   if (centengine_group) {
     if (dir_infos.st_uid || dir_infos.st_gid != centengine_group->gr_gid) {
-      SPDLOG_LOGGER_ERROR(config_logger,
+      SPDLOG_LOGGER_ERROR(_logger,
                           "directory {} must be owned by root@centreon-engine",
                           directory);
     }
@@ -275,8 +276,8 @@ whitelist::e_refresh_result whitelist::parse_dir(
 
   if (dir_infos.st_mode & S_IRWXO ||
       (dir_infos.st_mode & S_IRWXG) != S_IRGRP + S_IXGRP) {
-    SPDLOG_LOGGER_ERROR(config_logger,
-                        "directory {} must have 750 right access", directory);
+    SPDLOG_LOGGER_ERROR(_logger, "directory {} must have 750 right access",
+                        directory);
   }
 
   e_refresh_result res = e_refresh_result::empty_directory;

--- a/engine/src/main.cc
+++ b/engine/src/main.cc
@@ -116,12 +116,12 @@ int main(int argc, char* argv[]) {
 #endif  // HAVE_GETOPT_H
 
   // Load singletons and global variable.
+  log_v2::load("centengine");
+
+  /* It's time to set the logger. Later, we will have acceses from multiple
+   * threads and we'll only be able to change atomic values. */
   config = new configuration::state;
 
-  // Hack to instanciate the logger.
-  log_v2::load("centengine");
-  auto config_logger = log_v2::instance().get(log_v2::CONFIG);
-  auto process_logger = log_v2::instance().get(log_v2::PROCESS);
   init_loggers();
   configuration::applier::logging::instance();
   com::centreon::common::pool::load(g_io_context, runtime_logger);

--- a/tests/broker-engine/start-stop.robot
+++ b/tests/broker-engine/start-stop.robot
@@ -27,6 +27,7 @@ BESS1
 BESS2
     [Documentation]    Start-Stop Broker/Engine - Broker started first - Engine stopped first
     [Tags]    broker    engine    start-stop
+    Ctn Clear Retention
     Ctn Config Engine    ${1}
     Ctn Config Broker    central
     Ctn Config Broker    module


### PR DESCRIPTION
## Description

The Engine configuration module has its own loggers and doesn't need anymore Engine's loggers.

REFS: MON-111552
