### PR TITLE
Mon 34072 dependencies escalations reviewed

### DIFF
--- a/broker/core/inc/com/centreon/broker/stats/center.hh
+++ b/broker/core/inc/com/centreon/broker/stats/center.hh
@@ -96,8 +96,8 @@ class center {
   void get_processing_stats(ProcessingStats* response)
       ABSL_LOCKS_EXCLUDED(_stats_m);
   const BrokerStats& stats() const;
-  void lock() ABSL_EXCLUSIVE_LOCK_FUNCTION(_stats);
-  void unlock() ABSL_UNLOCK_FUNCTION(_stats);
+  void lock() ABSL_EXCLUSIVE_LOCK_FUNCTION(_stats_m);
+  void unlock() ABSL_UNLOCK_FUNCTION(_stats_m);
 
   /**
    * @brief Set the value pointed by ptr to the value value.

--- a/broker/neb/src/callbacks.cc
+++ b/broker/neb/src/callbacks.cc
@@ -4075,7 +4075,8 @@ class otl_protobuf
   }
 
   void set_obj(opentelemetry::proto::collector::metrics::v1::
-                   ExportMetricsServiceRequest&& obj) override {
+                   ExportMetricsServiceRequest&& obj
+               [[maybe_unused]]) override {
     throw com::centreon::exceptions::msg_fmt("unauthorized usage {}",
                                              typeid(*this).name());
   }

--- a/common/inc/com/centreon/common/process.hh
+++ b/common/inc/com/centreon/common/process.hh
@@ -46,7 +46,7 @@ class process : public std::enable_shared_from_this<process> {
 
   std::deque<std::shared_ptr<std::string>> _stdin_write_queue
       ABSL_GUARDED_BY(_protect);
-  bool _write_pending = false ABSL_GUARDED_BY(_protect);
+  bool _write_pending ABSL_GUARDED_BY(_protect) = false;
 
   std::shared_ptr<detail::boost_process> _proc ABSL_GUARDED_BY(_protect);
 

--- a/engine/inc/com/centreon/engine/configuration/applier/hostdependency.hh
+++ b/engine/inc/com/centreon/engine/configuration/applier/hostdependency.hh
@@ -26,8 +26,6 @@ namespace configuration {
 class hostdependency;
 class state;
 
-size_t hostdependency_key(const configuration::hostdependency& hd);
-
 namespace applier {
 class hostdependency {
   void _expand_hosts(std::set<std::string> const& hosts,

--- a/engine/inc/com/centreon/engine/configuration/applier/hostdependency.hh
+++ b/engine/inc/com/centreon/engine/configuration/applier/hostdependency.hh
@@ -1,22 +1,21 @@
-/*
-** Copyright 2011-2013,2017 Centreon
-**
-** This file is part of Centreon Engine.
-**
-** Centreon Engine is free software: you can redistribute it and/or
-** modify it under the terms of the GNU General Public License version 2
-** as published by the Free Software Foundation.
-**
-** Centreon Engine is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-** General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with Centreon Engine. If not, see
-** <http://www.gnu.org/licenses/>.
-*/
-
+/**
+ * Copyright 2011-2013,2017 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
 #ifndef CCE_CONFIGURATION_APPLIER_HOSTDEPENDENCY_HH
 #define CCE_CONFIGURATION_APPLIER_HOSTDEPENDENCY_HH
 
@@ -27,28 +26,29 @@ namespace configuration {
 class hostdependency;
 class state;
 
+size_t hostdependency_key(const configuration::hostdependency& hd);
+
 namespace applier {
 class hostdependency {
- public:
-  hostdependency();
-  hostdependency(hostdependency const& right) = delete;
-  ~hostdependency() throw();
-  hostdependency& operator=(hostdependency const& right) = delete;
-  void add_object(configuration::hostdependency const& obj);
-  void expand_objects(configuration::state& s);
-  void modify_object(configuration::hostdependency const& obj);
-  void remove_object(configuration::hostdependency const& obj);
-  void resolve_object(configuration::hostdependency const& obj);
-
- private:
   void _expand_hosts(std::set<std::string> const& hosts,
                      std::set<std::string> const& hostgroups,
                      configuration::state& s,
                      std::set<std::string>& expanded);
+
+ public:
+  hostdependency() = default;
+  hostdependency(const hostdependency&) = delete;
+  ~hostdependency() noexcept = default;
+  hostdependency& operator=(const hostdependency&) = delete;
+  void add_object(configuration::hostdependency const& obj);
+  void modify_object(configuration::hostdependency const& obj);
+  void remove_object(configuration::hostdependency const& obj);
+  void expand_objects(configuration::state& s);
+  void resolve_object(configuration::hostdependency const& obj);
 };
 }  // namespace applier
 }  // namespace configuration
 
-}
+}  // namespace com::centreon::engine
 
 #endif  // !CCE_CONFIGURATION_APPLIER_HOSTDEPENDENCY_HH

--- a/engine/inc/com/centreon/engine/configuration/applier/hostescalation.hh
+++ b/engine/inc/com/centreon/engine/configuration/applier/hostescalation.hh
@@ -1,22 +1,20 @@
-/*
-** Copyright 2011-2013,2017 Centreon
-**
-** This file is part of Centreon Engine.
-**
-** Centreon Engine is free software: you can redistribute it and/or
-** modify it under the terms of the GNU General Public License version 2
-** as published by the Free Software Foundation.
-**
-** Centreon Engine is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-** General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with Centreon Engine. If not, see
-** <http://www.gnu.org/licenses/>.
-*/
-
+/**
+ * Copyright 2011-2013,2017-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 #ifndef CCE_CONFIGURATION_APPLIER_HOSTESCALATION_HH
 #define CCE_CONFIGURATION_APPLIER_HOSTESCALATION_HH
 
@@ -29,28 +27,27 @@ class state;
 
 namespace applier {
 class hostescalation {
- public:
-  hostescalation();
-  hostescalation(hostescalation const& right) = delete;
-  ~hostescalation() throw();
-  hostescalation& operator=(hostescalation const& right) = delete;
-  void add_object(configuration::hostescalation const& obj);
-  void expand_objects(configuration::state& s);
-  void modify_object(configuration::hostescalation const& obj);
-  void remove_object(configuration::hostescalation const& obj);
-  void resolve_object(configuration::hostescalation const& obj);
-
- private:
   void _expand_hosts(std::set<std::string> const& h,
                      std::set<std::string> const& hg,
                      configuration::state const& s,
                      std::set<std::string>& expanded);
   void _inherits_special_vars(configuration::hostescalation& obj,
                               configuration::state& s);
+
+ public:
+  hostescalation() = default;
+  ~hostescalation() noexcept = default;
+  hostescalation(hostescalation const&) = delete;
+  hostescalation& operator=(hostescalation const&) = delete;
+  void add_object(const configuration::hostescalation& obj);
+  void modify_object(configuration::hostescalation const& obj);
+  void remove_object(configuration::hostescalation const& obj);
+  void expand_objects(configuration::state& s);
+  void resolve_object(configuration::hostescalation const& obj);
 };
 }  // namespace applier
 }  // namespace configuration
 
-}
+}  // namespace com::centreon::engine
 
 #endif  // !CCE_CONFIGURATION_APPLIER_HOSTESCALATION_HH

--- a/engine/inc/com/centreon/engine/configuration/applier/servicedependency.hh
+++ b/engine/inc/com/centreon/engine/configuration/applier/servicedependency.hh
@@ -1,22 +1,21 @@
 /**
  * Copyright 2011-2013,2017 Centreon
  *
- * This file is part of Centreon Engine.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Centreon Engine is free software: you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Centreon Engine is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- * You should have received a copy of the GNU General Public License
- * along with Centreon Engine. If not, see
- * <http://www.gnu.org/licenses/>.
+ * For more information : contact@centreon.com
+ *
  */
-
 #ifndef CCE_CONFIGURATION_APPLIER_SERVICEDEPENDENCY_HH
 #define CCE_CONFIGURATION_APPLIER_SERVICEDEPENDENCY_HH
 
@@ -26,6 +25,8 @@ namespace configuration {
 // Forward declarations.
 class servicedependency;
 class state;
+
+size_t servicedependency_key(const servicedependency& sd);
 
 namespace applier {
 class servicedependency {

--- a/engine/inc/com/centreon/engine/configuration/applier/state.hh
+++ b/engine/inc/com/centreon/engine/configuration/applier/state.hh
@@ -1,22 +1,20 @@
 /**
  * Copyright 2011-2024 Centreon
  *
- * This file is part of Centreon Engine.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Centreon Engine is free software: you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Centreon Engine is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- * You should have received a copy of the GNU General Public License
- * along with Centreon Engine. If not, see
- * <http://www.gnu.org/licenses/>.
+ * For more information : contact@centreon.com
  */
-
 #ifndef CCE_CONFIGURATION_APPLIER_STATE_HH
 #define CCE_CONFIGURATION_APPLIER_STATE_HH
 

--- a/engine/inc/com/centreon/engine/configuration/applier/timeperiod.hh
+++ b/engine/inc/com/centreon/engine/configuration/applier/timeperiod.hh
@@ -1,22 +1,20 @@
-/*
-** Copyright 2011-2013,2017 Centreon
-**
-** This file is part of Centreon Engine.
-**
-** Centreon Engine is free software: you can redistribute it and/or
-** modify it under the terms of the GNU General Public License version 2
-** as published by the Free Software Foundation.
-**
-** Centreon Engine is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-** General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with Centreon Engine. If not, see
-** <http://www.gnu.org/licenses/>.
-*/
-
+/**
+ * Copyright 2011-2013,2017-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 #ifndef CCE_CONFIGURATION_APPLIER_TIMEPERIOD_HH
 #define CCE_CONFIGURATION_APPLIER_TIMEPERIOD_HH
 
@@ -32,24 +30,30 @@ class timeperiod;
 
 namespace applier {
 class timeperiod {
+  void _add_exclusions(std::set<std::string> const& exclusions,
+                       com::centreon::engine::timeperiod* tp);
+
  public:
-  timeperiod();
-  timeperiod(timeperiod const& right);
-  ~timeperiod() throw();
-  timeperiod& operator=(timeperiod const& right);
-  void add_object(configuration::timeperiod const& obj);
+  /**
+   * @brief Default constructor.
+   */
+  timeperiod() = default;
+
+  /**
+   * @brief Destructor.
+   */
+  ~timeperiod() noexcept = default;
+  timeperiod(const timeperiod&) = delete;
+  timeperiod& operator=(const timeperiod&) = delete;
+  void add_object(const configuration::timeperiod& obj);
   void expand_objects(configuration::state& s);
   void modify_object(configuration::timeperiod const& obj);
   void remove_object(configuration::timeperiod const& obj);
   void resolve_object(configuration::timeperiod const& obj);
-
- private:
-  void _add_exclusions(std::set<std::string> const& exclusions,
-                       com::centreon::engine::timeperiod* tp);
 };
 }  // namespace applier
 }  // namespace configuration
 
-}
+}  // namespace com::centreon::engine
 
 #endif  // !CCE_CONFIGURATION_APPLIER_TIMEPERIOD_HH

