### PR TITLE
chore(ci): migrate centos 7 eol repositories to vault.centreon.org

### DIFF
--- a/ci/docker/Dockerfile.collect-alma8
+++ b/ci/docker/Dockerfile.collect-alma8
@@ -10,8 +10,7 @@ RUN echo 'http_caching=none' >> /etc/yum.conf && \
     sed -i 's/best=True/best=False/g' /etc/dnf/dnf.conf && \
     dnf install -y dnf-plugins-core
 RUN dnf config-manager --set-enabled powertools
-RUN curl -o centreon-release.rpm "http://yum-1.centreon.com/standard/21.10/el8/stable/noarch/RPMS/centreon-release-21.10-1.el8.noarch.rpm"
-RUN dnf install --nogpgcheck centreon-release.rpm
+RUN dnf config-manager --add-repo https://packages.centreon.com/artifactory/rpm-standard/22.10/el8/centreon-22.10.repo
 RUN dnf config-manager --set-enabled 'centreon-testing*'
 RUN curl -LsS "https://r.mariadb.com/downloads/mariadb_repo_setup" | bash -s -- --os-type=rhel --os-version=8 --mariadb-server-version="mariadb-10.5"
 RUN dnf clean all && dnf install -y cmake \

--- a/ci/docker/Dockerfile.collect-alma8
+++ b/ci/docker/Dockerfile.collect-alma8
@@ -42,7 +42,7 @@ RUN dnf clean all && dnf install -y cmake \
     rpm-build
 RUN dnf update libarchive
 
-RUN pip3 install conan==1.57.0 --prefix=/usr --upgrade
+RUN pip3 install conan==1.62.0 --prefix=/usr --upgrade
 RUN rm -rf ~/.conan/profiles/default
 COPY conanfile.txt .
 RUN cat conanfile.txt

--- a/ci/docker/Dockerfile.collect-alma8
+++ b/ci/docker/Dockerfile.collect-alma8
@@ -11,7 +11,7 @@ RUN echo 'http_caching=none' >> /etc/yum.conf && \
     dnf install -y dnf-plugins-core
 RUN dnf config-manager --set-enabled powertools
 RUN dnf config-manager --add-repo https://packages.centreon.com/artifactory/rpm-standard/22.10/el8/centreon-22.10.repo
-RUN dnf config-manager --set-enabled 'centreon-testing*'
+RUN dnf config-manager --set-enabled 'centreon-22.10-testing*'
 RUN curl -LsS "https://r.mariadb.com/downloads/mariadb_repo_setup" | bash -s -- --os-type=rhel --os-version=8 --mariadb-server-version="mariadb-10.5"
 RUN dnf clean all && dnf install -y cmake \
     gcc \

--- a/ci/docker/Dockerfile.collect-centos7
+++ b/ci/docker/Dockerfile.collect-centos7
@@ -14,14 +14,14 @@ RUN curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos7-amd64/
     curl https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip --output sonar-scanner-cli-4.7.0.2747-linux.zip
 RUN bash -e <<EOF
 for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-*);do
-  if [[ $file == "/etc/yum.repos.d/CentOS-CR.repo" ]];then
+  if [[ "$file" == "/etc/yum.repos.d/CentOS-CR.repo" ]];then
     echo "Enabling vault.centos.org in $file"
-    sed -i 's/baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+    sed -i "s/baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g" $file
   else
     echo "Disabling mirrorlist.centos.org in $file"
-    sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
+    sed -i "s/mirrorlist\=/\#mirrorlist\=/g" $file
     echo "Enabling vault.centos.org in $file"
-    sed -i 's/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+    sed -i "s/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g" $file
   fi
 done
 EOF

--- a/ci/docker/Dockerfile.collect-centos7
+++ b/ci/docker/Dockerfile.collect-centos7
@@ -12,6 +12,14 @@ RUN curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos7-amd64/
     curl http://yum-1.centreon.com/standard/21.10/el7/stable/x86_64/RPMS/rrdtool-devel-1.7.2-1.el7.centos.x86_64.rpm --output rrdtool-devel-1.7.2-1.el7.centos.x86_64.rpm && \
     curl http://yum-1.centreon.com/standard/21.10/el7/stable/x86_64/RPMS/rrdtool-1.7.2-1.el7.centos.x86_64.rpm --output rrdtool-1.7.2-1.el7.centos.x86_64.rpm && \
     curl https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip --output sonar-scanner-cli-4.7.0.2747-linux.zip
+RUN bash -e <<EOF
+for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-*);do
+	echo "Disabling mirrorlist.centos.org"
+	sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
+	echo "Enabling vault.centos.org"
+	sed -i 's/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+done
+EOF
 RUN yum -y upgrade && yum -y update && \
     yum -y install make \
     openssh-server \

--- a/ci/docker/Dockerfile.collect-centos7
+++ b/ci/docker/Dockerfile.collect-centos7
@@ -41,16 +41,16 @@ RUN yum -y upgrade && yum -y update && \
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN bash -e <<EOF
 for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-SCLo*);do
