### PR TITLE
fix(release): fix checkout depth in release action

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -25,6 +25,8 @@ runs:
   steps:
     - name: Checkout sources
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        fetch-depth: 0
 
     - name: Get released versions for components
       run: |


### PR DESCRIPTION
## Description

* fixed release action checkout depth to avoid having a shallow clone with limited git data

REFS: #126186