--- a/engine/inc/com/centreon/engine/configuration/hostdependency.hh
+++ b/engine/inc/com/centreon/engine/configuration/hostdependency.hh
@@ -26,6 +26,7 @@
 namespace com::centreon::engine {
 
 namespace configuration {
+
 class hostdependency : public object {
  public:
   enum action_on {
@@ -96,6 +97,8 @@ class hostdependency : public object {
   opt<unsigned int> _notification_failure_options;
   static std::unordered_map<std::string, setter_func> const _setters;
 };
+
+size_t hostdependency_key(const hostdependency& hd);
 
 typedef std::shared_ptr<hostdependency> hostdependency_ptr;
 typedef std::set<hostdependency> set_hostdependency;

--- a/engine/inc/com/centreon/engine/configuration/hostdependency.hh
+++ b/engine/inc/com/centreon/engine/configuration/hostdependency.hh
@@ -44,7 +44,7 @@ class hostdependency : public object {
 
   hostdependency();
   hostdependency(hostdependency const& right);
-  ~hostdependency() throw() override;
+  ~hostdependency() noexcept override = default;
   hostdependency& operator=(hostdependency const& right);
   bool operator==(hostdependency const& right) const throw();
   bool operator!=(hostdependency const& right) const throw();

--- a/engine/inc/com/centreon/engine/configuration/hostescalation.hh
+++ b/engine/inc/com/centreon/engine/configuration/hostescalation.hh
@@ -22,7 +22,6 @@
 #include "com/centreon/engine/configuration/group.hh"
 #include "com/centreon/engine/configuration/object.hh"
 #include "com/centreon/engine/opt.hh"
-#include "com/centreon/engine/shared.hh"
 
 namespace com::centreon::engine {
 

--- a/engine/inc/com/centreon/engine/configuration/hostescalation.hh
+++ b/engine/inc/com/centreon/engine/configuration/hostescalation.hh
@@ -68,7 +68,6 @@ class hostescalation : public object {
   void notification_interval(unsigned int interval);
   unsigned int notification_interval() const throw();
   bool notification_interval_defined() const throw();
-  Uuid const& uuid() const;
 
  private:
   typedef bool (*setter_func)(hostescalation&, char const*);
@@ -91,8 +90,9 @@ class hostescalation : public object {
   opt<unsigned int> _last_notification;
   opt<unsigned int> _notification_interval;
   static std::unordered_map<std::string, setter_func> const _setters;
-  Uuid _uuid;
 };
+
+size_t hostescalation_key(const hostescalation& he);
 
 typedef std::shared_ptr<hostescalation> hostescalation_ptr;
 typedef std::set<hostescalation> set_hostescalation;

--- a/engine/inc/com/centreon/engine/configuration/object.hh
+++ b/engine/inc/com/centreon/engine/configuration/object.hh
@@ -51,7 +51,7 @@ class object {
 
   object(object_type type);
   object(object const& right);
-  virtual ~object() noexcept;
+  virtual ~object() noexcept = default;
   object& operator=(object const& right);
   bool operator==(object const& right) const noexcept;
   bool operator!=(object const& right) const noexcept;

--- a/engine/inc/com/centreon/engine/configuration/servicedependency.hh
+++ b/engine/inc/com/centreon/engine/configuration/servicedependency.hh
@@ -45,7 +45,7 @@ class servicedependency : public object {
 
   servicedependency();
   servicedependency(servicedependency const& right);
-  ~servicedependency() throw() override;
+  ~servicedependency() noexcept override = default;
   servicedependency& operator=(servicedependency const& right);
   bool operator==(servicedependency const& right) const throw();
   bool operator!=(servicedependency const& right) const throw();

--- a/engine/inc/com/centreon/engine/configuration/servicedependency.hh
+++ b/engine/inc/com/centreon/engine/configuration/servicedependency.hh
@@ -26,6 +26,7 @@
 namespace com::centreon::engine {
 
 namespace configuration {
+
 class servicedependency : public object {
  public:
   enum action_on {
@@ -113,6 +114,8 @@ class servicedependency : public object {
   group<list_string> _service_description;
   static std::unordered_map<std::string, setter_func> const _setters;
 };
+
+size_t servicedependency_key(const servicedependency& sd);
 
 typedef std::shared_ptr<servicedependency> servicedependency_ptr;
 typedef std::set<servicedependency> set_servicedependency;

--- a/engine/inc/com/centreon/engine/configuration/serviceescalation.hh
+++ b/engine/inc/com/centreon/engine/configuration/serviceescalation.hh
@@ -22,7 +22,6 @@
 #include "com/centreon/engine/configuration/group.hh"
 #include "com/centreon/engine/configuration/object.hh"
 #include "com/centreon/engine/opt.hh"
-#include "com/centreon/engine/shared.hh"
 
 namespace com::centreon::engine::configuration {
 

--- a/engine/inc/com/centreon/engine/configuration/serviceescalation.hh
+++ b/engine/inc/com/centreon/engine/configuration/serviceescalation.hh
@@ -40,7 +40,6 @@ class serviceescalation : public object {
   group<list_string> _servicegroups;
   group<list_string> _service_description;
   static std::unordered_map<std::string, setter_func> const _setters;
-  Uuid _uuid;
 
   bool _set_contactgroups(std::string const& value);
   bool _set_escalation_options(std::string const& value);
@@ -72,7 +71,7 @@ class serviceescalation : public object {
   bool operator!=(serviceescalation const& right) const noexcept;
   bool operator<(serviceescalation const& right) const;
   void check_validity() const override;
-  key_type const& key() const throw();
+  key_type const& key() const noexcept;
   void merge(object const& obj) override;
   bool parse(char const* key, char const* value) override;
 
@@ -82,25 +81,26 @@ class serviceescalation : public object {
   void escalation_options(unsigned int options) noexcept;
   unsigned short escalation_options() const noexcept;
   void escalation_period(std::string const& period);
-  std::string const& escalation_period() const throw();
-  bool escalation_period_defined() const throw();
-  void first_notification(unsigned int n) throw();
-  unsigned int first_notification() const throw();
-  list_string& hostgroups() throw();
-  list_string const& hostgroups() const throw();
-  list_string& hosts() throw();
-  list_string const& hosts() const throw();
-  void last_notification(unsigned int options) throw();
-  unsigned int last_notification() const throw();
-  void notification_interval(unsigned int interval) throw();
-  unsigned int notification_interval() const throw();
-  bool notification_interval_defined() const throw();
-  list_string& servicegroups() throw();
-  list_string const& servicegroups() const throw();
-  list_string& service_description() throw();
-  list_string const& service_description() const throw();
-  Uuid const& uuid() const;
+  std::string const& escalation_period() const noexcept;
+  bool escalation_period_defined() const noexcept;
+  void first_notification(unsigned int n) noexcept;
+  unsigned int first_notification() const noexcept;
+  list_string& hostgroups() noexcept;
+  list_string const& hostgroups() const noexcept;
+  list_string& hosts() noexcept;
+  list_string const& hosts() const noexcept;
+  void last_notification(unsigned int options) noexcept;
+  unsigned int last_notification() const noexcept;
+  void notification_interval(unsigned int interval) noexcept;
+  unsigned int notification_interval() const noexcept;
+  bool notification_interval_defined() const noexcept;
+  list_string& servicegroups() noexcept;
+  list_string const& servicegroups() const noexcept;
+  list_string& service_description() noexcept;
+  list_string const& service_description() const noexcept;
 };
+
+size_t serviceescalation_key(const serviceescalation& he);
 
 typedef std::shared_ptr<serviceescalation> serviceescalation_ptr;
 typedef std::set<serviceescalation> set_serviceescalation;

--- a/engine/inc/com/centreon/engine/dependency.hh
+++ b/engine/inc/com/centreon/engine/dependency.hh
@@ -1,40 +1,44 @@
-/*
-** Copyright 2011-2019 Centreon
-**
-** This file is part of Centreon Engine.
-**
-** Centreon Engine is free software: you can redistribute it and/or
-** modify it under the terms of the GNU General Public License version 2
-** as published by the Free Software Foundation.
-**
-** Centreon Engine is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-** General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with Centreon Engine. If not, see
-** <http://www.gnu.org/licenses/>.
-*/
-
+/**
+ * Copyright 2011-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
 #ifndef CENTREON_ENGINE_DEPENDENCY_HH
 #define CENTREON_ENGINE_DEPENDENCY_HH
 
 #include <com/centreon/engine/timeperiod.hh>
 
-namespace com::centreon::engine {;
+namespace com::centreon::engine {
 
 class dependency {
+  /* This key is a hash of the configuration attributes of this hostdependency,
+   * essentially used when a new configuration is applied to engine. */
+  const size_t _internal_key;
+
  public:
   enum types { notification = 1, execution };
 
-  dependency(std::string const& dependent_hostname,
-             std::string const& hostname,
+  dependency(size_t key,
+             const std::string& dependent_hostname,
+             const std::string& hostname,
              types dependency_type,
              bool inherits_parent,
              bool fail_on_pending,
-             std::string const& dependency_period);
-  virtual ~dependency() {}
+             const std::string& dependency_period);
+  virtual ~dependency() noexcept = default;
 
   types get_dependency_type() const;
   void set_dependency_type(types dependency_type);
@@ -57,6 +61,7 @@ class dependency {
   virtual bool operator==(dependency const& obj) throw();
   bool operator!=(dependency const& obj) throw();
   virtual bool operator<(dependency const& obj) throw();
+  size_t internal_key() const;
 
   com::centreon::engine::timeperiod* dependency_period_ptr;
 
@@ -71,6 +76,6 @@ class dependency {
   bool _contains_circular_path;
 };
 
-};
+};  // namespace com::centreon::engine
 
 #endif  // CENTREON_ENGINE_DEPENDENCY_HH

--- a/engine/inc/com/centreon/engine/escalation.hh
+++ b/engine/inc/com/centreon/engine/escalation.hh
@@ -1,22 +1,20 @@
-/*
-** Copyright 2011-2019 Centreon
-**
-** This file is part of Centreon Engine.
-**
-** Centreon Engine is free software: you can redistribute it and/or
-** modify it under the terms of the GNU General Public License version 2
-** as published by the Free Software Foundation.
-**
-** Centreon Engine is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-** General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with Centreon Engine. If not, see
-** <http://www.gnu.org/licenses/>.
-*/
-
+/**
+ * Copyright 2011-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 #ifndef CCE_ESCALATION_HH
 #define CCE_ESCALATION_HH
 
@@ -29,13 +27,22 @@ namespace com::centreon::engine {
 class timeperiod;
 
 class escalation {
+  uint32_t _first_notification;
+  uint32_t _last_notification;
+  double _notification_interval;
+  std::string _escalation_period;
+  uint32_t _escalate_on;
+  contactgroup_map_unsafe _contact_groups;
+  const size_t _internal_key;
+
  public:
   escalation(uint32_t first_notification,
              uint32_t last_notification,
              double notification_interval,
              std::string const& escalation_period,
              uint32_t escalate_on,
-             Uuid const& uuid);
+             const size_t key);
+  virtual ~escalation() noexcept = default;
 
   std::string const& get_escalation_period() const;
   uint32_t get_first_notification() const;
@@ -48,7 +55,7 @@ class escalation {
   bool get_escalate_on(notifier::notification_flag type) const;
   void set_escalate_on(uint32_t escalate_on);
   virtual bool is_viable(int state, uint32_t notification_number) const;
-  Uuid const& get_uuid() const;
+  size_t internal_key() const;
 
   contactgroup_map_unsafe const& get_contactgroups() const;
   contactgroup_map_unsafe& get_contactgroups();
@@ -56,16 +63,7 @@ class escalation {
 
   notifier* notifier_ptr;
   timeperiod* escalation_period_ptr;
-
- private:
-  uint32_t _first_notification;
-  uint32_t _last_notification;
-  double _notification_interval;
-  std::string _escalation_period;
-  uint32_t _escalate_on;
-  contactgroup_map_unsafe _contact_groups;
-  Uuid _uuid;
 };
-}
+}  // namespace com::centreon::engine
 
 #endif  // !CCE_ESCALATION_HH

--- a/engine/inc/com/centreon/engine/hostdependency.hh
+++ b/engine/inc/com/centreon/engine/hostdependency.hh
@@ -1,22 +1,21 @@
-/*
-** Copyright 2011-2019 Centreon
-**
-** This file is part of Centreon Engine.
-**
-** Centreon Engine is free software: you can redistribute it and/or
-** modify it under the terms of the GNU General Public License version 2
-** as published by the Free Software Foundation.
-**
-** Centreon Engine is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-** General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with Centreon Engine. If not, see
-** <http://www.gnu.org/licenses/>.
-*/
-
+/**
+ * Copyright 2011-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
 #ifndef CCE_OBJECTS_HOSTDEPENDENCY_HH
 #define CCE_OBJECTS_HOSTDEPENDENCY_HH
 
@@ -28,9 +27,9 @@ namespace com::centreon::engine {
 class host;
 class hostdependency;
 class timeperiod;
-}
+}  // namespace com::centreon::engine
 
-typedef std::unordered_multimap<
+typedef absl::btree_multimap<
     std::string,
     std::shared_ptr<com::centreon::engine::hostdependency>>
     hostdependency_mmap;
@@ -38,8 +37,9 @@ typedef std::unordered_multimap<
 namespace com::centreon::engine {
 class hostdependency : public dependency {
  public:
-  hostdependency(std::string const& dependent_hostname,
-                 std::string const& hostname,
+  hostdependency(size_t key,
+                 const std::string& dependent_hostname,
+                 const std::string& hostname,
                  dependency::types dependency_type,
                  bool inherits_parent,
                  bool fail_on_up,
@@ -66,6 +66,8 @@ class hostdependency : public dependency {
   static hostdependency_mmap hostdependencies;
   static hostdependency_mmap::iterator hostdependencies_find(
       configuration::hostdependency const& k);
+  static hostdependency_mmap::iterator hostdependencies_find(
+      const std::pair<std::string_view, size_t>& key);
 
   host* master_host_ptr;
   host* dependent_host_ptr;
@@ -76,7 +78,7 @@ class hostdependency : public dependency {
   bool _fail_on_unreachable;
 };
 
-}
+}  // namespace com::centreon::engine
 
 std::ostream& operator<<(std::ostream& os,
                          com::centreon::engine::hostdependency const& obj);

--- a/engine/inc/com/centreon/engine/hostdependency.hh
+++ b/engine/inc/com/centreon/engine/hostdependency.hh
@@ -29,7 +29,7 @@ class hostdependency;
 class timeperiod;
 }  // namespace com::centreon::engine
 
-typedef absl::btree_multimap<
+typedef std::unordered_multimap<
     std::string,
     std::shared_ptr<com::centreon::engine::hostdependency>>
     hostdependency_mmap;

--- a/engine/inc/com/centreon/engine/hostdependency.hh
+++ b/engine/inc/com/centreon/engine/hostdependency.hh
@@ -66,8 +66,6 @@ class hostdependency : public dependency {
   static hostdependency_mmap hostdependencies;
   static hostdependency_mmap::iterator hostdependencies_find(
       configuration::hostdependency const& k);
-  static hostdependency_mmap::iterator hostdependencies_find(
-      const std::pair<std::string_view, size_t>& key);
 
   host* master_host_ptr;
   host* dependent_host_ptr;

--- a/engine/inc/com/centreon/engine/hostescalation.hh
+++ b/engine/inc/com/centreon/engine/hostescalation.hh
@@ -31,6 +31,10 @@ typedef std::unordered_multimap<
     hostescalation_mmap;
 
 namespace com::centreon::engine {
+namespace configuration {
+class hostescalation;
+}
+
 class hostescalation : public escalation {
  public:
   hostescalation(std::string const& host_name,
@@ -45,6 +49,8 @@ class hostescalation : public escalation {
   std::string const& get_hostname() const;
   bool is_viable(int state, uint32_t notification_number) const override;
   void resolve(int& w, int& e) override;
+
+  bool matches(const configuration::hostescalation& obj) const;
 
   static hostescalation_mmap hostescalations;
 

--- a/engine/inc/com/centreon/engine/hostescalation.hh
+++ b/engine/inc/com/centreon/engine/hostescalation.hh
@@ -1,22 +1,20 @@
-/*
-** Copyright 2011-2019 Centreon
-**
-** This file is part of Centreon Engine.
-**
-** Centreon Engine is free software: you can redistribute it and/or
-** modify it under the terms of the GNU General Public License version 2
-** as published by the Free Software Foundation.
-**
-** Centreon Engine is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-** General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with Centreon Engine. If not, see
-** <http://www.gnu.org/licenses/>.
-*/
-
+/**
+ * Copyright 2011-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 #ifndef CCE_HOSTESCALATION_HH
 #define CCE_HOSTESCALATION_HH
 #include "com/centreon/engine/escalation.hh"
@@ -25,7 +23,7 @@
 namespace com::centreon::engine {
 class host;
 class hostescalation;
-}
+}  // namespace com::centreon::engine
 
 typedef std::unordered_multimap<
     std::string,
@@ -41,8 +39,8 @@ class hostescalation : public escalation {
                  double notification_interval,
                  std::string const& escalation_period,
                  uint32_t escalate_on,
-                 Uuid const& uuid);
-  virtual ~hostescalation();
+                 const size_t key);
+  ~hostescalation() override = default;
 
   std::string const& get_hostname() const;
   bool is_viable(int state, uint32_t notification_number) const override;
@@ -54,6 +52,6 @@ class hostescalation : public escalation {
   std::string _hostname;
 };
 
-}
+}  // namespace com::centreon::engine
 
 #endif  // !CCE_HOSTESCALATION_HH

--- a/engine/inc/com/centreon/engine/servicedependency.hh
+++ b/engine/inc/com/centreon/engine/servicedependency.hh
@@ -87,8 +87,8 @@ class servicedependency : public dependency {
   static servicedependency_mmap servicedependencies;
   static servicedependency_mmap::iterator servicedependencies_find(
       configuration::servicedependency const& k);
-  static servicedependency_mmap::iterator servicedependencies_find(
-      const std::tuple<std::string, std::string, size_t>& key);
+  //  static servicedependency_mmap::iterator servicedependencies_find(
+  //      const std::tuple<std::string, std::string, size_t>& key);
 };
 
 };  // namespace com::centreon::engine

--- a/engine/inc/com/centreon/engine/servicedependency.hh
+++ b/engine/inc/com/centreon/engine/servicedependency.hh
@@ -87,8 +87,6 @@ class servicedependency : public dependency {
   static servicedependency_mmap servicedependencies;
   static servicedependency_mmap::iterator servicedependencies_find(
       configuration::servicedependency const& k);
-  //  static servicedependency_mmap::iterator servicedependencies_find(
-  //      const std::tuple<std::string, std::string, size_t>& key);
 };
 
 };  // namespace com::centreon::engine

--- a/engine/inc/com/centreon/engine/servicedependency.hh
+++ b/engine/inc/com/centreon/engine/servicedependency.hh
@@ -1,22 +1,22 @@
-/*
-** Copyright 2011-2013 Merethis
-**
-** This file is part of Centreon Engine.
-**
-** Centreon Engine is free software: you can redistribute it and/or
-** modify it under the terms of the GNU General Public License version 2
-** as published by the Free Software Foundation.
-**
-** Centreon Engine is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-** General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with Centreon Engine. If not, see
-** <http://www.gnu.org/licenses/>.
-*/
-
+/**
+ * Copyright 2011-2013 Merethis
+ * Copyright 2014-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
 #ifndef CCE_OBJECTS_SERVICEDEPENDENCY_HH
 #define CCE_OBJECTS_SERVICEDEPENDENCY_HH
 #include "com/centreon/engine/configuration/servicedependency.hh"
@@ -28,7 +28,7 @@ namespace com::centreon::engine {
 class service;
 class servicedependency;
 class timeperiod;
-}
+}  // namespace com::centreon::engine
 
 typedef std::unordered_multimap<
     std::pair<std::string, std::string>,
@@ -38,8 +38,16 @@ typedef std::unordered_multimap<
 
 namespace com::centreon::engine {
 class servicedependency : public dependency {
+  std::string _dependent_service_description;
+  std::string _service_description;
+  bool _fail_on_ok;
+  bool _fail_on_warning;
+  bool _fail_on_unknown;
+  bool _fail_on_critical;
+
  public:
-  servicedependency(std::string const& dependent_host_name,
+  servicedependency(size_t key,
+                    std::string const& dependent_host_name,
                     std::string const& dependent_service_description,
                     std::string const& host_name,
                     std::string const& service_description,
@@ -79,17 +87,11 @@ class servicedependency : public dependency {
   static servicedependency_mmap servicedependencies;
   static servicedependency_mmap::iterator servicedependencies_find(
       configuration::servicedependency const& k);
-
- private:
-  std::string _dependent_service_description;
-  std::string _service_description;
-  bool _fail_on_ok;
-  bool _fail_on_warning;
-  bool _fail_on_unknown;
-  bool _fail_on_critical;
+  static servicedependency_mmap::iterator servicedependencies_find(
+      const std::tuple<std::string, std::string, size_t>& key);
 };
 
-};
+};  // namespace com::centreon::engine
 
 std::ostream& operator<<(std::ostream& os,
                          com::centreon::engine::servicedependency const& obj);

--- a/engine/inc/com/centreon/engine/serviceescalation.hh
+++ b/engine/inc/com/centreon/engine/serviceescalation.hh
@@ -1,22 +1,20 @@
-/*
-** Copyright 2011-2019 Centreon
-**
-** This file is part of Centreon Engine.
-**
-** Centreon Engine is free software: you can redistribute it and/or
-** modify it under the terms of the GNU General Public License version 2
-** as published by the Free Software Foundation.
-**
-** Centreon Engine is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-** General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with Centreon Engine. If not, see
-** <http://www.gnu.org/licenses/>.
-*/
-
+/**
+ * Copyright 2011-2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 #ifndef CCE_SERVICEESCALATION_HH
 #define CCE_SERVICEESCALATION_HH
 
@@ -44,8 +42,8 @@ class serviceescalation : public escalation {
                     double notification_interval,
                     std::string const& escalation_period,
                     uint32_t escalate_on,
-                    Uuid const& uuid);
-  virtual ~serviceescalation();
+                    const size_t key);
+  ~serviceescalation() override = default;
   std::string const& get_hostname() const;
   std::string const& get_description() const;
   bool is_viable(int state, uint32_t notification_number) const override;
@@ -58,6 +56,6 @@ class serviceescalation : public escalation {
   std::string _description;
 };
 
-}
+}  // namespace com::centreon::engine
 
 #endif  // !CCE_SERVICEESCALATION_HH

--- a/engine/inc/com/centreon/engine/serviceescalation.hh
+++ b/engine/inc/com/centreon/engine/serviceescalation.hh
@@ -33,6 +33,11 @@ typedef std::unordered_multimap<
     serviceescalation_mmap;
 
 namespace com::centreon::engine {
+
+namespace configuration {
+class serviceescalation;
+}
+
 class serviceescalation : public escalation {
  public:
   serviceescalation(std::string const& hostname,
@@ -48,6 +53,7 @@ class serviceescalation : public escalation {
   std::string const& get_description() const;
   bool is_viable(int state, uint32_t notification_number) const override;
   void resolve(int& w, int& e) override;
+  bool matches(const configuration::serviceescalation& obj) const;
 
   static serviceescalation_mmap serviceescalations;
 

--- a/engine/src/anomalydetection.cc
+++ b/engine/src/anomalydetection.cc
@@ -1129,8 +1129,6 @@ bool anomalydetection::parse_perfdata(std::string const& perfdata,
   /* We should master this string, so no need to check if it is utf-8 */
   calculated_result.set_output(oss.str());
 
-  timestamp now(timestamp::now());
-
   // Update check result.
   timeval tv;
   gettimeofday(&tv, nullptr);

--- a/engine/src/checkable.cc
+++ b/engine/src/checkable.cc
@@ -1,22 +1,21 @@
 /**
  * Copyright 2011-2019,2022-2024 Centreon
  *
- * This file is part of Centreon Engine.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Centreon Engine is free software: you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Centreon Engine is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- * You should have received a copy of the GNU General Public License
- * along with Centreon Engine. If not, see
- * <http://www.gnu.org/licenses/>.
+ * For more information : contact@centreon.com
+ *
  */
-
 #include "com/centreon/engine/checkable.hh"
 #include "com/centreon/engine/exceptions/error.hh"
 #include "com/centreon/engine/globals.hh"
@@ -51,8 +50,7 @@ checkable::checkable(const std::string& name,
                      bool obsess_over,
                      const std::string& timezone,
                      uint64_t icon_id)
-    : check_period_ptr{nullptr},
-      _name{name},
+    : _name{name},
       _display_name{display_name.empty() ? name : display_name},
       _check_command{check_command},
       _check_interval{check_interval},
@@ -93,7 +91,8 @@ checkable::checkable(const std::string& name,
       _event_handler_ptr{nullptr},
       _check_command_ptr{nullptr},
       _is_executing{false},
-      _icon_id{icon_id} {
+      _icon_id{icon_id},
+      check_period_ptr{nullptr} {
   if (max_attempts <= 0 || retry_interval <= 0 || freshness_threshold < 0) {
     std::ostringstream oss;
     bool empty{true};

--- a/engine/src/configuration/applier/hostdependency.cc
+++ b/engine/src/configuration/applier/hostdependency.cc
@@ -26,15 +26,15 @@
 
 using namespace com::centreon::engine::configuration;
 
-/**
- *  Default constructor.
- */
-applier::hostdependency::hostdependency() {}
-
-/**
- *  Destructor.
- */
-applier::hostdependency::~hostdependency() throw() {}
+namespace com::centreon::engine::configuration {
+size_t hostdependency_key(const hostdependency& hd) {
+  assert(hd.hosts().size() == 1 && hd.hostgroups().empty() &&
+         hd.dependent_hosts().size() == 1 && hd.dependent_hostgroups().empty());
+  return absl::HashOf(hd.dependency_period(), hd.dependency_type(),
+                      *hd.dependent_hosts().begin(), *hd.hosts().begin(),
+                      hd.inherits_parent(), hd.notification_failure_options());
+}
+}  // namespace com::centreon::engine::configuration
 
 /**
  *  Add new hostdependency.
@@ -77,7 +77,8 @@ void applier::hostdependency::add_object(
       configuration::hostdependency::execution_dependency)
     // Create executon dependency.
     hd = std::make_shared<engine::hostdependency>(
-        *obj.dependent_hosts().begin(), *obj.hosts().begin(),
+        hostdependency_key(obj), *obj.dependent_hosts().begin(),
+        *obj.hosts().begin(),
         static_cast<engine::hostdependency::types>(obj.dependency_type()),
         obj.inherits_parent(),
         static_cast<bool>(obj.execution_failure_options() &
@@ -92,7 +93,8 @@ void applier::hostdependency::add_object(
   else
     // Create notification dependency.
     hd = std::make_shared<engine::hostdependency>(
-        *obj.dependent_hosts().begin(), *obj.hosts().begin(),
+        hostdependency_key(obj), *obj.dependent_hosts().begin(),
+        *obj.hosts().begin(),
         static_cast<engine::hostdependency::types>(obj.dependency_type()),
         obj.inherits_parent(),
         static_cast<bool>(obj.notification_failure_options() &

--- a/engine/src/configuration/applier/hostdependency.cc
+++ b/engine/src/configuration/applier/hostdependency.cc
@@ -26,16 +26,6 @@
 
 using namespace com::centreon::engine::configuration;
 
-namespace com::centreon::engine::configuration {
-size_t hostdependency_key(const hostdependency& hd) {
-  assert(hd.hosts().size() == 1 && hd.hostgroups().empty() &&
-         hd.dependent_hosts().size() == 1 && hd.dependent_hostgroups().empty());
-  return absl::HashOf(hd.dependency_period(), hd.dependency_type(),
-                      *hd.dependent_hosts().begin(), *hd.hosts().begin(),
-                      hd.inherits_parent(), hd.notification_failure_options());
-}
-}  // namespace com::centreon::engine::configuration
-
 /**
  *  Add new hostdependency.
  *

--- a/engine/src/configuration/applier/hostescalation.cc
+++ b/engine/src/configuration/applier/hostescalation.cc
@@ -242,7 +242,7 @@ void applier::hostescalation::resolve_object(
   for (hostescalation_mmap::iterator it{p.first}; it != p.second; ++it) {
     /* It's a pity but for now we don't have any idea or key to verify if
      * the hostescalation is the good one. */
-    if (it->second->internal_key() == key) {
+    if (it->second->internal_key() == key && it->second->matches(obj)) {
       found = true;
       // Resolve host escalation.
       it->second->resolve(config_warnings, config_errors);

--- a/engine/src/configuration/applier/servicedependency.cc
+++ b/engine/src/configuration/applier/servicedependency.cc
@@ -29,17 +29,6 @@
 
 using namespace com::centreon::engine::configuration;
 
-namespace com::centreon::engine::configuration {
-size_t servicedependency_key(const servicedependency& sd) {
-  return absl::HashOf(sd.dependency_period(), sd.dependency_type(),
-                      *sd.hosts().begin(), *sd.service_description().begin(),
-                      *sd.dependent_hosts().begin(),
-                      *sd.dependent_service_description().begin(),
-                      sd.execution_failure_options(), sd.inherits_parent(),
-                      sd.notification_failure_options());
-}
-}  // namespace com::centreon::engine::configuration
-
 /**
  *  Add new service dependency.
  *

--- a/engine/src/configuration/applier/serviceescalation.cc
+++ b/engine/src/configuration/applier/serviceescalation.cc
@@ -255,8 +255,8 @@ void applier::serviceescalation::resolve_object(
                          << "concerning host '" << hostname << "' and service '"
                          << desc << "'";
   size_t key = serviceescalation_key(obj);
-  for (serviceescalation_mmap::iterator it{p.first}; it != p.second; ++it) {
-    if (it->second->internal_key() == key) {
+  for (serviceescalation_mmap::iterator it = p.first; it != p.second; ++it) {
+    if (it->second->internal_key() == key && it->second->matches(obj)) {
       found = true;
       // Resolve service escalation.
       it->second->resolve(config_warnings, config_errors);

--- a/engine/src/configuration/applier/state.cc
+++ b/engine/src/configuration/applier/state.cc
@@ -937,12 +937,12 @@ void applier::state::_check_contactgroups() const {
           found->second.get() != pp.second) {
         engine_logger(log_config_error, basic)
             << "Error on contactgroup !!! The contactgroup " << pp.first
-            << " used in serviceescalation " << p.second->get_uuid().to_string()
+            << " used in serviceescalation " << p.second->internal_key()
             << " is not or badly defined";
         config_logger->error(
             "Error on contactgroup !!! The contactgroup {} used in "
             "serviceescalation {} is not or badly defined",
-            pp.first, p.second->get_uuid().to_string());
+            pp.first, p.second->internal_key());
         throw engine_error() << "This is a bug";
       }
     }
@@ -956,12 +956,12 @@ void applier::state::_check_contactgroups() const {
           found->second.get() != pp.second) {
         engine_logger(log_config_error, basic)
             << "Error on contactgroup !!! The contactgroup " << pp.first
-            << " used in hostescalation " << p.second->get_uuid().to_string()
+            << " used in hostescalation " << p.second->internal_key()
             << " is not or badly defined";
         config_logger->error(
             "Error on contactgroup !!! The contactgroup {} used in "
             "hostescalation {} is not or badly defined",
-            pp.first, p.second->get_uuid().to_string());
+            pp.first, p.second->internal_key());
         throw engine_error() << "This is a bug";
       }
     }

--- a/engine/src/configuration/applier/timeperiod.cc
+++ b/engine/src/configuration/applier/timeperiod.cc
@@ -29,36 +29,6 @@
 using namespace com::centreon::engine::configuration;
 
 /**
- *  Default constructor.
- */
-applier::timeperiod::timeperiod() {}
-
-/**
- *  Copy constructor.
- *
- *  @param[in] right Object to copy.
- */
-applier::timeperiod::timeperiod(applier::timeperiod const& right) {
-  (void)right;
-}
-
-/**
- *  Destructor.
- */
-applier::timeperiod::~timeperiod() throw() {}
-
-/**
- *  Assignment operator.
- *
- *  @param[in] right Object to copy.
- */
-applier::timeperiod& applier::timeperiod::operator=(
-    applier::timeperiod const& right) {
-  (void)right;
-  return (*this);
-}
-
-/**
  *  Add new time period.
  *
  *  @param[in] obj  The new time period to add in the monitoring engine.

--- a/engine/src/configuration/hostdependency.cc
+++ b/engine/src/configuration/hostdependency.cc
@@ -33,11 +33,15 @@ using namespace com::centreon::engine::logging;
 #define SETTER(type, method) \
   &object::setter<hostdependency, type, &hostdependency::method>::generic
 
+namespace com::centreon::engine::configuration {
 size_t hostdependency_key(const hostdependency& hd) {
+  assert(hd.hosts().size() == 1 && hd.hostgroups().empty() &&
+         hd.dependent_hosts().size() == 1 && hd.dependent_hostgroups().empty());
   return absl::HashOf(hd.dependency_period(), hd.dependency_type(),
                       *hd.dependent_hosts().begin(), *hd.hosts().begin(),
                       hd.inherits_parent(), hd.notification_failure_options());
 }
+}  // namespace com::centreon::engine::configuration
 
 std::unordered_map<std::string,
                    hostdependency::setter_func> const hostdependency::_setters{

--- a/engine/src/configuration/hostdependency.cc
+++ b/engine/src/configuration/hostdependency.cc
@@ -33,6 +33,12 @@ using namespace com::centreon::engine::logging;
 #define SETTER(type, method) \
   &object::setter<hostdependency, type, &hostdependency::method>::generic
 
+size_t hostdependency_key(const hostdependency& hd) {
+  return absl::HashOf(hd.dependency_period(), hd.dependency_type(),
+                      *hd.dependent_hosts().begin(), *hd.hosts().begin(),
+                      hd.inherits_parent(), hd.notification_failure_options());
+}
+
 std::unordered_map<std::string,
                    hostdependency::setter_func> const hostdependency::_setters{
     {"hostgroup", SETTER(std::string const&, _set_hostgroups)},
@@ -86,11 +92,6 @@ hostdependency::hostdependency()
 hostdependency::hostdependency(hostdependency const& right) : object(right) {
   operator=(right);
 }
-
-/**
- *  Destructor.
- */
-hostdependency::~hostdependency() noexcept {}
 
 /**
  *  Copy constructor.

--- a/engine/src/configuration/hostescalation.cc
+++ b/engine/src/configuration/hostescalation.cc
@@ -26,6 +26,17 @@ using namespace com::centreon::engine::configuration;
 #define SETTER(type, method) \
   &object::setter<hostescalation, type, &hostescalation::method>::generic
 
+namespace com::centreon::engine::configuration {
+
+size_t hostescalation_key(const hostescalation& he) {
+  return absl::HashOf(*he.hosts().begin(), he.contactgroups(),
+                      he.escalation_options(), he.escalation_period(),
+                      he.first_notification(), he.last_notification(),
+                      he.notification_interval());
+}
+
+}  // namespace com::centreon::engine::configuration
+
 std::unordered_map<std::string,
                    hostescalation::setter_func> const hostescalation::_setters{
     {"hostgroup", SETTER(std::string const&, _set_hostgroups)},
@@ -88,7 +99,6 @@ hostescalation& hostescalation::operator=(hostescalation const& right) {
     _hosts = right._hosts;
     _last_notification = right._last_notification;
     _notification_interval = right._notification_interval;
-    _uuid = right._uuid;
   }
   return *this;
 }
@@ -238,7 +248,6 @@ bool hostescalation::contactgroups_defined() const throw() {
  */
 void hostescalation::escalation_options(unsigned short options) throw() {
   _escalation_options = options;
-  return;
 }
 
 /**
@@ -257,7 +266,6 @@ unsigned short hostescalation::escalation_options() const throw() {
  */
 void hostescalation::escalation_period(std::string const& period) {
   _escalation_period = period;
-  return;
 }
 
 /**
@@ -285,7 +293,6 @@ bool hostescalation::escalation_period_defined() const throw() {
  */
 void hostescalation::first_notification(unsigned int n) throw() {
   _first_notification = n;
-  return;
 }
 
 /**
@@ -340,7 +347,6 @@ set_string const& hostescalation::hosts() const throw() {
  */
 void hostescalation::last_notification(unsigned int n) throw() {
   _last_notification = n;
-  return;
 }
 
 /**
@@ -359,7 +365,6 @@ unsigned int hostescalation::last_notification() const throw() {
  */
 void hostescalation::notification_interval(unsigned int interval) {
   _notification_interval = interval;
-  return;
 }
 
 /**
@@ -491,13 +496,4 @@ bool hostescalation::_set_last_notification(unsigned int value) {
 bool hostescalation::_set_notification_interval(unsigned int value) {
   _notification_interval = value;
   return true;
-}
-
-/**
- *  Get uuid value.
- *
- *  @return uuid.
- */
-Uuid const& hostescalation::uuid(void) const {
-  return _uuid;
 }

--- a/engine/src/configuration/object.cc
+++ b/engine/src/configuration/object.cc
@@ -70,11 +70,6 @@ object::object(object const& right) {
 }
 
 /**
- *  Destructor.
- */
-object::~object() noexcept {}
-
-/**
  *  Copy constructor.
  *
  *  @param[in] right The object to copy.

--- a/engine/src/configuration/servicedependency.cc
+++ b/engine/src/configuration/servicedependency.cc
@@ -111,11 +111,6 @@ servicedependency::servicedependency(servicedependency const& right)
 }
 
 /**
- *  Destructor.
- */
-servicedependency::~servicedependency() throw() {}
-
-/**
  *  Copy constructor.
  *
  *  @param[in] right The servicedependency to copy.

--- a/engine/src/configuration/servicedependency.cc
+++ b/engine/src/configuration/servicedependency.cc
@@ -30,6 +30,20 @@ using namespace com::centreon;
 using namespace com::centreon::engine::configuration;
 using namespace com::centreon::engine::logging;
 
+namespace com::centreon::engine::configuration {
+size_t servicedependency_key(const servicedependency& sd) {
+  assert(sd.hosts().size() == 1 && sd.service_description().size() == 1 &&
+         sd.dependent_hosts().size() == 1 &&
+         sd.dependent_service_description().size() == 1);
+  return absl::HashOf(sd.dependency_period(), sd.dependency_type(),
+                      *sd.hosts().begin(), *sd.service_description().begin(),
+                      *sd.dependent_hosts().begin(),
+                      *sd.dependent_service_description().begin(),
+                      sd.execution_failure_options(), sd.inherits_parent(),
+                      sd.notification_failure_options());
+}
+}  // namespace com::centreon::engine::configuration
+
 #define SETTER(type, method) \
   &object::setter<servicedependency, type, &servicedependency::method>::generic
 

--- a/engine/src/configuration/serviceescalation.cc
+++ b/engine/src/configuration/serviceescalation.cc
@@ -29,6 +29,15 @@ using namespace com::centreon::engine::logging;
 #define SETTER(type, method) \
   &object::setter<serviceescalation, type, &serviceescalation::method>::generic
 
+namespace com::centreon::engine::configuration {
+size_t serviceescalation_key(const serviceescalation& se) {
+  return absl::HashOf(*se.hosts().begin(), *se.service_description().begin(),
+                      se.contactgroups(), se.escalation_options(),
+                      se.escalation_period(), se.first_notification(),
+                      se.last_notification(), se.notification_interval());
+}
+}  // namespace com::centreon::engine::configuration
+
 std::unordered_map<std::string, serviceescalation::setter_func> const
     serviceescalation::_setters{
         {"host", SETTER(std::string const&, _set_hosts)},
@@ -99,7 +108,6 @@ serviceescalation& serviceescalation::operator=(
     _notification_interval = right._notification_interval;
     _servicegroups = right._servicegroups;
     _service_description = right._service_description;
-    _uuid = right._uuid;
   }
   return *this;
 }
@@ -192,8 +200,8 @@ bool serviceescalation::operator==(serviceescalation const& right) const
  *
  *  @return True if is not the same serviceescalation, otherwise false.
  */
-bool serviceescalation::operator!=(serviceescalation const& right) const
-    throw() {
+bool serviceescalation::operator!=(
+    serviceescalation const& right) const noexcept {
   return !operator==(right);
 }
 
@@ -251,7 +259,7 @@ void serviceescalation::check_validity() const {
  *
  *  @return This object.
  */
-serviceescalation::key_type const& serviceescalation::key() const throw() {
+serviceescalation::key_type const& serviceescalation::key() const noexcept {
   return *this;
 }
 
@@ -639,13 +647,4 @@ bool serviceescalation::_set_servicegroups(std::string const& value) {
 bool serviceescalation::_set_service_description(std::string const& value) {
   _service_description = value;
   return true;
-}
-
-/**
- *  Get uuid value.
- *
- *  @return uuid.
- */
-Uuid const& serviceescalation::uuid(void) const {
-  return _uuid;
 }

--- a/engine/src/dependency.cc
+++ b/engine/src/dependency.cc
@@ -1,22 +1,21 @@
 /**
  * Copyright 2011-2024 Centreon
  *
- * This file is part of Centreon Engine.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Centreon Engine is free software: you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Centreon Engine is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- * You should have received a copy of the GNU General Public License
- * along with Centreon Engine. If not, see
- * <http://www.gnu.org/licenses/>.
+ * For more information : contact@centreon.com
+ *
  */
-
 #include "com/centreon/engine/dependency.hh"
 
 #include "com/centreon/engine/exceptions/error.hh"
@@ -26,13 +25,15 @@
 using namespace com::centreon::engine;
 using namespace com::centreon::engine::logging;
 
-dependency::dependency(std::string const& dependent_hostname,
-                       std::string const& hostname,
+dependency::dependency(size_t key,
+                       const std::string& dependent_hostname,
+                       const std::string& hostname,
                        types dependency_type,
                        bool inherits_parent,
                        bool fail_on_pending,
-                       std::string const& dependency_period)
-    : _dependency_type{dependency_type},
+                       const std::string& dependency_period)
+    : _internal_key{key},
+      _dependency_type{dependency_type},
       _dependent_hostname{dependent_hostname},
       _hostname{hostname},
       _dependency_period{dependency_period},
@@ -169,4 +170,8 @@ bool dependency::operator<(dependency const& obj) noexcept {
   else if (_circular_path_checked != obj.get_circular_path_checked())
     return _circular_path_checked < obj.get_circular_path_checked();
   return _contains_circular_path < obj.get_contains_circular_path();
+}
+
+size_t dependency::internal_key() const {
+  return _internal_key;
 }

--- a/engine/src/escalation.cc
+++ b/engine/src/escalation.cc
@@ -1,22 +1,20 @@
 /**
  * Copyright 2011-2024 Centreon
  *
- * This file is part of Centreon Engine.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Centreon Engine is free software: you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Centreon Engine is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- * You should have received a copy of the GNU General Public License
- * along with Centreon Engine. If not, see
- * <http://www.gnu.org/licenses/>.
+ * For more information : contact@centreon.com
  */
-
 #include "com/centreon/engine/escalation.hh"
 #include "com/centreon/engine/exceptions/error.hh"
 #include "com/centreon/engine/globals.hh"
@@ -31,16 +29,16 @@ escalation::escalation(uint32_t first_notification,
                        double notification_interval,
                        std::string const& escalation_period,
                        uint32_t escalate_on,
-                       Uuid const& uuid)
-    : notifier_ptr{nullptr},
-      escalation_period_ptr{nullptr},
-      _first_notification{first_notification},
+                       const size_t key)
+    : _first_notification{first_notification},
       _last_notification{last_notification},
       _notification_interval{
           (notification_interval < 0) ? 0 : notification_interval},
       _escalation_period{escalation_period},
       _escalate_on{escalate_on},
-      _uuid{uuid} {}
+      _internal_key{key},
+      notifier_ptr{nullptr},
+      escalation_period_ptr{nullptr} {}
 
 std::string const& escalation::get_escalation_period() const {
   return _escalation_period;
@@ -167,6 +165,6 @@ void escalation::resolve(int& w __attribute__((unused)), int& e) {
   }
 }
 
-Uuid const& escalation::get_uuid() const {
-  return _uuid;
+size_t escalation::internal_key() const {
+  return _internal_key;
 }

--- a/engine/src/hostdependency.cc
+++ b/engine/src/hostdependency.cc
@@ -324,24 +324,3 @@ hostdependency_mmap::iterator hostdependency::hostdependencies_find(
   }
   return p.first == p.second ? hostdependencies.end() : p.first;
 }
-
-/**
- *  Find a service dependency from its key.
- *
- *  @param[in] k The service dependency configuration.
- *
- *  @return Iterator to the element if found,
- *          servicedependencies().end() otherwise.
- */
-hostdependency_mmap::iterator hostdependency::hostdependencies_find(
-    const std::pair<std::string_view, size_t>& key) {
-  std::pair<hostdependency_mmap::iterator, hostdependency_mmap::iterator> p;
-
-  p = hostdependencies.equal_range(key.first);
-  while (p.first != p.second) {
-    if (p.first->second->internal_key() == key.second)
-      break;
-    ++p.first;
-  }
-  return p.first == p.second ? hostdependencies.end() : p.first;
-}

--- a/engine/src/hostdependency.cc
+++ b/engine/src/hostdependency.cc
@@ -1,24 +1,24 @@
 /**
  * Copyright 2011-2024 Centreon
  *
- * This file is part of Centreon Engine.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Centreon Engine is free software: you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Centreon Engine is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- * You should have received a copy of the GNU General Public License
- * along with Centreon Engine. If not, see
- * <http://www.gnu.org/licenses/>.
+ * For more information : contact@centreon.com
+ *
  */
-
 #include "com/centreon/engine/hostdependency.hh"
 #include "com/centreon/engine/broker.hh"
+#include "com/centreon/engine/configuration/applier/hostdependency.hh"
 #include "com/centreon/engine/configuration/applier/state.hh"
 #include "com/centreon/engine/exceptions/error.hh"
 #include "com/centreon/engine/globals.hh"
@@ -28,15 +28,16 @@
 
 using namespace com::centreon;
 using namespace com::centreon::engine;
-using namespace com::centreon::engine::configuration::applier;
 using namespace com::centreon::engine::logging;
 using namespace com::centreon::engine::string;
 
 hostdependency_mmap hostdependency::hostdependencies;
 
 /**
- *  Create a host dependency definition.
+ *  Create a host dependency definition. The key is given by the
+ *  applier::configuration::hostdependency object from its attributes.
  *
+ *  @param[in] key                 key representing this hostdependency.
  *  @param[in] dependent_hostname  Dependant host name.
  *  @param[in] hostname            Host name.
  *  @param[in] dependency_type     Dependency type.
@@ -49,7 +50,8 @@ hostdependency_mmap hostdependency::hostdependencies;
  *
  *  @return New host dependency.
  */
-hostdependency::hostdependency(std::string const& dependent_hostname,
+hostdependency::hostdependency(size_t key,
+                               std::string const& dependent_hostname,
                                std::string const& hostname,
                                dependency::types dependency_type,
                                bool inherits_parent,
@@ -58,7 +60,8 @@ hostdependency::hostdependency(std::string const& dependent_hostname,
                                bool fail_on_unreachable,
                                bool fail_on_pending,
                                std::string const& dependency_period)
-    : dependency(dependent_hostname,
+    : dependency(key,
+                 dependent_hostname,
                  hostname,
                  dependency_type,
                  inherits_parent,
@@ -230,7 +233,7 @@ void hostdependency::resolve(int& w, int& e) {
   int errors{0};
 
   // Find the dependent host.
-  host_map::const_iterator it{host::hosts.find(_dependent_hostname)};
+  host_map::const_iterator it = host::hosts.find(_dependent_hostname);
   if (it == host::hosts.end() || !it->second) {
     engine_logger(log_verification_error, basic)
         << "Error: Dependent host specified in host dependency for "
@@ -309,45 +312,36 @@ void hostdependency::resolve(int& w, int& e) {
  */
 hostdependency_mmap::iterator hostdependency::hostdependencies_find(
     const com::centreon::engine::configuration::hostdependency& k) {
-  typedef hostdependency_mmap collection;
-  std::pair<collection::iterator, collection::iterator> p;
+  std::pair<hostdependency_mmap::iterator, hostdependency_mmap::iterator> p;
+
+  size_t key = configuration::hostdependency_key(k);
 
   p = hostdependencies.equal_range(*k.dependent_hosts().begin());
   while (p.first != p.second) {
-    configuration::hostdependency current;
-    current.configuration::object::operator=(k);
-    current.dependent_hosts().insert(p.first->second->get_dependent_hostname());
-    current.hosts().insert(p.first->second->get_hostname());
-    current.dependency_period(
-        (!p.first->second->get_dependency_period().empty()
-             ? p.first->second->get_dependency_period().c_str()
-             : ""));
-    current.inherits_parent(p.first->second->get_inherits_parent());
-    unsigned int options((p.first->second->get_fail_on_up()
-                              ? configuration::hostdependency::up
-                              : 0) |
-                         (p.first->second->get_fail_on_down()
-                              ? configuration::hostdependency::down
-                              : 0) |
-                         (p.first->second->get_fail_on_unreachable()
-                              ? configuration::hostdependency::unreachable
-                              : 0) |
-                         (p.first->second->get_fail_on_pending()
-                              ? configuration::hostdependency::pending
-                              : 0));
-    if (p.first->second->get_dependency_type() ==
-        engine::hostdependency::notification) {
-      current.dependency_type(
-          configuration::hostdependency::notification_dependency);
-      current.notification_failure_options(options);
-    } else {
-      current.dependency_type(
-          configuration::hostdependency::execution_dependency);
-      current.execution_failure_options(options);
-    }
-    if (current == k)
+    if (p.first->second->internal_key() == key)
       break;
     ++p.first;
   }
-  return (p.first == p.second) ? hostdependencies.end() : p.first;
+  return p.first == p.second ? hostdependencies.end() : p.first;
+}
+
+/**
+ *  Find a service dependency from its key.
+ *
+ *  @param[in] k The service dependency configuration.
+ *
+ *  @return Iterator to the element if found,
+ *          servicedependencies().end() otherwise.
+ */
+hostdependency_mmap::iterator hostdependency::hostdependencies_find(
+    const std::pair<std::string_view, size_t>& key) {
+  std::pair<hostdependency_mmap::iterator, hostdependency_mmap::iterator> p;
+
+  p = hostdependencies.equal_range(key.first);
+  while (p.first != p.second) {
+    if (p.first->second->internal_key() == key.second)
+      break;
+    ++p.first;
+  }
+  return p.first == p.second ? hostdependencies.end() : p.first;
 }

--- a/engine/src/hostescalation.cc
+++ b/engine/src/hostescalation.cc
@@ -1,22 +1,20 @@
 /**
  * Copyright 2011-2024 Centreon
  *
- * This file is part of Centreon Engine.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Centreon Engine is free software: you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Centreon Engine is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- * You should have received a copy of the GNU General Public License
- * along with Centreon Engine. If not, see
- * <http://www.gnu.org/licenses/>.
+ * For more information : contact@centreon.com
  */
-
 #include "com/centreon/engine/hostescalation.hh"
 #include "com/centreon/engine/broker.hh"
 #include "com/centreon/engine/configuration/applier/state.hh"
@@ -52,16 +50,14 @@ hostescalation::hostescalation(std::string const& host_name,
                                double notification_interval,
                                std::string const& escalation_period,
                                uint32_t escalate_on,
-                               Uuid const& uuid)
+                               const size_t key)
     : escalation{first_notification, last_notification, notification_interval,
-                 escalation_period,  escalate_on,       uuid},
+                 escalation_period,  escalate_on,       key},
       _hostname{host_name} {
   if (host_name.empty())
     throw engine_error() << "Could not create escalation "
                          << "on host '" << host_name << "'";
 }
-
-hostescalation::~hostescalation() {}
 
 std::string const& hostescalation::get_hostname() const {
   return _hostname;

--- a/engine/src/hostescalation.cc
+++ b/engine/src/hostescalation.cc
@@ -126,3 +126,25 @@ void hostescalation::resolve(int& w, int& e) {
     throw engine_error() << "Cannot resolve host escalation";
   }
 }
+
+bool hostescalation::matches(const configuration::hostescalation& obj) const {
+  uint32_t escalate_on =
+      ((obj.escalation_options() & configuration::hostescalation::down)
+           ? notifier::down
+           : notifier::none) |
+      ((obj.escalation_options() & configuration::hostescalation::unreachable)
+           ? notifier::unreachable
+           : notifier::none) |
+      ((obj.escalation_options() & configuration::hostescalation::recovery)
+           ? notifier::up
+           : notifier::none);
+  if (_hostname != *obj.hosts().begin() ||
+      get_first_notification() != obj.first_notification() ||
+      get_last_notification() != obj.last_notification() ||
+      get_notification_interval() != obj.notification_interval() ||
+      get_escalation_period() != obj.escalation_period() ||
+      get_escalate_on() != escalate_on)
+    return false;
+
+  return true;
+}

--- a/engine/src/servicedependency.cc
+++ b/engine/src/servicedependency.cc
@@ -18,6 +18,7 @@
  */
 #include "com/centreon/engine/servicedependency.hh"
 #include "com/centreon/engine/broker.hh"
+#include "com/centreon/engine/configuration/applier/servicedependency.hh"
 #include "com/centreon/engine/exceptions/error.hh"
 #include "com/centreon/engine/globals.hh"
 #include "com/centreon/engine/logging/logger.hh"
@@ -387,18 +388,20 @@ void servicedependency::resolve(int& w, int& e) {
  * @return Iterator to the element if found, servicedependencies().end()
  * otherwise.
  */
-servicedependency_mmap::iterator servicedependency::servicedependencies_find(
-    const std::tuple<std::string, std::string, size_t>& key) {
-  size_t k = std::get<2>(key);
-  std::pair<servicedependency_mmap::iterator, servicedependency_mmap::iterator>
-      p = servicedependencies.equal_range({std::get<0>(key), std::get<1>(key)});
-  while (p.first != p.second) {
-    if (p.first->second->internal_key() == k)
-      break;
-    ++p.first;
-  }
-  return p.first == p.second ? servicedependencies.end() : p.first;
-}
+// servicedependency_mmap::iterator servicedependency::servicedependencies_find(
+//     const std::tuple<std::string, std::string, size_t>& key) {
+//   size_t k = std::get<2>(key);
+//   std::pair<servicedependency_mmap::iterator,
+//   servicedependency_mmap::iterator>
+//       p = servicedependencies.equal_range({std::get<0>(key),
+//       std::get<1>(key)});
+//   while (p.first != p.second) {
+//     if (p.first->second->internal_key() == k)
+//       break;
+//     ++p.first;
+//   }
+//   return p.first == p.second ? servicedependencies.end() : p.first;
+// }
 
 /**
  *  Find a service dependency from its key.
@@ -410,50 +413,63 @@ servicedependency_mmap::iterator servicedependency::servicedependencies_find(
  */
 servicedependency_mmap::iterator servicedependency::servicedependencies_find(
     configuration::servicedependency const& k) {
-  typedef servicedependency_mmap collection;
-  std::pair<collection::iterator, collection::iterator> p;
-  p = servicedependencies.equal_range(std::make_pair(
-      k.dependent_hosts().front(), k.dependent_service_description().front()));
+  size_t key = configuration::servicedependency_key(k);
+  std::pair<servicedependency_mmap::iterator, servicedependency_mmap::iterator>
+      p = servicedependencies.equal_range(
+          std::make_pair(k.dependent_hosts().front(),
+                         k.dependent_service_description().front()));
   while (p.first != p.second) {
-    configuration::servicedependency current;
-    current.configuration::object::operator=(k);
-    current.dependent_hosts().push_back(
-        p.first->second->get_dependent_hostname());
-    current.dependent_service_description().push_back(
-        p.first->second->get_dependent_service_description());
-    current.hosts().push_back(p.first->second->get_hostname());
-    current.service_description().push_back(
-        p.first->second->get_service_description());
-    current.dependency_period(p.first->second->get_dependency_period());
-    current.inherits_parent(p.first->second->get_inherits_parent());
-    unsigned int options((p.first->second->get_fail_on_ok()
-                              ? configuration::servicedependency::ok
-                              : 0) |
-                         (p.first->second->get_fail_on_warning()
-                              ? configuration::servicedependency::warning
-                              : 0) |
-                         (p.first->second->get_fail_on_unknown()
-                              ? configuration::servicedependency::unknown
-                              : 0) |
-                         (p.first->second->get_fail_on_critical()
-                              ? configuration::servicedependency::critical
-                              : 0) |
-                         (p.first->second->get_fail_on_pending()
-                              ? configuration::servicedependency::pending
-                              : 0));
-    if (p.first->second->get_dependency_type() ==
-        engine::dependency::notification) {
-      current.dependency_type(
-          configuration::servicedependency::notification_dependency);
-      current.notification_failure_options(options);
-    } else {
-      current.dependency_type(
-          configuration::servicedependency::execution_dependency);
-      current.execution_failure_options(options);
-    }
-    if (current == k)
+    if (p.first->second->internal_key() == key)
       break;
     ++p.first;
   }
-  return (p.first == p.second) ? servicedependencies.end() : p.first;
+  return p.first == p.second ? servicedependencies.end() : p.first;
+
+  //  typedef servicedependency_mmap collection;
+  //  std::pair<collection::iterator, collection::iterator> p;
+  //  p = servicedependencies.equal_range(std::make_pair(
+  //      k.dependent_hosts().front(),
+  //      k.dependent_service_description().front()));
+  //  while (p.first != p.second) {
+  //    configuration::servicedependency current;
+  //    current.configuration::object::operator=(k);
+  //    current.dependent_hosts().push_back(
+  //        p.first->second->get_dependent_hostname());
+  //    current.dependent_service_description().push_back(
+  //        p.first->second->get_dependent_service_description());
+  //    current.hosts().push_back(p.first->second->get_hostname());
+  //    current.service_description().push_back(
+  //        p.first->second->get_service_description());
+  //    current.dependency_period(p.first->second->get_dependency_period());
+  //    current.inherits_parent(p.first->second->get_inherits_parent());
+  //    unsigned int options((p.first->second->get_fail_on_ok()
+  //                              ? configuration::servicedependency::ok
+  //                              : 0) |
+  //                         (p.first->second->get_fail_on_warning()
+  //                              ? configuration::servicedependency::warning
+  //                              : 0) |
+  //                         (p.first->second->get_fail_on_unknown()
+  //                              ? configuration::servicedependency::unknown
+  //                              : 0) |
+  //                         (p.first->second->get_fail_on_critical()
+  //                              ? configuration::servicedependency::critical
+  //                              : 0) |
+  //                         (p.first->second->get_fail_on_pending()
+  //                              ? configuration::servicedependency::pending
+  //                              : 0));
+  //    if (p.first->second->get_dependency_type() ==
+  //        engine::dependency::notification) {
+  //      current.dependency_type(
+  //          configuration::servicedependency::notification_dependency);
+  //      current.notification_failure_options(options);
+  //    } else {
+  //      current.dependency_type(
+  //          configuration::servicedependency::execution_dependency);
+  //      current.execution_failure_options(options);
+  //    }
+  //    if (current == k)
+  //      break;
+  //    ++p.first;
+  //  }
+  //  return (p.first == p.second) ? servicedependencies.end() : p.first;
 }

--- a/engine/src/servicedependency.cc
+++ b/engine/src/servicedependency.cc
@@ -380,30 +380,6 @@ void servicedependency::resolve(int& w, int& e) {
 }
 
 /**
- * @brief Find a service dependency from the given key.
- *
- * @param key A tuple containing a host name, a service description and a hash
- * matching the service dependency.
- *
- * @return Iterator to the element if found, servicedependencies().end()
- * otherwise.
- */
-// servicedependency_mmap::iterator servicedependency::servicedependencies_find(
-//     const std::tuple<std::string, std::string, size_t>& key) {
-//   size_t k = std::get<2>(key);
-//   std::pair<servicedependency_mmap::iterator,
-//   servicedependency_mmap::iterator>
-//       p = servicedependencies.equal_range({std::get<0>(key),
-//       std::get<1>(key)});
-//   while (p.first != p.second) {
-//     if (p.first->second->internal_key() == k)
-//       break;
-//     ++p.first;
-//   }
-//   return p.first == p.second ? servicedependencies.end() : p.first;
-// }
-
-/**
  *  Find a service dependency from its key.
  *
  *  @param[in] k The service dependency configuration.
@@ -424,52 +400,4 @@ servicedependency_mmap::iterator servicedependency::servicedependencies_find(
     ++p.first;
   }
   return p.first == p.second ? servicedependencies.end() : p.first;
-
-  //  typedef servicedependency_mmap collection;
-  //  std::pair<collection::iterator, collection::iterator> p;
-  //  p = servicedependencies.equal_range(std::make_pair(
-  //      k.dependent_hosts().front(),
-  //      k.dependent_service_description().front()));
-  //  while (p.first != p.second) {
-  //    configuration::servicedependency current;
-  //    current.configuration::object::operator=(k);
-  //    current.dependent_hosts().push_back(
-  //        p.first->second->get_dependent_hostname());
-  //    current.dependent_service_description().push_back(
-  //        p.first->second->get_dependent_service_description());
-  //    current.hosts().push_back(p.first->second->get_hostname());
-  //    current.service_description().push_back(
-  //        p.first->second->get_service_description());
-  //    current.dependency_period(p.first->second->get_dependency_period());
-  //    current.inherits_parent(p.first->second->get_inherits_parent());
-  //    unsigned int options((p.first->second->get_fail_on_ok()
-  //                              ? configuration::servicedependency::ok
-  //                              : 0) |
-  //                         (p.first->second->get_fail_on_warning()
-  //                              ? configuration::servicedependency::warning
-  //                              : 0) |
-  //                         (p.first->second->get_fail_on_unknown()
-  //                              ? configuration::servicedependency::unknown
-  //                              : 0) |
-  //                         (p.first->second->get_fail_on_critical()
-  //                              ? configuration::servicedependency::critical
-  //                              : 0) |
-  //                         (p.first->second->get_fail_on_pending()
-  //                              ? configuration::servicedependency::pending
-  //                              : 0));
-  //    if (p.first->second->get_dependency_type() ==
-  //        engine::dependency::notification) {
-  //      current.dependency_type(
-  //          configuration::servicedependency::notification_dependency);
-  //      current.notification_failure_options(options);
-  //    } else {
-  //      current.dependency_type(
-  //          configuration::servicedependency::execution_dependency);
-  //      current.execution_failure_options(options);
-  //    }
-  //    if (current == k)
-  //      break;
-  //    ++p.first;
-  //  }
-  //  return (p.first == p.second) ? servicedependencies.end() : p.first;
 }

--- a/engine/src/serviceescalation.cc
+++ b/engine/src/serviceescalation.cc
@@ -1,22 +1,20 @@
 /**
  * Copyright 2011-2024 Centreon
  *
- * This file is part of Centreon Engine.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Centreon Engine is free software: you can redistribute it and/or
- * modify it under the terms of the GNU General Public License version 2
- * as published by the Free Software Foundation.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Centreon Engine is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * General Public License for more details.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
- * You should have received a copy of the GNU General Public License
- * along with Centreon Engine. If not, see
- * <http://www.gnu.org/licenses/>.
+ * For more information : contact@centreon.com
  */
-
 #include "com/centreon/engine/serviceescalation.hh"
 #include "com/centreon/engine/broker.hh"
 #include "com/centreon/engine/configuration/applier/state.hh"
@@ -37,9 +35,9 @@ serviceescalation::serviceescalation(std::string const& hostname,
                                      double notification_interval,
                                      std::string const& escalation_period,
                                      uint32_t escalate_on,
-                                     Uuid const& uuid)
+                                     const size_t key)
     : escalation{first_notification, last_notification, notification_interval,
-                 escalation_period,  escalate_on,       uuid},
+                 escalation_period,  escalate_on,       key},
       _hostname{hostname},
       _description{description} {
   if (hostname.empty())
@@ -49,8 +47,6 @@ serviceescalation::serviceescalation(std::string const& hostname,
     throw engine_error() << "Could not create escalation "
                          << "on a service without description";
 }
-
-serviceescalation::~serviceescalation() {}
 
 std::string const& serviceescalation::get_hostname() const {
   return _hostname;

--- a/engine/src/serviceescalation.cc
+++ b/engine/src/serviceescalation.cc
@@ -123,3 +123,30 @@ void serviceescalation::resolve(int& w, int& e) {
     throw engine_error() << "Cannot resolve service escalation";
   }
 }
+
+bool serviceescalation::matches(
+    const configuration::serviceescalation& obj) const {
+  uint32_t escalate_on =
+      ((obj.escalation_options() & configuration::serviceescalation::warning)
+           ? notifier::warning
+           : notifier::none) |
+      ((obj.escalation_options() & configuration::serviceescalation::unknown)
+           ? notifier::unknown
+           : notifier::none) |
+      ((obj.escalation_options() & configuration::serviceescalation::critical)
+           ? notifier::critical
+           : notifier::none) |
+      ((obj.escalation_options() & configuration::serviceescalation::recovery)
+           ? notifier::ok
+           : notifier::none);
+  if (_hostname != obj.hosts().front() ||
+      _description != obj.service_description().front() ||
+      get_first_notification() != obj.first_notification() ||
+      get_last_notification() != obj.last_notification() ||
+      get_notification_interval() != obj.notification_interval() ||
+      get_escalation_period() != obj.escalation_period() ||
+      get_escalate_on() != escalate_on)
+    return false;
+
+  return true;
+}

--- a/engine/tests/configuration/applier/applier-hostescalation.cc
+++ b/engine/tests/configuration/applier/applier-hostescalation.cc
@@ -55,6 +55,24 @@ TEST_F(ApplierHostEscalation, AddEscalation) {
   ASSERT_EQ(hostescalation::hostescalations.size(), 2u);
 }
 
+TEST_F(ApplierHostEscalation, ResolveObject) {
+  configuration::applier::host hst_aply;
+  configuration::host hst;
+  ASSERT_TRUE(hst.parse("host_name", "test_host"));
+  ASSERT_TRUE(hst.parse("address", "127.0.0.1"));
+  ASSERT_TRUE(hst.parse("_HOST_ID", "12"));
+  hst_aply.add_object(hst);
+  ASSERT_EQ(host::hosts.size(), 1u);
+
+  configuration::applier::hostescalation he_apply;
+  configuration::hostescalation he;
+  ASSERT_TRUE(he.parse("host_name", "test_host"));
+  ASSERT_TRUE(he.parse("first_notification", "4"));
+  ASSERT_THROW(he_apply.resolve_object(he), std::exception);
+  he_apply.add_object(he);
+  ASSERT_NO_THROW(he_apply.resolve_object(he));
+}
+
 TEST_F(ApplierHostEscalation, RemoveEscalation) {
   configuration::applier::host hst_aply;
   configuration::host hst;

--- a/engine/tests/configuration/applier/applier-serviceescalation.cc
+++ b/engine/tests/configuration/applier/applier-serviceescalation.cc
@@ -74,6 +74,41 @@ TEST_F(ApplierServiceEscalation, AddEscalation) {
   ASSERT_EQ(serviceescalation::serviceescalations.size(), 2u);
 }
 
+TEST_F(ApplierServiceEscalation, ResolveObject) {
+  configuration::applier::host hst_aply;
+  configuration::host hst;
+  ASSERT_TRUE(hst.parse("host_name", "test_host"));
+  ASSERT_TRUE(hst.parse("address", "127.0.0.1"));
+  ASSERT_TRUE(hst.parse("_HOST_ID", "12"));
+  hst_aply.add_object(hst);
+  ASSERT_EQ(host::hosts.size(), 1u);
+
+  configuration::applier::command cmd_aply;
+  configuration::command cmd;
+  cmd.parse("command_name", "cmd");
+  cmd.parse("command_line", "echo 1");
+  cmd_aply.add_object(cmd);
+
+  configuration::applier::service svc_aply;
+  configuration::service svc;
+  ASSERT_TRUE(svc.parse("host", "test_host"));
+  ASSERT_TRUE(svc.parse("service_description", "test_svc"));
+  ASSERT_TRUE(svc.parse("service_id", "12"));
+  ASSERT_TRUE(svc.parse("check_command", "cmd"));
+  svc.set_host_id(12);
+  svc_aply.add_object(svc);
+  ASSERT_EQ(service::services.size(), 1u);
+
+  configuration::applier::serviceescalation se_apply;
+  configuration::serviceescalation se;
+  ASSERT_TRUE(se.parse("host", "test_host"));
+  ASSERT_TRUE(se.parse("service_description", "test_svc"));
+  ASSERT_TRUE(se.parse("first_notification", "4"));
+  ASSERT_THROW(se_apply.resolve_object(se), std::exception);
+  se_apply.add_object(se);
+  ASSERT_NO_THROW(se_apply.resolve_object(se));
+}
+
 TEST_F(ApplierServiceEscalation, RemoveEscalation) {
   configuration::applier::host hst_aply;
   configuration::host hst;

--- a/engine/tests/notifications/host_downtime_notification.cc
+++ b/engine/tests/notifications/host_downtime_notification.cc
@@ -89,7 +89,7 @@ TEST_F(HostDowntimeNotification, SimpleHostDowntime) {
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, 12345)};
 
   ASSERT_TRUE(host_escalation);
   uint64_t id{_host->get_next_notification_id()};
@@ -138,7 +138,7 @@ TEST_F(HostDowntimeNotification,
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, 12345)};
 
   ASSERT_TRUE(host_escalation);
   uint64_t id{_host->get_next_notification_id()};

--- a/engine/tests/notifications/host_flapping_notification.cc
+++ b/engine/tests/notifications/host_flapping_notification.cc
@@ -109,8 +109,9 @@ TEST_F(HostFlappingNotification, SimpleHostFlapping) {
   for (size_t i = 0; i < tperiod->days.size(); ++i)
     tperiod->days[i].emplace_back(0, 86400);
 
-  std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, Uuid())};
+  std::unique_ptr<engine::hostescalation> host_escalation =
+      std::make_unique<engine::hostescalation>("host_name", 0, 1, 1.0,
+                                               "tperiod", 7, 12345);
 
   ASSERT_TRUE(host_escalation);
   uint64_t id{_host->get_next_notification_id()};
@@ -160,7 +161,7 @@ TEST_F(HostFlappingNotification, SimpleHostFlappingStartTwoTimes) {
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, 12345)};
 
   ASSERT_TRUE(host_escalation);
   uint64_t id{_host->get_next_notification_id()};
@@ -199,7 +200,7 @@ TEST_F(HostFlappingNotification, SimpleHostFlappingStopTwoTimes) {
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, 12345)};
 
   ASSERT_TRUE(host_escalation);
   uint64_t id{_host->get_next_notification_id()};

--- a/engine/tests/notifications/host_normal_notification.cc
+++ b/engine/tests/notifications/host_normal_notification.cc
@@ -95,7 +95,7 @@ TEST_F(HostNotification, SimpleNormalHostNotification) {
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, 12345)};
 
   ASSERT_TRUE(host_escalation);
   uint64_t id{_host->get_next_notification_id()};
@@ -122,7 +122,7 @@ TEST_F(HostNotification, SimpleNormalHostNotificationNotificationsdisabled) {
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, 12345)};
 
   ASSERT_TRUE(host_escalation);
   uint64_t id{_host->get_next_notification_id()};
@@ -144,7 +144,7 @@ TEST_F(HostNotification, SimpleNormalHostNotificationNotifierNotifdisabled) {
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, 12345)};
 
   ASSERT_TRUE(host_escalation);
   uint64_t id{_host->get_next_notification_id()};
@@ -166,7 +166,7 @@ TEST_F(HostNotification, SimpleNormalHostNotificationOutsideTimeperiod) {
     tperiod->days[i].emplace_back(43200, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, 12345)};
   _host->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(host_escalation);
@@ -188,7 +188,7 @@ TEST_F(HostNotification,
     tperiod->days[i].emplace_back(43200, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, 12345)};
   _host->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(host_escalation);
@@ -208,7 +208,7 @@ TEST_F(HostNotification, SimpleNormalHostNotificationForcedNotification) {
     tperiod->days[i].emplace_back(43200, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, 12345)};
   _host->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(host_escalation);
@@ -229,7 +229,7 @@ TEST_F(HostNotification, SimpleNormalHostNotificationWithDowntime) {
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, 12345)};
   _host->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(host_escalation);
@@ -250,7 +250,7 @@ TEST_F(HostNotification, SimpleNormalHostNotificationWithFlapping) {
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, 12345)};
   _host->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(host_escalation);
@@ -271,7 +271,7 @@ TEST_F(HostNotification, SimpleNormalHostNotificationWithSoftState) {
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, 12345)};
   _host->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(host_escalation);
@@ -292,7 +292,7 @@ TEST_F(HostNotification,
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, 12345)};
   _host->set_notification_period_ptr(tperiod.get());
 
   _host->set_acknowledgement(AckType::NORMAL);
@@ -313,7 +313,7 @@ TEST_F(HostNotification, SimpleNormalHostNotificationAfterPreviousTooSoon) {
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, 12345)};
   _host->set_notification_period_ptr(tperiod.get());
 
   _host->set_acknowledgement(AckType::NORMAL);
@@ -336,7 +336,7 @@ TEST_F(HostNotification,
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, 12345)};
   _host->set_notification_period_ptr(tperiod.get());
 
   _host->set_acknowledgement(AckType::NORMAL);
@@ -360,7 +360,7 @@ TEST_F(HostNotification, SimpleNormalHostNotificationOnStateNotNotified) {
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, 12345)};
   _host->set_notification_period_ptr(tperiod.get());
 
   _host->set_acknowledgement(AckType::NONE);
@@ -384,7 +384,7 @@ TEST_F(HostNotification,
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, 12345)};
   _host->set_notification_period_ptr(tperiod.get());
 
   _host->set_acknowledgement(AckType::NONE);
@@ -410,7 +410,7 @@ TEST_F(HostNotification,
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "", 7, 12345)};
   _host->set_notification_period_ptr(tperiod.get());
 
   _host->set_acknowledgement(AckType::NONE);
@@ -435,7 +435,7 @@ TEST_F(HostNotification, SimpleNormalHostNotificationNotifierDelayTooShort) {
     tperiod->days[i].emplace_back(0, 86400);
 
   std::unique_ptr<engine::hostescalation> host_escalation{
-      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, Uuid())};
+      new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7, 12345)};
 
   ASSERT_TRUE(host_escalation);
   uint64_t id{_host->get_next_notification_id()};

--- a/engine/tests/notifications/host_recovery_notification.cc
+++ b/engine/tests/notifications/host_recovery_notification.cc
@@ -60,9 +60,10 @@ class HostRecovery : public ::testing::Test {
     for (size_t i = 0; i < _tperiod->days.size(); ++i)
       _tperiod->days[i].emplace_back(0, 86400);
 
+    /* 12345 is here to simulate a key. It won't allow any look up */
     std::unique_ptr<engine::hostescalation> host_escalation{
         new engine::hostescalation("host_name", 0, 1, 1.0, "tperiod", 7,
-                                   Uuid())};
+                                   12345)};
 
     _host->get_next_notification_id();
     _host->set_notification_period_ptr(_tperiod.get());

--- a/engine/tests/notifications/service_flapping_notification.cc
+++ b/engine/tests/notifications/service_flapping_notification.cc
@@ -130,7 +130,7 @@ TEST_F(ServiceFlappingNotification, SimpleServiceFlapping) {
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("host_name", "test_description", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+                                    "tperiod", 7, 12345)};
 
   ASSERT_TRUE(service_escalation);
   uint64_t id{_service->get_next_notification_id()};
@@ -183,7 +183,7 @@ TEST_F(ServiceFlappingNotification, SimpleServiceFlappingStartTwoTimes) {
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("host_name", "test_description", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+                                    "tperiod", 7, 12345)};
 
   ASSERT_TRUE(service_escalation);
   uint64_t id{_service->get_next_notification_id()};
@@ -223,7 +223,7 @@ TEST_F(ServiceFlappingNotification, SimpleServiceFlappingStopTwoTimes) {
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("host_name", "test_description", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+                                    "tperiod", 7, 12345)};
 
   ASSERT_TRUE(service_escalation);
   uint64_t id{_service->get_next_notification_id()};

--- a/engine/tests/notifications/service_normal_notification.cc
+++ b/engine/tests/notifications/service_normal_notification.cc
@@ -112,7 +112,7 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotification) {
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+                                    "tperiod", 7, 12345)};
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
   _svc->set_last_hard_state_change(43200);
@@ -141,7 +141,7 @@ TEST_F(ServiceNotification,
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+                                    "tperiod", 7, 12345)};
 
   ASSERT_TRUE(service_escalation);
   uint64_t id{_svc->get_next_notification_id()};
@@ -165,7 +165,7 @@ TEST_F(ServiceNotification,
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+                                    "tperiod", 7, 12345)};
 
   ASSERT_TRUE(service_escalation);
   uint64_t id{_svc->get_next_notification_id()};
@@ -188,7 +188,7 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationOutsideTimeperiod) {
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+                                    12345)};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
@@ -211,7 +211,7 @@ TEST_F(ServiceNotification,
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+                                    12345)};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
@@ -232,7 +232,7 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationForcedNotification) {
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+                                    12345)};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
@@ -254,7 +254,7 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationWithDowntime) {
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+                                    12345)};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
@@ -276,7 +276,7 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationWithFlapping) {
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+                                    12345)};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
@@ -298,7 +298,7 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationWithSoftState) {
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+                                    12345)};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);
@@ -320,7 +320,7 @@ TEST_F(ServiceNotification,
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+                                    12345)};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_acknowledgement(AckType::NORMAL);
@@ -343,7 +343,7 @@ TEST_F(ServiceNotification,
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+                                    12345)};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_acknowledgement(AckType::NORMAL);
@@ -367,7 +367,7 @@ TEST_F(ServiceNotification,
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+                                    12345)};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_acknowledgement(AckType::NORMAL);
@@ -392,7 +392,7 @@ TEST_F(ServiceNotification, SimpleNormalServiceNotificationOnStateNotNotified) {
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+                                    12345)};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_acknowledgement(AckType::NONE);
@@ -417,7 +417,7 @@ TEST_F(ServiceNotification,
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+                                    12345)};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_acknowledgement(AckType::NONE);
@@ -444,7 +444,7 @@ TEST_F(ServiceNotification,
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+                                    12345)};
   _svc->set_notification_period_ptr(tperiod.get());
 
   _svc->set_acknowledgement(AckType::NONE);