-	echo "Disabling mirrorlist.centos.org"
-	sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
+  echo "Disabling mirrorlist.centos.org"
+  sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
   if [[ "$file" == "/etc/yum.repos.d/CentOS-SCLo-scl.repo" ]];then
-	  echo "Enabling vault.centos.org in scl."
-	  sed -i 's/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+    echo "Enabling vault.centos.org in scl."
+    sed -i 's/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
   elif [[ "$file" == "/etc/yum.repos.d/CentOS-SCLo-scl-rh.repo" ]];then
-	  echo "Enabling vault.centos.org in scl-rh"
-	  sed -i 's/\#\ baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
-	else
-		echo "Not a SCL repo file"
+    echo "Enabling vault.centos.org in scl-rh"
+    sed -i 's/\#\ baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+  else
+    echo "Not a SCL repo file"
   fi
 done
 EOF

--- a/ci/docker/Dockerfile.collect-centos7
+++ b/ci/docker/Dockerfile.collect-centos7
@@ -39,7 +39,7 @@ RUN yum -y upgrade && yum -y update && \
     rrdtool*.rpm  && \
     yum clean all
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
-RUN bashe -e <<EOF
+RUN bash -e <<EOF
 for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-SCLo*);do
 	echo "Disabling mirrorlist.centos.org"
 	sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file

--- a/ci/docker/Dockerfile.collect-centos7
+++ b/ci/docker/Dockerfile.collect-centos7
@@ -77,7 +77,7 @@ RUN ln -s /usr/bin/cmake3 /usr/bin/cmake
 COPY conanfile.txt .
 RUN cat conanfile.txt
 RUN source /opt/rh/devtoolset-9/enable && source /opt/rh/rh-python38/enable && \
-    pip3 install conan==1.57.0 --upgrade &&\
+    pip3 install conan==1.62.0 --upgrade &&\
     /opt/rh/rh-python38/root/usr/local/bin/conan install . -s compiler.cppstd=14 -s compiler.libcxx=libstdc++11 --build='*'
 
 RUN unzip -q sonar-scanner-cli-4.7.0.2747-linux.zip

--- a/ci/docker/Dockerfile.collect-centos7
+++ b/ci/docker/Dockerfile.collect-centos7
@@ -12,16 +12,16 @@ RUN curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos7-amd64/
     curl http://yum-1.centreon.com/standard/21.10/el7/stable/x86_64/RPMS/rrdtool-devel-1.7.2-1.el7.centos.x86_64.rpm --output rrdtool-devel-1.7.2-1.el7.centos.x86_64.rpm && \
     curl http://yum-1.centreon.com/standard/21.10/el7/stable/x86_64/RPMS/rrdtool-1.7.2-1.el7.centos.x86_64.rpm --output rrdtool-1.7.2-1.el7.centos.x86_64.rpm && \
     curl https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip --output sonar-scanner-cli-4.7.0.2747-linux.zip
-RUN bash -e <<EOF
+RUN bash -e <<'EOF'
 for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-*);do
   if [[ "$file" == "/etc/yum.repos.d/CentOS-CR.repo" ]];then
     echo "Enabling vault.centos.org in $file"
-    sed -i "s/baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g" $file
+    sed -i 's/baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
   else
     echo "Disabling mirrorlist.centos.org in $file"
-    sed -i "s/mirrorlist\=/\#mirrorlist\=/g" $file
+    sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
     echo "Enabling vault.centos.org in $file"
-    sed -i "s/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g" $file
+    sed -i 's/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
   fi
 done
 EOF

--- a/ci/docker/Dockerfile.collect-centos7
+++ b/ci/docker/Dockerfile.collect-centos7
@@ -14,13 +14,14 @@ RUN curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos7-amd64/
     curl https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip --output sonar-scanner-cli-4.7.0.2747-linux.zip
 RUN bash -e <<EOF
 for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-*);do
-  echo "Disabling mirrorlist.centos.org in $file"
-  sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
-  echo "Enabling vault.centos.org in $file"
-  sed -i 's/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
   if [[ "$file" == "/etc/yum.repos.d/CentOS-CR.repo" ]];then
     echo "Enabling vault.centos.org in $file"
     sed -i 's/baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+  else
+    echo "Disabling mirrorlist.centos.org in $file"
+    sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
+    echo "Enabling vault.centos.org in $file"
+    sed -i 's/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
   fi
 done
 EOF

--- a/ci/docker/Dockerfile.collect-centos7
+++ b/ci/docker/Dockerfile.collect-centos7
@@ -14,7 +14,7 @@ RUN curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos7-amd64/
     curl https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip --output sonar-scanner-cli-4.7.0.2747-linux.zip
 RUN bash -e <<EOF
 for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-*);do
-  if [[ "$file" == "/etc/yum.repos.d/CentOS-CR.repo" ]];then
+  if [[ $file == "/etc/yum.repos.d/CentOS-CR.repo" ]];then
     echo "Enabling vault.centos.org in $file"
     sed -i 's/baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
   else

