### PR TITLE
Avoid template loops (causing infinite loop) while calculating dimension

### DIFF
--- a/gorgone/gorgone/modules/centreon/mbi/libs/centreon/Service.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/centreon/Service.pm
@@ -153,7 +153,7 @@ sub IstemplateLooping {
 	my $currentTemplate = shift;
 
 	my $query = "SELECT service_id, service_description, service_template_model_stm_id FROM service WHERE service_id = $currentTemplate";
-	my $sth = $db->query($query);
+	my $sth = $db->query({ query => $query });
 	my $row = $sth->fetchrow_hashref();
 
 	my $parentId = $row->{"service_template_model_stm_id"};
@@ -170,7 +170,7 @@ sub IstemplateLooping {
 	
 	while($hasParent){
 		my $query = "SELECT service_id, service_description, service_template_model_stm_id FROM service WHERE service_id = $parentId LIMIT 1";
-		my $sth = $db->query($query);
+		my $sth = $db->query({ query => $query });
 		my $row = $sth->fetchrow_hashref();			
 		my $grandParentId = $row->{"service_template_model_stm_id"};
 		

--- a/gorgone/gorgone/modules/centreon/mbi/libs/centreon/Service.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/centreon/Service.pm
@@ -157,7 +157,7 @@ sub IstemplateLooping {
 	my $row = $sth->fetchrow_hashref();
 
 	my $parentId = $row->{"service_template_model_stm_id"};
-	
+
 	my $isLooping = 0;
 	my $hasParent = 0;
 
@@ -167,7 +167,7 @@ sub IstemplateLooping {
 		$hasParent = 1;
 		push(@parent_templates, $parentId);# add used template to array
 	}
-	
+
 	while($hasParent){
 		my $query = "SELECT service_id, service_description, service_template_model_stm_id FROM service WHERE service_id = $parentId LIMIT 1";
 		my $sth = $db->query({ query => $query });


### PR DESCRIPTION


## Description
Templates inheriting themselves make the dimension builder script go in an infinite loop, thus blocking the ETL process.

Keeping track of the templates already inherited allows us to throw an error in case this issue happens : 

```
[Wed Jun 26 10:46:07 2024] [INFO] Starting program...(pid=12931)
[Wed Jun 26 10:46:07 2024] [INFO] Searching for duplicate host/service entries
[Wed Jun 26 10:46:08 2024] [INFO] Getting host properties from Centreon database
[Wed Jun 26 10:46:10 2024] [INFO] Updating host dimension in Centstorage
[Wed Jun 26 10:46:10 2024] [INFO] Getting hostgroup properties from Centreon database
[Wed Jun 26 10:46:10 2024] [INFO] Updating hostgroup dimension in Centstorage
[Wed Jun 26 10:46:10 2024] [INFO] Getting hostcategories properties from Centreon database
[Wed Jun 26 10:46:10 2024] [INFO] Updating hostcategories dimension in Centstorage
[Wed Jun 26 10:46:10 2024] [INFO] Getting servicecategories properties from Centreon database
[Wed Jun 26 10:46:10 2024] [INFO] Updating servicecategories dimension in Centstorage
[Wed Jun 26 10:46:10 2024] [INFO] Getting service properties from Centreon database
[Wed Jun 26 10:46:14 2024] [ERROR] The service template with id = 2701 inherits the template ID = 2702 more than once, please check relations of the template with ID = 2701!
[Wed Jun 26 10:46:14 2024] [FATAL] Program terminated with errors
```

**Fixes** #MON-125661

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master