@@ -471,7 +471,7 @@ TEST_F(ServiceNotification,
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+                                    "tperiod", 7, 12345)};
 
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
@@ -937,7 +937,7 @@ TEST_F(ServiceNotification, WarnCritServiceNotification) {
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+                                    "tperiod", 7, 12345)};
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
   _svc->set_last_hard_state_change(43200);
@@ -974,7 +974,7 @@ TEST_F(ServiceNotification, SimpleNormalVolatileServiceNotification) {
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+                                    "tperiod", 7, 12345)};
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
   _svc->set_last_hard_state_change(43200);
@@ -1023,7 +1023,7 @@ TEST_F(ServiceNotification, RecoveryNotifEvenIfServiceAcknowledged) {
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0,
-                                    "tperiod", 7, Uuid())};
+                                    "tperiod", 7, 12345)};
   _svc->set_current_state(engine::service::state_critical);
   _svc->set_last_state(engine::service::state_critical);
   _svc->set_last_hard_state_change(43200);
@@ -1083,7 +1083,7 @@ TEST_F(ServiceNotification, SimpleVolatileServiceNotificationWithDowntime) {
 
   std::unique_ptr<engine::serviceescalation> service_escalation{
       new engine::serviceescalation("test_host", "test_svc", 0, 1, 1.0, "", 7,
-                                    Uuid())};
+                                    12345)};
   _svc->set_notification_period_ptr(tperiod.get());
 
   ASSERT_TRUE(service_escalation);


### PR DESCRIPTION
## Description

Hostescalations, serviceescalations, hostdependencies and servicedependencies had a uuid as key when they were stored as configuration. It is no more used and replaced by a Hash built from their attributes. So now, we can find this hash directly from the object, this simplifies the code and remove a dependency to the engine code.

REFS: MON-34072