--- a/ci/docker/Dockerfile.collect-centos7
+++ b/ci/docker/Dockerfile.collect-centos7
@@ -39,6 +39,14 @@ RUN yum -y upgrade && yum -y update && \
     rrdtool*.rpm  && \
     yum clean all
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
+RUN bashe -e <<EOF
+for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-SCLo*);do
+	echo "Disabling mirrorlist.centos.org"
+	sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
+	echo "Enabling vault.centos.org"
+	sed -i 's/\# baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+done
+EOF
 RUN yum -y install devtoolset-9 \
     MariaDB*.rpm \
     rh-python38 \

--- a/ci/docker/Dockerfile.collect-centos7
+++ b/ci/docker/Dockerfile.collect-centos7
@@ -43,8 +43,15 @@ RUN bash -e <<EOF
 for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-SCLo*);do
 	echo "Disabling mirrorlist.centos.org"
 	sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
-	echo "Enabling vault.centos.org"
-	sed -i 's/\# baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+  if [[ "$file" == "/etc/yum.repos.d/CentOS-SCLo-scl.repo" ]];then
+	  echo "Enabling vault.centos.org in scl."
+	  sed -i 's/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+  elif [[ "$file" == "/etc/yum.repos.d/CentOS-SCLo-scl-rh.repo" ]];then
+	  echo "Enabling vault.centos.org in scl-rh"
+	  sed -i 's/\#\ baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+	else
+		echo "Not a SCL repo file"
+  fi
 done
 EOF
 RUN yum -y install devtoolset-9 \

--- a/ci/docker/Dockerfile.collect-centos7
+++ b/ci/docker/Dockerfile.collect-centos7
@@ -44,7 +44,7 @@ RUN yum -y upgrade && yum -y update && \
     rrdtool*.rpm  && \
     yum clean all
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
-RUN bash -e <<EOF
+RUN bash -e <<'EOF'
 for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-SCLo*);do
   echo "Disabling mirrorlist.centos.org in $file"
   sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file

--- a/ci/docker/Dockerfile.collect-centos7
+++ b/ci/docker/Dockerfile.collect-centos7
@@ -14,10 +14,14 @@ RUN curl https://downloads.mariadb.com/MariaDB/mariadb-10.5.8/yum/centos7-amd64/
     curl https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip --output sonar-scanner-cli-4.7.0.2747-linux.zip
 RUN bash -e <<EOF
 for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-*);do
-	echo "Disabling mirrorlist.centos.org"
-	sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
-	echo "Enabling vault.centos.org"
-	sed -i 's/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+  echo "Disabling mirrorlist.centos.org in $file"
+  sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
+  echo "Enabling vault.centos.org in $file"
+  sed -i 's/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+  if [[ "$file" == "/etc/yum.repos.d/CentOS-CR.repo" ]];then
+    echo "Enabling vault.centos.org in $file"
+    sed -i 's/baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+  fi
 done
 EOF
 RUN yum -y upgrade && yum -y update && \
@@ -41,7 +45,7 @@ RUN yum -y upgrade && yum -y update && \
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 RUN bash -e <<EOF
 for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-SCLo*);do
-  echo "Disabling mirrorlist.centos.org"
+  echo "Disabling mirrorlist.centos.org in $file"
   sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
   if [[ "$file" == "/etc/yum.repos.d/CentOS-SCLo-scl.repo" ]];then
     echo "Enabling vault.centos.org in scl."

--- a/ci/docker/Dockerfile.collect-centos7
+++ b/ci/docker/Dockerfile.collect-centos7
@@ -50,10 +50,10 @@ for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-SCLo*);do
   sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
   if [[ "$file" == "/etc/yum.repos.d/CentOS-SCLo-scl.repo" ]];then
     echo "Enabling vault.centos.org in scl."
-    sed -i 's/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+    sed -i 's/\#\ baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
   elif [[ "$file" == "/etc/yum.repos.d/CentOS-SCLo-scl-rh.repo" ]];then
     echo "Enabling vault.centos.org in scl-rh"
-    sed -i 's/\#\ baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+    sed -i 's/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
   else
     echo "Not a SCL repo file"
   fi

--- a/ci/docker/Dockerfile.collect-debian-bullseye
+++ b/ci/docker/Dockerfile.collect-debian-bullseye
@@ -32,7 +32,7 @@ RUN apt-get -y update && \
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 RUN python3 get-pip.py
-RUN pip3 install conan==1.57.0
+RUN pip3 install conan==1.62.0
 RUN ln -s /usr/local/bin/conan /usr/bin/conan
 RUN rm -rf ~/.conan/profiles/default
 COPY conanfile.txt .


### PR DESCRIPTION
## Description

* handle CentOS 7 EOL and its removal of mirrorlist.centos.org
* bump conan from 1.57 to 1.62
* fix broken repo file path in almalinux 8 dockerfile

REF: #MON-136235

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

