### PR TITLE
fix(gorgone-mbi): escape db password when connecting using mysql cli

### DIFF
--- a/gorgone/gorgone/modules/centreon/mbi/libs/Utils.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/Utils.pm
@@ -66,14 +66,15 @@ sub checkBasicOptions {
 
 sub buildCliMysqlArgs {
     my ($self, $con) = @_;
-
-    my $args = '-u "' . $con->{user} . '" ' .
-        '-p"' . $con->{password} . '" ' . 
-        '-h "' . $con->{host} . '" ' .
-		'-P ' . $con->{port};
+    my $password = $con->{password};
+    # as we will use a bash command we need to use single quote to protect against every characters, and escape single quote)
+    $password =~ s/'/'"'"'/;
+    my $args = "-u'" . $con->{user} . "' " .
+        "-p'" . $password . "' " .
+        "-h '" . $con->{host} . "' " .
+        "-P " . $con->{port};
     return $args;
 }
-
 sub getYesterdayTodayDate {
     my ($self) = @_;
 


### PR DESCRIPTION
## Description
password with $ where not working previously, now password can have special character like *%"éè'

**Fixes** Refs:MON-125661

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] master

<h2> How this pull request can be tested ? </h2>
On mbi make a centreonbi user with special character in the password
in /etc/centreon-bi/reports-profile.xml update the password you just set.
lanuch the ETL : 
`/usr/share/centreon-bi/etl/importData.pl -r --ignore-databin && /usr/share/centreon-bi/etl/dimensionsBuilder.pl -r`
## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

