### PR TITLE
Enh servicedisco api migrate

### DIFF
--- a/gorgone/docs/modules/centreon/autodiscovery.md
+++ b/gorgone/docs/modules/centreon/autodiscovery.md
@@ -1,0 +1,172 @@
+# Autodiscovery
+
+## Description
+
+This module aims to extend Centreon Autodiscovery server functionalities.
+
+## Configuration
+
+No specific configuration.
+
+#### Example
+
+```yaml
+name: autodiscovery
+package: "gorgone::modules::centreon::autodiscovery::hooks"
+enable: true
+```
+
+## Events
+
+| Event | Description |
+| :- | :- |
+| AUTODISCOVERYREADY | Internal event to notify the core |
+| GETDISCOVERYRESULTS | Internal event to retrieve discovery results from logs |
+| UPDATEDISCOVERYRESULTS | Internal event to update tasks/jobs result table |
+| GETDISCOVERYJOB | Get discovery job result |
+| ADDDISCOVERYJOB | Add a discovery job |
+| GETDISCOVERYTASK | Get discovery task result |
+| ADDDISCOVERYTASK | Get a discovery task |
+
+## API
+
+### Add a discovery task
+
+| Endpoint | Method |
+| :- | :- |
+| /api/centreon/autodiscovery/task | `POST` |
+
+#### Headers
+
+| Header | Value |
+| :- | :- |
+| Accept | application/json |
+| Content-Type | application/json |
+
+#### Body
+
+| Key | Value |
+| :- | :- |
+| id | Identifier of the task (random if empty) |
+| command | Command line to execute to perform the discovery |
+| timeout | Time in seconds before the command is considered timed out |
+| target | Identifier of the target on which to execute the command |
+
+```json
+{
+    "id": "<id of the task>",
+    "command": "<command to execute>",
+    "timeout": "<timeout in seconds>",
+    "target": "<target id>"
+}
+```
+
+#### Example
+
+```bash
+curl --request POST "https://hostname:8443/api/centreon/autodiscovery/task" \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --data "{
+    \"command\": \"perl /usr/lib/centreon/plugins/centreon_generic_snmp.pl --plugin=os::linux::local::plugin --mode=discovery-snmp --subnet='10.1.2.3/24' --snmp-port='161' --snmp-version='2c' --snmp-community='public'\",
+    \"timeout\": 300,
+    \"target\": 2
+}"
+```
+
+### Get a discovery task results
+
+| Endpoint | Method |
+| :- | :- |
+| /api/centreon/autodiscovery/task/:id | `GET` |
+
+#### Headers
+
+| Header | Value |
+| :- | :- |
+| Accept | application/json |
+
+#### Path variables
+
+| Variable | Description |
+| :- | :- |
+| id | Identifier of the task |
+
+#### Example
+
+```bash
+curl --request GET "https://hostname:8443/api/centreon/autodiscovery/task/autodiscovery_task_3209230948" \
+  --header "Accept: application/json"
+```
+
+### Add a discovery job
+
+| Endpoint | Method |
+| :- | :- |
+| /api/centreon/autodiscovery/job | `POST` |
+
+#### Headers
+
+| Header | Value |
+| :- | :- |
+| Accept | application/json |
+| Content-Type | application/json |
+
+#### Body
+
+| Key | Value |
+| :- | :- |
+| id | Identifier of the task (random if empty) |
+| timespec | Cron-like time specification |
+| command | Command line to execute to perform the discovery |
+| timeout | Time in seconds before the command is considered timed out |
+| target | Identifier of the target on which to execute the command |
+
+```json
+{
+    "id": "<id of the task>",
+    "timespec": "<cron-like time specification>",
+    "command": "<command to execute>",
+    "timeout": "<timeout in seconds>",
+    "target": "<target id>"
+}
+```
+
+#### Example
+
+```bash
+curl --request POST "https://hostname:8443/api/centreon/autodiscovery/job" \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --data "{
+    \"timespec\": \"0 10 * * *\",
+    \"command\": \"perl /usr/lib/centreon/plugins/centreon_generic_snmp.pl --plugin=os::linux::local::plugin --mode=discovery-snmp --subnet='10.1.2.3/24' --snmp-port='161' --snmp-version='2c' --snmp-community='public'\",
+    \"timeout\": 300,
+    \"target\": 2
+}"
+```
+
+### Get a discovery job results
+
+| Endpoint | Method |
+| :- | :- |
+| /api/centreon/autodiscovery/job/:id | `GET` |
+
+#### Headers
+
+| Header | Value |
+| :- | :- |
+| Accept | application/json |
+
+#### Path variables
+
+| Variable | Description |
+| :- | :- |
+| id | Identifier of the job |
+
+#### Example
+
+```bash
+curl --request GET "https://hostname:8443/api/centreon/autodiscovery/job/autodiscovery_job_40894092083" \
+  --header "Accept: application/json"
+```

--- a/gorgone/docs/modules/centreon/autodiscovery.md
+++ b/gorgone/docs/modules/centreon/autodiscovery.md
@@ -93,13 +93,13 @@ curl --request POST "https://hostname:8443/api/centreon/autodiscovery/job" \
 
 | Key | Value | Description |
 | :- | :- | :- |
-| filter_rules       | array     | Run the selected rule of discovery | 
-| force_rule         | ```1|0``` | Run also disabled rules |
-| filter_hosts       | array     | Run all discovery rules linked to all templates of host used by selected host |
-| filter_pollers     | array     | Run all discovery rules linked to all poller linked with rule |
-| manual             | ```1|0``` | Run discovery for manual scan |
-| dry_run            | ```1|0``` | Run discovery without configuration change                  |
-| no_generate_config | ```1|0``` | No configuration generation (even if there is some changes) |
+| filter_rules       | array | Run the selected rule of discovery | 
+| force_rule         | `1|0` | Run also disabled rules |
+| filter_hosts       | array | Run all discovery rules linked to all templates of host used by selected host |
+| filter_pollers     | array | Run all discovery rules linked to all poller linked with rule |
+| manual             | `1|0` | Run discovery for manual scan |
+| dry_run            | `1|0` | Run discovery without configuration change                  |
+| no_generate_config | `1|0` | No configuration generation (even if there is some changes) |
 
 ```json
 {

--- a/gorgone/docs/modules/centreon/autodiscovery.md
+++ b/gorgone/docs/modules/centreon/autodiscovery.md
@@ -20,84 +20,14 @@ enable: true
 
 | Event | Description |
 | :- | :- |
-| AUTODISCOVERYREADY | Internal event to notify the core |
-| GETDISCOVERYRESULTS | Internal event to retrieve discovery results from logs |
-| UPDATEDISCOVERYRESULTS | Internal event to update tasks/jobs result table |
-| GETDISCOVERYJOB | Get discovery job result |
-| ADDDISCOVERYJOB | Add a discovery job |
-| GETDISCOVERYTASK | Get discovery task result |
-| ADDDISCOVERYTASK | Get a discovery task |
+| AUTODISCOVERYREADY       | Internal event to notify the core               |
+| AUTODISCOVERYLISTENER    | Internal event to get host discovery results    |
+| SERVICEDISCOVERYLISTENER | Internal event to get service discovery results |
+| ADDDISCOVERYJOB          | Add a host discovery job                        |
+| LAUNCHDISCOVERY          | execute a host discovery job                    |
+| LAUNCHSERVICEDISCOVERY   | execute a service discovery job                 |
 
 ## API
-
-### Add a discovery task
-
-| Endpoint | Method |
-| :- | :- |
-| /centreon/autodiscovery/task | `POST` |
-
-#### Headers
-
-| Header | Value |
-| :- | :- |
-| Accept | application/json |
-| Content-Type | application/json |
-
-#### Body
-
-| Key | Value |
-| :- | :- |
-| id | Identifier of the task (random if empty) |
-| command | Command line to execute to perform the discovery |
-| timeout | Time in seconds before the command is considered timed out |
-| target | Identifier of the target on which to execute the command |
-
-```json
-{
-    "id": "<id of the task>",
-    "command": "<command to execute>",
-    "timeout": "<timeout in seconds>",
-    "target": "<target id>"
-}
-```
-
-#### Example
-
-```bash
-curl --request POST "https://hostname:8443/api/centreon/autodiscovery/task" \
-  --header "Accept: application/json" \
-  --header "Content-Type: application/json" \
-  --data "{
-    \"command\": \"perl /usr/lib/centreon/plugins/centreon_generic_snmp.pl --plugin=os::linux::local::plugin --mode=discovery-snmp --subnet='10.1.2.3/24' --snmp-port='161' --snmp-version='2c' --snmp-community='public'\",
-    \"timeout\": 300,
-    \"target\": 2
-}"
-```
-
-### Get a discovery task results
-
-| Endpoint | Method |
-| :- | :- |
-| /centreon/autodiscovery/task/:id | `GET` |
-
-#### Headers
-
-| Header | Value |
-| :- | :- |
-| Accept | application/json |
-
-#### Path variables
-
-| Variable | Description |
-| :- | :- |
-| id | Identifier of the task |
-
-#### Example
-
-```bash
-curl --request GET "https://hostname:8443/api/centreon/autodiscovery/task/autodiscovery_task_3209230948" \
-  --header "Accept: application/json"
-```
 
 ### Add a discovery job
 
@@ -146,27 +76,50 @@ curl --request POST "https://hostname:8443/api/centreon/autodiscovery/job" \
 }"
 ```
 
-### Get a discovery job results
+### Execute a service discovery job
 
 | Endpoint | Method |
 | :- | :- |
-| /centreon/autodiscovery/job/:id | `GET` |
+| /centreon/autodiscovery/services | `POST` |
 
 #### Headers
 
 | Header | Value |
 | :- | :- |
 | Accept | application/json |
+| Content-Type | application/json |
 
-#### Path variables
+#### Body
 
-| Variable | Description |
-| :- | :- |
-| id | Identifier of the job |
+| Key | Value | Description |
+| :- | :- | :- |
+| filter_rules       | array     | Run the selected rule of discovery | 
+| force_rule         | ```1|0``` | Run also disabled rules |
+| filter_hosts       | array     | Run all discovery rules linked to all templates of host used by selected host |
+| filter_pollers     | array     | Run all discovery rules linked to all poller linked with rule |
+| manual             | ```1|0``` | Run discovery for manual scan |
+| dry_run            | ```1|0``` | Run discovery without configuration change                  |
+| no_generate_config | ```1|0``` | No configuration generation (even if there is some changes) |
+
+```json
+{
+    "filter_rules": ["<rule1>", "<rule2>", ...],
+    "force_rule": <1|0>,
+    "filter_hosts": ["<host1>", "<host2>", ...],
+    "filter_pollers": ["<poller1>", "<poller2>", ...],
+    "manual": <1|0>,
+    "dry_run": <1|0>,
+    "no_generate_config": <1|0>
+}
+```
 
 #### Example
 
 ```bash
-curl --request GET "https://hostname:8443/api/centreon/autodiscovery/job/autodiscovery_job_40894092083" \
-  --header "Accept: application/json"
+curl --request POST "https://hostname:8443/api/centreon/autodiscovery/services" \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "filters_rules": ["OS-Linux-SNMP-Disk-Name", "OS-Linux-SNMP-Traffic-Name"]
+}'
 ```

--- a/gorgone/docs/modules/centreon/autodiscovery.md
+++ b/gorgone/docs/modules/centreon/autodiscovery.md
@@ -278,6 +278,6 @@ curl --request POST "https://hostname:8443/api/centreon/autodiscovery/services" 
   --header "Accept: application/json" \
   --header "Content-Type: application/json" \
   --data '{
-    "filters_rules": ["OS-Linux-SNMP-Disk-Name", "OS-Linux-SNMP-Traffic-Name"]
+    "filter_rules": ["OS-Linux-SNMP-Disk-Name", "OS-Linux-SNMP-Traffic-Name"]
 }'
 ```

--- a/gorgone/docs/modules/centreon/autodiscovery.md
+++ b/gorgone/docs/modules/centreon/autodiscovery.md
@@ -34,7 +34,7 @@ enable: true
 
 | Endpoint | Method |
 | :- | :- |
-| /api/centreon/autodiscovery/task | `POST` |
+| /centreon/autodiscovery/task | `POST` |
 
 #### Headers
 
@@ -78,7 +78,7 @@ curl --request POST "https://hostname:8443/api/centreon/autodiscovery/task" \
 
 | Endpoint | Method |
 | :- | :- |
-| /api/centreon/autodiscovery/task/:id | `GET` |
+| /centreon/autodiscovery/task/:id | `GET` |
 
 #### Headers
 
@@ -103,7 +103,7 @@ curl --request GET "https://hostname:8443/api/centreon/autodiscovery/task/autodi
 
 | Endpoint | Method |
 | :- | :- |
-| /api/centreon/autodiscovery/job | `POST` |
+| /centreon/autodiscovery/job | `POST` |
 
 #### Headers
 
@@ -150,7 +150,7 @@ curl --request POST "https://hostname:8443/api/centreon/autodiscovery/job" \
 
 | Endpoint | Method |
 | :- | :- |
-| /api/centreon/autodiscovery/job/:id | `GET` |
+| /centreon/autodiscovery/job/:id | `GET` |
 
 #### Headers
 

--- a/gorgone/docs/modules/centreon/autodiscovery.md
+++ b/gorgone/docs/modules/centreon/autodiscovery.md
@@ -90,7 +90,7 @@ With the following keys for the `post_execution` entry:
 
 #### Examples
 
-#### Execute immediately without post-execution commands
+##### Execute immediately without post-execution commands
 
 ```bash
 curl --request POST "https://hostname:8443/api/centreon/autodiscovery/hosts" \
@@ -109,7 +109,7 @@ curl --request POST "https://hostname:8443/api/centreon/autodiscovery/hosts" \
 }"
 ```
 
-#### Execute immediately with post-execution commands
+##### Execute immediately with post-execution commands
 
 ```bash
 curl --request POST "https://hostname:8443/api/centreon/autodiscovery/hosts" \
@@ -135,7 +135,7 @@ curl --request POST "https://hostname:8443/api/centreon/autodiscovery/hosts" \
 }"
 ```
 
-#### Schedule execution without post-execution commands
+##### Schedule execution without post-execution commands
 
 ```bash
 curl --request POST "https://hostname:8443/api/centreon/autodiscovery/hosts" \
@@ -156,7 +156,7 @@ curl --request POST "https://hostname:8443/api/centreon/autodiscovery/hosts" \
 }"
 ```
 
-#### Schedule execution with post-execution commands
+##### Schedule execution with post-execution commands
 
 ```bash
 curl --request POST "https://hostname:8443/api/centreon/autodiscovery/hosts" \
@@ -249,35 +249,70 @@ curl --request DELETE "https://hostname:8443/api/centreon/autodiscovery/hosts/di
 
 #### Body
 
-| Key                  | Value | Description                                                                   |
-|:---------------------|:------|:------------------------------------------------------------------------------|
-| filter\_rules        | array | Run the selected rule of discovery                                            |
-| force\_rule          | `1|0` | Run also disabled rules                                                       |
-| filter\_hosts        | array | Run all discovery rules linked to all templates of host used by selected host |
-| filter\_pollers      | array | Run all discovery rules linked to all poller linked with rule                 |
-| manual               | `1|0` | Run discovery for manual scan                                                 |
-| dry\_run             | `1|0` | Run discovery without configuration change                                    |
-| no\_generate\_config | `1|0` | No configuration generation (even if there is some changes)                   |
+| Key                  | Value                                                                                             |
+|:---------------------|:--------------------------------------------------------------------------------------------------|
+| filter\_rules        | Array of rules to use for discovery (empty means all)                                             |
+| force\_rule          | Run disabled rules ('0': not forced, '1': forced)                                                 |
+| filter\_hosts        | Array of hosts against which run the discovery (empty means all)                                  |
+| filter\_pollers      | Array of pollers for which linked hosts will be discovered against (empty means all)              |
+| manual               | Run discovery for manual scan from web UI ('0': automatic, '1': manual)                           |
+| dry\_run             | Run discovery without configuration change ('0': changes, '1': dry run)                           |
+| no\_generate\_config | No configuration generation (even if there is some changes) ('0': generation, '1': no generation) |
 
 ```json
 {
-    "filter_rules": ["<rule1>", "<rule2>", ...],
-    "force_rule": <1|0>,
-    "filter_hosts": ["<host1>", "<host2>", ...],
-    "filter_pollers": ["<poller1>", "<poller2>", ...],
-    "manual": <1|0>,
-    "dry_run": <1|0>,
-    "no_generate_config": <1|0>
+    "filter_rules": "<array of rules>",
+    "force_rule": "<run disabled rules>",
+    "filter_hosts": "<array of hosts>",
+    "filter_pollers": "<array of pollers>",
+    "manual": "<manual scan>",
+    "dry_run": "<run without changes>",
+    "no_generate_config": "<no configuration generation>"
 }
 ```
 
-#### Example
+#### Examples
+
+##### Execute discovery with defined rules (even if disabled)
 
 ```bash
 curl --request POST "https://hostname:8443/api/centreon/autodiscovery/services" \
   --header "Accept: application/json" \
   --header "Content-Type: application/json" \
-  --data '{
-    "filter_rules": ["OS-Linux-SNMP-Disk-Name", "OS-Linux-SNMP-Traffic-Name"]
-}'
+  --data "{
+    \"filter_rules\": [
+        \"OS-Linux-SNMP-Disk-Name\",
+        \"OS-Linux-SNMP-Traffic-Name\"
+    ],
+    \"force_rule\": 1
+}"
+```
+
+##### Execute discovery for defined hosts
+
+```bash
+curl --request POST "https://hostname:8443/api/centreon/autodiscovery/services" \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --data "{
+    \"filter_hosts\": [
+        \"Host-1\",
+        \"Host-2\",
+        \"Host-3\"
+    ]
+}"
+```
+
+##### Execute discovery for defined poller (without changes)
+
+```bash
+curl --request POST "https://hostname:8443/api/centreon/autodiscovery/services" \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --data "{
+    \"filter_pollers\": [
+        \"Poller-1\"
+    ],
+    \"dry_run\": 1
+}"
 ```

--- a/gorgone/docs/modules/centreon/autodiscovery.md
+++ b/gorgone/docs/modules/centreon/autodiscovery.md
@@ -6,7 +6,10 @@ This module aims to extend Centreon Autodiscovery server functionalities.
 
 ## Configuration
 
-No specific configuration.
+| Directive       | Description                                                            | Default value |
+|:----------------|:-----------------------------------------------------------------------|:--------------|
+| global\_timeout | Time in seconds before a discovery command is considered timed out     | `300`         |
+| check\_interval | Time in seconds defining frequency at which results will be search for | `15`          |
 
 #### Example
 
@@ -14,92 +17,247 @@ No specific configuration.
 name: autodiscovery
 package: "gorgone::modules::centreon::autodiscovery::hooks"
 enable: true
+global_timeout: 60
+check_interval: 10
 ```
 
 ## Events
 
-| Event | Description |
-| :- | :- |
+| Event                    | Description                                     |
+|:-------------------------|:------------------------------------------------|
 | AUTODISCOVERYREADY       | Internal event to notify the core               |
-| AUTODISCOVERYLISTENER    | Internal event to get host discovery results    |
+| HOSTDISCOVERYLISTENER    | Internal event to get host discovery results    |
 | SERVICEDISCOVERYLISTENER | Internal event to get service discovery results |
-| ADDDISCOVERYJOB          | Add a host discovery job                        |
-| LAUNCHDISCOVERY          | execute a host discovery job                    |
-| LAUNCHSERVICEDISCOVERY   | execute a service discovery job                 |
+| ADDHOSTDISCOVERYJOB      | Add a host discovery job                        |
+| DELETEHOSTDISCOVERYJOB   | Delete a host discovery job                     |
+| LAUNCHHOSTDISCOVERY      | Execute a host discovery job                    |
+| LAUNCHSERVICEDISCOVERY   | Execute a service discovery job                 |
 
 ## API
 
-### Add a discovery job
+### Add a host discovery job
 
-| Endpoint | Method |
-| :- | :- |
-| /centreon/autodiscovery/job | `POST` |
+| Endpoint                      | Method |
+|:------------------------------|:-------|
+| /centreon/autodiscovery/hosts | `POST` |
 
 #### Headers
 
-| Header | Value |
-| :- | :- |
-| Accept | application/json |
+| Header       | Value            |
+|:-------------|:-----------------|
+| Accept       | application/json |
 | Content-Type | application/json |
 
 #### Body
 
-| Key | Value |
-| :- | :- |
-| id | Identifier of the task (random if empty) |
-| timespec | Cron-like time specification |
-| command | Command line to execute to perform the discovery |
-| timeout | Time in seconds before the command is considered timed out |
-| target | Identifier of the target on which to execute the command |
+| Key             | Value                                                      |
+|:----------------|:-----------------------------------------------------------|
+| job\_id         | ID of the Host Discovery job                               |
+| target          | Identifier of the target on which to execute the command   |
+| command_line    | Command line to execute to perform the discovery           |
+| timeout         | Time in seconds before the command is considered timed out |
+| execution       | Execution settings                                         |
+| post\_execution | Post-execution settings                                    |
+
+With the following keys for the `execution` entry:
+
+| Key        | Value                                           |
+|:-----------|:------------------------------------------------|
+| mode       | Execution mode ('0': immediate, '1': scheduled) |
+| parameters | Parameters needed by execution mode             |
+
+With the following keys for the `post_execution` entry:
+
+| Key      | Value                            |
+|:---------|:---------------------------------|
+| commands | Array of commands to be executed |
 
 ```json
 {
-    "id": "<id of the task>",
-    "timespec": "<cron-like time specification>",
-    "command": "<command to execute>",
+    "job_id": "<id of the job>",
+    "target": "<target id>",
+    "command_line": "<command to execute>",
     "timeout": "<timeout in seconds>",
-    "target": "<target id>"
+    "execution": {
+        "mode": "<execution mode>",
+        "parameters": "<execution parameters>",
+    },
+    "post_execution": {
+        "commands": "<array of commands>",
+    }
 }
 ```
+
+#### Examples
+
+#### Execute immediately without post-execution commands
+
+```bash
+curl --request POST "https://hostname:8443/api/centreon/autodiscovery/hosts" \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --data "{
+    \"job_id\": 14,
+    \"target\": 3,
+    \"command_line\": \"perl /usr/lib/centreon/plugins/centreon_generic_snmp.pl --plugin=os::linux::local::plugin --mode=discovery-snmp --subnet='10.1.2.3/24' --snmp-port='161' --snmp-version='2c' --snmp-community='public'\",
+    \"timeout\": 300,
+    \"execution\": {
+        \"mode\": 0,
+        \"parameters\": {}
+    },
+    \"post_execution\": {}
+}"
+```
+
+#### Execute immediately with post-execution commands
+
+```bash
+curl --request POST "https://hostname:8443/api/centreon/autodiscovery/hosts" \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --data "{
+    \"job_id\": 14,
+    \"target\": 3,
+    \"command_line\": \"perl /usr/lib/centreon/plugins/centreon_generic_snmp.pl --plugin=os::linux::local::plugin --mode=discovery-snmp --subnet='10.1.2.3/24' --snmp-port='161' --snmp-version='2c' --snmp-community='public'\",
+    \"timeout\": 300,
+    \"execution\": {
+        \"mode\": 0,
+        \"parameters\": {}
+    },
+    \"post_execution\": {
+        \"commands\": [
+            {
+                \"action\": \"COMMAND\",
+                \"command_line\": \"/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --job-id=14\"
+            }
+        ]
+    }
+}"
+```
+
+#### Schedule execution without post-execution commands
+
+```bash
+curl --request POST "https://hostname:8443/api/centreon/autodiscovery/hosts" \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --data "{
+    \"job_id\": 14,
+    \"target\": 3,
+    \"command_line\": \"perl /usr/lib/centreon/plugins/centreon_generic_snmp.pl --plugin=os::linux::local::plugin --mode=discovery-snmp --subnet='10.1.2.3/24' --snmp-port='161' --snmp-version='2c' --snmp-community='public'\",
+    \"timeout\": 300,
+    \"execution\": {
+        \"mode\": 1,
+        \"parameters\": {
+            \"cron_definition\": \"*/10 * * * *\"
+        }
+    },
+    \"post_execution\": {}
+}"
+```
+
+#### Schedule execution with post-execution commands
+
+```bash
+curl --request POST "https://hostname:8443/api/centreon/autodiscovery/hosts" \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/json" \
+  --data "{
+    \"job_id\": 14,
+    \"target\": 3,
+    \"command_line\": \"perl /usr/lib/centreon/plugins/centreon_generic_snmp.pl --plugin=os::linux::local::plugin --mode=discovery-snmp --subnet='10.1.2.3/24' --snmp-port='161' --snmp-version='2c' --snmp-community='public'\",
+    \"timeout\": 300,
+    \"execution\": {
+        \"mode\": 1,
+        \"parameters\": {
+            \"cron_definition\": \"*/10 * * * *\"
+        }
+    },
+    \"post_execution\": {
+        \"commands\": [
+            {
+                \"action\": \"COMMAND\",
+                \"command_line\": \"/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --job-id=14\"
+            }
+        ]
+    }
+}"
+```
+
+### Launch a host discovery job
+
+| Endpoint                                   | Method |
+|:-------------------------------------------|:-------|
+| /centreon/autodiscovery/hosts/:id/schedule | `GET`  |
+
+#### Headers
+
+| Header       | Value            |
+|:-------------|:-----------------|
+| Accept       | application/json |
+
+#### Path variables
+
+| Variable | Description           |
+|:---------|:----------------------|
+| id       | Identifier of the job |
 
 #### Example
 
 ```bash
-curl --request POST "https://hostname:8443/api/centreon/autodiscovery/job" \
-  --header "Accept: application/json" \
-  --header "Content-Type: application/json" \
-  --data "{
-    \"timespec\": \"0 10 * * *\",
-    \"command\": \"perl /usr/lib/centreon/plugins/centreon_generic_snmp.pl --plugin=os::linux::local::plugin --mode=discovery-snmp --subnet='10.1.2.3/24' --snmp-port='161' --snmp-version='2c' --snmp-community='public'\",
-    \"timeout\": 300,
-    \"target\": 2
-}"
+curl --request GET "https://hostname:8443/api/centreon/autodiscovery/hosts/:id/schedule" \
+  --header "Accept: application/json"
+```
+
+### Delete a host discovery job
+
+| Endpoint                             | Method   |
+|:-------------------------------------|:---------|
+| /centreon/autodiscovery/hosts/:token | `DELETE` |
+
+#### Headers
+
+| Header | Value            |
+|:-------|:-----------------|
+| Accept | application/json |
+
+#### Path variables
+
+| Variable | Description                |
+|:---------|:---------------------------|
+| token    | Token of the scheduled job |
+
+#### Example
+
+```bash
+curl --request DELETE "https://hostname:8443/api/centreon/autodiscovery/hosts/discovery_14_6b7d1bb8" \
+  --header "Accept: application/json"
 ```
 
 ### Execute a service discovery job
 
-| Endpoint | Method |
-| :- | :- |
+| Endpoint                         | Method |
+|:---------------------------------|:-------|
 | /centreon/autodiscovery/services | `POST` |
 
 #### Headers
 
-| Header | Value |
-| :- | :- |
-| Accept | application/json |
+| Header       | Value            |
+|:-------------|:-----------------|
+| Accept       | application/json |
 | Content-Type | application/json |
 
 #### Body
 
-| Key | Value | Description |
-| :- | :- | :- |
-| filter_rules       | array | Run the selected rule of discovery | 
-| force_rule         | `1|0` | Run also disabled rules |
-| filter_hosts       | array | Run all discovery rules linked to all templates of host used by selected host |
-| filter_pollers     | array | Run all discovery rules linked to all poller linked with rule |
-| manual             | `1|0` | Run discovery for manual scan |
-| dry_run            | `1|0` | Run discovery without configuration change                  |
-| no_generate_config | `1|0` | No configuration generation (even if there is some changes) |
+| Key                  | Value | Description                                                                   |
+|:---------------------|:------|:------------------------------------------------------------------------------|
+| filter\_rules        | array | Run the selected rule of discovery                                            |
+| force\_rule          | `1|0` | Run also disabled rules                                                       |
+| filter\_hosts        | array | Run all discovery rules linked to all templates of host used by selected host |
+| filter\_pollers      | array | Run all discovery rules linked to all poller linked with rule                 |
+| manual               | `1|0` | Run discovery for manual scan                                                 |
+| dry\_run             | `1|0` | Run discovery without configuration change                                    |
+| no\_generate\_config | `1|0` | No configuration generation (even if there is some changes)                   |
 
 ```json
 {

--- a/gorgone/docs/modules/centreon/autodiscovery.md
+++ b/gorgone/docs/modules/centreon/autodiscovery.md
@@ -316,33 +316,3 @@ curl --request POST "https://hostname:8443/api/centreon/autodiscovery/services" 
     \"dry_run\": 1
 }"
 ```
-
-### Developer manual
-
-This module heavily uses the gorgone-action module to work.
-
-Here is a diagram of how these modules interact: 
-
-
-![image](./centreon-gorgone-autodiscovery-archi.png)
-
-
-Dotted lines mean a ZMQ message is sent. Direct lines mean the function is called normally.
-
-
-Each column represents a Linux thread, as Gorgone is multi-threaded.
-
-
-For each ZMQ message, names are described in the [events section](#events) of each module,
-and for putlog the second part is the 'code' used by gorgone-autodiscovery 
-and defined as constant in the [class.pm](../../../gorgone/modules/centreon/autodiscovery/class.pm) file.
-
-
-The gorgone-action module does not send the result directly to the calling module. It sends a putlog message instead, processed by core.\
-Core keeps track of every module waiting for a particular event (use library.pm::addlistener to show interest in an event)\
-
-and dispatch another message to the waiting module.
-
-gorgone-core also stores the log in a local sqlite database.
-
-

--- a/gorgone/docs/modules/centreon/autodiscovery.md
+++ b/gorgone/docs/modules/centreon/autodiscovery.md
@@ -7,7 +7,7 @@ This module aims to extend Centreon Autodiscovery server functionalities.
 ## Configuration
 
 | Directive       | Description                                                            | Default value |
-|:----------------|:-----------------------------------------------------------------------|:--------------|
+| :-------------- | :--------------------------------------------------------------------- | :------------ |
 | global\_timeout | Time in seconds before a discovery command is considered timed out     | `300`         |
 | check\_interval | Time in seconds defining frequency at which results will be search for | `15`          |
 
@@ -24,7 +24,7 @@ check_interval: 10
 ## Events
 
 | Event                    | Description                                     |
-|:-------------------------|:------------------------------------------------|
+| :----------------------- | :---------------------------------------------- |
 | AUTODISCOVERYREADY       | Internal event to notify the core               |
 | HOSTDISCOVERYLISTENER    | Internal event to get host discovery results    |
 | SERVICEDISCOVERYLISTENER | Internal event to get service discovery results |
@@ -38,20 +38,20 @@ check_interval: 10
 ### Add a host discovery job
 
 | Endpoint                      | Method |
-|:------------------------------|:-------|
+| :---------------------------- | :----- |
 | /centreon/autodiscovery/hosts | `POST` |
 
 #### Headers
 
 | Header       | Value            |
-|:-------------|:-----------------|
+| :----------- | :--------------- |
 | Accept       | application/json |
 | Content-Type | application/json |
 
 #### Body
 
 | Key             | Value                                                      |
-|:----------------|:-----------------------------------------------------------|
+| :-------------- | :--------------------------------------------------------- |
 | job\_id         | ID of the Host Discovery job                               |
 | target          | Identifier of the target on which to execute the command   |
 | command_line    | Command line to execute to perform the discovery           |
@@ -62,14 +62,14 @@ check_interval: 10
 With the following keys for the `execution` entry:
 
 | Key        | Value                                           |
-|:-----------|:------------------------------------------------|
+| :--------- | :---------------------------------------------- |
 | mode       | Execution mode ('0': immediate, '1': scheduled) |
 | parameters | Parameters needed by execution mode             |
 
 With the following keys for the `post_execution` entry:
 
 | Key      | Value                            |
-|:---------|:---------------------------------|
+| :------- | :------------------------------- |
 | commands | Array of commands to be executed |
 
 ```json
@@ -187,19 +187,19 @@ curl --request POST "https://hostname:8443/api/centreon/autodiscovery/hosts" \
 ### Launch a host discovery job
 
 | Endpoint                                   | Method |
-|:-------------------------------------------|:-------|
+| :----------------------------------------- | :----- |
 | /centreon/autodiscovery/hosts/:id/schedule | `GET`  |
 
 #### Headers
 
 | Header       | Value            |
-|:-------------|:-----------------|
+| :----------- | :--------------- |
 | Accept       | application/json |
 
 #### Path variables
 
 | Variable | Description           |
-|:---------|:----------------------|
+| :------- | :-------------------- |
 | id       | Identifier of the job |
 
 #### Example
@@ -212,19 +212,19 @@ curl --request GET "https://hostname:8443/api/centreon/autodiscovery/hosts/:id/s
 ### Delete a host discovery job
 
 | Endpoint                             | Method   |
-|:-------------------------------------|:---------|
+| :----------------------------------- | :------- |
 | /centreon/autodiscovery/hosts/:token | `DELETE` |
 
 #### Headers
 
 | Header | Value            |
-|:-------|:-----------------|
+| :----- | :--------------- |
 | Accept | application/json |
 
 #### Path variables
 
 | Variable | Description                |
-|:---------|:---------------------------|
+| :------- | :------------------------- |
 | token    | Token of the scheduled job |
 
 #### Example
@@ -237,20 +237,20 @@ curl --request DELETE "https://hostname:8443/api/centreon/autodiscovery/hosts/di
 ### Execute a service discovery job
 
 | Endpoint                         | Method |
-|:---------------------------------|:-------|
+| :------------------------------- | :----- |
 | /centreon/autodiscovery/services | `POST` |
 
 #### Headers
 
 | Header       | Value            |
-|:-------------|:-----------------|
+| :----------- | :--------------- |
 | Accept       | application/json |
 | Content-Type | application/json |
 
 #### Body
 
 | Key                  | Value                                                                                             |
-|:---------------------|:--------------------------------------------------------------------------------------------------|
+| :------------------- | :------------------------------------------------------------------------------------------------ |
 | filter\_rules        | Array of rules to use for discovery (empty means all)                                             |
 | force\_rule          | Run disabled rules ('0': not forced, '1': forced)                                                 |
 | filter\_hosts        | Array of hosts against which run the discovery (empty means all)                                  |

--- a/gorgone/docs/modules/centreon/autodiscovery.md
+++ b/gorgone/docs/modules/centreon/autodiscovery.md
@@ -316,3 +316,33 @@ curl --request POST "https://hostname:8443/api/centreon/autodiscovery/services" 
     \"dry_run\": 1
 }"
 ```
+
+### Developer manual
+
+This module heavily uses the gorgone-action module to work.
+
+Here is a diagram of how these modules interact: 
+
+
+![image](./centreon-gorgone-autodiscovery-archi.png)
+
+
+Dotted lines mean a ZMQ message is sent. Direct lines mean the function is called normally.
+
+
+Each column represents a Linux thread, as Gorgone is multi-threaded.
+
+
+For each ZMQ message, names are described in the [events section](#events) of each module,
+and for putlog the second part is the 'code' used by gorgone-autodiscovery 
+and defined as constant in the [class.pm](../../../gorgone/modules/centreon/autodiscovery/class.pm) file.
+
+
+The gorgone-action module does not send the result directly to the calling module. It sends a putlog message instead, processed by core.\
+Core keeps track of every module waiting for a particular event (use library.pm::addlistener to show interest in an event)\
+
+and dispatch another message to the waiting module.
+
+gorgone-core also stores the log in a local sqlite database.
+
+

--- a/gorgone/docs/modules/centreon/autodiscovery.md
+++ b/gorgone/docs/modules/centreon/autodiscovery.md
@@ -6,10 +6,13 @@ This module aims to extend Centreon Autodiscovery server functionalities.
 
 ## Configuration
 
-| Directive       | Description                                                            | Default value |
-| :-------------- | :--------------------------------------------------------------------- | :------------ |
-| global\_timeout | Time in seconds before a discovery command is considered timed out     | `300`         |
-| check\_interval | Time in seconds defining frequency at which results will be search for | `15`          |
+| Directive                            | Description                                                                                       | Default value |
+| :----------------------------------- | :------------------------------------------------------------------------------------------------ | :------------ |
+| global\_timeout                      | Time in seconds before a discovery command is considered timed out                                | `300`         |
+| check\_interval                      | Time in seconds defining frequency at which results will be search for                            | `15`          |
+| service\_parrallel\_commands\_poller | Number of commands run simultaneously on each Poller                                              | `8`           |
+| service\_check\_interval             | Time in seconds defining frequency at which results will be search for (for services discoveries) | `15`          |
+| service\_timeout                     | Time in seconds before a service discovery command is considered timed out                        | `90`          |
 
 #### Example
 
@@ -19,6 +22,9 @@ package: "gorgone::modules::centreon::autodiscovery::hooks"
 enable: true
 global_timeout: 60
 check_interval: 10
+service_parrallel_commands_poller: 15
+service_check_interval: 5
+service_timeout: 60
 ```
 
 ## Events

--- a/gorgone/gorgone/class/tpapi/centreonv2.pm
+++ b/gorgone/gorgone/class/tpapi/centreonv2.pm
@@ -196,22 +196,26 @@ sub request {
         critical_status => ''
     );
 
+    my $decoded = $self->json_decode(content => $content);
+
     # code 403 means forbidden (token not good maybe)
     if ($self->{http}->get_code() == 403) {
         $self->{token} = undef;
         $self->{is_logged} = 0;
         $self->{is_error} = 1;
         $self->{error} = 'token forbidden';
+        $self->{error} = $decoded->{message} if (defined($decoded) && defined($decoded->{message}));
         return 1;
     }
 
     if ($self->{http}->get_code() < 200 || $self->{http}->get_code() >= 300) {
         $self->{is_error} = 1;
-        $self->{error} =  "request error [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']";
+        my $message = $self->{http}->get_message();
+        $message = $decoded->{message} if (defined($decoded) && defined($decoded->{message}));
+        $self->{error} =  "request error [code: '" . $self->{http}->get_code() . "'] [message: '" . $message . "']";
         return 1;
     }
 
-    my $decoded = $self->json_decode(content => $content);
     return 1 if (!defined($decoded));
 
     return (0, $decoded);

--- a/gorgone/gorgone/class/tpapi/centreonv2.pm
+++ b/gorgone/gorgone/class/tpapi/centreonv2.pm
@@ -235,38 +235,18 @@ sub get_monitoring_hosts {
     );
 }
 
-sub get_scheduling_jobs {
+
+sub get_platform_versions {
     my ($self, %options) = @_;
 
-=pod
-    my $results = [
-        {
-            execution => {
-                parameters => {
-                    cron_definition => "* * * * *",
-                    is_paused => 0
-                },
-                mode => 1
-            },
-            post_execution => {
-                commands => [
-                    {
-                        action => 'COMMAND',
-                        command_line => '/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=9'
-                    }
-                ]
-            },
-            job_id => 9,
-            token => "discovery_9_f2b0ea11",
-            command_line => "/usr/lib/centreon/plugins/centreon_generic_snmp.pl --plugin=os::linux::local::plugin --mode=discovery-snmp --subnet='127.0.0.1/32' --snmp-community='public' --snmp-version='2c' --snmp-port='161' --snmp-timeout='1' \$_EXTRAOPTIONS\$",
-            target => 1,
-            status => 1,
-            last_execution => undef,
-            uuid_attributes => ["hostname", "ip"]
-        }
-    ];
-    return (0, $results);
-=cut
+    return $self->request(
+        method => 'GET',
+        endpoint => '/platform/versions'
+    );    
+}
+
+sub get_scheduling_jobs {
+    my ($self, %options) = @_;
 
     my $get_param;
     if (defined($options{search})) {

--- a/gorgone/gorgone/class/tpapi/centreonv2.pm
+++ b/gorgone/gorgone/class/tpapi/centreonv2.pm
@@ -1,0 +1,295 @@
+# 
+# Copyright 2019 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package gorgone::class::tpapi::centreonv2;
+
+use strict;
+use warnings;
+use JSON::XS;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self  = {};
+    bless $self, $class;
+
+    $self->{is_error} = 1;
+    $self->{error} = 'configuration missing';
+    $self->{is_logged} = 0;
+
+    return $self;
+}
+
+sub json_decode {
+    my ($self, %options) = @_;
+
+    my $decoded;
+    eval {
+        $decoded = JSON::XS->new->utf8->decode($options{content});
+    };
+    if ($@) {
+        $self->{is_error} = 1;
+        $self->{error} = "cannot decode json response: $@";
+        return undef;
+    }
+
+    return $decoded;
+}
+
+sub error {
+    my ($self, %options) = @_;
+
+    return $self->{error};
+}
+
+sub set_configuration {
+    my ($self, %options) = @_;
+
+    if (!defined($options{config})) {
+        return 1;
+    }
+
+    foreach (('base_url', 'username', 'password')) {
+        if (!defined($options{config}->{$_}) ||
+            $options{config}->{$_} eq '') {
+            $self->{error} = $_ . ' configuration missing';
+            return 1;
+        }
+
+        $self->{$_} = $options{config}->{$_};
+    }
+
+    $self->{base_url} =~ s/\/$//;
+
+    $self->{http_backend} = defined($options{config}->{backend}) ? $options{config}->{backend} : 'curl';
+
+    $self->{curl_opts} = ['CURLOPT_SSL_VERIFYPEER => 0'];
+    my $curl_opts = [];
+    if (defined($options{config}->{curlopts})) {
+        foreach (keys %{$options{config}->{curlopts}}) {
+            push @{$curl_opts}, $_ . ' => ' . $options{config}->{curlopts}->{$_};
+        }
+    }
+    if (scalar(@$curl_opts) > 0) {
+        $self->{curl_opts} = $curl_opts;
+    }
+
+    $self->{http} = gorgone::class::http::http->new(logger => $options{logger});
+    $self->{is_error} = 0;
+    return 0;
+}
+
+sub authenticate {
+    my ($self, %options) = @_;
+
+    my $json_request = {
+        security => {
+            credentials => {
+                login => $self->{username},
+                password => $self->{password}
+            }
+        }
+    };
+    my $encoded;
+    eval {
+        $encoded = encode_json($json_request);
+    };
+    if ($@) {
+        $self->{is_error} = 1;
+        $self->{error} = "cannot encode json request: $@";
+        return undef;
+    }
+
+    my ($code, $content) = $self->{http}->request(
+        http_backend => $self->{http_backend},
+        method => 'POST',
+        hostname => '',
+        full_url => $self->{base_url} . '/login',
+        query_form_post => $encoded,
+        header => [
+            'Accept-Type: application/json; charset=utf-8',
+            'Content-Type: application/json; charset=utf-8',
+        ],
+        curl_opt => $self->{curl_opts},
+        warning_status => '',
+        unknown_status => '',
+        critical_status => ''
+    );
+    if ($code) {
+        $self->{is_error} = 1;
+        $self->{error} = 'http request error';
+        return undef;
+    }
+    if ($self->{http}->get_code() < 200 || $self->{http}->get_code() >= 300) {
+        $self->{is_error} = 1;
+        $self->{error} =  "Login error [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']";
+        return undef;
+    }
+
+    my $decoded = $self->json_decode(content => $content);
+    return if (!defined($decoded));
+
+    my $token = defined($decoded->{security}->{token}) ? $decoded->{security}->{token} : undef;
+    if (!defined($token)) {
+        $self->{is_error} = 1;
+        $self->{error} = 'authenticate issue - cannot get token';
+        return undef;
+    }
+
+    $self->{token} = $token;
+    $self->{is_logged} = 1;
+}
+
+sub request {
+    my ($self, %options) = @_;
+
+    if (!defined($self->{base_url})) {
+        $self->{is_error} = 1;
+        $self->{error} = 'configuration missing';
+        return 1;
+    }
+
+    $self->{is_error} = 0;
+    if ($self->{is_logged} == 0) {
+        $self->authenticate();
+    }
+
+    return 1 if ($self->{is_logged} == 0);
+
+    # TODO: manage it properly
+    my $get_param = ['page=1', 'limit=10000'];
+    if (defined($options{get_param})) {
+        push @$get_param, @{$options{get_param}};
+    }
+
+    my ($code, $content) = $self->{http}->request(
+        http_backend => $self->{http_backend},
+        method => $options{method},
+        hostname => '',
+        full_url => $self->{base_url} . $options{endpoint},
+        query_form_post => $options{query_form_post},
+        get_param => $get_param,
+        header => [
+            'Accept-Type: application/json; charset=utf-8',
+            'Content-Type: application/json; charset=utf-8',
+            'X-AUTH-TOKEN: ' . $self->{token}
+        ],
+        curl_opt => $self->{curl_opts},
+        warning_status => '',
+        unknown_status => '',
+        critical_status => ''
+    );
+
+    # code 403 means forbidden (token not good maybe)
+    if ($self->{http}->get_code() == 403) {
+        $self->{token} = undef;
+        $self->{is_logged} = 0;
+        $self->{is_error} = 1;
+        $self->{error} = 'token forbidden';
+        return 1;
+    }
+
+    if ($self->{http}->get_code() < 200 || $self->{http}->get_code() >= 300) {
+        $self->{is_error} = 1;
+        $self->{error} =  "request error [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']";
+        return 1;
+    }
+
+    my $decoded = $self->json_decode(content => $content);
+    return 1 if (!defined($decoded));
+
+    return (0, $decoded);
+}
+
+sub get_monitoring_hosts {
+    my ($self, %options) = @_;
+
+    my $endpoint = '/monitoring/hosts';
+    $endpoint .= '/' . $options{host_id} if (defined($options{host_id}));
+
+    my $get_param;
+    if (defined($options{search})) {
+        $get_param = ['search=' . $options{search}];
+    }
+    
+    return $self->request(
+        method => 'GET',
+        endpoint => $endpoint,
+        get_param => $get_param
+    );
+}
+
+sub get_scheduling_jobs {
+    my ($self, %options) = @_;
+
+=pod
+    my $results = [
+        {
+            execution => {
+                parameters => {
+                    cron_definition => "* * * * *",
+                    is_paused => 0
+                },
+                mode => 1
+            },
+            post_execution => {
+                commands => [
+                    {
+                        action => 'COMMAND',
+                        command_line => '/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=9'
+                    }
+                ]
+            },
+            job_id => 9,
+            token => "discovery_9_f2b0ea11",
+            command_line => "/usr/lib/centreon/plugins/centreon_generic_snmp.pl --plugin=os::linux::local::plugin --mode=discovery-snmp --subnet='127.0.0.1/32' --snmp-community='public' --snmp-version='2c' --snmp-port='161' --snmp-timeout='1' \$_EXTRAOPTIONS\$",
+            target => 1,
+            status => 1,
+            last_execution => undef,
+            uuid_attributes => ["hostname", "ip"]
+        }
+    ];
+    return (0, $results);
+=cut
+
+    my $get_param;
+    if (defined($options{search})) {
+        $get_param = ['search=' . $options{search}];
+    }
+
+    my $endpoint = '/auto-discovery/scheduling/jobs';
+    return $self->request(
+        method => 'GET',
+        endpoint => $endpoint,
+        get_param => $get_param
+    );
+}
+
+sub DESTROY {
+    my ($self) = @_;
+
+    if ($self->{is_logged} == 1) {
+        $self->request(
+            method => 'GET',
+            endpoint => '/logout'
+        );
+    }
+}
+
+1;

--- a/gorgone/gorgone/class/tpapi/centreonv2.pm
+++ b/gorgone/gorgone/class/tpapi/centreonv2.pm
@@ -79,7 +79,7 @@ sub set_configuration {
 
     $self->{http_backend} = defined($options{config}->{backend}) ? $options{config}->{backend} : 'curl';
 
-    $self->{curl_opts} = ['CURLOPT_SSL_VERIFYPEER => 0'];
+    $self->{curl_opts} = ['CURLOPT_SSL_VERIFYPEER => 0', 'CURLOPT_POSTREDIR => CURL_REDIR_POST_ALL'];
     my $curl_opts = [];
     if (defined($options{config}->{curlopts})) {
         foreach (keys %{$options{config}->{curlopts}}) {

--- a/gorgone/gorgone/class/tpapi/centreonv2.pm
+++ b/gorgone/gorgone/class/tpapi/centreonv2.pm
@@ -222,6 +222,12 @@ sub request {
     return (0, $decoded);
 }
 
+sub get_token {
+    my ($self, %options) = @_;
+
+    return $self->{token};
+}
+
 sub get_monitoring_hosts {
     my ($self, %options) = @_;
 

--- a/gorgone/gorgone/class/tpapi/centreonv2.pm
+++ b/gorgone/gorgone/class/tpapi/centreonv2.pm
@@ -22,6 +22,7 @@ package gorgone::class::tpapi::centreonv2;
 
 use strict;
 use warnings;
+use gorgone::class::http::http;
 use JSON::XS;
 
 sub new {

--- a/gorgone/gorgone/class/tpapi/centreonv2.pm
+++ b/gorgone/gorgone/class/tpapi/centreonv2.pm
@@ -42,7 +42,7 @@ sub json_decode {
 
     my $decoded;
     eval {
-        $decoded = JSON::XS->new->utf8->decode($options{content});
+        $decoded = JSON::XS->new->decode($options{content});
     };
     if ($@) {
         $self->{is_error} = 1;

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -30,12 +30,13 @@ use gorgone::modules::centreon::autodiscovery::services::discovery;
 use gorgone::class::tpapi::clapi;
 use gorgone::class::tpapi::centreonv2;
 use gorgone::class::sqlquery;
-use ZMQ::LibZMQ4;
-use ZMQ::Constants qw(:all);
+use gorgone::class::frame;
 use JSON::XS;
 use Time::HiRes;
 use POSIX qw(strftime);
 use Digest::MD5 qw(md5_hex);
+use Try::Tiny;
+use EV;
 
 use constant JOB_SCHEDULED => 0;
 use constant JOB_FINISH => 1;
@@ -149,7 +150,7 @@ sub hdisco_add_cron {
         return (1, "missing 'cron_definition' parameter");
     }
 
-    $self->send_internal_action(
+    $self->send_internal_action({
         action => 'ADDLISTENER',
         data => [
             {
@@ -158,7 +159,7 @@ sub hdisco_add_cron {
                 token => 'cron-' . $options{discovery_token}
             }
         ]
-    );
+    });
 
     $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - add cron for job '" . $options{job}->{job_id} . "'");
     my $definition = {
@@ -170,13 +171,13 @@ sub hdisco_add_cron {
             timeout => (defined($options{job}->{timeout}) && $options{job}->{timeout} =~ /(\d+)/) ? $1 : $self->{global_timeout}
         }
     };
-    $self->send_internal_action(
+    $self->send_internal_action({
         action => 'ADDCRON',
         token => 'cron-' . $options{discovery_token},
         data => {
             content => [ $definition ]
         }
-    );
+    });
 
     return 0;
 }
@@ -302,7 +303,7 @@ sub get_host_job {
 
     my ($status, $results) = $self->{tpapi_centreonv2}->get_scheduling_jobs(search => '{"id": ' . $options{job_id} . '}');
     if ($status != 0) {
-        return (1, "cannot get host discovery job '$options{data}->{content}->{job_id}' - " . $self->{tpapi_centreonv2}->error());
+        return (1, "cannot get host discovery job '$options{job_id}' - " . $self->{tpapi_centreonv2}->error());
     }
 
     my $job;
@@ -328,13 +329,13 @@ sub hdisco_delete_cron {
 
     $self->{logger}->writeLogInfo("[autodiscovery] -class- host discovery - delete job '" . $job_id . "'");
 
-    $self->send_internal_action(
+    $self->send_internal_action({
         action => 'DELETECRON',
         token => $options{token},
         data => {   
             variables => [ $options{discovery_token} ]
         }
-    );
+    });
 }
 
 sub action_addhostdiscoveryjob {
@@ -352,51 +353,53 @@ sub action_addhostdiscoveryjob {
         return ;
     }
 
+    my $data = $options{frame}->getData();
+
     my ($status, $message, $job);
-    ($status, $message, $job) = $self->get_host_job(job_id => $options{data}->{content}->{job_id});
+    ($status, $message, $job) = $self->get_host_job(job_id => $data->{content}->{job_id});
     if ($status != 0) {
-        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - cannot get host discovery job '$options{data}->{content}->{job_id}' - " . $self->{tpapi_centreonv2}->error());
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - cannot get host discovery job '$data->{content}->{job_id}' - " . $self->{tpapi_centreonv2}->error());
         $self->send_log(
             code => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
             data => {
-                message => "cannot get job '$options{data}->{content}->{job_id}'"
+                message => "cannot get job '$data->{content}->{job_id}'"
             }
         );
         return 1;
     }
 
     if (!defined($job)) {
-        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - cannot get host discovery job '$options{data}->{content}->{job_id}' - " . $self->{tpapi_centreonv2}->error());
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - cannot get host discovery job '$data->{content}->{job_id}' - " . $self->{tpapi_centreonv2}->error());
         $self->send_log(
             code => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
             data => {
-                message => "cannot get job '$options{data}->{content}->{job_id}'"
+                message => "cannot get job '$data->{content}->{job_id}'"
             }
         );
         return 1;
     }
 
-    $job->{timeout} = $options{data}->{content}->{timeout};
+    $job->{timeout} = $data->{content}->{timeout};
     ($status, $message) = $self->hdisco_addupdate_job(job => $job);
     if ($status) {
-        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - add job '$options{data}->{content}->{job_id}' - $message");
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - add job '$data->{content}->{job_id}' - $message");
         $self->send_log(
             code => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
             data => {
-                message => "add job '$options{data}->{content}->{job_id}' - $message"
+                message => "add job '$data->{content}->{job_id}' - $message"
             }
         );
         return 1;
     }
 
     # Launch a immediate job.
-    if ($self->{hdisco_jobs_ids}->{ $options{data}->{content}->{job_id} }->{execution}->{mode} == EXECUTION_MODE_IMMEDIATE) {
+    if ($self->{hdisco_jobs_ids}->{ $data->{content}->{job_id} }->{execution}->{mode} == EXECUTION_MODE_IMMEDIATE) {
         ($status, $message) = $self->launchhostdiscovery(
-            job_id => $options{data}->{content}->{job_id},
-            timeout => $options{data}->{content}->{timeout},
+            job_id => $data->{content}->{job_id},
+            timeout => $data->{content}->{timeout},
             source => 'immediate'
         );
         if ($status) {
@@ -415,7 +418,7 @@ sub action_addhostdiscoveryjob {
         code => GORGONE_ACTION_FINISH_OK,
         token => $options{token},
         data => {
-            message => 'job ' . $options{data}->{content}->{job_id} . ' added'
+            message => 'job ' . $data->{content}->{job_id} . ' added'
         }
     );
     
@@ -461,7 +464,7 @@ sub launchhostdiscovery {
     $self->{hdisco_jobs_ids}->{$job_id}->{status} = JOB_RUNNING;
     my $timeout = (defined($options{timeout}) && $options{timeout} =~ /(\d+)/) ? $1 : $self->{global_timeout};
 
-    $self->send_internal_action(
+    $self->send_internal_action({
         action => 'ADDLISTENER',
         data => [
             {
@@ -473,9 +476,9 @@ sub launchhostdiscovery {
                 log_pace => $self->{check_interval}
             }
         ]
-    );
+    });
 
-    $self->send_internal_action(
+    $self->send_internal_action({
         action => 'COMMAND',
         target => $self->{hdisco_jobs_ids}->{$job_id}->{target},
         token => $self->{hdisco_jobs_ids}->{$job_id}->{token},
@@ -492,7 +495,7 @@ sub launchhostdiscovery {
                 }
             ]
         }
-    );
+    });
 
     return (0, "job '$job_id' launched");
 }
@@ -512,14 +515,16 @@ sub action_launchhostdiscovery {
         return ;
     }
 
+    my $data = $options{frame}->getData();
+
     my ($job_id, $timeout, $source);
-    if (defined($options{data}->{variables}->[0]) &&
-        defined($options{data}->{variables}->[1]) && $options{data}->{variables}->[1] eq 'schedule') {
-        $job_id = $options{data}->{variables}->[0];
+    if (defined($data->{variables}->[0]) &&
+        defined($data->{variables}->[1]) && $data->{variables}->[1] eq 'schedule') {
+        $job_id = $data->{variables}->[0];
         $source = 'immediate';
-    } elsif (defined($options{data}->{content}->{job_id})) {
-        $job_id = $options{data}->{content}->{job_id};
-        $timeout = $options{data}->{content}->{timeout};
+    } elsif (defined($data->{content}->{job_id})) {
+        $job_id = $data->{content}->{job_id};
+        $timeout = $data->{content}->{timeout};
         $source = 'cron';
     }
 
@@ -593,17 +598,19 @@ sub action_launchhostdiscovery {
 sub discovery_postcommand_result {
     my ($self, %options) = @_;
 
-    return 1 if (!defined($options{data}->{data}->{metadata}->{job_id}));
+    my $data = $options{frame}->getData();
 
-    my $job_id = $options{data}->{data}->{metadata}->{job_id};
+    return 1 if (!defined($data->{data}->{metadata}->{job_id}));
+
+    my $job_id = $data->{data}->{metadata}->{job_id};
     if (!defined($self->{hdisco_jobs_ids}->{$job_id})) {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - found result for inexistant job '" . $job_id . "'");
         return 1;
     }
 
-    my $exit_code = $options{data}->{data}->{result}->{exit_code};
-    my $output = (defined($options{data}->{data}->{result}->{stderr}) && $options{data}->{data}->{result}->{stderr} ne '') ?
-        $options{data}->{data}->{result}->{stderr} : $options{data}->{data}->{result}->{stdout};
+    my $exit_code = $data->{data}->{result}->{exit_code};
+    my $output = (defined($data->{data}->{result}->{stderr}) && $data->{data}->{result}->{stderr} ne '') ?
+        $data->{data}->{result}->{stderr} : $data->{data}->{result}->{stdout};
 
     if ($exit_code != 0) {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - execute discovery postcommand failed job '$job_id'");
@@ -623,12 +630,75 @@ sub discovery_postcommand_result {
     );
 }
 
+sub discovery_add_host_result {
+    my ($self, %options) = @_;
+
+    if ($options{builder}->{num_lines} == MAX_INSERT_BY_QUERY) {
+        my ($status) = $self->{class_object_centreon}->custom_execute(
+            request => $options{builder}->{query} . $options{builder}->{values},
+            bind_values => $options{builder}->{bind_values}
+        );
+        if ($status == -1) {
+            $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to insert job '$options{job_id}' results");
+            $self->update_job_status(
+                job_id => $options{job_id},
+                status => JOB_FAILED,
+                message => 'Failed to insert job results'
+            );
+            return 1;
+        }
+        $options{builder}->{num_lines} = 0;
+        $options{builder}->{values} = '';
+        $options{builder}->{append} = '';
+        $options{builder}->{bind_values} = ();
+    }
+
+    # Generate uuid based on attributs
+    my $uuid_char = '';
+    foreach (@{$options{uuid_parameters}}) {
+        $uuid_char .= $options{host}->{$_} if (defined($options{host}->{$_}) && $options{host}->{$_} ne '');
+    }
+    my $ctx = Digest::MD5->new;
+    $ctx->add($uuid_char);
+    my $digest = $ctx->hexdigest;
+    my $uuid = substr($digest, 0, 8) . '-' . substr($digest, 8, 4) . '-' . substr($digest, 12, 4) . '-' .
+        substr($digest, 16, 4) . '-' . substr($digest, 20, 12);
+    my $encoded_host = JSON::XS->new->encode($options{host});
+
+    # Build bulk insert
+    $options{builder}->{values} .= $options{builder}->{append} . '(?, ?, ?)';
+    $options{builder}->{append} = ', ';
+    push @{$options{builder}->{bind_values}}, $options{job_id}, $encoded_host, $uuid;
+    $options{builder}->{num_lines}++;
+    $options{builder}->{total_lines}++;
+
+    return 0;
+}
+
 sub discovery_command_result {
     my ($self, %options) = @_;
 
-    return 1 if (!defined($options{data}->{data}->{metadata}->{job_id}));
+=pod
+    use Devel::Size;
+    print "frame = " . (Devel::Size::total_size($options{frame}) / 1024 / 1024) . "==\n";
 
-    my $job_id = $options{data}->{data}->{metadata}->{job_id};
+    my $data = $options{frame}->getData();
+    print "data = " . (Devel::Size::total_size($data) / 1024 / 1024) . "==\n";
+
+    my $frame = $options{frame}->getFrame();
+    print "frame data = " . (Devel::Size::total_size($frame) / 1024 / 1024) . "==\n";
+
+    my $raw = $options{frame}->getRawData();
+    print "raw data = " . (Devel::Size::total_size($raw) / 1024 / 1024) . "==\n";
+
+    return 1;
+=cut
+
+    my $data = $options{frame}->getData();
+
+    return 1 if (!defined($data->{data}->{metadata}->{job_id}));
+
+    my $job_id = $data->{data}->{metadata}->{job_id};
     if (!defined($self->{hdisco_jobs_ids}->{$job_id})) {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - found result for inexistant job '" . $job_id . "'");
         return 1;
@@ -636,38 +706,22 @@ sub discovery_command_result {
 
     $self->{logger}->writeLogInfo("[autodiscovery] -class- host discovery - found result for job '" . $job_id . "'");
     my $uuid_parameters = $self->{hdisco_jobs_ids}->{$job_id}->{uuid_parameters};
-    my $exit_code = $options{data}->{data}->{result}->{exit_code};
-    my $output = (defined($options{data}->{data}->{result}->{stderr}) && $options{data}->{data}->{result}->{stderr} ne '') ?
-        $options{data}->{data}->{result}->{stderr} : $options{data}->{data}->{result}->{stdout};
+    my $exit_code = $data->{data}->{result}->{exit_code};
 
     if ($exit_code != 0) {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - execute discovery plugin failed job '$job_id'");
         $self->update_job_status(
             job_id => $job_id,
             status => JOB_FAILED,
-            message => $output
-        );
-        return 1;
-    }
-
-    my $result;
-    eval {
-        $result = JSON::XS->new->decode($output);
-    };
-
-    if ($@) {
-        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to decode discovery plugin response job '$job_id'");
-        $self->update_job_status(
-            job_id => $job_id,
-            status => JOB_FAILED,
-            message => 'Failed to decode discovery plugin response'
+            message => (defined($data->{data}->{result}->{stderr}) && $data->{data}->{result}->{stderr} ne '') ?
+                $data->{data}->{result}->{stderr} : $data->{data}->{result}->{stdout}
         );
         return 1;
     }
 
     # Delete previous results
-    my $query = "DELETE FROM mod_host_disco_host WHERE job_id = " . $self->{class_object_centreon}->quote(value => $job_id);
-    my ($status) = $self->{class_object_centreon}->custom_execute(request => $query);
+    my $query = "DELETE FROM mod_host_disco_host WHERE job_id = ?";
+    my ($status) = $self->{class_object_centreon}->custom_execute(request => $query, bind_values => [$job_id]);
     if ($status == -1) {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to delete previous job '$job_id' results");
         $self->update_job_status(
@@ -679,49 +733,45 @@ sub discovery_command_result {
     }
 
     # Add new results
-    my $number_of_lines = 0;
-    my $values = '';
-    my $append = '';
-    $query = "INSERT INTO mod_host_disco_host (job_id, discovery_result, uuid) VALUES ";
-    foreach my $host (@{$result->{results}}) {
-        if ($number_of_lines == MAX_INSERT_BY_QUERY) {
-            ($status) = $self->{class_object_centreon}->custom_execute(request => $query . $values);
-            if ($status == -1) {
-                $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to insert job '$job_id' results");
-                $self->update_job_status(
-                    job_id => $job_id,
-                    status => JOB_FAILED,
-                    message => 'Failed to insert job results'
-                );
-                return 1;
+    my $builder = {
+        query => "INSERT INTO mod_host_disco_host (job_id, discovery_result, uuid) VALUES ",
+        num_lines => 0,
+        total_lines => 0,
+        values => '',
+        append => '',
+        bind_values => []
+    };
+    my $duration = 0;
+
+    try {
+        my $json = JSON::XS->new();
+        $json->incr_parse($data->{data}->{result}->{stdout});
+        while (my $obj = $json->incr_parse()) {
+            if (ref($obj) eq 'HASH') {
+                foreach my $host (@{$obj->{results}}) {
+                    my $rv = $self->discovery_add_host_result(host => $host, job_id => $job_id, uuid_parameters => $uuid_parameters, builder => $builder);
+                    return 1 if ($rv);
+                }
+                $duration = $obj->{duration};
+            } elsif (ref($obj) eq 'ARRAY') {
+                foreach my $host (@$obj) {
+                    my $rv = $self->discovery_add_host_result(host => $host, job_id => $job_id, uuid_parameters => $uuid_parameters, builder => $builder);
+                    return 1 if ($rv);
+                }
             }
-            $number_of_lines = 0;
-            $values = '';
-            $append = '';
         }
+    } catch {
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to decode discovery plugin response job '$job_id'");
+        $self->update_job_status(
+            job_id => $job_id,
+            status => JOB_FAILED,
+            message => 'Failed to decode discovery plugin response'
+        );
+        return 1;
+    };
 
-        # Generate uuid based on attributs
-        my $uuid_char = '';
-        foreach (@$uuid_parameters) {
-            $uuid_char .= $host->{$_} if (defined($host->{$_}) && $host->{$_} ne '');
-        }
-        my $ctx = Digest::MD5->new;
-        $ctx->add($uuid_char);
-        my $digest = $ctx->hexdigest;
-        my $uuid = substr($digest, 0, 8) . '-' . substr($digest, 8, 4) . '-' . substr($digest, 12, 4) . '-' .
-            substr($digest, 16, 4) . '-' . substr($digest, 20, 12);
-        my $encoded_host = JSON::XS->new->encode($host);
-
-        # Build bulk insert
-        $values .= $append . "(" . $self->{class_object_centreon}->quote(value => $job_id) . ", " . 
-            $self->{class_object_centreon}->quote(value => $encoded_host) . ", " . 
-            $self->{class_object_centreon}->quote(value => $uuid) . ")";
-        $append = ', ';
-        $number_of_lines++;
-    }
-
-    if ($values ne '') {
-        ($status) = $self->{class_object_centreon}->custom_execute(request => $query . $values);
+    if ($builder->{values} ne '') {
+        ($status) = $self->{class_object_centreon}->custom_execute(request => $builder->{query} . $builder->{values}, bind_values => $builder->{bind_values});
         if ($status == -1) {
             $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to insert job '$job_id' results");
             $self->update_job_status(
@@ -738,7 +788,7 @@ sub discovery_command_result {
         $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - execute post command job '$job_id'");
         my $post_command = $self->{hdisco_jobs_ids}->{$job_id}->{post_execution}->{commands}->[0];
 
-        $self->send_internal_action(
+        $self->send_internal_action({
             action => $post_command->{action},
             token => $self->{hdisco_jobs_ids}->{$job_id}->{token},
             data => {
@@ -753,7 +803,7 @@ sub discovery_command_result {
                     }
                 ]
             }
-        );
+        });
     }
     
     $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - finished discovery command job '$job_id'");
@@ -761,8 +811,8 @@ sub discovery_command_result {
         job_id => $job_id,
         status => JOB_FINISH,
         message => 'Finished',
-        duration => $result->{duration},
-        discovered_items => $result->{discovered_items}
+        duration => $duration,
+        discovered_items => $builder->{total_lines}
     );
 
     return 0;
@@ -785,7 +835,9 @@ sub action_deletehostdiscoveryjob {
         return ;
     }
 
-    my $discovery_token = $options{data}->{variables}->[0];
+    my $data = $options{frame}->getData();
+
+    my $discovery_token = $data->{variables}->[0];
     my $job_id = (defined($discovery_token) && defined($self->{hdisco_jobs_tokens}->{$discovery_token})) ? 
         $self->{hdisco_jobs_tokens}->{$discovery_token} : undef;
     if (!defined($discovery_token) || $discovery_token eq '') {
@@ -856,21 +908,24 @@ sub update_job_information {
     return 1 if (!defined($options{values}) || ref($options{values}) ne 'HASH' || !keys %{$options{values}});
     
     my $query = "UPDATE mod_host_disco_job SET ";
+    my @bind_values = ();
     my $append = '';
     foreach (keys %{$options{values}}) {
-        $query .= $append . $_ . " = " .  $self->{class_object_centreon}->quote(value => $options{values}->{$_});
+        $query .= $append . $_ . ' = ?';
         $append = ', ';
+        push @bind_values, $options{values}->{$_};
     }
 
     $query .= " WHERE ";
     $append = '';
     foreach (@{$options{where_clause}}) {
         my ($key, $value) = each %{$_};
-        $query .= $append . $key . " = " . $self->{class_object_centreon}->quote(value => $value);
+        $query .= $append . $key . " = ?";
         $append = 'AND ';
+        push @bind_values, $value;
     }
 
-    my ($status) = $self->{class_object_centreon}->custom_execute(request => $query);
+    my ($status) = $self->{class_object_centreon}->custom_execute(request => $query, bind_values => \@bind_values);
     if ($status == -1) {
         $self->{logger}->writeLogError('[autodiscovery] Failed to update job information');
         return -1;
@@ -884,24 +939,26 @@ sub action_hostdiscoveryjoblistener {
 
     return 0 if (!$self->is_hdisco_synced());
     return 0 if (!defined($options{token}));
-    return 0 if (!defined($self->{hdisco_jobs_tokens}->{$options{token}}));
+    return 0 if (!defined($self->{hdisco_jobs_tokens}->{ $options{token} }));
 
-    my $job_id = $self->{hdisco_jobs_tokens}->{$options{token}};
-    if ($options{data}->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT && 
-        $options{data}->{data}->{metadata}->{source} eq 'autodiscovery-host-job-discovery') {
+    my $data = $options{frame}->getData();
+
+    my $job_id = $self->{hdisco_jobs_tokens}->{ $options{token} };
+    if ($data->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT && 
+        $data->{data}->{metadata}->{source} eq 'autodiscovery-host-job-discovery') {
         $self->discovery_command_result(%options);
         return 1;
     }
-    #if ($options{data}->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT && 
-    #    $options{data}->{data}->{metadata}->{source} eq 'autodiscovery-host-job-postcommand') {
+    #if ($data->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT && 
+    #    $data->{data}->{metadata}->{source} eq 'autodiscovery-host-job-postcommand') {
     #    $self->discovery_postcommand_result(%options);
     #    return 1;
     #}
 
     # Can happen if we have a execution command timeout
-    my $message = defined($options{data}->{data}->{result}->{stdout}) ? $options{data}->{data}->{result}->{stdout} : $options{data}->{data}->{message};
-    $message = $options{data}->{message} if (!defined($message));
-    if ($options{data}->{code} == GORGONE_ACTION_FINISH_KO) {
+    my $message = defined($data->{data}->{result}->{stdout}) ? $data->{data}->{result}->{stdout} : $data->{data}->{message};
+    $message = $data->{message} if (!defined($message));
+    if ($data->{code} == GORGONE_ACTION_FINISH_KO) {
         $self->{hdisco_jobs_ids}->{$job_id}->{status} = JOB_FAILED;
         $self->update_job_information(
             values => {
@@ -930,11 +987,13 @@ sub action_hostdiscoverycronlistener {
 
     return 0 if (!defined($self->{hdisco_jobs_tokens}->{ $discovery_token }));
 
+    my $data = $options{frame}->getData();
+
     my $job_id = $self->{hdisco_jobs_tokens}->{ $discovery_token };
-    if ($options{data}->{code} == GORGONE_ACTION_FINISH_KO) {
+    if ($data->{code} == GORGONE_ACTION_FINISH_KO) {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - job '" . $job_id . "' add cron error");
         $self->{hdisco_jobs_ids}->{$job_id}->{extra_infos}->{cron_added} = CRON_ADDED_KO;
-    } elsif ($options{data}->{code} == GORGONE_ACTION_FINISH_OK) {
+    } elsif ($data->{code} == GORGONE_ACTION_FINISH_OK) {
         $self->{logger}->writeLogInfo("[autodiscovery] -class- host discovery - job '" . $job_id . "' add cron ok");
         $self->{hdisco_jobs_ids}->{$job_id}->{extra_infos}->{cron_added} = CRON_ADDED_OK;
     }
@@ -948,7 +1007,7 @@ sub hdisco_add_joblistener {
     foreach (@{$options{jobs}}) {
         $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - register listener for '" . $_->{job_id} . "'");
 
-        $self->send_internal_action(
+        $self->send_internal_action({
             action => 'ADDLISTENER',
             data => [
                 {
@@ -959,7 +1018,7 @@ sub hdisco_add_joblistener {
                     log_pace => $self->{check_interval}
                 }
             ]
-        );
+        });
     }
 
     return 0;
@@ -1014,7 +1073,7 @@ sub action_launchservicediscovery {
     );
     my $status = $svc_discovery->launchdiscovery(
         token => $options{token},
-        data => $options{data}
+        frame => $options{frame}
     );
     if ($status == -1) {
         $self->send_log(
@@ -1058,21 +1117,32 @@ sub is_hdisco_synced {
 }
 
 sub event {
-    while (1) {
-        my $message = $connector->read_message();
-        last if (!defined($message));
+    my ($self, %options) = @_;
 
-        $connector->{logger}->writeLogDebug("[autodiscovery] Event: $message");
-        if ($message =~ /^\[(.*?)\]/) {
+    while ($self->{internal_socket}->has_pollin()) {
+        my $frame = gorgone::class::frame->new();
+        my (undef, $rv) = $self->read_message(frame => $frame);
+        next if ($rv);
+
+        my $raw = $frame->getFrame();
+        $self->{logger}->writeLogDebug("[autodiscovery] Event: " . $$raw) if ($connector->{logger}->is_debug());
+        if ($$raw =~ /^\[(.*?)\]/) {
             if ((my $method = $connector->can('action_' . lc($1)))) {
-                $message =~ /^\[(.*?)\]\s+\[(.*?)\]\s+\[.*?\]\s+(.*)$/m;
-                my ($action, $token) = ($1, $2);
-                my ($rv, $data) = $connector->json_decode(argument => $3, token => $token);
-                next if ($rv);
+                next if ($frame->parse({ releaseFrame => 1, decode => 1 }));
 
-                $method->($connector, token => $token, data => $data);
+                $method->($self, token => $frame->getToken(), frame => $frame);
             }
         }
+    }
+}
+
+sub periodic_exec {
+    $connector->is_module_installed();
+    $connector->hdisco_sync();
+
+    if ($connector->{stop} == 1) {
+        $connector->{logger}->writeLogInfo("[autodiscovery] $$ has quit");
+        exit(0);
     }
 }
 
@@ -1116,37 +1186,25 @@ sub run {
         db_centreon => $self->{db_centstorage}
     );
 
-    # Connect internal
-    $connector->{internal_socket} = gorgone::standard::library::connect_com(
+    $self->{internal_socket} = gorgone::standard::library::connect_com(
+        context => $self->{zmq_context},
         zmq_type => 'ZMQ_DEALER',
         name => 'gorgone-autodiscovery',
         logger => $self->{logger},
         type => $self->get_core_config(name => 'internal_com_type'),
         path => $self->get_core_config(name => 'internal_com_path')
     );
-    $connector->send_internal_action(
+    $self->send_internal_action({
         action => 'AUTODISCOVERYREADY',
         data => {}
-    );
-    $self->{poll} = [
-        {
-            socket  => $connector->{internal_socket},
-            events  => ZMQ_POLLIN,
-            callback => \&event,
-        }
-    ];
+    });
 
-    while (1) {
-        $self->is_module_installed();
-        $self->hdisco_sync();
+    $self->is_module_installed();
+    $self->hdisco_sync();
 
-        my $rev = zmq_poll($self->{poll}, 5000);
-        if (defined($rev) && $rev == 0 && $self->{stop} == 1) {
-            $self->{logger}->writeLogInfo("[autodiscovery] $$ has quit");
-            zmq_close($connector->{internal_socket});
-            exit(0);
-        }
-    }
+    my $watcher_timer = $self->{loop}->timer(5, 5, \&periodic_exec);
+    my $watcher_io = $self->{loop}->io($self->{internal_socket}->get_fd(), EV::READ, sub { $connector->event() } );
+    $self->{loop}->run();
 }
 
 1;

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -478,6 +478,12 @@ sub launchhostdiscovery {
         ]
     });
 
+    # plugins attribute format:
+    #    "plugins": {
+    #            "centreon-plugin-Cloud-Aws-Ec2-Api": 20220727,
+    #            ...
+    #    }
+
     $self->send_internal_action({
         action => 'COMMAND',
         target => $self->{hdisco_jobs_ids}->{$job_id}->{target},
@@ -490,7 +496,8 @@ sub launchhostdiscovery {
                     timeout => $timeout,
                     metadata => {
                         job_id => $job_id,
-                        source => 'autodiscovery-host-job-discovery'
+                        source => 'autodiscovery-host-job-discovery',
+                        pkg_install => $self->{hdisco_jobs_ids}->{$job_id}->{plugins}
                     }
                 }
             ]
@@ -677,22 +684,6 @@ sub discovery_add_host_result {
 
 sub discovery_command_result {
     my ($self, %options) = @_;
-
-=pod
-    use Devel::Size;
-    print "frame = " . (Devel::Size::total_size($options{frame}) / 1024 / 1024) . "==\n";
-
-    my $data = $options{frame}->getData();
-    print "data = " . (Devel::Size::total_size($data) / 1024 / 1024) . "==\n";
-
-    my $frame = $options{frame}->getFrame();
-    print "frame data = " . (Devel::Size::total_size($frame) / 1024 / 1024) . "==\n";
-
-    my $raw = $options{frame}->getRawData();
-    print "raw data = " . (Devel::Size::total_size($raw) / 1024 / 1024) . "==\n";
-
-    return 1;
-=cut
 
     my $data = $options{frame}->getData();
 

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -1118,7 +1118,7 @@ sub run {
     # Connect internal
     $connector->{internal_socket} = gorgone::standard::library::connect_com(
         zmq_type => 'ZMQ_DEALER',
-        name => 'gorgoneautodiscovery',
+        name => 'gorgone-autodiscovery',
         logger => $self->{logger},
         type => $self->{config_core}->{internal_com_type},
         path => $self->{config_core}->{internal_com_path}

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -521,7 +521,7 @@ sub action_launchservicediscovery {
     #    - for the listener we use the token: svc-disco-SVCNUMBER-COMMANDNUMBER
 
     # need to manage dry-run and manual
-    # add a progress bar of commands in log
+    # add a progress bar of commands in log (we do for each 5%)
 
     return 0;
 }

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -275,6 +275,7 @@ sub action_updatediscoveryresults {
             $job_id = $data->{metadata}->{job_id};
             $token = $message->{token};
             $uuid_attributes = JSON::XS->new->utf8->decode($data->{metadata}->{uuid_attributes});
+            last;
         } elsif ($message->{code} == 1) {
             my $data = JSON::XS->new->utf8->decode($message->{data});
 
@@ -282,6 +283,7 @@ sub action_updatediscoveryresults {
 
             $output = $data->{message};
             $token = $message->{token};
+            last;
         }
     }
 
@@ -348,7 +350,7 @@ sub action_updatediscoveryresults {
                 return 1;
             }
         }
-    } elsif ($exit_code > 0 && defined($job_id)) {
+    } elsif ($exit_code != 0 && defined($job_id)) {
         # Failed
         my $query = "UPDATE mod_host_disco_job " .
             "SET status = '2', duration = '0', discovered_items = '0', " .

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -25,6 +25,7 @@ use base qw(gorgone::class::module);
 use strict;
 use warnings;
 use gorgone::standard::library;
+use gorgone::standard::constants qw(:all);
 use gorgone::class::sqlquery;
 use ZMQ::LibZMQ4;
 use ZMQ::Constants qw(:all);
@@ -164,7 +165,7 @@ sub action_adddiscoveryjob {
     }
 
     $self->send_log(
-        code => $self->ACTION_FINISH_OK,
+        code => GORGONE_ACTION_FINISH_OK,
         token => $options{token},
         data => {
             id => $token

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -297,15 +297,14 @@ sub action_updatediscoveryresults {
         };
         if ($@) {
             # Failed
+            $self->{logger}->writeLogError('[autodiscovery] Failed to decode discovery plugin response: ' . $@);
             my $query = "UPDATE mod_host_disco_job " .
                 "SET status = '2', duration = '0', discovered_items = '0', " .
                 "message = 'Failed to decode discovery plugin response' " .
                 "WHERE id = '" . $job_id ."'";
             my $status = $self->{class_object_centreon}->transaction_query(request => $query);
-            if ($status == -1) {
-                $self->{logger}->writeLogError('[autodiscovery] Failed to decode discovery plugin response');
-                return 1;
-            }
+            $self->{logger}->writeLogError('[autodiscovery] Failed to update job status') if ($status == -1);
+            return 1;
         }
 
         # Finished
@@ -360,10 +359,8 @@ sub action_updatediscoveryresults {
             "message = " . $self->{class_object_centreon}->quote(value => $output) . " " .
             "WHERE id = '" . $job_id ."'";
         my $status = $self->{class_object_centreon}->transaction_query(request => $query);
-        if ($status == -1) {
-            $self->{logger}->writeLogError('[autodiscovery] Failed to update job status');
-            return 1;
-        }
+        $self->{logger}->writeLogError('[autodiscovery] Failed to update job status') if ($status == -1);
+        return 1;
     } elsif (defined($token)) {
         # Failed
         my $query = "UPDATE mod_host_disco_job " .
@@ -371,10 +368,8 @@ sub action_updatediscoveryresults {
             "message = " . $self->{class_object_centreon}->quote(value => $output) . " " .
             "WHERE token = '" . $token ."'";
         my $status = $self->{class_object_centreon}->transaction_query(request => $query);
-        if ($status == -1) {
-            $self->{logger}->writeLogError('[autodiscovery] Failed to update job status');
-            return 1;
-        }
+        $self->{logger}->writeLogError('[autodiscovery] Failed to update job status') if ($status == -1);
+        return 1;
     }
 
     return 0;

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -652,7 +652,7 @@ sub discovery_command_result {
 
     my $result;
     eval {
-        $result = JSON::XS->new->utf8->decode($output);
+        $result = JSON::XS->new->decode($output);
     };
 
     if ($@) {
@@ -710,7 +710,7 @@ sub discovery_command_result {
         my $digest = $ctx->hexdigest;
         my $uuid = substr($digest, 0, 8) . '-' . substr($digest, 8, 4) . '-' . substr($digest, 12, 4) . '-' .
             substr($digest, 16, 4) . '-' . substr($digest, 20, 12);
-        my $encoded_host = JSON::XS->new->utf8->encode($host);
+        my $encoded_host = JSON::XS->new->encode($host);
 
         # Build bulk insert
         $values .= $append . "(" . $self->{class_object_centreon}->quote(value => $job_id) . ", " . 

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -166,17 +166,15 @@ sub action_adddiscoveryjob {
         target => $options{data}->{content}->{target},
         timespec => $options{data}->{content}->{timespec},
         action => 'COMMAND',
-        parameters => {
-            [
-                command => $options{data}->{content}->{command},
-                timeout => $options{data}->{content}->{timeout},
-                metadata => {
-                    id => $id,
-                    source => 'autodiscovery',
-                    type => 'job',
-                }
-            ]
-        },
+        parameters =>  [
+            command => $options{data}->{content}->{command},
+            timeout => $options{data}->{content}->{timeout},
+            metadata => {
+                id => $id,
+                source => 'autodiscovery',
+                type => 'job',
+            }
+        ]
         keep_token => 1,
     };
     

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -888,12 +888,14 @@ sub action_hostdiscoveryjoblistener {
     #    return 1;
     #}
 
+    # Can happen if we have a execution command timeout
+    my $message = defined($options{data}->{data}->{result}->{stdout}) ? $options{data}->{data}->{result}->{stdout} : $options{data}->{message};
     if ($options{data}->{code} == GORGONE_ACTION_FINISH_KO) {
         $self->{hdisco_jobs_ids}->{$job_id}->{status} = JOB_FAILED;
         $self->update_job_information(
             values => {
                 status => JOB_FAILED,
-                message => $options{data}->{message},
+                message => $message,
                 duration => 0,
                 discovered_items => 0
             },

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -31,7 +31,6 @@ use gorgone::class::sqlquery;
 use ZMQ::LibZMQ4;
 use ZMQ::Constants qw(:all);
 use JSON::XS;
-use XML::Simple;
 use Time::HiRes;
 use POSIX qw(strftime);
 use Digest::MD5 qw(md5_hex);

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -93,6 +93,8 @@ sub class_handle_HUP {
 
 sub action_adddiscoveryjob {
     my ($self, %options) = @_;
+    
+    return if (!$self->is_module_installed());
 
     $options{token} = $self->generate_token() if (!defined($options{token}));
     my $token = 'autodiscovery_' . $self->generate_token(length => 8);
@@ -176,6 +178,8 @@ sub action_adddiscoveryjob {
 
 sub action_launchdiscovery {
     my ($self, %options) = @_;
+    
+    return if (!$self->is_module_installed());
 
     $self->{logger}->writeLogInfo("[autodiscovery] Launching discovery for job '" . $options{data}->{content}->{job_id} . "'");
 
@@ -215,6 +219,8 @@ sub action_launchdiscovery {
 sub action_getdiscoveryresults {
     my ($self, %options) = @_;
     
+    return if (!$self->is_module_installed());
+    
     # List running jobs
     my ($status, $data) = $self->{class_object_centreon}->custom_execute(
         request => "SELECT id, monitoring_server_id, token FROM mod_host_disco_job WHERE status = '3'",
@@ -247,6 +253,8 @@ sub action_getdiscoveryresults {
 
 sub action_updatediscoveryresults {
     my ($self, %options) = @_;
+    
+    return if (!$self->is_module_installed());
 
     return if (!defined($options{data}->{data}->{action}) || $options{data}->{data}->{action} ne "getlog" ||
         !defined($options{data}->{data}->{result}) || scalar(@{$options{data}->{data}->{result}} == 0));
@@ -363,6 +371,17 @@ sub action_updatediscoveryresults {
     }
 
     return 0;
+}
+
+sub is_module_installed {
+    my ($self) = @_;
+
+    my ($status, $data) = $self->{class_object_centreon}->custom_execute(
+        request => "SELECT id FROM modules_informations WHERE name = 'centreon-autodiscovery-server'",
+        mode => 2
+    );
+
+    (defined($data->[0]) && scalar($data->[0]) > 0) ? return 1 : return 0;
 }
 
 sub event {

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -508,8 +508,10 @@ sub action_launchservicediscovery {
     }
 
     $self->{service_discoveries}->{ $self->{service_number} } = {
+        token => $options{token},
         count_discoveries => $total,
         done_discoveries => 0,
+        current_progress => 0,
         rules => $rules,
         options => defined($options{data}->{content}) ? $options{data}->{content} : {}
     };

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -340,11 +340,13 @@ sub action_updatediscoveryresults {
             $append = ', '
         }
 
-        $query = "INSERT INTO mod_host_disco_host (job_id, discovery_result, uuid) VALUES " . $values;
-        $status = $self->{class_object_centreon}->transaction_query(request => $query);
-        if ($status == -1) {
-            $self->{logger}->writeLogError('[autodiscovery] Failed to insert job results');
-            return 1;
+        if (defined($values) && $values ne '') {
+            $query = "INSERT INTO mod_host_disco_host (job_id, discovery_result, uuid) VALUES " . $values;
+            $status = $self->{class_object_centreon}->transaction_query(request => $query);
+            if ($status == -1) {
+                $self->{logger}->writeLogError('[autodiscovery] Failed to insert job results');
+                return 1;
+            }
         }
     } elsif ($exit_code > 0 && defined($job_id)) {
         # Failed

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -443,7 +443,13 @@ sub action_launchservicediscovery {
         token => $options{token},
         data => $options{data}
     );
-    if ($status == 0) {
+    if ($status == -1) {
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_KO,
+            token => $options{token},
+            data => { message => 'cannot launch discovery' }
+        );
+    } elsif ($status == 0) {
         $self->{service_discoveries}->{ $svc_discovery->get_uuid() } = $svc_discovery;
     }
 }

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -480,9 +480,9 @@ sub launchhostdiscovery {
         target => $self->{hdisco_jobs_ids}->{$job_id}->{target},
         token => $self->{hdisco_jobs_ids}->{$job_id}->{token},
         data => {
+            instant => 1,
             content => [
                 {
-                    instant => 1,
                     command => $self->{hdisco_jobs_ids}->{$job_id}->{command_line},
                     timeout => $timeout,
                     metadata => {
@@ -742,9 +742,9 @@ sub discovery_command_result {
             action => $post_command->{action},
             token => $self->{hdisco_jobs_ids}->{$job_id}->{token},
             data => {
+                instant => 1,
                 content => [
                     {
-                        instant => 1,
                         command => $post_command->{command_line},
                         metadata => {
                             job_id => $job_id,

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -1042,7 +1042,8 @@ sub is_module_installed {
         return 0;
     }
 
-    if (defined($results->{modules}->{'centreon-autodiscovery-server'})) {
+    if (defined($results->{modules}) && ref($results->{modules}) eq 'HASH' &&
+        defined($results->{modules}->{'centreon-autodiscovery-server'})) {
         $self->{logger}->writeLogDebug('[autodiscovery] -class- host discovery - module autodiscovery installed');
         $self->{is_module_installed} = 1;
     }

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -27,6 +27,8 @@ use warnings;
 use gorgone::standard::library;
 use gorgone::standard::constants qw(:all);
 use gorgone::modules::centreon::autodiscovery::services::discovery;
+use gorgone::class::tpapi::clapi;
+use gorgone::class::tpapi::centreonv2;
 use gorgone::class::sqlquery;
 use ZMQ::LibZMQ4;
 use ZMQ::Constants qw(:all);
@@ -35,30 +37,48 @@ use Time::HiRes;
 use POSIX qw(strftime);
 use Digest::MD5 qw(md5_hex);
 
+use constant JOB_SCHEDULED => 0;
+use constant JOB_FINISH => 1;
+use constant JOB_FAILED => 2;
+use constant JOB_RUNNING => 3;
+use constant SAVE_RUNNING => 4;
+use constant SAVE_FINISH => 5;
+use constant SAVE_FAILED => 6;
+
+use constant CRON_ADDED_NONE => 0;
+use constant CRON_ADDED_OK => 1;
+use constant CRON_ADDED_KO => 2;
+use constant CRON_ADDED_PROGRESS => 3;
+
+use constant EXECUTION_MODE_IMMEDIATE => 0;
+use constant EXECUTION_MODE_CRON => 1;
+use constant EXECUTION_MODE_PAUSE => 2;
+
+use constant MAX_INSERT_BY_QUERY => 100;
+
 my %handlers = (TERM => {}, HUP => {});
 my ($connector);
 
 sub new {
     my ($class, %options) = @_;
-
-    $connector  = {};
-    $connector->{internal_socket} = undef;
-    $connector->{module_id} = $options{module_id};
-    $connector->{logger} = $options{logger};
-    $connector->{config} = $options{config};
-    $connector->{config_core} = $options{config_core};
-    $connector->{config_db_centreon} = $options{config_db_centreon};
-    $connector->{config_db_centstorage} = $options{config_db_centstorage};
-    $connector->{stop} = 0;
+    $connector = $class->SUPER::new(%options);
+    bless $connector, $class;
 
     $connector->{global_timeout} = (defined($options{config}->{global_timeout}) &&
         $options{config}->{global_timeout} =~ /(\d+)/) ? $1 : 300;
     $connector->{check_interval} = (defined($options{config}->{check_interval}) &&
         $options{config}->{check_interval} =~ /(\d+)/) ? $1 : 15;
+    $connector->{tpapi_clapi_name} = defined($options{config}->{tpapi_clapi}) && $options{config}->{tpapi_clapi} ne '' ? $options{config}->{tpapi_clapi} : 'clapi';
+    $connector->{tpapi_centreonv2_name} = defined($options{config}->{tpapi_centreonv2}) && $options{config}->{tpapi_centreonv2} ne '' ? 
+        $options{config}->{tpapi_centreonv2} : 'centreonv2';
+
+    $connector->{hdisco_synced} = 0;
+    $connector->{hdisco_synced_time} = -1;
+    $connector->{hdisco_jobs_tokens} = {};
+    $connector->{hdisco_jobs_ids} = {};
 
     $connector->{service_discoveries} = {};
 
-    bless $connector, $class;
     $connector->set_signal_handlers();
     return $connector;
 }
@@ -101,111 +121,345 @@ sub class_handle_HUP {
 Host Discovery part
 *******************
 
+For cron job, we use discovery token as cron ID.
+
 =cut
 
-sub action_adddiscoveryjob {
+sub hdisco_is_running_job {
     my ($self, %options) = @_;
-    
-    return if (!$self->is_module_installed());
 
-    $options{token} = $self->generate_token() if (!defined($options{token}));
-    my $token = 'autodiscovery_' . $self->generate_token(length => 8);
-    
-    # Scheduled
-    my $query = "UPDATE mod_host_disco_job " . 
-        "SET status = '0', duration = '0', discovered_items = '0', message = 'Scheduled' " .
-        "WHERE id = '" . $options{data}->{content}->{job_id} . "'";
-    my $status = $self->{class_object_centreon}->transaction_query(request => $query);
-    if ($status == -1) {
-        $self->{logger}->writeLogError('[autodiscovery] Failed to update job status');
+    if ($options{status} == JOB_RUNNING ||
+        $options{status} == SAVE_RUNNING) {
         return 1;
     }
 
-    # Retrieve uuid attributes
-    my $result;
-    $query = "SELECT uuid_attributes " .
-        "FROM mod_host_disco_provider mhdp " .
-        "JOIN mod_host_disco_job mhdj " .
-        "WHERE mhdj.provider_id = mhdp.id AND mhdj.id = '" . $options{data}->{content}->{job_id} . "'";
-    ($status, $result) = $self->{class_object_centreon}->custom_execute(request => $query, mode => 2);
-    if ($status == -1) {
-        $self->{logger}->writeLogError('[autodiscovery] Failed to retrieve uuid attributes');
-        return 1;
-    }
-    
-    my $uuid_attributes = $result->[0]->[0];    
-
-    my $timeout = (defined($options{data}->{content}->{timeout}) && $options{data}->{content}->{timeout} =~ /(\d+)/) ?
-        $options{data}->{content}->{timeout} : $self->{global_timeout};
-
-    if ($options{data}->{content}->{execution_mode} == 0) {
-        # Execute immediately
-        $self->action_launchdiscovery(
-            data => {
-                content => {
-                    target => $options{data}->{content}->{target},
-                    command => $options{data}->{content}->{command},
-                    timeout => $timeout,
-                    job_id => $options{data}->{content}->{job_id},
-                    uuid_attributes => $uuid_attributes,
-                    token => $token
-                }
-            }
-        );
-    } else {
-        # Schedule with cron
-        $self->{logger}->writeLogInfo("[autodiscovery] Add cron '" . $token . "' for job '" . $options{data}->{content}->{job_id} . "'");
-        my $definition = {
-            id => $token,
-            target => '1',
-            timespec => $options{data}->{content}->{timespec},
-            action => 'LAUNCHDISCOVERY',
-            parameters =>  {
-                target => $options{data}->{content}->{target},
-                command => $options{data}->{content}->{command},
-                timeout => $timeout,
-                job_id => $options{data}->{content}->{job_id},
-                uuid_attributes => $uuid_attributes,
-                token => $token
-            },
-            keep_token => 1,
-        };
-        
-        $self->send_internal_action(
-            action => 'ADDCRON',
-            token => $options{token},
-            data => {
-                content => [ $definition ],
-            }
-        );
-    }
-
-    $self->send_log(
-        code => GORGONE_ACTION_FINISH_OK,
-        token => $options{token},
-        data => {
-            id => $token
-        }
-    );
-    
     return 0;
 }
 
-sub action_launchdiscovery {
+sub hdisco_add_cron {
     my ($self, %options) = @_;
-    
-    return if (!$self->is_module_installed());
 
-    $self->{logger}->writeLogInfo("[autodiscovery] Launching discovery for job '" . $options{data}->{content}->{job_id} . "'");
+    if (!defined($options{job}->{execution}->{parameters}->{cron_definition}) || 
+        $options{job}->{execution}->{parameters}->{cron_definition} eq '') {
+        return (1, "missing 'cron_definition' parameter");
+    }
 
     $self->send_internal_action(
         action => 'ADDLISTENER',
         data => [
             {
                 identity => 'gorgoneautodiscovery',
-                event => 'AUTODISCOVERYLISTENER',
-                target => $options{data}->{content}->{target},
-                token => $options{data}->{content}->{token},
+                event => 'HOSTDISCOVERYCRONLISTENER',
+                token => 'cron-' . $options{discovery_token}
+            }
+        ]
+    );
+
+    $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - add cron for job '" . $options{job}->{job_id} . "'");
+    my $definition = {
+        id => $options{discovery_token},
+        timespec => $options{job}->{execution}->{parameters}->{cron_definition},
+        action => 'LAUNCHHOSTDISCOVERY',
+        parameters =>  {
+            job_id => $options{job}->{job_id},
+            timeout => $self->{global_timeout}
+        }
+    };
+    $self->send_internal_action(
+        action => 'ADDCRON',
+        token => 'cron-' . $options{discovery_token},
+        data => {
+            content => [ $definition ]
+        }
+    );
+
+    return 0;
+}
+
+sub hdisco_addupdate_job {
+    my ($self, %options) = @_;
+    my ($status, $message);
+
+    my $update = 0;
+    my $extra_infos = { cron_added => CRON_ADDED_NONE, listener_added => 0 };
+    if (defined($self->{hdisco_jobs_ids}->{ $options{job}->{job_id} })) {
+        $extra_infos = $self->{hdisco_jobs_ids}->{ $options{job}->{job_id} }->{extra_infos};
+        $update = 1;
+    } else {
+        $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - new job '" . $options{job}->{job_id} . "'");
+        # it's running so we have a token
+        if ($self->hdisco_is_running_job(status => $options{job}->{status})) {
+            $extra_infos->{listener_added} = 1;
+            $self->hdisco_add_joblistener(
+                jobs => [
+                    { job_id => $options{job}->{job_id}, target => $options{job}->{target}, token => $options{job}->{token} }
+                ]
+            );
+        }
+    }
+
+    # cron changed: we remove old definition
+    # right now: can be immediate or schedule (not both)
+    if ($update == 1 &&
+        ($self->{hdisco_jobs_ids}->{ $options{job}->{job_id} }->{execution}->{mode} == EXECUTION_MODE_IMMEDIATE || 
+         (defined($self->{hdisco_jobs_ids}->{ $options{job}->{job_id} }->{execution}->{parameters}->{cron_definition}) &&
+          defined($options{job}->{execution}->{parameters}->{cron_definition}) &&
+          $self->{hdisco_jobs_ids}->{ $options{job}->{job_id} }->{execution}->{parameters}->{cron_definition} ne $options{job}->{execution}->{parameters}->{cron_definition}
+         )
+        )
+    ) {
+        $self->hdisco_delete_cron(discovery_token => $options{job}->{token});
+        $extra_infos->{cron_added} = CRON_ADDED_NONE;
+    }
+
+    $self->{hdisco_jobs_ids}->{ $options{job}->{job_id} } = $options{job};
+    $self->{hdisco_jobs_ids}->{ $options{job}->{job_id} }->{extra_infos} = $extra_infos;
+    if (!defined($options{job}->{token})) {
+        my $discovery_token = 'discovery_' . $options{job}->{job_id} . '_' . $self->generate_token(length => 4);
+        if ($self->update_job_information(
+            values => {
+                token => $discovery_token
+            },
+            where_clause => [
+                { id => $options{job}->{job_id} }
+            ]
+        ) == -1) {
+            return (1, 'cannot add discovery token'); 
+        }
+
+        $self->{hdisco_jobs_ids}->{ $options{job}->{job_id} }->{token} = $discovery_token;
+        $options{job}->{token} = $discovery_token;
+    }
+
+    if (defined($options{job}->{token})) {
+        $self->{hdisco_jobs_tokens}->{ $options{job}->{token} } = $options{job}->{job_id};
+    }
+
+    if ($self->{hdisco_jobs_ids}->{ $options{job}->{job_id} }->{execution}->{mode} == EXECUTION_MODE_CRON &&
+        ($extra_infos->{cron_added} == CRON_ADDED_NONE || $extra_infos->{cron_added} == CRON_ADDED_KO)
+    ) {
+        ($status, $message) = $self->hdisco_add_cron(job => $options{job}, discovery_token => $options{job}->{token});
+        return ($status, $message) if ($status);
+        $self->{hdisco_jobs_ids}->{ $options{job}->{job_id} }->{extra_infos}->{cron_added} = CRON_ADDED_PROGRESS;
+    }
+
+    return 0;
+}
+
+sub hdisco_sync {
+    my ($self, %options) = @_;
+
+    return if ($self->{hdisco_synced} == 1 && (time() - $self->{hdisco_synced_time}) < 600);
+
+    $self->{logger}->writeLogInfo('[autodiscovery] -class- host discovery - sync started');
+    my ($status, $results, $message);
+
+    ($status, $results) = $self->{tpapi_centreonv2}->get_scheduling_jobs();
+    if ($status != 0) {
+        $self->{logger}->writeLogError('[autodiscovery] -class- host discovery - cannot get host discovery jobs - ' . $self->{tpapi_centreonv2}->error());
+        return ;
+    }
+
+    my $jobs = {};
+    foreach my $job (@{$results->{result}}) {
+        ($status, $message) = $self->hdisco_addupdate_job(job => $job);
+        if ($status) {
+             $self->{logger}->writeLogError('[autodiscovery] -class- host discovery - addupdate job - ' . $message);
+        }
+
+        $jobs->{ $job->{job_id} } = 1;
+    }
+
+    foreach my $job_id (keys %{$self->{hdisco_jobs_ids}}) {
+        next if (defined($jobs->{$job_id}));
+
+        $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - delete job '" . $job_id . "'");
+        if (defined($self->{hdisco_jobs_ids}->{$job_id}->{token})) {
+            $self->hdisco_delete_cron(discovery_token => $self->{hdisco_jobs_ids}->{$job_id}->{token});
+            delete $self->{hdisco_jobs_tokens}->{ $self->{hdisco_jobs_ids}->{$job_id}->{token} };
+        }
+        delete $self->{hdisco_jobs_ids}->{$job_id};
+    }
+
+    $self->{hdisco_synced_time} = time();
+    $self->{hdisco_synced} = 1;
+}
+
+sub get_host_job {
+    my ($self, %options) = @_;
+
+    my ($status, $results) = $self->{tpapi_centreonv2}->get_scheduling_jobs(search => '{"id": ' . $options{job_id} . '}');
+    if ($status != 0) {
+        return (1, "cannot get host discovery job '$options{data}->{content}->{job_id}' - " . $self->{tpapi_centreonv2}->error());
+    }
+
+    my $job;
+    foreach my $entry (@{$results->{result}}) {
+        if ($entry->{job_id} == $options{job_id}) {
+            $job = $entry;
+            last;
+        }
+    }
+
+    return (0, 'ok', $job);
+}
+
+sub hdisco_delete_cron {
+    my ($self, %options) = @_;
+
+    return if (!defined($self->{hdisco_jobs_tokens}->{ $options{discovery_token} }));
+    my $job_id = $self->{hdisco_jobs_tokens}->{ $options{discovery_token} };
+    return if (
+        $self->{hdisco_jobs_ids}->{$job_id}->{extra_infos}->{cron_added} == CRON_ADDED_NONE ||
+        $self->{hdisco_jobs_ids}->{$job_id}->{extra_infos}->{cron_added} == CRON_ADDED_KO
+    );
+
+    $self->{logger}->writeLogInfo("[autodiscovery] -class- host discovery - delete job '" . $job_id . "'");
+
+    $self->send_internal_action(
+        action => 'DELETECRON',
+        token => $options{token},
+        data => {   
+            variables => [ $options{discovery_token} ]
+        }
+    );
+}
+
+sub action_addhostdiscoveryjob {
+    my ($self, %options) = @_;
+
+    $options{token} = $self->generate_token() if (!defined($options{token}));
+    if (!$self->is_hdisco_synced()) {
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_KO,
+            token => $options{token},
+            data => {
+                message => 'host discovery synchronization issue'
+            }
+        );
+        return ;
+    }
+
+    my ($status, $message, $job);
+    ($status, $message, $job) = $self->get_host_job(job_id => $options{data}->{content}->{job_id});
+    if ($status != 0) {
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - cannot get host discovery job '$options{data}->{content}->{job_id}' - " . $self->{tpapi_centreonv2}->error());
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_KO,
+            token => $options{token},
+            data => {
+                message => "cannot get job '$options{data}->{content}->{job_id}'"
+            }
+        );
+        return 1;
+    }
+
+    if (!defined($job)) {
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - cannot get host discovery job '$options{data}->{content}->{job_id}' - " . $self->{tpapi_centreonv2}->error());
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_KO,
+            token => $options{token},
+            data => {
+                message => "cannot get job '$options{data}->{content}->{job_id}'"
+            }
+        );
+        return 1;
+    }
+
+    ($status, $message) = $self->hdisco_addupdate_job(job => $job);
+    if ($status) {
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - add job '$options{data}->{content}->{job_id}' - $message");
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_KO,
+            token => $options{token},
+            data => {
+                message => "add job '$options{data}->{content}->{job_id}' - $message"
+            }
+        );
+        return 1;
+    }
+
+    # Launch a immediate job.
+    if ($self->{hdisco_jobs_ids}->{ $options{data}->{content}->{job_id} }->{execution}->{mode} == EXECUTION_MODE_IMMEDIATE) {
+        my $timeout = (defined($options{data}->{content}->{timeout}) && $options{data}->{content}->{timeout} =~ /(\d+)/) ?
+            $options{data}->{content}->{timeout} : $self->{global_timeout};
+        ($status, $message) = $self->action_launchhostdiscovery(
+            data => {
+                content => {
+                    timeout => $timeout,
+                    job_id => $options{data}->{content}->{job_id}
+                }
+            }
+        );
+        if ($status) {
+            $self->send_log(
+                code => GORGONE_ACTION_FINISH_KO,
+                token => $options{token},
+                data => {
+                    message => "launch issue - $message"
+                }
+            );
+            return 1;
+        }
+    }
+
+    $self->send_log(
+        code => GORGONE_ACTION_FINISH_OK,
+        token => $options{token},
+        data => {
+            message => 'job ' . $options{data}->{content}->{job_id} . ' added'
+        }
+    );
+    
+    return 0;
+}
+
+sub launchhostdiscovery {
+    my ($self, %options) = @_;
+    
+    return (1, 'host discovery sync not done') if (!$self->is_hdisco_synced());
+
+    my $job_id = $options{job_id};
+
+    if (!defined($job_id) || !defined($self->{hdisco_jobs_ids}->{$job_id})) {
+        return (1, 'trying to launch discovery for inexistant job');
+    }
+    if ($self->hdisco_is_running_job(status => $self->{hdisco_jobs_ids}->{$job_id}->{status})) {
+        return (1, 'job is already running');
+    }
+    if ($self->{hdisco_jobs_ids}->{$job_id}->{execution}->{mode} == EXECUTION_MODE_PAUSE) {
+        return (1, 'job is paused');
+    }
+
+    $self->{logger}->writeLogInfo("[autodiscovery] -class- host discovery - launching discovery for job '" . $job_id . "'");
+
+    # Running
+    if ($self->update_job_information(
+        values => {
+            status => JOB_RUNNING,
+            message => 'Running',
+            last_execution => strftime("%F %H:%M:%S", localtime),
+            duration => 0,
+            discovered_items => 0
+        },
+        where_clause => [
+            {
+                id => $job_id
+            }
+        ]
+    ) == -1) {
+        return (1, 'cannot update job status');
+    }
+    $self->{hdisco_jobs_ids}->{$job_id}->{status} = JOB_RUNNING;
+
+    $self->send_internal_action(
+        action => 'ADDLISTENER',
+        data => [
+            {
+                identity => 'gorgoneautodiscovery',
+                event => 'HOSTDISCOVERYJOBLISTENER',
+                target => $self->{hdisco_jobs_ids}->{$job_id}->{target},
+                token => $self->{hdisco_jobs_ids}->{$job_id}->{token},
                 timeout => defined($options{data}->{content}->{timeout}) && $options{data}->{content}->{timeout} =~ /(\d+)/ ? 
                     $1 + $self->{check_interval} + 15 : undef,
                 log_pace => $self->{check_interval}
@@ -215,35 +469,143 @@ sub action_launchdiscovery {
 
     $self->send_internal_action(
         action => 'COMMAND',
-        target => $options{data}->{content}->{target},
-        token => $options{data}->{content}->{token},
+        target => $self->{hdisco_jobs_ids}->{$job_id}->{target},
+        token => $self->{hdisco_jobs_ids}->{$job_id}->{token},
         data => {
             content => [
                 {
                     instant => 1,
-                    command => $options{data}->{content}->{command},
-                    timeout => $options{data}->{content}->{timeout},
+                    command => $self->{hdisco_jobs_ids}->{$job_id}->{command_line},
+                    timeout => defined($options{data}->{content}->{timeout}) && $options{data}->{content}->{timeout} =~ /(\d+)/ ? $1 : undef,
                     metadata => {
-                        job_id => $options{data}->{content}->{job_id},
-                        uuid_attributes => $options{data}->{content}->{uuid_attributes},
-                        source => 'autodiscovery'
+                        job_id => $job_id,
+                        source => 'autodiscovery-host-job-discovery'
                     }
                 }
             ]
         }
     );
 
-    # Running
-    my $query = "UPDATE mod_host_disco_job " .
-        "SET status = '3', duration = '0', discovered_items = '0', " .
-        "creation_date = '" . strftime("%F %H:%M:%S", localtime) . "', " .
-        "token = '" . $options{data}->{content}->{token} . "', message = 'Running' " .
-        "WHERE id = '" . $options{data}->{content}->{job_id} . "'";
-    my $status = $self->{class_object_centreon}->transaction_query(request => $query);
-    if ($status == -1) {
-        $self->{logger}->writeLogError('[autodiscovery] Failed to update job status');
+    return 0;
+}
+
+sub action_launchhostdiscovery {
+    my ($self, %options) = @_;
+
+    $options{token} = $self->generate_token() if (!defined($options{token}));
+    if (!$self->is_hdisco_synced()) {
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_KO,
+            token => $options{token},
+            data => {
+                message => 'host discovery synchronization issue'
+            }
+        );
+        return ;
+    }
+
+    my $job_id;
+    if (defined($options{data}->{variables}->[0]) &&
+        defined($options{data}->{variables}->[1]) && $options{data}->{variables}->[1] eq 'schedule') {
+        $job_id = $options{data}->{variables}->[0];
+    } elsif (defined($options{data}->{content}->{job_id})) {
+        $job_id = $options{data}->{content}->{job_id};
+    }
+
+    my ($status, $message, $job);
+    ($status, $message, $job) = $self->get_host_job(job_id => $job_id);
+    if ($status != 0) {
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - cannot get host discovery job '$job_id' - " . $self->{tpapi_centreonv2}->error());
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_KO,
+            token => $options{token},
+            data => {
+                message => "cannot get job '$job_id'"
+            }
+        );
         return 1;
     }
+
+    if (!defined($job)) {
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - cannot get host discovery job '$job_id' - " . $self->{tpapi_centreonv2}->error());
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_KO,
+            token => $options{token},
+            data => {
+                message => "cannot get job '$job_id'"
+            }
+        );
+        return 1;
+    }
+
+    ($status, $message) = $self->hdisco_addupdate_job(job => $job);
+    if ($status) {
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - add job '$job_id' - $message");
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_KO,
+            token => $options{token},
+            data => {
+                message => "add job '$job_id' - $message"
+            }
+        );
+        return 1;
+    }
+
+    ($status, $message) = $self->launchhostdiscovery(job_id => $job_id, %options);
+    if ($status) {
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - launch discovery job '$job_id' - $message");
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_KO,
+            token => $options{token},
+            instant => 1,
+            data => {
+                message => $message
+            }
+        );
+        return 1;
+    }
+
+    $self->send_log(
+        code => GORGONE_ACTION_FINISH_OK,
+        token => $options{token},
+        instant => 1,
+        data => {
+            message => "job '$job_id' launched"
+        }
+    );
+}
+
+sub discovery_postcommand_result {
+    my ($self, %options) = @_;
+
+    return 1 if (!defined($options{data}->{data}->{metadata}->{job_id}));
+
+    my $job_id = $options{data}->{data}->{metadata}->{job_id};
+    if (!defined($self->{hdisco_jobs_ids}->{$job_id})) {
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - found result for inexistant job '" . $job_id . "'");
+        return 1;
+    }
+
+    my $exit_code = $options{data}->{data}->{result}->{exit_code};
+    my $output = (defined($options{data}->{data}->{result}->{stderr}) && $options{data}->{data}->{result}->{stderr} ne '') ?
+        $options{data}->{data}->{result}->{stderr} : $options{data}->{data}->{result}->{stdout};
+
+    if ($exit_code != 0) {
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - execute discovery postcommand failed job '$job_id'");
+        $self->update_job_status(
+            job_id => $job_id,
+            status => SAVE_FAILED,
+            message => $output
+        );
+        return 1;
+    }
+
+    $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - finished discovery postcommand job '$job_id'");
+    $self->update_job_status(
+        job_id => $job_id,
+        status => SAVE_FINISH,
+        message => 'Finished'
+    );
 }
 
 sub discovery_command_result {
@@ -251,20 +613,25 @@ sub discovery_command_result {
 
     return 1 if (!defined($options{data}->{data}->{metadata}->{job_id}));
 
-    $self->{logger}->writeLogInfo("[autodiscovery] Found result for job '" . $options{data}->{data}->{metadata}->{job_id} . "'");
-    my $uuid_attributes = JSON::XS->new->utf8->decode($options{data}->{data}->{metadata}->{uuid_attributes});
     my $job_id = $options{data}->{data}->{metadata}->{job_id};
+    if (!defined($self->{hdisco_jobs_ids}->{$job_id})) {
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - found result for inexistant job '" . $job_id . "'");
+        return 1;
+    }
+
+    $self->{logger}->writeLogInfo("[autodiscovery] -class- host discovery - found result for job '" . $job_id . "'");
+    my $uuid_attributes = $self->{hdisco_jobs_ids}->{$job_id}->{uuid_attributes};
     my $exit_code = $options{data}->{data}->{result}->{exit_code};
     my $output = (defined($options{data}->{data}->{result}->{stderr}) && $options{data}->{data}->{result}->{stderr} ne '') ?
         $options{data}->{data}->{result}->{stderr} : $options{data}->{data}->{result}->{stdout};
 
     if ($exit_code != 0) {
-        my $query = "UPDATE mod_host_disco_job " .
-            "SET status = '2', duration = '0', discovered_items = '0', " .
-            "message = " . $self->{class_object_centreon}->quote(value => $output) . " " .
-            "WHERE id = " . $self->{class_object_centreon}->quote(value => $job_id);
-        my $status = $self->{class_object_centreon}->transaction_query(request => $query);
-        $self->{logger}->writeLogError('[autodiscovery] Failed to update job status') if ($status == -1);
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - execute discovery plugin failed job '$job_id'");
+        $self->update_job_status(
+            job_id => $job_id,
+            status => JOB_FAILED,
+            message => $output
+        );
         return 1;
     }
 
@@ -274,42 +641,53 @@ sub discovery_command_result {
     };
 
     if ($@) {
-        # Failed
-        $self->{logger}->writeLogError('[autodiscovery] Failed to decode discovery plugin response: ' . $@);
-        my $query = "UPDATE mod_host_disco_job " .
-            "SET status = '2', duration = '0', discovered_items = '0', " .
-            "message = 'Failed to decode discovery plugin response' " .
-            "WHERE id = '" . $job_id ."'";
-        my $status = $self->{class_object_centreon}->transaction_query(request => $query);
-        $self->{logger}->writeLogError('[autodiscovery] Failed to update job status') if ($status == -1);
-        return 1;
-    }
-
-    # Finished
-    my $query = "UPDATE mod_host_disco_job SET status = '1', duration = '" . $result->{duration} ."', " . 
-        "discovered_items = '" . $result->{discovered_items} ."', message = 'Finished' " .
-        "WHERE id = '" . $job_id ."'";
-    my $status = $self->{class_object_centreon}->transaction_query(request => $query);
-    if ($status == -1) {
-        $self->{logger}->writeLogError('[autodiscovery] Failed to update job status');
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to decode discovery plugin response job '$job_id'");
+        $self->update_job_status(
+            job_id => $job_id,
+            status => JOB_FAILED,
+            message => 'Failed to decode discovery plugin response'
+        );
         return 1;
     }
 
     # Delete previous results
-    $query = "DELETE FROM mod_host_disco_host WHERE job_id = '" . $job_id ."'";
-    $status = $self->{class_object_centreon}->transaction_query(request => $query);
+    my $query = "DELETE FROM mod_host_disco_host WHERE job_id = " . $self->{class_object_centreon}->quote(value => $job_id);
+    my ($status) = $self->{class_object_centreon}->custom_execute(request => $query);
     if ($status == -1) {
-        $self->{logger}->writeLogError('[autodiscovery] Failed to delete previous job results');
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to delete previous job '$job_id' results");
+        $self->update_job_status(
+            job_id => $job_id,
+            status => JOB_FAILED,
+            message => 'Failed to delete previous job results'
+        );
         return 1;
     }
 
     # Add new results
-    my $values;
+    my $number_of_lines = 0;
+    my $values = '';
     my $append = '';
+    $query = "INSERT INTO mod_host_disco_host (job_id, discovery_result, uuid) VALUES ";
     foreach my $host (@{$result->{results}}) {
+        if ($number_of_lines == MAX_INSERT_BY_QUERY) {
+            ($status) = $self->{class_object_centreon}->custom_execute(request => $query . $values);
+            if ($status == -1) {
+                $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to insert job '$job_id' results");
+                $self->update_job_status(
+                    job_id => $job_id,
+                    status => JOB_FAILED,
+                    message => 'Failed to insert job results'
+                );
+                return 1;
+            }
+            $number_of_lines = 0;
+            $values = '';
+            $append = '';
+        }
+
         # Generate uuid based on attributs
         my $uuid_char = '';
-        foreach (@{$uuid_attributes}) {
+        foreach (@$uuid_attributes) {
             $uuid_char .= $host->{$_} if (defined($host->{$_}) && $host->{$_} ne '');
         }
         my $ctx = Digest::MD5->new;
@@ -319,76 +697,253 @@ sub discovery_command_result {
             substr($digest, 16, 4) . '-' . substr($digest, 20, 12);
         my $encoded_host = JSON::XS->new->utf8->encode($host);
 
-        $values .= $append . "('" . $job_id . "', " . 
-            $self->{class_object_centreon}->quote(value => $encoded_host) . ", '" . $uuid . "')";
+        # Build bulk insert
+        $values .= $append . "(" . $self->{class_object_centreon}->quote(value => $job_id) . ", " . 
+            $self->{class_object_centreon}->quote(value => $encoded_host) . ", " . 
+            $self->{class_object_centreon}->quote(value => $uuid) . ")";
         $append = ', ';
+        $number_of_lines++;
     }
 
-    if (defined($values) && $values ne '') {
-        $query = "INSERT INTO mod_host_disco_host (job_id, discovery_result, uuid) VALUES " . $values;
-        $status = $self->{class_object_centreon}->transaction_query(request => $query);
+    if ($values ne '') {
+        ($status) = $self->{class_object_centreon}->custom_execute(request => $query . $values);
         if ($status == -1) {
-            $self->{logger}->writeLogError('[autodiscovery] Failed to insert job results');
+            $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to insert job '$job_id' results");
+            $self->update_job_status(
+                job_id => $job_id,
+                status => JOB_FAILED,
+                message => 'Failed to insert job results'
+            );
             return 1;
         }
     }
 
-    return 1;
+    if (defined($self->{hdisco_jobs_ids}->{$job_id}->{post_execution}->{commands}) &&
+        scalar(@{$self->{hdisco_jobs_ids}->{$job_id}->{post_execution}->{commands}}) > 0) {
+        $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - execute post command job '$job_id'");
+        my $post_command = $self->{hdisco_jobs_ids}->{$job_id}->{post_execution}->{commands}->[0];
+
+        $self->send_internal_action(
+            action => $post_command->{action},
+            token => $self->{hdisco_jobs_ids}->{$job_id}->{token},
+            data => {
+                content => [
+                    {
+                        instant => 1,
+                        command => $post_command->{command_line},
+                        metadata => {
+                            job_id => $job_id,
+                            source => 'autodiscovery-host-job-postcommand'
+                        }
+                    }
+                ]
+            }
+        );
+    }
+    
+    $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - finished discovery command job '$job_id'");
+    $self->update_job_status(
+        job_id => $job_id,
+        status => JOB_FINISH,
+        message => 'Finished',
+        duration => $result->{duration},
+        discovered_items => $result->{discovered_items}
+    );
+
+    return 0;
 }
 
-sub action_autodiscoverylistener {
+sub action_deletehostdiscoveryjob {
     my ($self, %options) = @_;
 
-    return if (!$self->is_module_installed());
-    return 0 if (!defined($options{token}));
+    #  delete is call when it's in pause (execution_mode 2).
+    #  in fact, we do a curl to sync. If don't exist in database, we remove it. otherwise we do nothing
+    $options{token} = $self->generate_token() if (!defined($options{token}));
+    if (!$self->is_hdisco_synced()) {
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_KO,
+            token => $options{token},
+            data => {
+                message => 'host discovery synchronization issue'
+            }
+        );
+        return ;
+    }
 
-    if ($options{data}->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT) {
+    my $discovery_token = $options{data}->{variables}->[0];
+    my $job_id = (defined($discovery_token) && defined($self->{hdisco_jobs_tokens}->{$discovery_token})) ? 
+        $self->{hdisco_jobs_tokens}->{$discovery_token} : undef;
+    if (!defined($discovery_token) || $discovery_token eq '') {
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - missing ':token' variable to delete discovery");
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_KO,
+            token => $options{token},
+            data => { message => 'missing discovery token' }
+        );
+        return 1;
+    }
+
+    my ($status, $message, $job);
+    ($status, $message, $job) = $self->get_host_job(job_id => $job_id);
+    if ($status != 0) {
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - cannot get host discovery job '$job_id' - " . $self->{tpapi_centreonv2}->error());
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_KO,
+            token => $options{token},
+            data => {
+                message => "cannot get job '$job_id'"
+            }
+        );
+        return 1;
+    }
+
+    if (!defined($job)) {
+        $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - delete job '" . $job_id . "'");
+        if (defined($self->{hdisco_jobs_ids}->{$job_id}->{token})) {
+            $self->hdisco_delete_cron(discovery_token => $discovery_token);
+            delete $self->{hdisco_jobs_tokens}->{$discovery_token};
+        }
+        delete $self->{hdisco_jobs_ids}->{$job_id};
+    } else {
+        $self->hdisco_addupdate_job(job => $job);
+    }
+
+    $self->send_log(
+        code => GORGONE_ACTION_FINISH_OK,
+        token => $options{token},
+        data => { message => 'job ' . $discovery_token . ' deleted' }
+    );
+    
+    return 0;
+}
+
+sub update_job_status {
+    my ($self, %options) = @_;
+
+    my $values = { status => $options{status}, message => $options{message} };
+    $values->{duration} = $options{duration} if (defined($options{duration}));
+    $values->{discovered_items} = $options{discovered_items} if (defined($options{discovered_items}));
+    $self->update_job_information(
+        values => $values,
+        where_clause => [
+            {
+                id => $options{job_id}
+            }
+        ]
+    );
+    $self->{hdisco_jobs_ids}->{$options{job_id}}->{status} = $options{status};
+}
+
+sub update_job_information {
+    my ($self, %options) = @_;
+
+    return 1 if (!defined($options{where_clause}) || ref($options{where_clause}) ne 'ARRAY' || scalar($options{where_clause}) < 1);
+    return 1 if (!defined($options{values}) || ref($options{values}) ne 'HASH' || !keys %{$options{values}});
+    
+    my $query = "UPDATE mod_host_disco_job SET ";
+    my $append = '';
+    foreach (keys %{$options{values}}) {
+        $query .= $append . $_ . " = " .  $self->{class_object_centreon}->quote(value => $options{values}->{$_});
+        $append = ', ';
+    }
+
+    $query .= " WHERE ";
+    $append = '';
+    foreach (@{$options{where_clause}}) {
+        my ($key, $value) = each %{$_};
+        $query .= $append . $key . " = " . $self->{class_object_centreon}->quote(value => $value);
+        $append = 'AND ';
+    }
+
+    my ($status) = $self->{class_object_centreon}->custom_execute(request => $query);
+    if ($status == -1) {
+        $self->{logger}->writeLogError('[autodiscovery] Failed to update job information');
+        return -1;
+    }
+
+    return 0;
+}
+
+sub action_hostdiscoveryjoblistener {
+    my ($self, %options) = @_;
+
+    return 0 if (!$self->is_hdisco_synced());
+    return 0 if (!defined($options{token}));
+    return 0 if (!defined($self->{hdisco_jobs_tokens}->{$options{token}}));
+
+    my $job_id = $self->{hdisco_jobs_tokens}->{$options{token}};
+    if ($options{data}->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT && 
+        $options{data}->{data}->{metadata}->{source} eq 'autodiscovery-host-job-discovery') {
         $self->discovery_command_result(%options);
         return 1;
     }
+    #if ($options{data}->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT && 
+    #    $options{data}->{data}->{metadata}->{source} eq 'autodiscovery-host-job-postcommand') {
+    #    $self->discovery_postcommand_result(%options);
+    #    return 1;
+    #}
+
     if ($options{data}->{code} == GORGONE_ACTION_FINISH_KO) {
-        my $query = "UPDATE mod_host_disco_job " .
-            "SET status = '2', duration = '0', discovered_items = '0', " .
-            "message = " . $self->{class_object_centreon}->quote(value => $options{data}->{message}) . " " .
-            "WHERE token = " . $self->{class_object_centreon}->quote(value => $options{token});
-        my $status = $self->{class_object_centreon}->transaction_query(request => $query);
-        $self->{logger}->writeLogError('[autodiscovery] Failed to update job status') if ($status == -1);
+        $self->{hdisco_jobs_ids}->{$job_id}->{status} = JOB_FAILED;
+        $self->update_job_information(
+            values => {
+                status => JOB_FAILED,
+                message => $options{data}->{message},
+                duration => 0,
+                discovered_items => 0
+            },
+            where_clause => [
+                {
+                    id => $job_id
+                }
+            ]
+        );
         return 1;
     }
 
     return 1;
 }
 
-sub register_listener {
+sub action_hostdiscoverycronlistener {
     my ($self, %options) = @_;
-    
-    return if (!$self->is_module_installed());
-    
-    # List running jobs
-    my ($status, $data) = $self->{class_object_centreon}->custom_execute(
-        request => "SELECT id, monitoring_server_id, token FROM mod_host_disco_job WHERE status = '3'",
-        mode => 1,
-        keys => 'id'
-    );
 
-    # Sync logs and try to retrieve results for each jobs
-    foreach my $job_id (keys %$data) {
-        $self->{logger}->writeLogDebug("[autodiscovery] register listener for '" . $job_id . "'");
+    return 0 if (!defined($options{token}) || $options{token} !~ /^cron-(.*)/);
+    my $discovery_token = $1;
+
+    return 0 if (!defined($self->{hdisco_jobs_tokens}->{ $discovery_token }));
+
+    my $job_id = $self->{hdisco_jobs_tokens}->{ $discovery_token };
+    if ($options{data}->{code} == GORGONE_ACTION_FINISH_KO) {
+        $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - job '" . $job_id . "' add cron error");
+        $self->{hdisco_jobs_ids}->{$job_id}->{extra_infos}->{cron_added} = CRON_ADDED_KO;
+    } elsif ($options{data}->{code} == GORGONE_ACTION_FINISH_OK) {
+        $self->{logger}->writeLogInfo("[autodiscovery] -class- host discovery - job '" . $job_id . "' add cron ok");
+        $self->{hdisco_jobs_ids}->{$job_id}->{extra_infos}->{cron_added} = CRON_ADDED_OK;
+    }
+
+    return 1;
+}
+
+sub hdisco_add_joblistener {
+    my ($self, %options) = @_;
+
+    foreach (@{$options{jobs}}) {
+        $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - register listener for '" . $_->{job_id} . "'");
 
         $self->send_internal_action(
             action => 'ADDLISTENER',
             data => [
                 {
                     identity => 'gorgoneautodiscovery',
-                    event => 'AUTODISCOVERYLISTENER',
-                    target => $data->{$job_id}->{monitoring_server_id},
-                    token => $data->{$job_id}->{token},
+                    event => 'HOSTDISCOVERYJOBLISTENER',
+                    target => $_->{target},
+                    token => $_->{token},
                     log_pace => $self->{check_interval}
                 }
             ]
         );
     }
-    
+
     return 0;
 }
 
@@ -431,6 +986,7 @@ sub action_launchservicediscovery {
     my $svc_discovery = gorgone::modules::centreon::autodiscovery::services::discovery->new(
         module_id => $self->{module_id},
         logger => $self->{logger},
+        tpapi_clapi => $self->{tpapi_clapi},
         internal_socket => $self->{internal_socket},
         config => $self->{config},
         config_core => $self->{config_core},
@@ -453,15 +1009,10 @@ sub action_launchservicediscovery {
     }
 }
 
-sub is_module_installed {
+sub is_hdisco_synced {
     my ($self) = @_;
 
-    my ($status, $data) = $self->{class_object_centreon}->custom_execute(
-        request => "SELECT id FROM modules_informations WHERE name = 'centreon-autodiscovery-server'",
-        mode => 2
-    );
-
-    (defined($data->[0]) && scalar($data->[0]) > 0) ? return 1 : return 0;
+    return $self->{hdisco_synced} == 1 ? 1 : 0;
 }
 
 sub event {
@@ -484,7 +1035,20 @@ sub event {
 
 sub run {
     my ($self, %options) = @_;
-    
+
+    $self->{tpapi_clapi} = gorgone::class::tpapi::clapi->new();
+    $self->{tpapi_clapi}->set_configuration(
+        config => $self->{tpapi}->get_configuration(name => $self->{tpapi_clapi_name})
+    );
+    $self->{tpapi_centreonv2} = gorgone::class::tpapi::centreonv2->new();
+    my ($status) = $self->{tpapi_centreonv2}->set_configuration(
+        config => $self->{tpapi}->get_configuration(name => $self->{tpapi_centreonv2_name}),
+        logger => $self->{logger}
+    );
+    if ($status) {
+        $self->{logger}->writeLogError('[autodiscovery] -class- host discovery - configure api centreonv2 - ' . $self->{tpapi_centreonv2}->error());
+    }
+
     $self->{db_centreon} = gorgone::class::db->new(
         dsn => $self->{config_db_centreon}->{dsn},
         user => $self->{config_db_centreon}->{username},
@@ -529,9 +1093,9 @@ sub run {
         }
     ];
 
-    $self->register_listener();
-
     while (1) {
+        $self->hdisco_sync();
+
         # we try to do all we can
         my $rev = zmq_poll($self->{poll}, 5000);
         if (defined($rev) && $rev == 0 && $self->{stop} == 1) {

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -1060,7 +1060,8 @@ sub is_hdisco_synced {
 sub event {
     while (1) {
         my $message = gorgone::standard::library::zmq_dealer_read_message(socket => $connector->{internal_socket});
-        
+        last if (!defined($message));
+
         $connector->{logger}->writeLogDebug("[autodiscovery] Event: $message");
         if ($message =~ /^\[(.*?)\]/) {
             if ((my $method = $connector->can('action_' . lc($1)))) {
@@ -1070,8 +1071,6 @@ sub event {
                 $method->($connector, token => $token, data => $data);
             }
         }
-
-        last unless (gorgone::standard::library::zmq_still_read(socket => $connector->{internal_socket}));
     }
 }
 

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -357,11 +357,9 @@ sub run {
         type => $self->{config_core}->{internal_com_type},
         path => $self->{config_core}->{internal_com_path}
     );
-    gorgone::standard::library::zmq_send_message(
-        socket => $connector->{internal_socket},
+    $connector->send_internal_action(
         action => 'AUTODISCOVERYREADY',
-        data => {},
-        json_encode => 1
+        data => {}
     );
     $self->{poll} = [
         {

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -483,8 +483,9 @@ sub action_launchservicediscovery {
     # get hosts
     #################
     gorgone::modules::centreon::autodiscovery::services::resources::reset_macro_hosts();
+    my $total = 0;
     foreach my $rule_id (keys %$rules) {
-        ($status, $message, my $hosts) = gorgone::modules::centreon::autodiscovery::services::resources::get_hosts(
+        ($status, $message, my $hosts, my $count) = gorgone::modules::centreon::autodiscovery::services::resources::get_hosts(
             host_template => $rules->{$rule_id}->{host_template},
             poller_id => $rules->{$rule_id}->{poller_id},
             class_object_centreon => $self->{class_object_centreon},
@@ -502,21 +503,25 @@ sub action_launchservicediscovery {
             next;
         }
 
+        $total += $count;
         $rules->{$rule_id}->{hosts} = $hosts;
     }
 
     $self->{service_discoveries}->{ $self->{service_number} } = {
+        count_discoveries => $total,
+        done_discoveries => 0,
         rules => $rules,
         options => defined($options{data}->{content}) ? $options{data}->{content} : {}
     };
 
-    #use Data::Dumper; print Data::Dumper::Dumper($self->{service_discoveries});
+    use Data::Dumper; print Data::Dumper::Dumper($self->{service_discoveries});
 
     # We need to do a method to execute and add listeners (timeout of 120 seconds)
     #    - can execute 10 commands by pollers
     #    - for the listener we use the token: svc-disco-SVCNUMBER-COMMANDNUMBER
 
     # need to manage dry-run and manual
+    # add a progress bar of commands in log
 
     return 0;
 }

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -339,9 +339,11 @@ sub action_updatediscoveryresults {
             my $digest = $ctx->hexdigest;
             my $uuid = substr($digest, 0, 8) . '-' . substr($digest, 8, 4) . '-' . substr($digest, 12, 4) . '-' .
                 substr($digest, 16, 4) . '-' . substr($digest, 20, 12);
+            my $encoded_host = JSON::XS->new->utf8->encode($host);
 
-            $values .= $append . "('" . $job_id . "', '" . JSON::XS->new->utf8->encode($host) ."', '" . $uuid . "')";
-            $append = ', '
+            $values .= $append . "('" . $job_id . "', " . 
+                $self->{class_object_centreon}->quote(value => $encoded_host) . ", '" . $uuid . "')";
+            $append = ', ';
         }
 
         if (defined($values) && $values ne '') {

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -625,7 +625,7 @@ sub discovery_command_result {
     }
 
     $self->{logger}->writeLogInfo("[autodiscovery] -class- host discovery - found result for job '" . $job_id . "'");
-    my $uuid_attributes = $self->{hdisco_jobs_ids}->{$job_id}->{uuid_attributes};
+    my $uuid_parameters = $self->{hdisco_jobs_ids}->{$job_id}->{uuid_parameters};
     my $exit_code = $options{data}->{data}->{result}->{exit_code};
     my $output = (defined($options{data}->{data}->{result}->{stderr}) && $options{data}->{data}->{result}->{stderr} ne '') ?
         $options{data}->{data}->{result}->{stderr} : $options{data}->{data}->{result}->{stdout};
@@ -692,7 +692,7 @@ sub discovery_command_result {
 
         # Generate uuid based on attributs
         my $uuid_char = '';
-        foreach (@$uuid_attributes) {
+        foreach (@$uuid_parameters) {
             $uuid_char .= $host->{$_} if (defined($host->{$_}) && $host->{$_} ne '');
         }
         my $ctx = Digest::MD5->new;

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -59,8 +59,11 @@ sub new {
     $connector->{service_pollers} = {};
     $connector->{service_audit_user_id} = undef;
     $connector->{service_number} = 0;
+    $connector->{service_parrallel_commands_poller} = 8;
+    $connector->{service_current_commands_poller} = {};
 
     bless $connector, $class;
+    $connector->{service_uuid} = $connector->generate_token(length => 4);
     $connector->set_signal_handlers();
     return $connector;
 }
@@ -229,7 +232,7 @@ sub action_launchdiscovery {
                         job_id => $options{data}->{content}->{job_id},
                         uuid_attributes => $options{data}->{content}->{uuid_attributes},
                         source => 'autodiscovery'
-                    },
+                    }
                 }
             ]
         }
@@ -415,6 +418,125 @@ sub get_clapi_user {
     return 0;
 }
 
+sub service_response_parsing {
+    my ($self, %options) = @_;
+
+    use Data::Dumper; print Data::Dumper::Dumper(\%options);
+}
+
+sub action_servicediscoverylistener {
+    my ($self, %options) = @_;
+
+    return 0 if (!defined($options{token}));
+
+    # 'svc-disco-SVCUUID-SVCNUMBER-RULEID-HOSTID' . $self->{service_uuid} . '-' . $service_number . '-' . $rule_id . '-' . $host->{host_id}
+    return 0 if ($options{token} !~ /^svc-disco-(?:.*?)-(\d+)-(\d+)-(\d+)/);
+    my ($service_number, $rule_id, $host_id) = ($1, $2, $3);
+
+    # if i have GORGONE_MODULE_ACTION_COMMAND_RESULT, i can't have GORGONE_ACTION_FINISH_KO
+    if ($options{data}->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT) {
+        my $exit_code = $options{data}->{data}->{result}->{exit_code};
+        if ($exit_code == 0) {
+            $self->service_response_parsing(
+                service_number => $service_number,
+                rule_id => $rule_id,
+                host_id => $host_id,
+                response => $options{data}->{data}->{result}->{stdout}
+            );
+        } elsif ($self->{service_discoveries}->{$service_number}->{manual} == 1) {
+            $self->{service_discoveries}->{$service_number}->{rules}->{$rule_id}->{manual}->{$host_id} = { message => $options{data}->{data}->{message}, data => $options{data}->{data}, discovery => {} };
+        }
+    } elsif ($options{data}->{code} == GORGONE_ACTION_FINISH_KO) {
+        if ($self->{service_discoveries}->{$service_number}->{manual} == 1) {
+            $self->{service_discoveries}->{$service_number}->{rules}->{$rule_id}->{manual}->{$host_id} = { message => $options{data}->{data}->{message}, data => $options{data}->{data}, discovery => {} };
+        }
+    } else {
+        return 0;
+    }
+
+    $self->{service_current_commands_poller}->{ $self->{service_discoveries}->{$service_number}->{hosts}->{$host_id}->{poller_id} }--;
+    $self->service_execute_commands();
+
+    print "==============================================\n";
+    print "=== service_number = $service_number \n";
+    print Data::Dumper::Dumper($self->{service_current_commands_poller});
+    print Data::Dumper::Dumper($options{data});
+    print "============= $self->{service_discoveries}->{ $service_number }->{done_discoveries} =======================\n";
+    print "==============================================\n";
+
+    $self->{service_discoveries}->{ $service_number }->{done_discoveries}++;
+    if ($self->{service_discoveries}->{ $service_number }->{done_discoveries} == $self->{service_discoveries}->{ $service_number }->{count_discoveries}) {
+        print "==============================================\n";
+        print "============= FINISHED =======================\n";
+        print "==============================================\n";
+    }
+
+    return 0;
+}
+
+sub service_execute_commands {
+    my ($self, %options) = @_;
+
+    foreach my $service_number (keys %{$self->{service_discoveries}}) {
+        foreach my $rule_id (keys %{$self->{service_discoveries}->{$service_number}->{rules}}) {
+            foreach my $poller_id (keys %{$self->{service_discoveries}->{$service_number}->{rules}->{$rule_id}->{hosts}}) {
+                next if (scalar(@{$self->{service_discoveries}->{$service_number}->{rules}->{$rule_id}->{hosts}->{$poller_id}}) <= 0);
+                $self->{service_current_commands_poller}->{$poller_id} = 0 if (!defined($self->{service_current_commands_poller}->{$poller_id}));
+                
+                while (1) {
+                    last if ($self->{service_current_commands_poller}->{$poller_id} >= $self->{service_parrallel_commands_poller});
+                    my $host_id = shift @{$self->{service_discoveries}->{$service_number}->{rules}->{$rule_id}->{hosts}->{$poller_id}};
+                    last if (!defined($host_id));
+
+                    my $host = $self->{service_discoveries}->{$service_number}->{hosts}->{$host_id};
+                    $self->{service_current_commands_poller}->{$poller_id}++;
+
+                    my $command = gorgone::modules::centreon::autodiscovery::services::resources::substitute_service_discovery_command(
+                        command_line => $self->{service_discoveries}->{$service_number}->{rules}->{$rule_id}->{command_line},
+                        host => $host,
+                        poller => $self->{service_pollers}->{$poller_id}
+                    );
+
+                    $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{service_number}" . 
+                        $self->{service_discoveries}->{$service_number}->{rules}->{$rule_id}->{rule_alias} . "] [" . 
+                        $self->{service_pollers}->{$poller_id}->{name} . "] [" .
+                        $host->{host_name} . "] -> substitute string: " . $command
+                    );
+
+                    $self->send_internal_action(
+                        action => 'ADDLISTENER',
+                        data => [
+                            {
+                                identity => 'gorgoneautodiscovery',
+                                event => 'SERVICEDISCOVERYLISTENER',
+                                target => $poller_id,
+                                token => 'svc-disco-' . $self->{service_uuid} . '-' . $service_number . '-' . $rule_id . '-' . $host_id,
+                                timeout => 120,
+                                log_pace => 15
+                            }
+                        ]
+                    );
+
+                    $self->send_internal_action(
+                        action => 'COMMAND',
+                        target => $poller_id,
+                        token => 'svc-disco-' . $self->{service_uuid} . '-' . $service_number . '-' . $rule_id . '-' . $host_id,
+                        data => {
+                            content => [
+                                {
+                                    instant => 1,
+                                    command => $command,
+                                    timeout => 90
+                                }
+                            ]
+                        }
+                    );
+                }
+            }
+        }
+    }
+}
+
 sub action_launchservicediscovery {
     my ($self, %options) = @_;
 
@@ -483,6 +605,7 @@ sub action_launchservicediscovery {
     # get hosts
     #################
     gorgone::modules::centreon::autodiscovery::services::resources::reset_macro_hosts();
+    my $all_hosts = {};
     my $total = 0;
     foreach my $rule_id (keys %$rules) {
         ($status, $message, my $hosts, my $count) = gorgone::modules::centreon::autodiscovery::services::resources::get_hosts(
@@ -504,23 +627,39 @@ sub action_launchservicediscovery {
         }
 
         $total += $count;
-        $rules->{$rule_id}->{hosts} = $hosts;
+        $rules->{$rule_id}->{manual} = {};
+        $rules->{$rule_id}->{hosts} = $hosts->{pollers};
+        $all_hosts = { %$all_hosts, %{$hosts->{infos}} };
+    }
+
+    if ($total == 0) {
+        $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{service_number}, message => 'no hosts found');
+        return -1;
     }
 
     $self->{service_discoveries}->{ $self->{service_number} } = {
         token => $options{token},
         count_discoveries => $total,
         done_discoveries => 0,
-        current_progress => 0,
+        progress => 0,
+        progress_div => 0,
         rules => $rules,
-        options => defined($options{data}->{content}) ? $options{data}->{content} : {}
+        manual => defined($options{data}->{content}->{manual}) ? 1 : 0,
+        options => defined($options{data}->{content}) ? $options{data}->{content} : {},
+        hosts => $all_hosts,
+        journal => []
     };
 
     use Data::Dumper; print Data::Dumper::Dumper($self->{service_discoveries});
 
+    $self->service_execute_commands();
+    
+    use Data::Dumper;
+    print Data::Dumper::Dumper($self->{service_current_commands_poller});
+
     # We need to do a method to execute and add listeners (timeout of 120 seconds)
     #    - can execute 10 commands by pollers
-    #    - for the listener we use the token: svc-disco-SVCNUMBER-COMMANDNUMBER
+    #    - for the listener we use the token: svc-disco-GENNUM-SVCNUMBER-RULEID-HOSTID
 
     # need to manage dry-run and manual
     # add a progress bar of commands in log (we do for each 5%)

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -194,7 +194,8 @@ sub action_launchdiscovery {
                 event => 'AUTODISCOVERYLISTENER',
                 target => $options{data}->{content}->{target},
                 token => $options{data}->{content}->{token},
-                timeout => $options{data}->{content}->{timeout},
+                timeout => defined($options{data}->{content}->{timeout}) && $options{data}->{content}->{timeout} =~ /(\d+)/ ? 
+                    $1 + $self->{check_interval} + 15 : undef,
                 log_pace => $self->{check_interval}
             }
         ]

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -1,0 +1,401 @@
+# 
+# Copyright 2019 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package gorgone::modules::centreon::autodiscovery::class;
+
+use base qw(gorgone::class::module);
+
+use strict;
+use warnings;
+use gorgone::standard::library;
+use gorgone::class::sqlquery;
+use ZMQ::LibZMQ4;
+use ZMQ::Constants qw(:all);
+use JSON::XS;
+use Time::HiRes;
+
+my %tasks;
+my %jobs;
+my %handlers = (TERM => {}, HUP => {});
+my ($connector);
+
+sub new {
+    my ($class, %options) = @_;
+
+    $connector  = {};
+    $connector->{internal_socket} = undef;
+    $connector->{module_id} = $options{module_id};
+    $connector->{logger} = $options{logger};
+    $connector->{config} = $options{config};
+    $connector->{config_core} = $options{config_core};
+    $connector->{stop} = 0;
+    $connector->{sync_time} =
+        (defined($options{config}->{sync_time}) && $options{config}->{sync_time} =~ /(\d+)/) ? $1 : 50;
+    $connector->{last_sync_time} = -1;
+
+    bless $connector, $class;
+    $connector->set_signal_handlers();
+    return $connector;
+}
+
+sub set_signal_handlers {
+    my $self = shift;
+
+    $SIG{TERM} = \&class_handle_TERM;
+    $handlers{TERM}->{$self} = sub { $self->handle_TERM() };
+    $SIG{HUP} = \&class_handle_HUP;
+    $handlers{HUP}->{$self} = sub { $self->handle_HUP() };
+}
+
+sub handle_HUP {
+    my $self = shift;
+    $self->{reload} = 0;
+}
+
+sub handle_TERM {
+    my $self = shift;
+    $self->{logger}->writeLogInfo("[autodiscovery] -class- $$ Receiving order to stop...");
+    $self->{stop} = 1;
+}
+
+sub class_handle_TERM {
+    foreach (keys %{$handlers{TERM}}) {
+        &{$handlers{TERM}->{$_}}();
+    }
+}
+
+sub class_handle_HUP {
+    foreach (keys %{$handlers{HUP}}) {
+        &{$handlers{HUP}->{$_}}();
+    }
+}
+
+sub action_adddiscoverytask {
+    my ($self, %options) = @_;
+
+    $options{token} = $self->generate_token() if (!defined($options{token}));
+    my $id = 'autodiscovery_task_' . $self->generate_token(length => 12) if (!defined($options{data}->{content}->{id}));
+    
+    $self->{logger}->writeLogInfo("[autodiscovery] -class- Add task '" . $id . "'");
+    $self->send_internal_action(
+        action => 'COMMAND',
+        target => $options{data}->{content}->{target},
+        token => $id,
+        data => {
+            content => {
+                %{$options{data}->{content}},
+                metadata => {
+                    id => $id,
+                    source => 'autodiscovery',
+                    type => 'task',
+                },
+            }
+        }
+    );
+
+    $self->send_log(
+        code => $self->ACTION_FINISH_OK,
+        token => $options{token},
+        data => {
+            id => $id
+        }
+    );
+
+    $tasks{$id} = { target => $options{data}->{content}->{target} };
+    
+    return 0;
+}
+
+sub action_getdiscoverytask {
+    my ($self, %options) = @_;
+
+    $options{token} = $self->generate_token() if (!defined($options{token}));
+
+    if (!defined($options{data}->{variables}[0])) {
+        $self->{logger}->writeLogError("[autodiscovery] -class- Need to specify job id");
+        $self->send_log(
+            code => $self->ACTION_FINISH_KO,
+            token => $options{token},
+            data => {
+                message => 'need to specify job id'
+            }
+        );
+        return 1;
+    }
+    my $id = $options{data}->{variables}[0];
+    
+    $self->send_log(
+        code => $self->ACTION_FINISH_OK,
+        token => $options{token},
+        data => {
+            results => $tasks{$id}->{results}
+        }
+    );
+    
+    return 0;
+}
+
+sub action_adddiscoveryjob {
+    my ($self, %options) = @_;
+
+    $options{token} = $self->generate_token() if (!defined($options{token}));
+    my $id = 'autodiscovery_job_' . $self->generate_token(length => 12) if (!defined($options{data}->{content}->{id}));
+
+    $self->{logger}->writeLogInfo("[autodiscovery] -class- Add job '" . $id . "'");
+    my $definition = {
+        id => $id,
+        target => $options{data}->{content}->{target},
+        timespec => $options{data}->{content}->{timespec},
+        action => 'COMMAND',
+        parameters => {
+            command => $options{data}->{content}->{command},
+            timeout => $options{data}->{content}->{timeout},
+            metadata => {
+                id => $id,
+                source => 'autodiscovery',
+                type => 'job',
+            }
+        },
+        keep_token => 1,
+    };
+    
+    $self->send_internal_action(
+        action => 'ADDCRON',
+        token => $options{token},
+        data => {
+            content => [ $definition ],
+        }
+    );
+
+    $self->send_log(
+        code => $self->ACTION_FINISH_OK,
+        token => $options{token},
+        data => {
+            id => $id
+        }
+    );
+
+    $jobs{$id} = { target => $options{data}->{content}->{target} };
+    
+    return 0;
+}
+
+sub action_getdiscoveryjob {
+    my ($self, %options) = @_;
+
+    $options{token} = $self->generate_token() if (!defined($options{token}));
+
+    if (!defined($options{data}->{variables}[0])) {
+        $self->{logger}->writeLogError("[autodiscovery] -class- Need to specify job id");
+        $self->send_log(
+            code => $self->ACTION_FINISH_KO,
+            token => $options{token},
+            data => {
+                message => 'need to specify job id'
+            }
+        );
+        return 1;
+    }
+    my $id = $options{data}->{variables}[0];
+    
+    $self->send_log(
+        code => $self->ACTION_FINISH_OK,
+        token => $options{token},
+        data => {
+            results => $jobs{$id}->{results}
+        }
+    );
+    
+    return 0;
+}
+
+sub action_syncdiscoverylogs {
+    my ($self, %options) = @_;
+
+    $options{token} = $self->generate_token() if (!defined($options{token}));
+
+    $self->{logger}->writeLogDebug("[autodiscovery] -class- Discovery logs sync start");
+    my %synced;
+    foreach my $id (keys %tasks) {
+        next if (!defined($tasks{$id}->{target}) || defined($synced{$tasks{$id}->{target}}) ||
+            defined($tasks{$id}->{results}));
+        $self->send_internal_action(
+            action => 'GETLOG',
+            token => $options{token},
+            target => $tasks{$id}->{target},
+            data => {}
+        );
+        $synced{$tasks{$id}->{target}} = 1;
+    }
+    foreach my $id (keys %jobs) {
+        next if (!defined($jobs{$id}->{target}) || defined($synced{$jobs{$id}->{target}}));
+        $self->send_internal_action(
+            action => 'GETLOG',
+            token => $options{token},
+            target => $jobs{$id}->{target},
+            data => {}
+        );
+        $synced{$jobs{$id}->{target}} = 1;
+    }
+    
+    return 0;
+}
+
+sub action_getdiscoveryresults {
+    my ($self, %options) = @_;
+
+    foreach my $id (keys %tasks) {
+        next if (defined($tasks{$id}->{results}));
+        $self->{logger}->writeLogDebug("[autodiscovery] -class- Get logs results for task '" . $id . "'");
+        $self->send_internal_action(
+            action => 'GETLOG',
+            data => {
+                token => $id
+            }
+        );
+    }
+    foreach my $id (keys %jobs) {
+        $self->{logger}->writeLogDebug("[autodiscovery] -class- Get logs results for job '" . $id . "'");
+        $self->send_internal_action(
+            action => 'GETLOG',
+            data => {
+                token => $id
+            }
+        );
+    }
+    
+    return 0;
+}
+
+sub action_updatediscoveryresults {
+    my ($self, %options) = @_;
+
+    return if (!defined($options{data}->{data}->{action}) || $options{data}->{data}->{action} ne "getlog" &&
+        !defined($options{data}->{data}->{result}));
+
+    foreach my $message_id (sort keys %{$options{data}->{data}->{result}}) {
+        my $data = JSON::XS->new->utf8->decode($options{data}->{data}->{result}->{$message_id}->{data});
+        next if (!defined($data->{exit_code}) || !defined($data->{metadata}->{id}) ||
+            !defined($data->{metadata}->{source}) || $data->{metadata}->{source} ne 'autodiscovery');
+
+        if ($data->{metadata}->{type} eq 'task') {
+            $self->{logger}->writeLogInfo(
+                "[autodiscovery] -class- Found result for task '" . $data->{metadata}->{id} . "'"
+            );
+            $tasks{$data->{metadata}->{id}}->{results} = $data;
+        } elsif ($data->{metadata}->{type} eq 'job') {
+            $jobs{$data->{metadata}->{id}}->{results} = $data ;
+        }
+    }
+
+    return 0;
+}
+
+sub event {
+    while (1) {
+        my $message = gorgone::standard::library::zmq_dealer_read_message(socket => $connector->{internal_socket});
+        
+        $connector->{logger}->writeLogDebug("[autodiscovery] -class- Event: $message");
+        if ($message =~ /^\[ACK\]\s+\[(.*?)\]\s+(.*)$/m) {
+            my $token = $1;
+            my $data = JSON::XS->new->utf8->decode($2);
+            my $method = $connector->can('action_updatediscoveryresults');
+            $method->($connector, data => $data);
+        } else {
+            $message =~ /^\[(.*?)\]\s+\[(.*?)\]\s+\[.*?\]\s+(.*)$/m;
+            if ((my $method = $connector->can('action_' . lc($1)))) {
+                $message =~ /^\[(.*?)\]\s+\[(.*?)\]\s+\[.*?\]\s+(.*)$/m;
+                my ($action, $token) = ($1, $2);
+                my $data = JSON::XS->new->utf8->decode($3);
+                $method->($connector, token => $token, data => $data);
+            }
+        }
+
+        last unless (gorgone::standard::library::zmq_still_read(socket => $connector->{internal_socket}));
+    }
+}
+
+sub run {
+    my ($self, %options) = @_;
+    
+    # Database creation. We stay in the loop still there is an error
+    $self->{db_centreon} = gorgone::class::db->new(
+        dsn => $self->{config_db_centreon}->{dsn},
+        user => $self->{config_db_centreon}->{username},
+        password => $self->{config_db_centreon}->{password},
+        force => 2,
+        logger => $self->{logger}
+    );
+    ##### Load objects #####
+    $self->{class_object} = gorgone::class::sqlquery->new(
+        logger => $self->{logger},
+        db_centreon => $self->{db_centreon}
+    );
+
+    # Connect internal
+    $connector->{internal_socket} = gorgone::standard::library::connect_com(
+        zmq_type => 'ZMQ_DEALER',
+        name => 'gorgoneautodiscovery',
+        logger => $self->{logger},
+        type => $self->{config_core}->{internal_com_type},
+        path => $self->{config_core}->{internal_com_path}
+    );
+    gorgone::standard::library::zmq_send_message(
+        socket => $connector->{internal_socket},
+        action => 'AUTODISCOVERYREADY',
+        data => {},
+        json_encode => 1
+    );
+    $self->{poll} = [
+        {
+            socket  => $connector->{internal_socket},
+            events  => ZMQ_POLLIN,
+            callback => \&event,
+        }
+    ];
+    
+    $self->send_internal_action(
+        action => 'ADDCRON',
+        data => {
+            content => [
+                {
+                    id => 'autodiscovery_getdiscoveryresults',
+                    target => undef,
+                    timespec => '* * * * *',
+                    action => 'GETDISCOVERYRESULTS',
+                    parameters => {},
+                    keep_token => 1,
+                }
+            ]
+        }
+    );
+
+    while (1) {
+        # we try to do all we can
+        my $rev = zmq_poll($self->{poll}, 5000);
+        if (defined($rev) && $rev == 0 && $self->{stop} == 1) {
+            $self->{logger}->writeLogInfo("[autodiscovery] -class- $$ has quit");
+            zmq_close($connector->{internal_socket});
+            exit(0);
+        }
+    }
+}
+
+1;

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -268,7 +268,7 @@ sub action_updatediscoveryresults {
 
     foreach my $message (@{$options{data}->{data}->{result}}) {
         if ($message->{code} > 0) {
-            my $data = JSON::XS->new->utf8->decode($message->{data});
+            my $data = JSON::XS->new->decode($message->{data});
             if (!defined($data->{result}->{exit_code}) || !defined($data->{metadata}->{job_id}) ||
                 !defined($data->{metadata}->{source}) || $data->{metadata}->{source} ne 'autodiscovery') {
                 $self->{logger}->writeLogInfo("[autodiscovery] Found result for token '" . $message->{token} . "'");
@@ -293,7 +293,7 @@ sub action_updatediscoveryresults {
     if ($exit_code == 0 && defined($job_id)) {
         my $result;
         eval {
-            $result = JSON::XS->new->utf8->decode($output);
+            $result = JSON::XS->new->decode($output);
         };
         if ($@) {
             # Failed

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -71,7 +71,7 @@ sub handle_HUP {
 
 sub handle_TERM {
     my $self = shift;
-    $self->{logger}->writeLogInfo("[autodiscovery] -class- $$ Receiving order to stop...");
+    $self->{logger}->writeLogInfo("[autodiscovery] $$ Receiving order to stop...");
     $self->{stop} = 1;
 }
 
@@ -93,7 +93,7 @@ sub action_adddiscoverytask {
     $options{token} = $self->generate_token() if (!defined($options{token}));
     my $id = 'autodiscovery_task_' . $self->generate_token(length => 12) if (!defined($options{data}->{content}->{id}));
     
-    $self->{logger}->writeLogInfo("[autodiscovery] -class- Add task '" . $id . "'");
+    $self->{logger}->writeLogInfo("[autodiscovery] Add task '" . $id . "'");
     $self->send_internal_action(
         action => 'COMMAND',
         target => $options{data}->{content}->{target},
@@ -131,7 +131,7 @@ sub action_getdiscoverytask {
     $options{token} = $self->generate_token() if (!defined($options{token}));
 
     if (!defined($options{data}->{variables}[0])) {
-        $self->{logger}->writeLogError("[autodiscovery] -class- Need to specify job id");
+        $self->{logger}->writeLogError("[autodiscovery] Need to specify job id");
         $self->send_log(
             code => $self->ACTION_FINISH_KO,
             token => $options{token},
@@ -160,7 +160,7 @@ sub action_adddiscoveryjob {
     $options{token} = $self->generate_token() if (!defined($options{token}));
     my $id = 'autodiscovery_job_' . $self->generate_token(length => 12) if (!defined($options{data}->{content}->{id}));
 
-    $self->{logger}->writeLogInfo("[autodiscovery] -class- Add job '" . $id . "'");
+    $self->{logger}->writeLogInfo("[autodiscovery] Add job '" . $id . "'");
     my $definition = {
         id => $id,
         target => $options{data}->{content}->{target},
@@ -205,7 +205,7 @@ sub action_getdiscoveryjob {
     $options{token} = $self->generate_token() if (!defined($options{token}));
 
     if (!defined($options{data}->{variables}[0])) {
-        $self->{logger}->writeLogError("[autodiscovery] -class- Need to specify job id");
+        $self->{logger}->writeLogError("[autodiscovery] Need to specify job id");
         $self->send_log(
             code => $self->ACTION_FINISH_KO,
             token => $options{token},
@@ -265,7 +265,7 @@ sub action_getdiscoveryresults {
 
     foreach my $id (keys %tasks) {
         next if (defined($tasks{$id}->{results}));
-        $self->{logger}->writeLogDebug("[autodiscovery] -class- Get logs results for task '" . $id . "'");
+        $self->{logger}->writeLogDebug("[autodiscovery] Get logs results for task '" . $id . "'");
         $self->send_internal_action(
             action => 'GETLOG',
             data => {
@@ -274,7 +274,7 @@ sub action_getdiscoveryresults {
         );
     }
     foreach my $id (keys %jobs) {
-        $self->{logger}->writeLogDebug("[autodiscovery] -class- Get logs results for job '" . $id . "'");
+        $self->{logger}->writeLogDebug("[autodiscovery] Get logs results for job '" . $id . "'");
         $self->send_internal_action(
             action => 'GETLOG',
             data => {
@@ -298,9 +298,7 @@ sub action_updatediscoveryresults {
             !defined($data->{metadata}->{source}) || $data->{metadata}->{source} ne 'autodiscovery');
 
         if ($data->{metadata}->{type} eq 'task') {
-            $self->{logger}->writeLogInfo(
-                "[autodiscovery] -class- Found result for task '" . $data->{metadata}->{id} . "'"
-            );
+            $self->{logger}->writeLogInfo("[autodiscovery] Found result for task '" . $data->{metadata}->{id} . "'");
             $tasks{$data->{metadata}->{id}}->{results} = $data;
         } elsif ($data->{metadata}->{type} eq 'job') {
             $jobs{$data->{metadata}->{id}}->{results} = $data ;
@@ -314,7 +312,7 @@ sub event {
     while (1) {
         my $message = gorgone::standard::library::zmq_dealer_read_message(socket => $connector->{internal_socket});
         
-        $connector->{logger}->writeLogDebug("[autodiscovery] -class- Event: $message");
+        $connector->{logger}->writeLogDebug("[autodiscovery] Event: $message");
         if ($message =~ /^\[ACK\]\s+\[(.*?)\]\s+(.*)$/m) {
             my $token = $1;
             my $data = JSON::XS->new->utf8->decode($2);
@@ -391,7 +389,7 @@ sub run {
         # we try to do all we can
         my $rev = zmq_poll($self->{poll}, 5000);
         if (defined($rev) && $rev == 0 && $self->{stop} == 1) {
-            $self->{logger}->writeLogInfo("[autodiscovery] -class- $$ has quit");
+            $self->{logger}->writeLogInfo("[autodiscovery] $$ has quit");
             zmq_close($connector->{internal_socket});
             exit(0);
         }

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -49,6 +49,7 @@ sub new {
     $connector->{config} = $options{config};
     $connector->{config_core} = $options{config_core};
     $connector->{config_db_centreon} = $options{config_db_centreon};
+    $connector->{config_db_centstorage} = $options{config_db_centstorage};
     $connector->{stop} = 0;
 
     $connector->{global_timeout} = (defined($options{config}->{global_timeout}) &&
@@ -434,10 +435,11 @@ sub action_launchservicediscovery {
         internal_socket => $self->{internal_socket},
         config => $self->{config},
         config_core => $self->{config_core},
-        service_number => $self->{service_number}
+        service_number => $self->{service_number},
+        class_object_centreon => $self->{class_object_centreon},
+        class_object_centstorage => $self->{class_object_centstorage}
     );
     my $status = $svc_discovery->launchdiscovery(
-        class_object_centreon => $self->{class_object_centreon},
         token => $options{token},
         data => $options{data}
     );
@@ -485,10 +487,21 @@ sub run {
         force => 2,
         logger => $self->{logger}
     );
+    $self->{db_centstorage} = gorgone::class::db->new(
+        dsn => $self->{config_db_centstorage}->{dsn},
+        user => $self->{config_db_centstorage}->{username},
+        password => $self->{config_db_centstorage}->{password},
+        force => 2,
+        logger => $self->{logger}
+    );
     
     $self->{class_object_centreon} = gorgone::class::sqlquery->new(
         logger => $self->{logger},
         db_centreon => $self->{db_centreon}
+    );
+    $self->{class_object_centstorage} = gorgone::class::sqlquery->new(
+        logger => $self->{logger},
+        db_centreon => $self->{db_centstorage}
     );
 
     # Connect internal

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -899,7 +899,8 @@ sub action_hostdiscoveryjoblistener {
     #}
 
     # Can happen if we have a execution command timeout
-    my $message = defined($options{data}->{data}->{result}->{stdout}) ? $options{data}->{data}->{result}->{stdout} : $options{data}->{message};
+    my $message = defined($options{data}->{data}->{result}->{stdout}) ? $options{data}->{data}->{result}->{stdout} : $options{data}->{data}->{message};
+    $message = $options{data}->{message} if (!defined($message));
     if ($options{data}->{code} == GORGONE_ACTION_FINISH_KO) {
         $self->{hdisco_jobs_ids}->{$job_id}->{status} = JOB_FAILED;
         $self->update_job_information(

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -99,14 +99,16 @@ sub action_adddiscoverytask {
         target => $options{data}->{content}->{target},
         token => $id,
         data => {
-            content => {
-                %{$options{data}->{content}},
-                metadata => {
-                    id => $id,
-                    source => 'autodiscovery',
-                    type => 'task',
-                },
-            }
+            content => [
+                {
+                    %{$options{data}->{content}},
+                    metadata => {
+                        id => $id,
+                        source => 'autodiscovery',
+                        type => 'task',
+                    },
+                }
+            ]
         }
     );
 
@@ -165,13 +167,15 @@ sub action_adddiscoveryjob {
         timespec => $options{data}->{content}->{timespec},
         action => 'COMMAND',
         parameters => {
-            command => $options{data}->{content}->{command},
-            timeout => $options{data}->{content}->{timeout},
-            metadata => {
-                id => $id,
-                source => 'autodiscovery',
-                type => 'job',
-            }
+            [
+                command => $options{data}->{content}->{command},
+                timeout => $options{data}->{content}->{timeout},
+                metadata => {
+                    id => $id,
+                    source => 'autodiscovery',
+                    type => 'job',
+                }
+            ]
         },
         keep_token => 1,
     };

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -1067,7 +1067,9 @@ sub event {
             if ((my $method = $connector->can('action_' . lc($1)))) {
                 $message =~ /^\[(.*?)\]\s+\[(.*?)\]\s+\[.*?\]\s+(.*)$/m;
                 my ($action, $token) = ($1, $2);
-                my $data = JSON::XS->new->utf8->decode($3);
+                my ($rv, $data) = $connector->json_decode(argument => $3, token => $token);
+                next if ($rv);
+
                 $method->($connector, token => $token, data => $data);
             }
         }

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -745,7 +745,7 @@ sub discovery_command_result {
                 instant => 1,
                 content => [
                     {
-                        command => $post_command->{command_line},
+                        command => $post_command->{command_line} . ' --token=' . $self->{tpapi_centreonv2}->get_token(),
                         metadata => {
                             job_id => $job_id,
                             source => 'autodiscovery-host-job-postcommand'

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -1059,7 +1059,7 @@ sub is_hdisco_synced {
 
 sub event {
     while (1) {
-        my $message = gorgone::standard::library::zmq_dealer_read_message(socket => $connector->{internal_socket});
+        my $message = $connector->read_message();
         last if (!defined($message));
 
         $connector->{logger}->writeLogDebug("[autodiscovery] Event: $message");
@@ -1121,8 +1121,8 @@ sub run {
         zmq_type => 'ZMQ_DEALER',
         name => 'gorgone-autodiscovery',
         logger => $self->{logger},
-        type => $self->{config_core}->{internal_com_type},
-        path => $self->{config_core}->{internal_com_path}
+        type => $self->get_core_config(name => 'internal_com_type'),
+        path => $self->get_core_config(name => 'internal_com_path')
     );
     $connector->send_internal_action(
         action => 'AUTODISCOVERYREADY',

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -58,35 +58,34 @@ use constant EXECUTION_MODE_PAUSE => 2;
 use constant MAX_INSERT_BY_QUERY => 100;
 
 my %handlers = (TERM => {}, HUP => {});
-my ($connector);
 
 sub new {
     my ($class, %options) = @_;
-    $connector = $class->SUPER::new(%options);
-    bless $connector, $class;
+    my $self = $class->SUPER::new(%options);
+    bless $self, $class;
 
-    $connector->{global_timeout} = (defined($options{config}->{global_timeout}) &&
+    $self->{global_timeout} = (defined($options{config}->{global_timeout}) &&
         $options{config}->{global_timeout} =~ /(\d+)/) ? $1 : 300;
-    $connector->{check_interval} = (defined($options{config}->{check_interval}) &&
+    $self->{check_interval} = (defined($options{config}->{check_interval}) &&
         $options{config}->{check_interval} =~ /(\d+)/) ? $1 : 15;
-    $connector->{tpapi_clapi_name} = defined($options{config}->{tpapi_clapi}) && $options{config}->{tpapi_clapi} ne '' ? $options{config}->{tpapi_clapi} : 'clapi';
-    $connector->{tpapi_centreonv2_name} = defined($options{config}->{tpapi_centreonv2}) && $options{config}->{tpapi_centreonv2} ne '' ? 
+    $self->{tpapi_clapi_name} = defined($options{config}->{tpapi_clapi}) && $options{config}->{tpapi_clapi} ne '' ? $options{config}->{tpapi_clapi} : 'clapi';
+    $self->{tpapi_centreonv2_name} = defined($options{config}->{tpapi_centreonv2}) && $options{config}->{tpapi_centreonv2} ne '' ?
         $options{config}->{tpapi_centreonv2} : 'centreonv2';
 
-    $connector->{is_module_installed} = 0;
-    $connector->{is_module_installed_check_interval} = 60;
-    $connector->{is_module_installed_last_check} = -1;
+    $self->{is_module_installed} = 0;
+    $self->{is_module_installed_check_interval} = 60;
+    $self->{is_module_installed_last_check} = -1;
 
-    $connector->{hdisco_synced} = 0;
-    $connector->{hdisco_synced_failed_time} = -1;
-    $connector->{hdisco_synced_ok_time} = -1;
-    $connector->{hdisco_jobs_tokens} = {};
-    $connector->{hdisco_jobs_ids} = {};
+    $self->{hdisco_synced} = 0;
+    $self->{hdisco_synced_failed_time} = -1;
+    $self->{hdisco_synced_ok_time} = -1;
+    $self->{hdisco_jobs_tokens} = {};
+    $self->{hdisco_jobs_ids} = {};
 
-    $connector->{service_discoveries} = {};
+    $self->{service_discoveries} = {};
 
-    $connector->set_signal_handlers();
-    return $connector;
+    $self->set_signal_handlers();
+    return $self;
 }
 
 sub set_signal_handlers {
@@ -596,7 +595,7 @@ sub action_launchhostdiscovery {
         code => GORGONE_ACTION_FINISH_OK,
         token => $options{token},
         instant => 1,
-        data => {
+        data    => {
             message => $message
         }
     );
@@ -622,8 +621,8 @@ sub discovery_postcommand_result {
     if ($exit_code != 0) {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - execute discovery postcommand failed job '$job_id'");
         $self->update_job_status(
-            job_id => $job_id,
-            status => SAVE_FAILED,
+            job_id  => $job_id,
+            status  => SAVE_FAILED,
             message => $output
         );
         return 1;
@@ -631,8 +630,8 @@ sub discovery_postcommand_result {
 
     $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - finished discovery postcommand job '$job_id'");
     $self->update_job_status(
-        job_id => $job_id,
-        status => SAVE_FINISH,
+        job_id  => $job_id,
+        status  => SAVE_FINISH,
         message => 'Finished'
     );
 }
@@ -642,14 +641,14 @@ sub discovery_add_host_result {
 
     if ($options{builder}->{num_lines} == MAX_INSERT_BY_QUERY) {
         my ($status) = $self->{class_object_centreon}->custom_execute(
-            request => $options{builder}->{query} . $options{builder}->{values},
+            request     => $options{builder}->{query} . $options{builder}->{values},
             bind_values => $options{builder}->{bind_values}
         );
         if ($status == -1) {
             $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to insert job '$options{job_id}' results");
             $self->update_job_status(
-                job_id => $options{job_id},
-                status => JOB_FAILED,
+                job_id  => $options{job_id},
+                status  => JOB_FAILED,
                 message => 'Failed to insert job results'
             );
             return 1;
@@ -702,8 +701,8 @@ sub discovery_command_result {
     if ($exit_code != 0) {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - execute discovery plugin failed job '$job_id'");
         $self->update_job_status(
-            job_id => $job_id,
-            status => JOB_FAILED,
+            job_id  => $job_id,
+            status  => JOB_FAILED,
             message => (defined($data->{data}->{result}->{stderr}) && $data->{data}->{result}->{stderr} ne '') ?
                 $data->{data}->{result}->{stderr} : $data->{data}->{result}->{stdout}
         );
@@ -712,12 +711,12 @@ sub discovery_command_result {
 
     # Delete previous results
     my $query = "DELETE FROM mod_host_disco_host WHERE job_id = ?";
-    my ($status) = $self->{class_object_centreon}->custom_execute(request => $query, bind_values => [$job_id]);
+    my ($status) = $self->{class_object_centreon}->custom_execute(request => $query, bind_values => [ $job_id ]);
     if ($status == -1) {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to delete previous job '$job_id' results");
         $self->update_job_status(
-            job_id => $job_id,
-            status => JOB_FAILED,
+            job_id  => $job_id,
+            status  => JOB_FAILED,
             message => 'Failed to delete previous job results'
         );
         return 1;
@@ -725,11 +724,11 @@ sub discovery_command_result {
 
     # Add new results
     my $builder = {
-        query => "INSERT INTO mod_host_disco_host (job_id, discovery_result, uuid) VALUES ",
-        num_lines => 0,
+        query       => "INSERT INTO mod_host_disco_host (job_id, discovery_result, uuid) VALUES ",
+        num_lines   => 0,
         total_lines => 0,
-        values => '',
-        append => '',
+        values      => '',
+        append      => '',
         bind_values => []
     };
     my $duration = 0;
@@ -754,8 +753,8 @@ sub discovery_command_result {
     } catch {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to decode discovery plugin response job '$job_id'");
         $self->update_job_status(
-            job_id => $job_id,
-            status => JOB_FAILED,
+            job_id  => $job_id,
+            status  => JOB_FAILED,
             message => 'Failed to decode discovery plugin response'
         );
         return 1;
@@ -766,8 +765,8 @@ sub discovery_command_result {
         if ($status == -1) {
             $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to insert job '$job_id' results");
             $self->update_job_status(
-                job_id => $job_id,
-                status => JOB_FAILED,
+                job_id  => $job_id,
+                status  => JOB_FAILED,
                 message => 'Failed to insert job results'
             );
             return 1;
@@ -781,12 +780,12 @@ sub discovery_command_result {
 
         $self->send_internal_action({
             action => $post_command->{action},
-            token => $self->{hdisco_jobs_ids}->{$job_id}->{token},
-            data => {
+            token  => $self->{hdisco_jobs_ids}->{$job_id}->{token},
+            data   => {
                 instant => 1,
                 content => [
                     {
-                        command => $post_command->{command_line} . ' --token=' . $self->{tpapi_centreonv2}->get_token(),
+                        command  => $post_command->{command_line} . ' --token=' . $self->{tpapi_centreonv2}->get_token(),
                         metadata => {
                             job_id => $job_id,
                             source => 'autodiscovery-host-job-postcommand'
@@ -796,13 +795,13 @@ sub discovery_command_result {
             }
         });
     }
-    
+
     $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - finished discovery command job '$job_id'");
     $self->update_job_status(
-        job_id => $job_id,
-        status => JOB_FINISH,
-        message => 'Finished',
-        duration => $duration,
+        job_id           => $job_id,
+        status           => JOB_FINISH,
+        message          => 'Finished',
+        duration         => $duration,
         discovered_items => $builder->{total_lines}
     );
 
@@ -817,26 +816,26 @@ sub action_deletehostdiscoveryjob {
     $options{token} = $self->generate_token() if (!defined($options{token}));
     if (!$self->is_hdisco_synced()) {
         $self->send_log(
-            code => GORGONE_ACTION_FINISH_KO,
+            code  => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
-            data => {
+            data  => {
                 message => 'host discovery synchronization issue'
             }
         );
-        return ;
+        return;
     }
 
     my $data = $options{frame}->getData();
 
     my $discovery_token = $data->{variables}->[0];
-    my $job_id = (defined($discovery_token) && defined($self->{hdisco_jobs_tokens}->{$discovery_token})) ? 
+    my $job_id = (defined($discovery_token) && defined($self->{hdisco_jobs_tokens}->{$discovery_token})) ?
         $self->{hdisco_jobs_tokens}->{$discovery_token} : undef;
     if (!defined($discovery_token) || $discovery_token eq '') {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - missing ':token' variable to delete discovery");
         $self->send_log(
-            code => GORGONE_ACTION_FINISH_KO,
+            code  => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
-            data => { message => 'missing discovery token' }
+            data  => { message => 'missing discovery token' }
         );
         return 1;
     }
@@ -846,9 +845,9 @@ sub action_deletehostdiscoveryjob {
     if ($status != 0) {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - cannot get host discovery job '$job_id' - " . $self->{tpapi_centreonv2}->error());
         $self->send_log(
-            code => GORGONE_ACTION_FINISH_KO,
+            code  => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
-            data => {
+            data  => {
                 message => "cannot get job '$job_id'"
             }
         );
@@ -867,11 +866,11 @@ sub action_deletehostdiscoveryjob {
     }
 
     $self->send_log(
-        code => GORGONE_ACTION_FINISH_OK,
+        code  => GORGONE_ACTION_FINISH_OK,
         token => $options{token},
-        data => { message => 'job ' . $discovery_token . ' deleted' }
+        data  => { message => 'job ' . $discovery_token . ' deleted' }
     );
-    
+
     return 0;
 }
 
@@ -882,7 +881,7 @@ sub update_job_status {
     $values->{duration} = $options{duration} if (defined($options{duration}));
     $values->{discovered_items} = $options{discovered_items} if (defined($options{discovered_items}));
     $self->update_job_information(
-        values => $values,
+        values       => $values,
         where_clause => [
             {
                 id => $options{job_id}
@@ -897,7 +896,7 @@ sub update_job_information {
 
     return 1 if (!defined($options{where_clause}) || ref($options{where_clause}) ne 'ARRAY' || scalar($options{where_clause}) < 1);
     return 1 if (!defined($options{values}) || ref($options{values}) ne 'HASH' || !keys %{$options{values}});
-    
+
     my $query = "UPDATE mod_host_disco_job SET ";
     my @bind_values = ();
     my $append = '';
@@ -935,12 +934,12 @@ sub action_hostdiscoveryjoblistener {
     my $data = $options{frame}->getData();
 
     my $job_id = $self->{hdisco_jobs_tokens}->{ $options{token} };
-    if ($data->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT && 
+    if ($data->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT &&
         $data->{data}->{metadata}->{source} eq 'autodiscovery-host-job-discovery') {
         $self->discovery_command_result(%options);
         return 1;
     }
-    #if ($data->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT && 
+    #if ($data->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT &&
     #    $data->{data}->{metadata}->{source} eq 'autodiscovery-host-job-postcommand') {
     #    $self->discovery_postcommand_result(%options);
     #    return 1;
@@ -952,10 +951,10 @@ sub action_hostdiscoveryjoblistener {
     if ($data->{code} == GORGONE_ACTION_FINISH_KO) {
         $self->{hdisco_jobs_ids}->{$job_id}->{status} = JOB_FAILED;
         $self->update_job_information(
-            values => {
-                status => JOB_FAILED,
-                message => $message,
-                duration => 0,
+            values       => {
+                status           => JOB_FAILED,
+                message          => $message,
+                duration         => 0,
                 discovered_items => 0
             },
             where_clause => [
@@ -1000,12 +999,12 @@ sub hdisco_add_joblistener {
 
         $self->send_internal_action({
             action => 'ADDLISTENER',
-            data => [
+            data   => [
                 {
                     identity => 'gorgoneautodiscovery',
-                    event => 'HOSTDISCOVERYJOBLISTENER',
-                    target => $_->{target},
-                    token => $_->{token},
+                    event    => 'HOSTDISCOVERYJOBLISTENER',
+                    target   => $_->{target},
+                    token    => $_->{token},
                     log_pace => $self->{check_interval}
                 }
             ]
@@ -1022,7 +1021,11 @@ Service Discovery part
 **********************
 
 =cut
-
+sub getDiscoveryListener {
+    my ($self, $uuid) = @_;
+    return undef if (!defined($self->{service_discoveries}->{ $uuid }));
+    return $self->{service_discoveries}->{$uuid}->can("discoverylistener"), $self->{service_discoveries}->{$uuid} ;
+}
 sub action_servicediscoverylistener {
     my ($self, %options) = @_;
 
@@ -1032,17 +1035,25 @@ sub action_servicediscoverylistener {
     return 0 if ($options{token} !~ /^svc-disco-(.*?)-(\d+)-(\d+)/);
 
     my ($uuid, $rule_id, $host_id) = ($1, $2, $3);
-    return 0 if (!defined($self->{service_discoveries}->{ $uuid }));
 
-    $self->{service_discoveries}->{ $uuid }->discoverylistener(
+    my ($discoverylistener_method, $local_self) = $self->getDiscoveryListener($uuid);
+    return 0 if (!defined($discoverylistener_method));
+
+    $discoverylistener_method->(
+        $local_self,
         rule_id => $rule_id,
         host_id => $host_id,
         %options
     );
 
-    if ($self->{service_discoveries}->{ $uuid }->is_finished()) {
+    if ($self->is_finished($uuid)) {
         delete $self->{service_discoveries}->{ $uuid };
     }
+}
+
+sub is_finished {
+    my ($self, $uuid) = @_;
+    return $self->{service_discoveries}->{ $uuid }->is_finished();
 }
 
 sub action_launchservicediscovery {
@@ -1052,28 +1063,28 @@ sub action_launchservicediscovery {
 
     $self->{service_number}++;
     my $svc_discovery = gorgone::modules::centreon::autodiscovery::services::discovery->new(
-        module_id => $self->{module_id},
-        logger => $self->{logger},
-        tpapi_clapi => $self->{tpapi_clapi},
-        internal_socket => $self->{internal_socket},
-        config => $self->{config},
-        config_core => $self->{config_core},
-        service_number => $self->{service_number},
-        class_object_centreon => $self->{class_object_centreon},
+        module_id                => $self->{module_id},
+        logger                   => $self->{logger},
+        tpapi_clapi              => $self->{tpapi_clapi},
+        internal_socket          => $self->{internal_socket},
+        config                   => $self->{config},
+        config_core              => $self->{config_core},
+        service_number           => $self->{service_number},
+        class_object_centreon    => $self->{class_object_centreon},
         class_object_centstorage => $self->{class_object_centstorage}
     );
+    $self->{service_discoveries}->{ $svc_discovery->get_uuid() } = $svc_discovery;
+
     my $status = $svc_discovery->launchdiscovery(
         token => $options{token},
         frame => $options{frame}
     );
     if ($status == -1) {
         $self->send_log(
-            code => GORGONE_ACTION_FINISH_KO,
+            code  => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
-            data => { message => 'cannot launch discovery' }
+            data  => { message => 'cannot launch discovery' }
         );
-    } elsif ($status == 0) {
-        $self->{service_discoveries}->{ $svc_discovery->get_uuid() } = $svc_discovery;
     }
 }
 
@@ -1116,9 +1127,9 @@ sub event {
         next if ($rv);
 
         my $raw = $frame->getFrame();
-        $self->{logger}->writeLogDebug("[autodiscovery] Event: " . $$raw) if ($connector->{logger}->is_debug());
+        $self->{logger}->writeLogDebug("[autodiscovery] Event: " . $$raw) if ($self->{logger}->is_debug());
         if ($$raw =~ /^\[(.*?)\]/) {
-            if ((my $method = $connector->can('action_' . lc($1)))) {
+            if ((my $method = $self->can('action_' . lc($1)))) {
                 next if ($frame->parse({ releaseFrame => 1, decode => 1 }));
 
                 $method->($self, token => $frame->getToken(), frame => $frame);
@@ -1128,11 +1139,12 @@ sub event {
 }
 
 sub periodic_exec {
-    $connector->is_module_installed();
-    $connector->hdisco_sync();
+    my $self = shift;
+    $self->is_module_installed();
+    $self->hdisco_sync();
 
-    if ($connector->{stop} == 1) {
-        $connector->{logger}->writeLogInfo("[autodiscovery] $$ has quit");
+    if ($self->{stop} == 1) {
+        $self->{logger}->writeLogInfo("[autodiscovery] $$ has quit");
         exit(0);
     }
 }
@@ -1154,48 +1166,49 @@ sub run {
     }
 
     $self->{db_centreon} = gorgone::class::db->new(
-        dsn => $self->{config_db_centreon}->{dsn},
-        user => $self->{config_db_centreon}->{username},
+        dsn      => $self->{config_db_centreon}->{dsn},
+        user     => $self->{config_db_centreon}->{username},
         password => $self->{config_db_centreon}->{password},
-        force => 2,
-        logger => $self->{logger}
+        force    => 2,
+        logger   => $self->{logger}
     );
     $self->{db_centstorage} = gorgone::class::db->new(
-        dsn => $self->{config_db_centstorage}->{dsn},
-        user => $self->{config_db_centstorage}->{username},
+        dsn      => $self->{config_db_centstorage}->{dsn},
+        user     => $self->{config_db_centstorage}->{username},
         password => $self->{config_db_centstorage}->{password},
-        force => 2,
-        logger => $self->{logger}
+        force    => 2,
+        logger   => $self->{logger}
     );
-    
+
     $self->{class_object_centreon} = gorgone::class::sqlquery->new(
-        logger => $self->{logger},
+        logger      => $self->{logger},
         db_centreon => $self->{db_centreon}
     );
     $self->{class_object_centstorage} = gorgone::class::sqlquery->new(
-        logger => $self->{logger},
+        logger      => $self->{logger},
         db_centreon => $self->{db_centstorage}
     );
 
     $self->{internal_socket} = gorgone::standard::library::connect_com(
-        context => $self->{zmq_context},
+        context  => $self->{zmq_context},
         zmq_type => 'ZMQ_DEALER',
-        name => 'gorgone-autodiscovery',
-        logger => $self->{logger},
-        type => $self->get_core_config(name => 'internal_com_type'),
-        path => $self->get_core_config(name => 'internal_com_path')
+        name     => 'gorgone-autodiscovery',
+        logger   => $self->{logger},
+        type     => $self->get_core_config(name => 'internal_com_type'),
+        path     => $self->get_core_config(name => 'internal_com_path')
     );
     $self->send_internal_action({
         action => 'AUTODISCOVERYREADY',
-        data => {}
+        data   => {}
     });
 
     $self->is_module_installed();
     $self->hdisco_sync();
 
-    my $watcher_timer = $self->{loop}->timer(5, 5, \&periodic_exec);
-    my $watcher_io = $self->{loop}->io($self->{internal_socket}->get_fd(), EV::READ, sub { $connector->event() } );
+    my $watcher_timer = $self->{loop}->timer(5, 5, sub {$self->periodic_exec()});
+    my $watcher_io = $self->{loop}->io($self->{internal_socket}->get_fd(), EV::READ, sub {$self->event()});
     $self->{loop}->run();
 }
 
 1;
+

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -27,7 +27,6 @@ use warnings;
 use gorgone::standard::library;
 use gorgone::standard::constants qw(:all);
 use gorgone::modules::centreon::autodiscovery::services::discovery;
-use gorgone::class::tpapi::clapi;
 use gorgone::class::tpapi::centreonv2;
 use gorgone::class::sqlquery;
 use gorgone::class::frame;
@@ -69,7 +68,6 @@ sub new {
         $options{config}->{global_timeout} =~ /(\d+)/) ? $1 : 300;
     $connector->{check_interval} = (defined($options{config}->{check_interval}) &&
         $options{config}->{check_interval} =~ /(\d+)/) ? $1 : 15;
-    $connector->{tpapi_clapi_name} = defined($options{config}->{tpapi_clapi}) && $options{config}->{tpapi_clapi} ne '' ? $options{config}->{tpapi_clapi} : 'clapi';
     $connector->{tpapi_centreonv2_name} = defined($options{config}->{tpapi_centreonv2}) && $options{config}->{tpapi_centreonv2} ne '' ? 
         $options{config}->{tpapi_centreonv2} : 'centreonv2';
 
@@ -1056,7 +1054,7 @@ sub action_launchservicediscovery {
     my $svc_discovery = gorgone::modules::centreon::autodiscovery::services::discovery->new(
         module_id => $self->{module_id},
         logger => $self->{logger},
-        tpapi_clapi => $self->{tpapi_clapi},
+        tpapi_centreonv2 => $self->{tpapi_centreonv2},
         internal_socket => $self->{internal_socket},
         config => $self->{config},
         config_core => $self->{config_core},
@@ -1144,10 +1142,6 @@ sub periodic_exec {
 sub run {
     my ($self, %options) = @_;
 
-    $self->{tpapi_clapi} = gorgone::class::tpapi::clapi->new();
-    $self->{tpapi_clapi}->set_configuration(
-        config => $self->{tpapi}->get_configuration(name => $self->{tpapi_clapi_name})
-    );
     $self->{tpapi_centreonv2} = gorgone::class::tpapi::centreonv2->new();
     my ($status) = $self->{tpapi_centreonv2}->set_configuration(
         config => $self->{tpapi}->get_configuration(name => $self->{tpapi_centreonv2_name}),

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -58,34 +58,35 @@ use constant EXECUTION_MODE_PAUSE => 2;
 use constant MAX_INSERT_BY_QUERY => 100;
 
 my %handlers = (TERM => {}, HUP => {});
+my ($connector);
 
 sub new {
     my ($class, %options) = @_;
-    my $self = $class->SUPER::new(%options);
-    bless $self, $class;
+    $connector = $class->SUPER::new(%options);
+    bless $connector, $class;
 
-    $self->{global_timeout} = (defined($options{config}->{global_timeout}) &&
+    $connector->{global_timeout} = (defined($options{config}->{global_timeout}) &&
         $options{config}->{global_timeout} =~ /(\d+)/) ? $1 : 300;
-    $self->{check_interval} = (defined($options{config}->{check_interval}) &&
+    $connector->{check_interval} = (defined($options{config}->{check_interval}) &&
         $options{config}->{check_interval} =~ /(\d+)/) ? $1 : 15;
-    $self->{tpapi_clapi_name} = defined($options{config}->{tpapi_clapi}) && $options{config}->{tpapi_clapi} ne '' ? $options{config}->{tpapi_clapi} : 'clapi';
-    $self->{tpapi_centreonv2_name} = defined($options{config}->{tpapi_centreonv2}) && $options{config}->{tpapi_centreonv2} ne '' ?
+    $connector->{tpapi_clapi_name} = defined($options{config}->{tpapi_clapi}) && $options{config}->{tpapi_clapi} ne '' ? $options{config}->{tpapi_clapi} : 'clapi';
+    $connector->{tpapi_centreonv2_name} = defined($options{config}->{tpapi_centreonv2}) && $options{config}->{tpapi_centreonv2} ne '' ? 
         $options{config}->{tpapi_centreonv2} : 'centreonv2';
 
-    $self->{is_module_installed} = 0;
-    $self->{is_module_installed_check_interval} = 60;
-    $self->{is_module_installed_last_check} = -1;
+    $connector->{is_module_installed} = 0;
+    $connector->{is_module_installed_check_interval} = 60;
+    $connector->{is_module_installed_last_check} = -1;
 
-    $self->{hdisco_synced} = 0;
-    $self->{hdisco_synced_failed_time} = -1;
-    $self->{hdisco_synced_ok_time} = -1;
-    $self->{hdisco_jobs_tokens} = {};
-    $self->{hdisco_jobs_ids} = {};
+    $connector->{hdisco_synced} = 0;
+    $connector->{hdisco_synced_failed_time} = -1;
+    $connector->{hdisco_synced_ok_time} = -1;
+    $connector->{hdisco_jobs_tokens} = {};
+    $connector->{hdisco_jobs_ids} = {};
 
-    $self->{service_discoveries} = {};
+    $connector->{service_discoveries} = {};
 
-    $self->set_signal_handlers();
-    return $self;
+    $connector->set_signal_handlers();
+    return $connector;
 }
 
 sub set_signal_handlers {
@@ -595,7 +596,7 @@ sub action_launchhostdiscovery {
         code => GORGONE_ACTION_FINISH_OK,
         token => $options{token},
         instant => 1,
-        data    => {
+        data => {
             message => $message
         }
     );
@@ -621,8 +622,8 @@ sub discovery_postcommand_result {
     if ($exit_code != 0) {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - execute discovery postcommand failed job '$job_id'");
         $self->update_job_status(
-            job_id  => $job_id,
-            status  => SAVE_FAILED,
+            job_id => $job_id,
+            status => SAVE_FAILED,
             message => $output
         );
         return 1;
@@ -630,8 +631,8 @@ sub discovery_postcommand_result {
 
     $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - finished discovery postcommand job '$job_id'");
     $self->update_job_status(
-        job_id  => $job_id,
-        status  => SAVE_FINISH,
+        job_id => $job_id,
+        status => SAVE_FINISH,
         message => 'Finished'
     );
 }
@@ -641,14 +642,14 @@ sub discovery_add_host_result {
 
     if ($options{builder}->{num_lines} == MAX_INSERT_BY_QUERY) {
         my ($status) = $self->{class_object_centreon}->custom_execute(
-            request     => $options{builder}->{query} . $options{builder}->{values},
+            request => $options{builder}->{query} . $options{builder}->{values},
             bind_values => $options{builder}->{bind_values}
         );
         if ($status == -1) {
             $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to insert job '$options{job_id}' results");
             $self->update_job_status(
-                job_id  => $options{job_id},
-                status  => JOB_FAILED,
+                job_id => $options{job_id},
+                status => JOB_FAILED,
                 message => 'Failed to insert job results'
             );
             return 1;
@@ -701,8 +702,8 @@ sub discovery_command_result {
     if ($exit_code != 0) {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - execute discovery plugin failed job '$job_id'");
         $self->update_job_status(
-            job_id  => $job_id,
-            status  => JOB_FAILED,
+            job_id => $job_id,
+            status => JOB_FAILED,
             message => (defined($data->{data}->{result}->{stderr}) && $data->{data}->{result}->{stderr} ne '') ?
                 $data->{data}->{result}->{stderr} : $data->{data}->{result}->{stdout}
         );
@@ -711,12 +712,12 @@ sub discovery_command_result {
 
     # Delete previous results
     my $query = "DELETE FROM mod_host_disco_host WHERE job_id = ?";
-    my ($status) = $self->{class_object_centreon}->custom_execute(request => $query, bind_values => [ $job_id ]);
+    my ($status) = $self->{class_object_centreon}->custom_execute(request => $query, bind_values => [$job_id]);
     if ($status == -1) {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to delete previous job '$job_id' results");
         $self->update_job_status(
-            job_id  => $job_id,
-            status  => JOB_FAILED,
+            job_id => $job_id,
+            status => JOB_FAILED,
             message => 'Failed to delete previous job results'
         );
         return 1;
@@ -724,11 +725,11 @@ sub discovery_command_result {
 
     # Add new results
     my $builder = {
-        query       => "INSERT INTO mod_host_disco_host (job_id, discovery_result, uuid) VALUES ",
-        num_lines   => 0,
+        query => "INSERT INTO mod_host_disco_host (job_id, discovery_result, uuid) VALUES ",
+        num_lines => 0,
         total_lines => 0,
-        values      => '',
-        append      => '',
+        values => '',
+        append => '',
         bind_values => []
     };
     my $duration = 0;
@@ -753,8 +754,8 @@ sub discovery_command_result {
     } catch {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to decode discovery plugin response job '$job_id'");
         $self->update_job_status(
-            job_id  => $job_id,
-            status  => JOB_FAILED,
+            job_id => $job_id,
+            status => JOB_FAILED,
             message => 'Failed to decode discovery plugin response'
         );
         return 1;
@@ -765,8 +766,8 @@ sub discovery_command_result {
         if ($status == -1) {
             $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - failed to insert job '$job_id' results");
             $self->update_job_status(
-                job_id  => $job_id,
-                status  => JOB_FAILED,
+                job_id => $job_id,
+                status => JOB_FAILED,
                 message => 'Failed to insert job results'
             );
             return 1;
@@ -780,12 +781,12 @@ sub discovery_command_result {
 
         $self->send_internal_action({
             action => $post_command->{action},
-            token  => $self->{hdisco_jobs_ids}->{$job_id}->{token},
-            data   => {
+            token => $self->{hdisco_jobs_ids}->{$job_id}->{token},
+            data => {
                 instant => 1,
                 content => [
                     {
-                        command  => $post_command->{command_line} . ' --token=' . $self->{tpapi_centreonv2}->get_token(),
+                        command => $post_command->{command_line} . ' --token=' . $self->{tpapi_centreonv2}->get_token(),
                         metadata => {
                             job_id => $job_id,
                             source => 'autodiscovery-host-job-postcommand'
@@ -795,13 +796,13 @@ sub discovery_command_result {
             }
         });
     }
-
+    
     $self->{logger}->writeLogDebug("[autodiscovery] -class- host discovery - finished discovery command job '$job_id'");
     $self->update_job_status(
-        job_id           => $job_id,
-        status           => JOB_FINISH,
-        message          => 'Finished',
-        duration         => $duration,
+        job_id => $job_id,
+        status => JOB_FINISH,
+        message => 'Finished',
+        duration => $duration,
         discovered_items => $builder->{total_lines}
     );
 
@@ -816,26 +817,26 @@ sub action_deletehostdiscoveryjob {
     $options{token} = $self->generate_token() if (!defined($options{token}));
     if (!$self->is_hdisco_synced()) {
         $self->send_log(
-            code  => GORGONE_ACTION_FINISH_KO,
+            code => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
-            data  => {
+            data => {
                 message => 'host discovery synchronization issue'
             }
         );
-        return;
+        return ;
     }
 
     my $data = $options{frame}->getData();
 
     my $discovery_token = $data->{variables}->[0];
-    my $job_id = (defined($discovery_token) && defined($self->{hdisco_jobs_tokens}->{$discovery_token})) ?
+    my $job_id = (defined($discovery_token) && defined($self->{hdisco_jobs_tokens}->{$discovery_token})) ? 
         $self->{hdisco_jobs_tokens}->{$discovery_token} : undef;
     if (!defined($discovery_token) || $discovery_token eq '') {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - missing ':token' variable to delete discovery");
         $self->send_log(
-            code  => GORGONE_ACTION_FINISH_KO,
+            code => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
-            data  => { message => 'missing discovery token' }
+            data => { message => 'missing discovery token' }
         );
         return 1;
     }
@@ -845,9 +846,9 @@ sub action_deletehostdiscoveryjob {
     if ($status != 0) {
         $self->{logger}->writeLogError("[autodiscovery] -class- host discovery - cannot get host discovery job '$job_id' - " . $self->{tpapi_centreonv2}->error());
         $self->send_log(
-            code  => GORGONE_ACTION_FINISH_KO,
+            code => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
-            data  => {
+            data => {
                 message => "cannot get job '$job_id'"
             }
         );
@@ -866,11 +867,11 @@ sub action_deletehostdiscoveryjob {
     }
 
     $self->send_log(
-        code  => GORGONE_ACTION_FINISH_OK,
+        code => GORGONE_ACTION_FINISH_OK,
         token => $options{token},
-        data  => { message => 'job ' . $discovery_token . ' deleted' }
+        data => { message => 'job ' . $discovery_token . ' deleted' }
     );
-
+    
     return 0;
 }
 
@@ -881,7 +882,7 @@ sub update_job_status {
     $values->{duration} = $options{duration} if (defined($options{duration}));
     $values->{discovered_items} = $options{discovered_items} if (defined($options{discovered_items}));
     $self->update_job_information(
-        values       => $values,
+        values => $values,
         where_clause => [
             {
                 id => $options{job_id}
@@ -896,7 +897,7 @@ sub update_job_information {
 
     return 1 if (!defined($options{where_clause}) || ref($options{where_clause}) ne 'ARRAY' || scalar($options{where_clause}) < 1);
     return 1 if (!defined($options{values}) || ref($options{values}) ne 'HASH' || !keys %{$options{values}});
-
+    
     my $query = "UPDATE mod_host_disco_job SET ";
     my @bind_values = ();
     my $append = '';
@@ -934,12 +935,12 @@ sub action_hostdiscoveryjoblistener {
     my $data = $options{frame}->getData();
 
     my $job_id = $self->{hdisco_jobs_tokens}->{ $options{token} };
-    if ($data->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT &&
+    if ($data->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT && 
         $data->{data}->{metadata}->{source} eq 'autodiscovery-host-job-discovery') {
         $self->discovery_command_result(%options);
         return 1;
     }
-    #if ($data->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT &&
+    #if ($data->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT && 
     #    $data->{data}->{metadata}->{source} eq 'autodiscovery-host-job-postcommand') {
     #    $self->discovery_postcommand_result(%options);
     #    return 1;
@@ -951,10 +952,10 @@ sub action_hostdiscoveryjoblistener {
     if ($data->{code} == GORGONE_ACTION_FINISH_KO) {
         $self->{hdisco_jobs_ids}->{$job_id}->{status} = JOB_FAILED;
         $self->update_job_information(
-            values       => {
-                status           => JOB_FAILED,
-                message          => $message,
-                duration         => 0,
+            values => {
+                status => JOB_FAILED,
+                message => $message,
+                duration => 0,
                 discovered_items => 0
             },
             where_clause => [
@@ -999,12 +1000,12 @@ sub hdisco_add_joblistener {
 
         $self->send_internal_action({
             action => 'ADDLISTENER',
-            data   => [
+            data => [
                 {
                     identity => 'gorgoneautodiscovery',
-                    event    => 'HOSTDISCOVERYJOBLISTENER',
-                    target   => $_->{target},
-                    token    => $_->{token},
+                    event => 'HOSTDISCOVERYJOBLISTENER',
+                    target => $_->{target},
+                    token => $_->{token},
                     log_pace => $self->{check_interval}
                 }
             ]
@@ -1021,11 +1022,7 @@ Service Discovery part
 **********************
 
 =cut
-sub getDiscoveryListener {
-    my ($self, $uuid) = @_;
-    return undef if (!defined($self->{service_discoveries}->{ $uuid }));
-    return $self->{service_discoveries}->{$uuid}->can("discoverylistener"), $self->{service_discoveries}->{$uuid} ;
-}
+
 sub action_servicediscoverylistener {
     my ($self, %options) = @_;
 
@@ -1035,25 +1032,17 @@ sub action_servicediscoverylistener {
     return 0 if ($options{token} !~ /^svc-disco-(.*?)-(\d+)-(\d+)/);
 
     my ($uuid, $rule_id, $host_id) = ($1, $2, $3);
+    return 0 if (!defined($self->{service_discoveries}->{ $uuid }));
 
-    my ($discoverylistener_method, $local_self) = $self->getDiscoveryListener($uuid);
-    return 0 if (!defined($discoverylistener_method));
-
-    $discoverylistener_method->(
-        $local_self,
+    $self->{service_discoveries}->{ $uuid }->discoverylistener(
         rule_id => $rule_id,
         host_id => $host_id,
         %options
     );
 
-    if ($self->is_finished($uuid)) {
+    if ($self->{service_discoveries}->{ $uuid }->is_finished()) {
         delete $self->{service_discoveries}->{ $uuid };
     }
-}
-
-sub is_finished {
-    my ($self, $uuid) = @_;
-    return $self->{service_discoveries}->{ $uuid }->is_finished();
 }
 
 sub action_launchservicediscovery {
@@ -1063,28 +1052,28 @@ sub action_launchservicediscovery {
 
     $self->{service_number}++;
     my $svc_discovery = gorgone::modules::centreon::autodiscovery::services::discovery->new(
-        module_id                => $self->{module_id},
-        logger                   => $self->{logger},
-        tpapi_clapi              => $self->{tpapi_clapi},
-        internal_socket          => $self->{internal_socket},
-        config                   => $self->{config},
-        config_core              => $self->{config_core},
-        service_number           => $self->{service_number},
-        class_object_centreon    => $self->{class_object_centreon},
+        module_id => $self->{module_id},
+        logger => $self->{logger},
+        tpapi_clapi => $self->{tpapi_clapi},
+        internal_socket => $self->{internal_socket},
+        config => $self->{config},
+        config_core => $self->{config_core},
+        service_number => $self->{service_number},
+        class_object_centreon => $self->{class_object_centreon},
         class_object_centstorage => $self->{class_object_centstorage}
     );
-    $self->{service_discoveries}->{ $svc_discovery->get_uuid() } = $svc_discovery;
-
     my $status = $svc_discovery->launchdiscovery(
         token => $options{token},
         frame => $options{frame}
     );
     if ($status == -1) {
         $self->send_log(
-            code  => GORGONE_ACTION_FINISH_KO,
+            code => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
-            data  => { message => 'cannot launch discovery' }
+            data => { message => 'cannot launch discovery' }
         );
+    } elsif ($status == 0) {
+        $self->{service_discoveries}->{ $svc_discovery->get_uuid() } = $svc_discovery;
     }
 }
 
@@ -1127,9 +1116,9 @@ sub event {
         next if ($rv);
 
         my $raw = $frame->getFrame();
-        $self->{logger}->writeLogDebug("[autodiscovery] Event: " . $$raw) if ($self->{logger}->is_debug());
+        $self->{logger}->writeLogDebug("[autodiscovery] Event: " . $$raw) if ($connector->{logger}->is_debug());
         if ($$raw =~ /^\[(.*?)\]/) {
-            if ((my $method = $self->can('action_' . lc($1)))) {
+            if ((my $method = $connector->can('action_' . lc($1)))) {
                 next if ($frame->parse({ releaseFrame => 1, decode => 1 }));
 
                 $method->($self, token => $frame->getToken(), frame => $frame);
@@ -1139,12 +1128,11 @@ sub event {
 }
 
 sub periodic_exec {
-    my $self = shift;
-    $self->is_module_installed();
-    $self->hdisco_sync();
+    $connector->is_module_installed();
+    $connector->hdisco_sync();
 
-    if ($self->{stop} == 1) {
-        $self->{logger}->writeLogInfo("[autodiscovery] $$ has quit");
+    if ($connector->{stop} == 1) {
+        $connector->{logger}->writeLogInfo("[autodiscovery] $$ has quit");
         exit(0);
     }
 }
@@ -1166,49 +1154,48 @@ sub run {
     }
 
     $self->{db_centreon} = gorgone::class::db->new(
-        dsn      => $self->{config_db_centreon}->{dsn},
-        user     => $self->{config_db_centreon}->{username},
+        dsn => $self->{config_db_centreon}->{dsn},
+        user => $self->{config_db_centreon}->{username},
         password => $self->{config_db_centreon}->{password},
-        force    => 2,
-        logger   => $self->{logger}
+        force => 2,
+        logger => $self->{logger}
     );
     $self->{db_centstorage} = gorgone::class::db->new(
-        dsn      => $self->{config_db_centstorage}->{dsn},
-        user     => $self->{config_db_centstorage}->{username},
+        dsn => $self->{config_db_centstorage}->{dsn},
+        user => $self->{config_db_centstorage}->{username},
         password => $self->{config_db_centstorage}->{password},
-        force    => 2,
-        logger   => $self->{logger}
+        force => 2,
+        logger => $self->{logger}
     );
-
+    
     $self->{class_object_centreon} = gorgone::class::sqlquery->new(
-        logger      => $self->{logger},
+        logger => $self->{logger},
         db_centreon => $self->{db_centreon}
     );
     $self->{class_object_centstorage} = gorgone::class::sqlquery->new(
-        logger      => $self->{logger},
+        logger => $self->{logger},
         db_centreon => $self->{db_centstorage}
     );
 
     $self->{internal_socket} = gorgone::standard::library::connect_com(
-        context  => $self->{zmq_context},
+        context => $self->{zmq_context},
         zmq_type => 'ZMQ_DEALER',
-        name     => 'gorgone-autodiscovery',
-        logger   => $self->{logger},
-        type     => $self->get_core_config(name => 'internal_com_type'),
-        path     => $self->get_core_config(name => 'internal_com_path')
+        name => 'gorgone-autodiscovery',
+        logger => $self->{logger},
+        type => $self->get_core_config(name => 'internal_com_type'),
+        path => $self->get_core_config(name => 'internal_com_path')
     );
     $self->send_internal_action({
         action => 'AUTODISCOVERYREADY',
-        data   => {}
+        data => {}
     });
 
     $self->is_module_installed();
     $self->hdisco_sync();
 
-    my $watcher_timer = $self->{loop}->timer(5, 5, sub {$self->periodic_exec()});
-    my $watcher_io = $self->{loop}->io($self->{internal_socket}->get_fd(), EV::READ, sub {$self->event()});
+    my $watcher_timer = $self->{loop}->timer(5, 5, \&periodic_exec);
+    my $watcher_io = $self->{loop}->io($self->{internal_socket}->get_fd(), EV::READ, sub { $connector->event() } );
     $self->{loop}->run();
 }
 
 1;
-

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -1040,7 +1040,7 @@ sub action_servicediscoverylistener {
         %options
     );
 
-    if ($self->{service_discoveries}->{ $uuid }->is_finished()) {
+    if (defined($self->{service_discoveries}->{ $uuid }) && $self->{service_discoveries}->{ $uuid }->is_finished()) {
         delete $self->{service_discoveries}->{ $uuid };
     }
 }
@@ -1060,8 +1060,11 @@ sub action_launchservicediscovery {
         config_core => $self->{config_core},
         service_number => $self->{service_number},
         class_object_centreon => $self->{class_object_centreon},
-        class_object_centstorage => $self->{class_object_centstorage}
+        class_object_centstorage => $self->{class_object_centstorage},
+        class_autodiscovery => $self
     );
+
+    $self->{service_discoveries}->{ $svc_discovery->get_uuid() } = $svc_discovery;
     my $status = $svc_discovery->launchdiscovery(
         token => $options{token},
         frame => $options{frame}
@@ -1072,8 +1075,7 @@ sub action_launchservicediscovery {
             token => $options{token},
             data => { message => 'cannot launch discovery' }
         );
-    } elsif ($status == 0) {
-        $self->{service_discoveries}->{ $svc_discovery->get_uuid() } = $svc_discovery;
+        delete $self->{service_discoveries}->{ $svc_discovery->get_uuid() };
     }
 }
 

--- a/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -1041,6 +1041,8 @@ sub action_servicediscoverylistener {
     );
 
     if (defined($self->{service_discoveries}->{ $uuid }) && $self->{service_discoveries}->{ $uuid }->is_finished()) {
+        return 0 if ($self->{service_discoveries}->{ $uuid }->is_post_execution());
+        $self->{service_discoveries}->{ $uuid }->service_discovery_post_exec();
         delete $self->{service_discoveries}->{ $uuid };
     }
 }

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -578,6 +578,13 @@ sub service_response_parsing {
     foreach my $attributes (@{$xml->{label}}) {
         $discovery_svc->{service_name} = '';
         $discovery_svc->{attributes} = $attributes;
+
+        $self->custom_variables(
+            discovery_svc => $discovery_svc,
+            rule => $self->{discovery}->{rules}->{ $options{rule_id} },
+            logger_pre_message => $logger_pre_message
+        );
+
         gorgone::modules::centreon::autodiscovery::services::resources::change_vars(
             discovery_svc => $discovery_svc,
             rule => $self->{discovery}->{rules}->{ $options{rule_id} },
@@ -604,11 +611,7 @@ sub service_response_parsing {
                 logger_pre_message => $logger_pre_message
             )
         );
-        $self->custom_variables(
-            discovery_svc => $discovery_svc,
-            rule => $self->{discovery}->{rules}->{ $options{rule_id} },
-            logger_pre_message => $logger_pre_message
-        );
+
         my $macros = gorgone::modules::centreon::autodiscovery::services::resources::get_macros(
             discovery_svc => $discovery_svc,
             rule => $self->{discovery}->{rules}->{ $options{rule_id} }

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -412,7 +412,6 @@ sub create_service {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot create service");
     }
     my $service_id = $self->{class_object_centreon}->{db_centreon}->last_insert_id();
-    $self->{logger}->writeLogError("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> PLOP last insert id = $service_id");
     
     $query = 'INSERT INTO host_service_relation (host_host_id, service_service_id) VALUES (' . $options{host_id} . ', ' . $service_id . ')';
     ($status) = $self->{class_object_centreon}->custom_execute(request => $query);

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -1,0 +1,394 @@
+# 
+# Copyright 2019 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package gorgone::modules::centreon::autodiscovery::services::discovery;
+
+use base qw(gorgone::class::module);
+
+use strict;
+use warnings;
+use gorgone::standard::library;
+use gorgone::standard::constants qw(:all);
+use gorgone::modules::centreon::autodiscovery::services::resources;
+use ZMQ::LibZMQ4;
+use ZMQ::Constants qw(:all);
+use XML::Simple;
+
+sub new {
+    my ($class, %options) = @_;
+
+    my $connector  = {};
+    $connector->{internal_socket} = $options{internal_socket};
+    $connector->{module_id} = $options{module_id};
+    $connector->{logger} = $options{logger};
+    $connector->{config} = $options{config};
+    $connector->{config_core} = $options{config_core};
+
+    $connector->{service_pollers} = {};
+    $connector->{service_audit_user_id} = undef;
+    $connector->{service_number} = 0;
+    $connector->{service_parrallel_commands_poller} = 8;
+    $connector->{service_current_commands_poller} = {};
+    $connector->{finished} = 0;
+
+    bless $connector, $class;
+    $connector->{uuid} = $connector->generate_token(length => 4) . ':' . $options{service_number};
+    return $connector;
+}
+
+sub get_uuid {
+    my ($self, %options) = @_;
+
+    return $self->{uuid};
+}
+
+sub is_finished {
+    my ($self, %options) = @_;
+
+    return $self->{finished};
+}
+
+sub get_clapi_user {
+    my ($self, %options) = @_;
+
+    $self->{clapi_user} = $self->{config}->{clapi_user};
+    $self->{clapi_password} = $self->{config}->{clapi_password};
+
+    if (!defined($self->{clapi_password})) {
+        return (-1, 'cannot get configuration for CLAPI user');
+    }
+
+    return 0;
+}
+
+sub service_response_parsing {
+    my ($self, %options) = @_;
+
+    my $rule_alias = $self->{discovery}->{rules}->{ $options{rule_id} }->{rule_alias};
+    my $poller_name = $self->{service_pollers}->{ $options{poller_id} }->{name};
+    my $host_name = $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name};
+    my $logger_pre_message = "[autodiscovery] -servicediscovery- $self->{uuid} [" . $rule_alias . "] [" . $poller_name . "] [" . $host_name . "]";
+
+    my $xml;
+    eval {
+        $xml = XMLin($options{response}, ForceArray => 1, KeyAttr => []);
+    };
+    if ($@) {
+        if ($self->{discovery}->{manual} == 1) {
+            $self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} } = {
+                message => 'load xml issue', discovery => {}
+            };
+        }
+        $self->{logger}->writeLogError("$logger_pre_message -> load xml issue");
+        $self->{logger}->writeLogDebug("$logger_pre_message -> load xml error: $@");
+        return -1;
+    }
+
+    my $discovery_svc = { discovered_services => {} };
+    foreach my $attributes (@{$xml->{label}}) {
+        $discovery_svc->{service_name} = '';
+        $discovery_svc->{attributes} = $attributes;
+        gorgone::modules::centreon::autodiscovery::services::resources::change_vars(
+            discovery_svc => $discovery_svc,
+            rule => $self->{discovery}->{rules}->{ $options{rule_id} },
+            logger => $self->{logger},
+            logger_pre_message => $logger_pre_message
+        );
+        if ($discovery_svc->{service_name} eq '') {
+            $self->{logger}->writeLogError("$logger_pre_message -> no value for service name");
+            next;
+        }
+
+        if (defined($discovery_svc->{discovered_services}->{  $discovery_svc->{service_name} })) {
+            $self->{logger}->writeLogError("$logger_pre_message -> service '" .  $discovery_svc->{service_name} . "' already created");
+            next;
+        }
+
+        $discovery_svc->{discovered_services}->{  $discovery_svc->{service_name} } = 1;
+
+        next if (
+            gorgone::modules::centreon::autodiscovery::services::resources::check_exinc(
+                discovery_svc => $discovery_svc,
+                rule => $self->{discovery}->{rules}->{ $options{rule_id} },
+                logger => $self->{logger},
+                logger_pre_message => $logger_pre_message
+            )
+        );
+        gorgone::modules::centreon::autodiscovery::services::resources::custom_variables(
+            discovery_svc => $discovery_svc,
+            rule => $self->{discovery}->{rules}->{ $options{rule_id} },
+            logger => $self->{logger},
+            logger_pre_message => $logger_pre_message
+        );
+        my $macros = gorgone::modules::centreon::autodiscovery::services::resources::get_macros(
+            discovery_svc => $discovery_svc,
+            rule => $self->{rules}->{ $options{rule_id} }
+        );
+        
+        my ($status, $service) = gorgone::modules::centreon::autodiscovery::services::resources::get_service(
+            class_object_centreon => $self->{class_object_centreon},
+            host_id => $options{host_id},
+            service_name => $discovery_svc->{service_name},
+            logger => $self->{logger},
+            logger_pre_message => $logger_pre_message
+        );
+        next if ($status == -1);
+
+        $self->{logger}->writeLogDebug("$logger_pre_message -> service '" .  $discovery_svc->{service_name} . "' ici");
+        #$self->crud_service(service => $service, host => $options{host}, macros => $macros);
+    }
+
+    #$self->disable_services(host => $options{host});
+}
+
+sub discoverylistener {
+    my ($self, %options) = @_;
+
+    # if i have GORGONE_MODULE_ACTION_COMMAND_RESULT, i can't have GORGONE_ACTION_FINISH_KO
+    if ($options{data}->{code} == GORGONE_MODULE_ACTION_COMMAND_RESULT) {
+        my $exit_code = $options{data}->{data}->{result}->{exit_code};
+        if ($exit_code == 0) {
+            $self->service_response_parsing(
+                rule_id => $options{rule_id},
+                host_id => $options{host_id},
+                poller_id => $self->{discovery}->{hosts}->{ $options{host_id} }->{poller_id},
+                response => $options{data}->{data}->{result}->{stdout}
+            );
+        } elsif ($self->{discovery}->{manual} == 1) {
+            $self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} } = { message => $options{data}->{data}->{message}, data => $options{data}->{data}, discovery => {} };
+        }
+    } elsif ($options{data}->{code} == GORGONE_ACTION_FINISH_KO) {
+        if ($self->{discovery}->{manual} == 1) {
+            $self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} } = { message => $options{data}->{data}->{message}, data => $options{data}->{data}, discovery => {} };
+        }
+    } else {
+        return 0;
+    }
+
+    $self->{service_current_commands_poller}->{ $self->{discovery}->{hosts}->{ $options{host_id} }->{poller_id} }--;
+    $self->service_execute_commands();
+
+    print "==============================================\n";
+    print "=== uuid = $self->{uuid} \n";
+    print Data::Dumper::Dumper($self->{service_current_commands_poller});
+    print Data::Dumper::Dumper($options{data});
+    print "============= $self->{discovery}->{done_discoveries} =======================\n";
+    print "==============================================\n";
+
+    $self->{discovery}->{done_discoveries}++;
+    if ($self->{discovery}->{done_discoveries} == $self->{discovery}->{count_discoveries}) {
+        $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} discovery finished");
+        $self->{finished} = 1;
+    }
+
+    return 0;
+}
+
+sub service_execute_commands {
+    my ($self, %options) = @_;
+
+    foreach my $rule_id (keys %{$self->{discovery}->{rules}}) {
+        foreach my $poller_id (keys %{$self->{discovery}->{rules}->{$rule_id}->{hosts}}) {
+            next if (scalar(@{$self->{discovery}->{rules}->{$rule_id}->{hosts}->{$poller_id}}) <= 0);
+            $self->{service_current_commands_poller}->{$poller_id} = 0 if (!defined($self->{service_current_commands_poller}->{$poller_id}));
+                
+            while (1) {
+                last if ($self->{service_current_commands_poller}->{$poller_id} >= $self->{service_parrallel_commands_poller});
+                my $host_id = shift @{$self->{discovery}->{rules}->{$rule_id}->{hosts}->{$poller_id}};
+                last if (!defined($host_id));
+
+                my $host = $self->{discovery}->{hosts}->{$host_id};
+                $self->{service_current_commands_poller}->{$poller_id}++;
+
+                my $command = gorgone::modules::centreon::autodiscovery::services::resources::substitute_service_discovery_command(
+                    command_line => $self->{discovery}->{rules}->{$rule_id}->{command_line},
+                    host => $host,
+                    poller => $self->{service_pollers}->{$poller_id}
+                );
+
+                $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} [" .
+                    $self->{discovery}->{rules}->{$rule_id}->{rule_alias} . "] [" . 
+                    $self->{service_pollers}->{$poller_id}->{name} . "] [" .
+                    $host->{host_name} . "] -> substitute string: " . $command
+                );
+
+                $self->send_internal_action(
+                    action => 'ADDLISTENER',
+                    data => [
+                        {
+                            identity => 'gorgoneautodiscovery',
+                            event => 'SERVICEDISCOVERYLISTENER',
+                            target => $poller_id,
+                            token => 'svc-disco-' . $self->{uuid} . '-' . $rule_id . '-' . $host_id,
+                            timeout => 120,
+                            log_pace => 15
+                        }
+                    ]
+                );
+
+                $self->send_internal_action(
+                    action => 'COMMAND',
+                    target => $poller_id,
+                    token => 'svc-disco-' . $self->{uuid} . '-' . $rule_id . '-' . $host_id,
+                    data => {
+                        content => [
+                            {
+                                instant => 1,
+                                command => $command,
+                                timeout => 90
+                            }
+                        ]
+                    }
+                );
+            }
+        }
+    }
+}
+
+sub launchdiscovery {
+    my ($self, %options) = @_;
+
+    $options{token} = $self->generate_token() if (!defined($options{token}));
+    $self->{service_number} = $options{service_number};
+    $self->{class_object_centreon} = $options{class_object_centreon};
+
+    $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} discovery start");
+    $self->send_log(
+        code => GORGONE_ACTION_BEGIN,
+        token => $options{token},
+        data => { message => 'servicediscovery start' }
+    );
+
+    ################
+    # get pollers
+    ################
+    $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} load pollers configuration");
+    my ($status, $message, $pollers) = gorgone::modules::centreon::autodiscovery::services::resources::get_pollers(
+        class_object_centreon => $self->{class_object_centreon}
+    );
+    if ($status < 0) {
+        $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{service_number}, message => $message);
+        return -1;
+    }
+    $self->{service_pollers} = $pollers;
+
+    ################
+    # get audit user
+    ################
+    $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} load audit configuration");
+    ($status, $message) = $self->get_clapi_user();
+    if ($status < 0) {
+        $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{service_number}, message => $message);
+        return -1;
+    }
+    ($status, $message, my $user_id) = gorgone::modules::centreon::autodiscovery::services::resources::get_pollers(
+        class_object_centreon => $self->{class_object_centreon}
+    );
+    if ($status < 0) {
+        $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{service_number}, message => $message);
+        return -1;
+    }
+    $self->{service_audit_user_id} = $user_id;
+
+    ################
+    # get rules
+    ################
+    $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} load rules configuration");
+    
+    ($status, $message, my $rules) = gorgone::modules::centreon::autodiscovery::services::resources::get_rules(
+        class_object_centreon => $self->{class_object_centreon},
+        filter_rules => $options{data}->{content}->{filter_rules},
+        force_rule => $options{data}->{content}->{force_rule}
+    );
+    if ($status < 0) {
+        $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{service_number}, message => $message);
+        return -1;
+    }
+
+    #################
+    # get hosts
+    #################
+    gorgone::modules::centreon::autodiscovery::services::resources::reset_macro_hosts();
+    my $all_hosts = {};
+    my $total = 0;
+    foreach my $rule_id (keys %$rules) {
+        ($status, $message, my $hosts, my $count) = gorgone::modules::centreon::autodiscovery::services::resources::get_hosts(
+            host_template => $rules->{$rule_id}->{host_template},
+            poller_id => $rules->{$rule_id}->{poller_id},
+            class_object_centreon => $self->{class_object_centreon},
+            with_macro => 1,
+            host_lookup => $options{data}->{content}->{filter_hosts},
+            poller_lookup => $options{data}->{content}->{filter_pollers}
+        );
+        if ($status < 0) {
+            $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{service_number}, message => $message);
+            return -1;
+        }
+        
+        if (!defined($hosts) || scalar(keys %$hosts) == 0) {
+            $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} no hosts found for rule '" . $options{rule}->{rule_alias} . "'");
+            next;
+        }
+
+        $total += $count;
+        $rules->{$rule_id}->{manual} = {};
+        $rules->{$rule_id}->{hosts} = $hosts->{pollers};
+        $all_hosts = { %$all_hosts, %{$hosts->{infos}} };
+
+        foreach (('rule_scan_display_custom', 'rule_variable_custom')) {
+            if (defined($rules->{$rule_id}->{$_}) && $rules->{$rule_id}->{$_} ne '') {
+                $rules->{$rule_id}->{$_} =~ s/\$([a-zA-Z_\-\.]*?)\$/\$discovery_svc->{attributes}->{$1}/msg;
+                $rules->{$rule_id}->{$_} =~ s/\@SERVICENAME\@/\$discovery_svc->{service_name}/msg;
+            }
+        }
+    }
+
+    if ($total == 0) {
+        $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => 'no hosts found');
+        return -1;
+    }
+
+    $self->{discovery} = {
+        token => $options{token},
+        count_discoveries => $total,
+        done_discoveries => 0,
+        progress => 0,
+        progress_div => 0,
+        rules => $rules,
+        manual => defined($options{data}->{content}->{manual}) ? 1 : 0,
+        options => defined($options{data}->{content}) ? $options{data}->{content} : {},
+        hosts => $all_hosts,
+        journal => []
+    };
+
+    use Data::Dumper; print Data::Dumper::Dumper($self->{discovery});
+
+    $self->service_execute_commands();
+    
+    use Data::Dumper;
+    print Data::Dumper::Dumper($self->{service_current_commands_poller});
+
+    # need to manage dry-run and manual
+    # add a progress bar of commands in log (we do for each 5%)
+
+    return 0;
+}
+
+1;

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -61,11 +61,9 @@ sub new {
 
 sub database_init_transaction {
     my ($self, %options) = @_;
-    
-    eval {
-        $self->{class_object_centreon}->{db_centreon}->transaction_mode(1);
-    };
-    if ($@) {
+
+    my $status = $self->{class_object_centreon}->{db_centreon}->transaction_mode(1);
+    if ($status == -1) {
         $self->{logger}->writeLogError("$@");
         return -1;
     }
@@ -75,14 +73,13 @@ sub database_init_transaction {
 sub database_commit_transaction {
     my ($self, %options) = @_;
     
-    eval {
-        $self->{class_object_centreon}->commit();
-        $self->{class_object_centreon}->transaction_mode(0);
-    };
-    if ($@) {
+    my $status = $self->{class_object_centreon}->commit();
+    if ($status == -1) {
         $self->{logger}->writeLogError("$@");
         return -1;
     }
+
+    $self->{class_object_centreon}->transaction_mode(0);
     return 0;
 }
 

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -181,7 +181,7 @@ sub restart_pollers {
 
     my $poller_ids = {};
     foreach my $poller_id (keys %{$self->{discovery}->{pollers_reload}}) {
-        $self->{logger}->writeLogError("[autodiscovery] -servicediscovery- $self->{uuid} generate poller config '" . $poller_id . "'");
+        $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} generate poller config '" . $poller_id . "'");
         $self->send_internal_action(
             action => 'COMMAND',
             token => $self->{discovery}->{token} . ':config',

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -739,9 +739,9 @@ sub service_execute_commands {
                     target => $poller_id,
                     token => 'svc-disco-' . $self->{uuid} . '-' . $rule_id . '-' . $host_id,
                     data => {
+                        instant => 1,
                         content => [
                             {
-                                instant => 1,
                                 command => $command,
                                 timeout => 90
                             }

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -824,7 +824,7 @@ sub launchdiscovery {
     ($status, $message, my $rules) = gorgone::modules::centreon::autodiscovery::services::resources::get_rules(
         class_object_centreon => $self->{class_object_centreon},
         filter_rules => $options{data}->{content}->{filter_rules},
-        force_rule => $options{data}->{content}->{force_rule}
+        force_rule => (defined($options{data}->{content}->{force_rule}) && $options{data}->{content}->{force_rule} =~ /^1$/) ? 1 : 0
     );
     if ($status < 0) {
         $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => $message);

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -186,10 +186,10 @@ sub update_service {
     my @update_macros = ();
     my @insert_macros = ();
     
-    if ($self->{discovery}->{manual} == 1) {
-        $self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} } = { discovery => {} }
-            if (!defined($self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} }));
-        $self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = { 
+    if ($self->{discovery}->{is_manual} == 1) {
+        $self->{discovery}->{manual}->{ $options{host_id} } = { discovery => {} }
+            if (!defined($self->{discovery}->{manual}->{ $options{host_id} }));
+        $self->{discovery}->{manual}->{ $options{host_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = { 
             type => 0,
             macros => {},
             description => $self->get_description(%options)
@@ -207,8 +207,8 @@ sub update_service {
             msg => 'template'
         }; 
         $self->{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service update template");
-        if ($self->{discovery}->{manual} == 1) {
-            $self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{service_template_model_stm_id} = $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id};
+        if ($self->{discovery}->{is_manual} == 1) {
+            $self->{discovery}->{manual}->{ $options{host_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{service_template_model_stm_id} = $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id};
         }
     }
     if ($options{service}->{activate} == '0') {
@@ -227,16 +227,16 @@ sub update_service {
                 name => $macro_name,
                 value => $options{macros}->{$macro_name}
             };
-            if ($self->{discovery}->{manual} == 1) {
-                $self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{macros}->{$macro_name} = { value => $options{macros}->{$macro_name}, type => 1 };
+            if ($self->{discovery}->{is_manual} == 1) {
+                $self->{discovery}->{manual}->{ $options{host_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{macros}->{$macro_name} = { value => $options{macros}->{$macro_name}, type => 1 };
             }
         } elsif ($options{service}->{macros}->{'$_SERVICE' . $macro_name . '$'} ne $options{macros}->{$macro_name})  {
             push @update_macros, {
                 name => $macro_name,
                 value => $options{macros}->{$macro_name}
             };
-            if ($self->{discovery}->{manual} == 1) {
-                $self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{macros}->{$macro_name} = { value => $options{macros}->{$macro_name}, type => 0 };
+            if ($self->{discovery}->{is_manual} == 1) {
+                $self->{discovery}->{manual}->{ $options{host_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{macros}->{$macro_name} = { value => $options{macros}->{$macro_name}, type => 0 };
             }
         }
     }
@@ -319,17 +319,17 @@ sub update_service {
 sub create_service {
     my ($self, %options) = @_;
     
-    if ($self->{discovery}->{manual} == 1) {
-        $self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} } = { discovery => {} }
-            if (!defined($self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} }));
-        $self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = { 
+    if ($self->{discovery}->{is_manual} == 1) {
+        $self->{discovery}->{manual}->{ $options{host_id} } = { discovery => {} }
+            if (!defined($self->{discovery}->{manual}->{ $options{host_id} }));
+        $self->{discovery}->{manual}->{ $options{host_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = { 
             type => 1, 
             service_template_model_stm_id => $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id},
             macros => {},
             description => $self->get_description(%options)
         };
         foreach (keys %{$options{macros}}) {
-            $self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{macros}->{$_} = {
+            $self->{discovery}->{manual}->{ $options{host_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{macros}->{$_} = {
                 value => $options{macros}->{$_},
                 type => 1
             };
@@ -463,10 +463,9 @@ sub service_response_parsing {
         $xml = XMLin($options{response}, ForceArray => 1, KeyAttr => []);
     };
     if ($@) {
-        if ($self->{discovery}->{manual} == 1) {
-            $self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} } = {
-                message => 'load xml issue', discovery => {}
-            };
+        if ($self->{discovery}->{is_manual} == 1) {
+            $self->{discovery}->{manual}->{ $options{host_id} } = { discovery => {} } if (!defined($self->{discovery}->{manual}->{ $options{host_id} }));
+            $self->{discovery}->{manual}->{ $options{host_id} }->{message} = 'load xml issue';
         }
         $self->{logger}->writeLogError("$logger_pre_message -> load xml issue");
         $self->{logger}->writeLogDebug("$logger_pre_message -> load xml error: $@");
@@ -558,13 +557,16 @@ sub discoverylistener {
             );
         } else {
             $self->{discovery}->{failed_discoveries}++;
-            if ($self->{discovery}->{manual} == 1) {
-                $self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} } = { message => $options{data}->{data}->{message}, data => $options{data}->{data}, discovery => {} };
+            if ($self->{discovery}->{is_manual} == 1) {
+                $self->{discovery}->{manual}->{ $options{host_id} } = { discovery => {} } if (!defined($self->{discovery}->{manual}->{ $options{host_id} }));
+                $self->{discovery}->{manual}->{ $options{host_id} }->{message} = $options{data}->{data}->{message};
+                $self->{discovery}->{manual}->{ $options{host_id} }->{data} = $options{data}->{data};
             }
         }
     } elsif ($options{data}->{code} == GORGONE_ACTION_FINISH_KO) {
-        if ($self->{discovery}->{manual} == 1) {
-            $self->{discovery}->{rules}->{ $options{rule_id} }->{manual}->{ $options{host_id} } = { message => $options{data}->{data}->{message}, data => $options{data}->{data}, discovery => {} };
+        if ($self->{discovery}->{is_manual} == 1) {
+            $self->{discovery}->{manual}->{ $options{host_id} } = { discovery => {} } if (!defined($self->{discovery}->{manual}->{ $options{host_id} }));
+            $self->{discovery}->{manual}->{ $options{host_id} }->{message} = $options{data}->{data}->{message};
         }
         $self->{discovery}->{failed_discoveries}++;
     } else {
@@ -575,12 +577,23 @@ sub discoverylistener {
     $self->service_execute_commands();
 
     $self->{discovery}->{done_discoveries}++;
-    
 
     $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} current count $self->{discovery}->{done_discoveries}/$self->{discovery}->{count_discoveries}");
     if ($self->{discovery}->{done_discoveries} == $self->{discovery}->{count_discoveries}) {
         $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} discovery finished");
         $self->{finished} = 1;
+
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_OK,
+            token => $options{token},
+            data => {
+                message => 'discovery finished',
+                failed_discoveries => $self->{discovery}->{failed_discoveries},
+                count_discoveries => $self->{discovery}->{count_discoveries},
+                journal => $self->{discovery}->{journal},
+                manual => $self->{discovery}->{manual}
+            }
+        );
 
         use Data::Dumper; print Data::Dumper::Dumper($self->{discovery});
     }
@@ -733,7 +746,6 @@ sub launchdiscovery {
         }
 
         $total += $count;
-        $rules->{$rule_id}->{manual} = {};
         $rules->{$rule_id}->{hosts} = $hosts->{pollers};
         $all_hosts = { %$all_hosts, %{$hosts->{infos}} };
 
@@ -758,7 +770,8 @@ sub launchdiscovery {
         progress => 0,
         progress_div => 0,
         rules => $rules,
-        manual => (defined($options{data}->{content}->{audit_enable}) && $options{data}->{content}->{manual} =~ /^1$/) ? 1 : 0,
+        manual => {},
+        is_manual => (defined($options{data}->{content}->{audit_enable}) && $options{data}->{content}->{manual} =~ /^1$/) ? 1 : 0,
         dry_run => (defined($options{data}->{content}->{audit_enable}) && $options{data}->{content}->{dry_run} =~ /^1$/) ? 1 : 0,
         audit_enable => (defined($options{data}->{content}->{audit_enable}) && $options{data}->{content}->{audit_enable} =~ /^1$/) ? 1 : 0,
         options => defined($options{data}->{content}) ? $options{data}->{content} : {},

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -490,7 +490,8 @@ sub disable_services {
     return if ($self->{discovery}->{rules}->{ $options{rule_id} }->{rule_disable} != 1 || !defined($self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }));
     foreach my $service (keys %{$self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }}) {
         my $service_description = $self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }->{$service}->{service_description};
-        if (!defined($options{discovered_services}->{discovered_services}->{$service_description}) && 
+
+        if (!defined($options{discovery_svc}->{discovered_services}->{$service_description}) && 
             $self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }->{$service}->{service_activate} == 1) {
             $self->{logger}->writeLogInfo("$options{logger_pre_message} -> disable service '" . $service_description . "'");
             next if ($self->{discovery}->{dry_run} == 1);

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -151,7 +151,7 @@ sub send_email {
             }
 
             if (scalar(@$body) > 0) {
-                $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} send email to '" . $contact_id .  "' (" . $self->{discovery}->{rules}->{$rule_id}->{contact}->{$contact_id}->{contact_email} . ")");
+                $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} send email to '" . $contact_id .  "' (" . $self->{discovery}->{rules}->{$rule_id}->{contact}->{$contact_id}->{contact_email} . ")");
 
                 my $smtp = Net::SMTP->new('localhost', Timeout => 15);
                 if (!defined($smtp)) {
@@ -302,7 +302,8 @@ sub update_service {
             msg => 'template',
             rule_id => $options{rule_id}
         }; 
-        $self->{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service update template");
+
+        $self->{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service update template");
         if ($self->{discovery}->{is_manual} == 1) {
             $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{service_template_model_stm_id} = $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id};
         }
@@ -315,7 +316,7 @@ sub update_service {
             type => 'enable',
             rule_id => $options{rule_id}
         };
-        $self->{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service enable");
+        $self->{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service enable");
     }
 
     foreach my $macro_name (keys %{$options{macros}}) {
@@ -346,7 +347,7 @@ sub update_service {
             msg => 'macros',
             rule_id => $options{rule_id}
         };
-        $self->{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service update/insert macros");
+        $self->{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service update/insert macros");
     }
 
     return $options{service}->{id} if ($self->{discovery}->{dry_run} == 1 || scalar(@journal) == 0);
@@ -507,7 +508,7 @@ sub crud_service {
     my $service_id;
     if (!defined($options{service})) {
         $service_id = $self->create_service(%options);
-        $self->{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service created");
+        $self->{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service created");
         if ($service_id != -1) {
             push @{$self->{discovery}->{journal}}, {
                 host_name => $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name},
@@ -532,13 +533,13 @@ sub disable_services {
 
         if (!defined($options{discovery_svc}->{discovered_services}->{$service_description}) && 
             $self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }->{$service}->{service_activate} == 1) {
-            $self->{logger}->writeLogInfo("$options{logger_pre_message} -> disable service '" . $service_description . "'");
+            $self->{logger}->writeLogDebug("$options{logger_pre_message} -> disable service '" . $service_description . "'");
             next if ($self->{discovery}->{dry_run} == 1);
 
             my $query = "UPDATE service SET service_activate = '0' WHERE service_id = " . $service;
             my ($status) = $self->{class_object_centreon}->custom_execute(request => $query);
             if ($status == -1) {
-                $self->{logger}->writeLogInfo("$options{logger_pre_message} -> cannot disable service '" . $service_description . "'");
+                $self->{logger}->writeLogError("$options{logger_pre_message} -> cannot disable service '" . $service_description . "'");
                 next;
             }
             
@@ -715,7 +716,7 @@ sub discoverylistener {
 
     $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} current count $self->{discovery}->{done_discoveries}/$self->{discovery}->{count_discoveries}");
     if ($self->{discovery}->{done_discoveries} == $self->{discovery}->{count_discoveries}) {
-        $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} discovery finished");
+        $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} discovery finished");
         $self->{finished} = 1;
 
         $self->send_log(
@@ -770,7 +771,7 @@ sub service_execute_commands {
                     vault_count => $options{vault_count}
                 );
 
-                $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} [" .
+                $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} [" .
                     $self->{discovery}->{rules}->{$rule_id}->{rule_alias} . "] [" . 
                     $self->{service_pollers}->{$poller_id}->{name} . "] [" .
                     $host->{host_name} . "] -> substitute string: " . $command
@@ -826,7 +827,7 @@ sub launchdiscovery {
     ################
     # get pollers
     ################
-    $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} load pollers configuration");
+    $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} load pollers configuration");
     my ($status, $message, $pollers) = gorgone::modules::centreon::autodiscovery::services::resources::get_pollers(
         class_object_centreon => $self->{class_object_centreon}
     );
@@ -839,7 +840,7 @@ sub launchdiscovery {
     ################
     # get audit user
     ################
-    $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} load audit configuration");
+    $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} load audit configuration");
 
     ($status, $message, my $audit_enable) = gorgone::modules::centreon::autodiscovery::services::resources::get_audit(
         class_object_centstorage => $self->{class_object_centstorage}
@@ -877,7 +878,8 @@ sub launchdiscovery {
     ################
     # get rules
     ################
-    $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} load rules configuration");
+
+    $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} load rules configuration");
     
     ($status, $message, my $rules) = gorgone::modules::centreon::autodiscovery::services::resources::get_rules(
         class_object_centreon => $self->{class_object_centreon},

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -41,7 +41,7 @@ sub new {
     $connector->{class_object_centreon} = $options{class_object_centreon};
     $connector->{class_object_centstorage} = $options{class_object_centstorage};
     $connector->{class_autodiscovery} = $options{class_autodiscovery};
-    $connector->{tpapi_clapi} = $options{tpapi_clapi};
+    $connector->{tpapi_centreonv2} = $options{tpapi_centreonv2};
     $connector->{mail_subject} = defined($connector->{config}->{mail_subject}) ? $connector->{config}->{mail_subject} : 'Centreon Auto Discovery';
     $connector->{mail_from} = defined($connector->{config}->{mail_from}) ? $connector->{config}->{mail_from} : 'centreon-autodisco';
 
@@ -188,17 +188,11 @@ sub restart_pollers {
     my $poller_ids = {};
     foreach my $poller_id (keys %{$self->{discovery}->{pollers_reload}}) {
         $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} generate poller config '" . $poller_id . "'");
-        $self->send_internal_action({
-            action => 'COMMAND',
-            token => $self->{discovery}->{token} . ':config',
-            data => {
-                content => [
-                    {
-                        command => $self->{tpapi_clapi}->get_applycfg_command(poller_id => $poller_id)
-                    }
-                ]
-            }
-        });
+
+        my ($status, $results) = $self->{tpapi_centreonv2}->monitoring_server_generate_reload(monitoring_server_id => $poller_id);
+        if ($status != 0) {
+            $self->{logger}->writeLogError("[autodiscovery] -servicediscovery- $self->{uuid} cannot generate poller config - " . $self->{tpapi_centreonv2}->error());
+        }
     }
 }
 
@@ -850,13 +844,18 @@ sub launchdiscovery {
         return -1;
     }
 
-    if (!defined($self->{tpapi_clapi}->get_username())) {
-        $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => 'clapi ' . $self->{tpapi_clapi}->error());
+    if (!defined($self->{tpapi_centreonv2}->get_username())) {
+        $self->send_log_msg_error(
+            token => $options{token},
+            subname => 'servicediscovery',
+            number => $self->{uuid},
+            message => 'cannot get api user: ' . $self->{tpapi_centreonv2}->error()
+        );
         return -1;
     }
     ($status, $message, my $user_id) = gorgone::modules::centreon::autodiscovery::services::resources::get_audit_user_id(
         class_object_centreon => $self->{class_object_centreon},
-        clapi_user => $self->{tpapi_clapi}->get_username()
+        user => $self->{tpapi_centreonv2}->get_username()
     );
     if ($status < 0) {
         $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => $message);

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -44,10 +44,15 @@ sub new {
     $connector->{tpapi_centreonv2} = $options{tpapi_centreonv2};
     $connector->{mail_subject} = defined($connector->{config}->{mail_subject}) ? $connector->{config}->{mail_subject} : 'Centreon Auto Discovery';
     $connector->{mail_from} = defined($connector->{config}->{mail_from}) ? $connector->{config}->{mail_from} : 'centreon-autodisco';
+    $connector->{service_parrallel_commands_poller} = (defined($options{config}->{service_parrallel_commands_poller}) &&
+        $options{config}->{service_parrallel_commands_poller} =~ /(\d+)/) ? $1 : 8;
+    $connector->{service_check_interval} = (defined($options{config}->{service_check_interval}) &&
+        $options{config}->{service_check_interval} =~ /(\d+)/) ? $1 : 15;
+    $connector->{service_timeout} = (defined($options{config}->{service_timeout}) &&
+        $options{config}->{service_timeout} =~ /(\d+)/) ? $1 : 90;
 
     $connector->{service_pollers} = {};
     $connector->{audit_user_id} = undef;
-    $connector->{service_parrallel_commands_poller} = 8;
     $connector->{service_current_commands_poller} = {};
     $connector->{finished} = 0;
     $connector->{post_execution} = 0;
@@ -779,8 +784,8 @@ sub service_execute_commands {
                             event => 'SERVICEDISCOVERYLISTENER',
                             target => $poller_id,
                             token => 'svc-disco-' . $self->{uuid} . '-' . $rule_id . '-' . $host_id,
-                            timeout => 120,
-                            log_pace => 15
+                            timeout => $self->{service_timeout} + $self->{service_check_interval} + 15,
+                            log_pace => $self->{service_check_interval}
                         }
                     ]
                 });
@@ -794,7 +799,7 @@ sub service_execute_commands {
                         content => [
                             {
                                 command => $command,
-                                timeout => 90
+                                timeout => $self->{service_timeout}
                             }
                         ]
                     }

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -20,7 +20,7 @@
 
 package gorgone::modules::centreon::autodiscovery::services::discovery;
 
-use base qw(gorgone::modules::centreon::autodiscovery::class);
+use base qw(gorgone::class::module);
 
 use strict;
 use warnings;
@@ -67,11 +67,6 @@ sub new {
     return $connector;
 }
 
-sub getDiscoveryListener {
-    my ($self,$uuid) = @_;
-    return $self->can("discoverylistener"), $self;
-}
-
 sub database_init_transaction {
     my ($self, %options) = @_;
 
@@ -85,7 +80,7 @@ sub database_init_transaction {
 
 sub database_commit_transaction {
     my ($self, %options) = @_;
-
+    
     my $status = $self->{class_object_centreon}->commit();
     if ($status == -1) {
         $self->{logger}->writeLogError("$@");
@@ -117,7 +112,7 @@ sub get_uuid {
 }
 
 sub is_finished {
-    my $self = shift;
+    my ($self, %options) = @_;
 
     return $self->{finished};
 }
@@ -201,7 +196,7 @@ sub restart_pollers {
 
 sub audit_update {
     my ($self, %options) = @_;
-
+    
     return if ($self->{discovery}->{audit_enable} != 1);
 
     my $query = 'INSERT INTO log_action (action_log_date, object_type, object_id, object_name, action_type, log_contact_id) VALUES (?, ?, ?, ?, ?, ?)';
@@ -243,7 +238,7 @@ sub custom_variables {
 
 sub get_description {
     my ($self, %options) = @_;
-
+    
     my $desc = $options{discovery_svc}->{service_name};
     if (defined($self->{discovery}->{rules}->{ $options{rule_id} }->{rule_scan_display_custom}) && $self->{discovery}->{rules}->{ $options{rule_id} }->{rule_scan_display_custom} ne '') {
         local $SIG{__DIE__} = 'IGNORE';
@@ -263,13 +258,13 @@ sub get_description {
 
 sub link_service_autodisco {
     my ($self, %options) = @_;
-
+    
     my $query = 'INSERT IGNORE INTO mod_auto_disco_rule_service_relation (rule_rule_id, service_service_id) VALUES (' . $options{rule_id} . ', ' . $options{service_id} . ')';
     my ($status, $sth) = $self->{class_object_centreon}->custom_execute(request => $query);
     if ($status == -1) {
         return -1;
     }
-
+    
     return 0;
 }
 
@@ -279,9 +274,9 @@ sub update_service {
     my @journal = ();
     my @update_macros = ();
     my @insert_macros = ();
-
+    
     if ($self->{discovery}->{is_manual} == 1) {
-        $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = {
+        $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = { 
             type => 0,
             macros => {},
             description => $self->get_description(%options)
@@ -298,7 +293,7 @@ sub update_service {
             type => 'update',
             msg => 'template',
             rule_id => $options{rule_id}
-        };
+        }; 
         $self->{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service update template");
         if ($self->{discovery}->{is_manual} == 1) {
             $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{service_template_model_stm_id} = $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id};
@@ -363,7 +358,7 @@ sub update_service {
             return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot update service");
         }
     }
-
+    
     foreach (@update_macros) {
         my $query = 'UPDATE on_demand_macro_service SET svc_macro_value = ? WHERE svc_svc_id = ' . $options{service}->{id} .  ' AND svc_macro_name = ?';
         my ($status) = $self->{class_object_centreon}->custom_execute(
@@ -384,7 +379,7 @@ sub update_service {
             return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot insert macro");
         }
     }
-
+    
     if ($self->link_service_autodisco(%options, service_id => $options{service}->{id}) == -1) {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot link service to autodisco");
     }
@@ -396,19 +391,19 @@ sub update_service {
 
     if (defined($query_update{service_activate})) {
         $self->audit_update(
-            object_type => 'service',
-            action_type => 'enable',
-            object_id => $options{service}->{id},
-            object_name => $options{discovery_svc}->{service_name},
+            object_type => 'service', 
+            action_type => 'enable', 
+            object_id => $options{service}->{id}, 
+            object_name => $options{discovery_svc}->{service_name}, 
             contact_id => $self->{audit_user_id}
         );
     }
     if (defined($query_update{service_template_model_stm_id})) {
         $self->audit_update(
-            object_type => 'service',
-            action_type => 'c',
-            object_id => $options{service}->{id},
-            object_name => $options{discovery_svc}->{service_name},
+            object_type => 'service', 
+            action_type => 'c', 
+            object_id => $options{service}->{id}, 
+            object_name => $options{discovery_svc}->{service_name}, 
             contact_id => $self->{audit_user_id},
             fields => { service_template_model_stm_id => $query_update{service_template_model_stm_id} }
         );
@@ -419,10 +414,10 @@ sub update_service {
 
 sub create_service {
     my ($self, %options) = @_;
-
+    
     if ($self->{discovery}->{is_manual} == 1) {
-        $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = {
-            type => 1,
+        $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = { 
+            type => 1, 
             service_template_model_stm_id => $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id},
             macros => {},
             description => $self->get_description(%options)
@@ -449,19 +444,19 @@ sub create_service {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot create service");
     }
     my $service_id = $self->{class_object_centreon}->{db_centreon}->last_insert_id();
-
+    
     $query = 'INSERT INTO host_service_relation (host_host_id, service_service_id) VALUES (' . $options{host_id} . ', ' . $service_id . ')';
     ($status) = $self->{class_object_centreon}->custom_execute(request => $query);
     if ($status == -1) {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot link service to host");
     }
-
+    
     $query = 'INSERT INTO extended_service_information (service_service_id) VALUES (' . $service_id . ')';
     ($status) = $self->{class_object_centreon}->custom_execute(request => $query);
     if ($status == -1) {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot service extended information");
     }
-
+    
     foreach (keys %{$options{macros}}) {
         $query = 'INSERT INTO on_demand_macro_service (svc_svc_id, svc_macro_name, svc_macro_value) VALUES (' . $service_id . ', ?, ?)';
         ($status) = $self->{class_object_centreon}->custom_execute(
@@ -476,21 +471,21 @@ sub create_service {
     if ($self->link_service_autodisco(%options, service_id => $service_id) == -1) {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot link service to autodisco");
     }
-
+    
     return -1 if ($self->database_commit_transaction() == -1);
 
     $self->{discovery}->{pollers_reload}->{ $options{poller_id} } = 1;
 
     $self->audit_update(
-        object_type => 'service',
-        action_type => 'a',
-        object_id => $service_id,
+        object_type => 'service', 
+        action_type => 'a', 
+        object_id => $service_id, 
         object_name => $options{discovery_svc}->{service_name},
         contact_id => $self->{audit_user_id},
         fields => {
-            service_template_model_id => $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id},
-            service_description => $options{discovery_svc}->{service_name},
-            service_register => '1',
+            service_template_model_id => $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id}, 
+            service_description => $options{discovery_svc}->{service_name}, 
+            service_register => '1', 
             service_hPars => $options{host_id}
         }
     );
@@ -500,7 +495,7 @@ sub create_service {
 
 sub crud_service {
     my ($self, %options) = @_;
-
+    
     my $service_id;
     if (!defined($options{service})) {
         $service_id = $self->create_service(%options);
@@ -516,18 +511,18 @@ sub crud_service {
     } else {
         $service_id = $self->update_service(%options);
     }
-
+    
     return 0;
 }
 
 sub disable_services {
     my ($self, %options) = @_;
-
+    
     return if ($self->{discovery}->{rules}->{ $options{rule_id} }->{rule_disable} != 1 || !defined($self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }));
     foreach my $service (keys %{$self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }}) {
         my $service_description = $self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }->{$service}->{service_description};
 
-        if (!defined($options{discovery_svc}->{discovered_services}->{$service_description}) &&
+        if (!defined($options{discovery_svc}->{discovered_services}->{$service_description}) && 
             $self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }->{$service}->{service_activate} == 1) {
             $self->{logger}->writeLogInfo("$options{logger_pre_message} -> disable service '" . $service_description . "'");
             next if ($self->{discovery}->{dry_run} == 1);
@@ -538,18 +533,18 @@ sub disable_services {
                 $self->{logger}->writeLogInfo("$options{logger_pre_message} -> cannot disable service '" . $service_description . "'");
                 next;
             }
-
+            
             push @{$self->{discovery}->{journal}}, {
                 host_name => $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name},
                 service_name => $service_description,
                 type => 'disable',
                 rule_id => $options{rule_id}
-            };
+            }; 
             $self->{discovery}->{pollers_reload}->{ $options{poller_id} } = 1;
             $self->audit_update(
-                object_type => 'service',
-                action_type => 'disable',
-                object_id => $service,
+                object_type => 'service', 
+                action_type => 'disable', 
+                object_id => $service, 
                 object_name => $service_description,
                 contact_id => $self->{audit_user_id}
             );
@@ -621,7 +616,7 @@ sub service_response_parsing {
             discovery_svc => $discovery_svc,
             rule => $self->{discovery}->{rules}->{ $options{rule_id} }
         );
-
+        
         my ($status, $service) = gorgone::modules::centreon::autodiscovery::services::resources::get_service(
             class_object_centreon => $self->{class_object_centreon},
             host_id => $options{host_id},
@@ -681,20 +676,19 @@ sub discoverylistener {
                 $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{data} = $data->{data};
             }
         }
-
     } elsif ($data->{code} == GORGONE_ACTION_FINISH_KO) {
         if ($self->{discovery}->{is_manual} == 1) {
             $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{failed} = 1;
             $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{message} = $data->{data}->{message};
         }
         $self->{discovery}->{failed_discoveries}++;
-
     } else {
         return 0;
     }
 
     $self->{service_current_commands_poller}->{ $self->{discovery}->{hosts}->{ $options{host_id} }->{poller_id} }--;
     $self->service_execute_commands();
+
     $self->{discovery}->{done_discoveries}++;
     my $progress = $self->{discovery}->{done_discoveries} * 100 / $self->{discovery}->{count_discoveries};
     my $div = int(int($progress) / 5);
@@ -706,7 +700,7 @@ sub discoverylistener {
             instant => 1,
             data => {
                 message => 'current progress',
-                complete => sprintf('%.2f', $progress)
+                complete => sprintf('%.2f', $progress) 
             }
         );
     }
@@ -744,7 +738,7 @@ sub service_execute_commands {
         foreach my $poller_id (keys %{$self->{discovery}->{rules}->{$rule_id}->{hosts}}) {
             next if (scalar(@{$self->{discovery}->{rules}->{$rule_id}->{hosts}->{$poller_id}}) <= 0);
             $self->{service_current_commands_poller}->{$poller_id} = 0 if (!defined($self->{service_current_commands_poller}->{$poller_id}));
-
+                
             while (1) {
                 last if ($self->{service_current_commands_poller}->{$poller_id} >= $self->{service_parrallel_commands_poller});
                 my $host_id = shift @{$self->{discovery}->{rules}->{$rule_id}->{hosts}->{$poller_id}};
@@ -761,7 +755,7 @@ sub service_execute_commands {
                 );
 
                 $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} [" .
-                    $self->{discovery}->{rules}->{$rule_id}->{rule_alias} . "] [" .
+                    $self->{discovery}->{rules}->{$rule_id}->{rule_alias} . "] [" . 
                     $self->{service_pollers}->{$poller_id}->{name} . "] [" .
                     $host->{host_name} . "] -> substitute string: " . $command
                 );
@@ -868,7 +862,7 @@ sub launchdiscovery {
     # get rules
     ################
     $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} load rules configuration");
-
+    
     ($status, $message, my $rules) = gorgone::modules::centreon::autodiscovery::services::resources::get_rules(
         class_object_centreon => $self->{class_object_centreon},
         filter_rules => $data->{content}->{filter_rules},
@@ -899,7 +893,7 @@ sub launchdiscovery {
             $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => $message);
             return -1;
         }
-
+        
         if (!defined($hosts) || scalar(keys %$hosts) == 0) {
             $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} no hosts found for rule '" . $options{rule}->{rule_alias} . "'");
             next;

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -20,7 +20,7 @@
 
 package gorgone::modules::centreon::autodiscovery::services::discovery;
 
-use base qw(gorgone::class::module);
+use base qw(gorgone::modules::centreon::autodiscovery::class);
 
 use strict;
 use warnings;
@@ -67,6 +67,11 @@ sub new {
     return $connector;
 }
 
+sub getDiscoveryListener {
+    my ($self,$uuid) = @_;
+    return $self->can("discoverylistener"), $self;
+}
+
 sub database_init_transaction {
     my ($self, %options) = @_;
 
@@ -80,7 +85,7 @@ sub database_init_transaction {
 
 sub database_commit_transaction {
     my ($self, %options) = @_;
-    
+
     my $status = $self->{class_object_centreon}->commit();
     if ($status == -1) {
         $self->{logger}->writeLogError("$@");
@@ -112,7 +117,7 @@ sub get_uuid {
 }
 
 sub is_finished {
-    my ($self, %options) = @_;
+    my $self = shift;
 
     return $self->{finished};
 }
@@ -196,7 +201,7 @@ sub restart_pollers {
 
 sub audit_update {
     my ($self, %options) = @_;
-    
+
     return if ($self->{discovery}->{audit_enable} != 1);
 
     my $query = 'INSERT INTO log_action (action_log_date, object_type, object_id, object_name, action_type, log_contact_id) VALUES (?, ?, ?, ?, ?, ?)';
@@ -238,7 +243,7 @@ sub custom_variables {
 
 sub get_description {
     my ($self, %options) = @_;
-    
+
     my $desc = $options{discovery_svc}->{service_name};
     if (defined($self->{discovery}->{rules}->{ $options{rule_id} }->{rule_scan_display_custom}) && $self->{discovery}->{rules}->{ $options{rule_id} }->{rule_scan_display_custom} ne '') {
         local $SIG{__DIE__} = 'IGNORE';
@@ -258,13 +263,13 @@ sub get_description {
 
 sub link_service_autodisco {
     my ($self, %options) = @_;
-    
+
     my $query = 'INSERT IGNORE INTO mod_auto_disco_rule_service_relation (rule_rule_id, service_service_id) VALUES (' . $options{rule_id} . ', ' . $options{service_id} . ')';
     my ($status, $sth) = $self->{class_object_centreon}->custom_execute(request => $query);
     if ($status == -1) {
         return -1;
     }
-    
+
     return 0;
 }
 
@@ -274,9 +279,9 @@ sub update_service {
     my @journal = ();
     my @update_macros = ();
     my @insert_macros = ();
-    
+
     if ($self->{discovery}->{is_manual} == 1) {
-        $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = { 
+        $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = {
             type => 0,
             macros => {},
             description => $self->get_description(%options)
@@ -293,7 +298,7 @@ sub update_service {
             type => 'update',
             msg => 'template',
             rule_id => $options{rule_id}
-        }; 
+        };
         $self->{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service update template");
         if ($self->{discovery}->{is_manual} == 1) {
             $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{service_template_model_stm_id} = $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id};
@@ -358,7 +363,7 @@ sub update_service {
             return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot update service");
         }
     }
-    
+
     foreach (@update_macros) {
         my $query = 'UPDATE on_demand_macro_service SET svc_macro_value = ? WHERE svc_svc_id = ' . $options{service}->{id} .  ' AND svc_macro_name = ?';
         my ($status) = $self->{class_object_centreon}->custom_execute(
@@ -379,7 +384,7 @@ sub update_service {
             return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot insert macro");
         }
     }
-    
+
     if ($self->link_service_autodisco(%options, service_id => $options{service}->{id}) == -1) {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot link service to autodisco");
     }
@@ -391,19 +396,19 @@ sub update_service {
 
     if (defined($query_update{service_activate})) {
         $self->audit_update(
-            object_type => 'service', 
-            action_type => 'enable', 
-            object_id => $options{service}->{id}, 
-            object_name => $options{discovery_svc}->{service_name}, 
+            object_type => 'service',
+            action_type => 'enable',
+            object_id => $options{service}->{id},
+            object_name => $options{discovery_svc}->{service_name},
             contact_id => $self->{audit_user_id}
         );
     }
     if (defined($query_update{service_template_model_stm_id})) {
         $self->audit_update(
-            object_type => 'service', 
-            action_type => 'c', 
-            object_id => $options{service}->{id}, 
-            object_name => $options{discovery_svc}->{service_name}, 
+            object_type => 'service',
+            action_type => 'c',
+            object_id => $options{service}->{id},
+            object_name => $options{discovery_svc}->{service_name},
             contact_id => $self->{audit_user_id},
             fields => { service_template_model_stm_id => $query_update{service_template_model_stm_id} }
         );
@@ -414,10 +419,10 @@ sub update_service {
 
 sub create_service {
     my ($self, %options) = @_;
-    
+
     if ($self->{discovery}->{is_manual} == 1) {
-        $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = { 
-            type => 1, 
+        $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = {
+            type => 1,
             service_template_model_stm_id => $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id},
             macros => {},
             description => $self->get_description(%options)
@@ -444,19 +449,19 @@ sub create_service {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot create service");
     }
     my $service_id = $self->{class_object_centreon}->{db_centreon}->last_insert_id();
-    
+
     $query = 'INSERT INTO host_service_relation (host_host_id, service_service_id) VALUES (' . $options{host_id} . ', ' . $service_id . ')';
     ($status) = $self->{class_object_centreon}->custom_execute(request => $query);
     if ($status == -1) {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot link service to host");
     }
-    
+
     $query = 'INSERT INTO extended_service_information (service_service_id) VALUES (' . $service_id . ')';
     ($status) = $self->{class_object_centreon}->custom_execute(request => $query);
     if ($status == -1) {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot service extended information");
     }
-    
+
     foreach (keys %{$options{macros}}) {
         $query = 'INSERT INTO on_demand_macro_service (svc_svc_id, svc_macro_name, svc_macro_value) VALUES (' . $service_id . ', ?, ?)';
         ($status) = $self->{class_object_centreon}->custom_execute(
@@ -471,21 +476,21 @@ sub create_service {
     if ($self->link_service_autodisco(%options, service_id => $service_id) == -1) {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot link service to autodisco");
     }
-    
+
     return -1 if ($self->database_commit_transaction() == -1);
 
     $self->{discovery}->{pollers_reload}->{ $options{poller_id} } = 1;
 
     $self->audit_update(
-        object_type => 'service', 
-        action_type => 'a', 
-        object_id => $service_id, 
+        object_type => 'service',
+        action_type => 'a',
+        object_id => $service_id,
         object_name => $options{discovery_svc}->{service_name},
         contact_id => $self->{audit_user_id},
         fields => {
-            service_template_model_id => $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id}, 
-            service_description => $options{discovery_svc}->{service_name}, 
-            service_register => '1', 
+            service_template_model_id => $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id},
+            service_description => $options{discovery_svc}->{service_name},
+            service_register => '1',
             service_hPars => $options{host_id}
         }
     );
@@ -495,7 +500,7 @@ sub create_service {
 
 sub crud_service {
     my ($self, %options) = @_;
-    
+
     my $service_id;
     if (!defined($options{service})) {
         $service_id = $self->create_service(%options);
@@ -511,18 +516,18 @@ sub crud_service {
     } else {
         $service_id = $self->update_service(%options);
     }
-    
+
     return 0;
 }
 
 sub disable_services {
     my ($self, %options) = @_;
-    
+
     return if ($self->{discovery}->{rules}->{ $options{rule_id} }->{rule_disable} != 1 || !defined($self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }));
     foreach my $service (keys %{$self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }}) {
         my $service_description = $self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }->{$service}->{service_description};
 
-        if (!defined($options{discovery_svc}->{discovered_services}->{$service_description}) && 
+        if (!defined($options{discovery_svc}->{discovered_services}->{$service_description}) &&
             $self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }->{$service}->{service_activate} == 1) {
             $self->{logger}->writeLogInfo("$options{logger_pre_message} -> disable service '" . $service_description . "'");
             next if ($self->{discovery}->{dry_run} == 1);
@@ -533,18 +538,18 @@ sub disable_services {
                 $self->{logger}->writeLogInfo("$options{logger_pre_message} -> cannot disable service '" . $service_description . "'");
                 next;
             }
-            
+
             push @{$self->{discovery}->{journal}}, {
                 host_name => $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name},
                 service_name => $service_description,
                 type => 'disable',
                 rule_id => $options{rule_id}
-            }; 
+            };
             $self->{discovery}->{pollers_reload}->{ $options{poller_id} } = 1;
             $self->audit_update(
-                object_type => 'service', 
-                action_type => 'disable', 
-                object_id => $service, 
+                object_type => 'service',
+                action_type => 'disable',
+                object_id => $service,
                 object_name => $service_description,
                 contact_id => $self->{audit_user_id}
             );
@@ -616,7 +621,7 @@ sub service_response_parsing {
             discovery_svc => $discovery_svc,
             rule => $self->{discovery}->{rules}->{ $options{rule_id} }
         );
-        
+
         my ($status, $service) = gorgone::modules::centreon::autodiscovery::services::resources::get_service(
             class_object_centreon => $self->{class_object_centreon},
             host_id => $options{host_id},
@@ -676,19 +681,20 @@ sub discoverylistener {
                 $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{data} = $data->{data};
             }
         }
+
     } elsif ($data->{code} == GORGONE_ACTION_FINISH_KO) {
         if ($self->{discovery}->{is_manual} == 1) {
             $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{failed} = 1;
             $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{message} = $data->{data}->{message};
         }
         $self->{discovery}->{failed_discoveries}++;
+
     } else {
         return 0;
     }
 
     $self->{service_current_commands_poller}->{ $self->{discovery}->{hosts}->{ $options{host_id} }->{poller_id} }--;
     $self->service_execute_commands();
-
     $self->{discovery}->{done_discoveries}++;
     my $progress = $self->{discovery}->{done_discoveries} * 100 / $self->{discovery}->{count_discoveries};
     my $div = int(int($progress) / 5);
@@ -700,7 +706,7 @@ sub discoverylistener {
             instant => 1,
             data => {
                 message => 'current progress',
-                complete => sprintf('%.2f', $progress) 
+                complete => sprintf('%.2f', $progress)
             }
         );
     }
@@ -738,7 +744,7 @@ sub service_execute_commands {
         foreach my $poller_id (keys %{$self->{discovery}->{rules}->{$rule_id}->{hosts}}) {
             next if (scalar(@{$self->{discovery}->{rules}->{$rule_id}->{hosts}->{$poller_id}}) <= 0);
             $self->{service_current_commands_poller}->{$poller_id} = 0 if (!defined($self->{service_current_commands_poller}->{$poller_id}));
-                
+
             while (1) {
                 last if ($self->{service_current_commands_poller}->{$poller_id} >= $self->{service_parrallel_commands_poller});
                 my $host_id = shift @{$self->{discovery}->{rules}->{$rule_id}->{hosts}->{$poller_id}};
@@ -755,7 +761,7 @@ sub service_execute_commands {
                 );
 
                 $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} [" .
-                    $self->{discovery}->{rules}->{$rule_id}->{rule_alias} . "] [" . 
+                    $self->{discovery}->{rules}->{$rule_id}->{rule_alias} . "] [" .
                     $self->{service_pollers}->{$poller_id}->{name} . "] [" .
                     $host->{host_name} . "] -> substitute string: " . $command
                 );
@@ -862,7 +868,7 @@ sub launchdiscovery {
     # get rules
     ################
     $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} load rules configuration");
-    
+
     ($status, $message, my $rules) = gorgone::modules::centreon::autodiscovery::services::resources::get_rules(
         class_object_centreon => $self->{class_object_centreon},
         filter_rules => $data->{content}->{filter_rules},
@@ -893,7 +899,7 @@ sub launchdiscovery {
             $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => $message);
             return -1;
         }
-        
+
         if (!defined($hosts) || scalar(keys %$hosts) == 0) {
             $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} no hosts found for rule '" . $options{rule}->{rule_alias} . "'");
             next;

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -40,6 +40,7 @@ sub new {
     $connector->{internal_socket} = $options{internal_socket};
     $connector->{class_object_centreon} = $options{class_object_centreon};
     $connector->{class_object_centstorage} = $options{class_object_centstorage};
+    $connector->{class_autodiscovery} = $options{class_autodiscovery};
     $connector->{tpapi_clapi} = $options{tpapi_clapi};
     $connector->{mail_subject} = defined($connector->{config}->{mail_subject}) ? $connector->{config}->{mail_subject} : 'Centreon Auto Discovery';
     $connector->{mail_from} = defined($connector->{config}->{mail_from}) ? $connector->{config}->{mail_from} : 'centreon-autodisco';
@@ -937,6 +938,12 @@ sub launchdiscovery {
     $self->service_execute_commands(vault_count => $vault_count);
 
     return 0;
+}
+
+sub event {
+    my ($self, %options) = @_;
+
+    $self->{class_autodiscovery}->event();
 }
 
 1;

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -50,6 +50,7 @@ sub new {
     $connector->{service_parrallel_commands_poller} = 8;
     $connector->{service_current_commands_poller} = {};
     $connector->{finished} = 0;
+    $connector->{post_execution} = 0;
 
     $connector->{safe_display} = Safe->new();
     $connector->{safe_display}->share('$values');
@@ -116,6 +117,12 @@ sub is_finished {
     my ($self, %options) = @_;
 
     return $self->{finished};
+}
+
+sub is_post_execution {
+    my ($self, %options) = @_;
+
+    return $self->{post_execution};
 }
 
 sub send_email {
@@ -722,13 +729,21 @@ sub discoverylistener {
                 manual => $self->{discovery}->{manual}
             }
         );
-
-        if ($self->{discovery}->{is_manual} == 0) {
-            $self->restart_pollers();
-            $self->send_email();
-        }
     }
 
+    return 0;
+}
+
+sub service_discovery_post_exec {
+    my ($self, %options) = @_;
+
+    $self->{post_execution} = 1;
+
+    if ($self->{discovery}->{is_manual} == 0) {
+        $self->restart_pollers();
+        $self->send_email();
+    }
+    
     return 0;
 }
 

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -288,7 +288,7 @@ sub get_contact {
         return 0;
     }
 
-    return defined($datas->[0]) ? $datas->[0] : undef;
+    return defined($datas->{ $options{contact_id} }) ? $datas->{ $options{contact_id} } : undef;
 }
 
 my $done_macro_host = {};

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -103,8 +103,17 @@ sub get_rules {
     my (%options) = @_;
     
     my $filter = "rule_activate = '1' AND ";
-    if (defined($options{force_rule})) {
+    if (defined($options{force_rule}) && $options{force_rule} == 1) {
         $filter = '';
+    }
+    if (defined($options{filter_rules}) && scalar(@{$options{filter_rules}}) > 0) {
+        my $append = '';
+        $filter .= 'rule_alias IN (';
+        foreach my $rule (@{$options{filter_rules}}) {
+            $filter .= $append . $options{class_object_centreon}->quote(value => $rule);
+            $append = ', ';
+        }
+        $filter .= ') AND ';
     }
 
     my ($status, $rules) = $options{class_object_centreon}->custom_execute(

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -215,7 +215,7 @@ sub get_rules {
         $rules->{ $_->[0] }->{linked_services} = {} if (!defined($rules->{ $_->[0] }->{linked_services}));
         $rules->{ $_->[0] }->{linked_services}->{ $_->[1] } = {} if (!defined($rules->{ $_->[0] }->{linked_services}->{ $_->[1] }));
         $rules->{ $_->[0] }->{linked_services}->{ $_->[1] }->{ $_->[2] } = {
-            service_activate => $_->[3], service_description => $_->[3]
+            service_activate => $_->[3], service_description => $_->[4]
         };
     }
     

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -328,6 +328,7 @@ sub get_hosts {
     }
 
     my $hosts = {};
+    my $count = 0;
     foreach my $host_id (keys %$datas) {
         if (defined($options{with_macro}) && $options{with_macro} == 1) {
             if (defined($done_macro_host->{ $host_id })) {
@@ -342,10 +343,11 @@ sub get_hosts {
             }
         }
 
+        $count++;
         push @{$hosts->{ $datas->{$host_id}->{poller_id} }}, $datas->{$host_id};
     }
 
-    return (0, '', $hosts);
+    return (0, '', $hosts, $count);
 }
 
 sub set_macro {
@@ -395,7 +397,7 @@ sub get_macros_host {
         foreach (@$datas) {
             set_macro(\%macros, $_->[0], $_->[1]);
         }
-    
+
         ($status, $datas) = $options{class_object_centreon}->custom_execute(
             request => "SELECT host_tpl_id FROM host_template_relation WHERE host_host_id = " . $lhost_id . " ORDER BY `order` DESC",
             mode => 2

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -1,0 +1,414 @@
+# 
+# Copyright 2019 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package gorgone::modules::centreon::autodiscovery::services::resources;
+
+use strict;
+use warnings;
+
+sub get_pollers {
+    my (%options) = @_;
+    
+    my ($status, $pollers) = $options{class_object_centreon}->custom_execute(
+        request => 'SELECT id, name FROM nagios_server',
+        mode => 1,
+        keys => 'id'
+    );
+    if ($status == -1) {
+        return (-1, 'cannot get poller list');
+    }
+
+    if (scalar(keys %$pollers) == 0) {
+        return (-1, 'no pollers found in configuration');
+    }
+
+    foreach my $poller_id (keys %$pollers) {
+        $pollers->{$poller_id}->{resources} = {};
+        ($status, my $resources) = $options{class_object_centreon}->custom_execute(
+            request =>
+                'SELECT resource_name, resource_line FROM cfg_resource_instance_relations, cfg_resource WHERE cfg_resource_instance_relations.instance_id = ' .
+                $options{class_object_centreon}->quote(value => $poller_id) . "AND cfg_resource_instance_relations.resource_id = cfg_resource.resource_id AND resource_activate = '1'",
+            mode => 2
+        );
+        if ($status == -1) {
+            return (-1, 'cannot get rules resource list');
+        }
+
+        foreach (@$resources) {
+            $pollers->{$poller_id}->{resources}->{ $_->[0] } = $_->[1];
+        }
+    }
+
+    return (0, '', $pollers);
+}
+
+sub get_audit_user_id {
+    my (%options) = @_;
+    my $user_id = 0;
+
+    my ($status, $contacts) = $options{class_object_centreon}->custom_execute(
+        request =>
+            'SELECT contact_id FROM contact WHERE contact_alias = ' .
+            $options{class_object_centreon}->quote(value => $options{clapi_user}),
+        mode => 2
+    );
+    if ($status == -1) {
+        return (-1, 'cannot get audit user');
+    }
+
+    if (defined($contacts->[0])) {
+        $user_id = $contacts->[0]->[0];
+    }
+
+    return (0, '', $user_id);
+}
+
+sub get_rules {
+    my (%options) = @_;
+    
+    my $filter = "rule_activate = '1' AND ";
+    if (defined($options{force_rule})) {
+        $filter = '';
+    }
+
+    my ($status, $rules) = $options{class_object_centreon}->custom_execute(
+        request =>
+            "SELECT rule_id, rule_alias, service_display_name, rule_disable, rule_update, command_line, service_template_model_id, rule_scan_display_custom, rule_variable_custom
+              FROM mod_auto_disco_rule, command WHERE " . $filter . " mod_auto_disco_rule.command_command_id = command.command_id",
+        mode => 1,
+        keys => 'rule_id'
+    );
+    if ($status == -1) {
+        return (-1, 'cannot get rules list');
+    }
+    if (scalar(keys %$rules) == 0) {
+        return (-1, 'no rules found in configuration');
+    }
+    
+    $filter = '(' . join(',', keys %$rules) . ')';
+    
+    ############################
+    # Get mod_auto_disco_change
+    ($status, my $datas) = $options{class_object_centreon}->custom_execute(
+        request => 'SELECT rule_id, change_str, change_regexp, change_replace, change_modifier FROM mod_auto_disco_change WHERE rule_id IN ' . $filter . ' ORDER BY rule_id, change_order ASC',
+        mode => 2
+    );
+    if ($status == -1) {
+        return (-1, 'cannot get rules change list');
+    }
+    foreach (@$datas) {
+        $rules->{ $_->[0] }->{change} = [] if (!defined($rules->{ $_->[0] }->{change}));
+        push @{$rules->{ $_->[0] }->{change}}, { change_str => $_->[1], change_regexp => $_->[2], change_replace => $_->[3], change_modifier => $_->[4] };
+    }
+    
+    #########################################
+    # Get mod_auto_disco_inclusion_exclusion
+    ($status, $datas) = $options{class_object_centreon}->custom_execute(
+        request => 'SELECT rule_id, exinc_type, exinc_str, exinc_regexp FROM mod_auto_disco_inclusion_exclusion WHERE rule_id IN ' . $filter . ' ORDER BY rule_id, exinc_order ASC',
+        mode => 2
+    );
+    if ($status == -1) {
+        return (-1, 'cannot get rules exinc list');
+    }
+    foreach (@$datas) {
+        $rules->{ $_->[0] }->{exinc} = [] if (!defined($rules->{ $_->[0] }->{exinc}));
+        push @{$rules->{ $_->[0] }->{exinc}}, { exinc_type => $_->[1], exinc_str => $_->[2], exinc_regexp => $_->[3] };
+    }
+    
+    #########################################
+    # Get mod_auto_disco_macro
+    ($status, $datas) = $options{class_object_centreon}->custom_execute(
+        request => 'SELECT rule_id, macro_name, macro_value, is_empty FROM mod_auto_disco_macro WHERE rule_id IN ' . $filter,
+        mode => 2
+    );
+    if ($status == -1) {
+        return (-1, 'cannot get rules macro list');
+    }
+    foreach (@$datas) {
+        $rules->{ $_->[0] }->{macro} = {} if (!defined($rules->{ $_->[0] }->{macro}));
+        $rules->{ $_->[0] }->{macro}->{ $_->[1] } = { macro_value => $_->[2], is_empty => $_->[3] };
+    }
+    
+    #########################################
+    # Get mod_auto_disco_inst_rule_relation
+    ($status, $datas) = $options{class_object_centreon}->custom_execute(
+        request => 'SELECT rule_rule_id as rule_id, instance_id FROM mod_auto_disco_inst_rule_relation WHERE rule_rule_id IN ' . $filter,
+        mode => 2
+    );
+    if ($status == -1) {
+        return (-1, 'cannot get rules instance list');
+    }
+    foreach (@$datas) {
+        $rules->{ $_->[0] }->{poller_id} = [] if (!defined($rules->{ $_->[0] }->{poller_id}));
+        push @{$rules->{ $_->[0] }->{poller_id}}, $_->[1];
+    }
+
+    #########################################
+    # Get mod_auto_disco_ht_rule_relation
+    ($status, $datas) = $options{class_object_centreon}->custom_execute(
+        request => 'SELECT rule_rule_id as rule_id, host_host_id FROM mod_auto_disco_ht_rule_relation WHERE rule_rule_id IN ' . $filter,
+        mode => 2
+    );
+    if ($status == -1) {
+        return (-1, 'cannot get rules host template list');
+    }
+    foreach (@$datas) {
+        $rules->{ $_->[0] }->{host_template} = [] if (!defined($rules->{ $_->[0] }->{host_template}));
+        push @{$rules->{ $_->[0] }->{host_template}}, $_->[1];
+    }
+    
+    ########################################
+    # Get services added by autodisco
+    ($status, $datas) = $options{class_object_centreon}->custom_execute(
+        request => 'SELECT rule_rule_id as rule_id, host_host_id as host_id, service_id, service_activate, service_description FROM mod_auto_disco_rule_service_relation, service, host_service_relation WHERE rule_rule_id IN ' . $filter . " AND mod_auto_disco_rule_service_relation.service_service_id = service.service_id AND service.service_id = host_service_relation.service_service_id",
+        mode => 2
+    );
+    if ($status == -1) {
+        return (-1, 'cannot get rules host template list');
+    }
+    foreach (@$datas) {
+        $rules->{ $_->[0] }->{linked_services} = {} if (!defined($rules->{ $_->[0] }->{linked_services}));
+        $rules->{ $_->[0] }->{linked_services}->{ $_->[1] } = {} if (!defined($rules->{ $_->[0] }->{linked_services}->{ $_->[1] }));
+        $rules->{ $_->[0] }->{linked_services}->{ $_->[1] }->{ $_->[2] } = {
+            service_activate => $_->[3], service_description => $_->[3]
+        };
+    }
+    
+    #########################################
+    # Get Contact
+    ($status, $datas) = $options{class_object_centreon}->custom_execute(
+        request => 'SELECT rule_id, contact_id, cg_id FROM mod_auto_disco_rule_contact_relation WHERE rule_id IN ' . $filter,
+        mode => 2
+    );
+    if ($status == -1) {
+        return (-1, 'cannot get rules contact list');
+    }
+    foreach (@$datas) {
+        if (defined($_->[1])) {
+            # Already add it
+            next if (defined($rules->{ $_->[0] }->{contact}->{ $_->[1] }));
+            if ((my $contact = get_contact(class_object_centreon => $options{class_object_centreon}, contact_id => $_->[1]))) {
+                $rules->{ $_->[0] }->{contact} = {} if (!defined($rules->{ $_->[0] }->{contact}));
+                $rules->{ $_->[0] }->{contact}->{ $contact->{contact_id} } = { contact_email => $contact->{contact_email} };
+            }
+        } elsif (defined($_->[2])) {
+            ($status, my $datas2) = $options{class_object_centreon}->custom_execute(
+                request => "SELECT contact_contact_id as contact_id FROM contactgroup, contactgroup_contact_relation WHERE contactgroup.cg_id = '" . $_->[2] . "' AND contactgroup.cg_id = contactgroup_contact_relation.contactgroup_cg_id",
+                mode => 2
+            );
+            if ($status == -1) {
+                return (-1, 'cannot get rules contactgroup list');
+            }
+            foreach my $row (@$datas2) {
+                # Already add it
+                next if (defined($rules->{ $_->[0] }->{contact}->{ $row->[1] }));
+                if ((my $contact = get_contact(class_object_centreon => $options{class_object_centreon}, contact_id => $row->[1]))) {
+                    $rules->{ $_->[0] }->{contact} = {} if (!defined($rules->{ $_->[0] }->{contact}));
+                    $rules->{ $_->[0] }->{contact}->{$contact->{contact_id}} = { contact_email => $contact->{contact_email} };
+                }
+            }
+        }
+    }
+
+    # Filter rules
+    if (defined($options{filter_rules}) && ref($options{filter_rules}) eq 'SCALAR') {
+        foreach (keys %$rules) {
+            my $find = 0;
+            foreach my $opt_rule (@{$options{filter_rules}}) {
+                if ($opt_rule eq $rules->{$_}->{rule_alias}) {
+                    $find = 1;
+                    last;
+                }
+            }
+            
+            if ($find == 0) {
+                delete $rules->{$_};
+            }
+        }
+    }
+
+    return (0, '', $rules);
+}
+
+sub get_contact {
+    my (%options) = @_;
+
+    my ($status, $datas) = $options{class_object_centreon}->custom_execute(
+        request => "SELECT contact_id, contact_email FROM contact WHERE contact_id = '" . $options{contact_id} . "' AND contact_activate = '1'",
+        mode => 1
+    );
+
+    if ($status == -1) {
+        return 0;
+    }
+
+    return defined($datas->[0]) ? $datas->[0] : undef;
+}
+
+my $done_macro_host = {};
+
+sub reset_macro_hosts {
+    $done_macro_host = {};
+}
+
+sub get_hosts {
+    my (%options) = @_;
+
+    if (!defined($options{host_template}) || scalar(@{$options{host_template}}) == 0) {
+        return (0, 'cannot get host list', []);
+    }
+
+    my $filter = '';
+    my $filter_append = '';
+    foreach (@{$options{host_template}}) {
+        $filter .= $filter_append . $options{class_object_centreon}->quote(value => $_);
+        $filter_append = ', ';
+    }
+    $filter = ' host_template_relation.host_tpl_id IN (' . $filter . ') AND ';
+
+    my $filter_host = '';
+    if (defined($options{host_lookup}) && ref($options{host_lookup}) eq 'ARRAY' && scalar(@{$options{host_lookup}}) > 0) {
+        my $filter_append = '';
+        foreach (@{$options{host_lookup}}) {
+            $filter_host .= $filter_append .$options{class_object_centreon}->quote(value => $_);
+            $filter_append = ', ';
+        }
+        $filter_host = ' host.host_name IN (' . $filter_host . ') AND ';
+    }
+    
+    my $filter_poller = '';
+    my $join_table = '';
+    if (defined($options{poller_lookup}) && ref($options{host_lookup}) eq 'ARRAY' && scalar(@{$options{poller_lookup}}) > 0) {
+        my $filter_append = '';
+        foreach (@{$options{poller_lookup}}) {
+            $filter_poller .= $filter_append . $options{class_object_centreon}->quote(value => $_);
+            $filter_append = ', ';
+        }
+        $filter_poller = ' nagios_server.name IN ('. $filter_poller .') AND nagios_server.id = ns_host_relation.nagios_server_id AND ';
+        $join_table = ', nagios_server ';
+    } elsif (defined($options{poller_id}) && scalar(@{$options{poller_id}}) > 0){
+        my $filter_append = '';
+        foreach (@{$options{poller_id}}) {
+            $filter_poller .= $filter_append . $options{class_object_centreon}->quote(value => $_);
+            $filter_append = ', ';
+        }
+        $filter_poller =' ns_host_relation.nagios_server_id IN (' . $filter_poller . ') AND nagios_server.id = ns_host_relation.nagios_server_id AND ';
+        $join_table = ', nagios_server ';
+    }
+
+    my ($status, $datas) = $options{class_object_centreon}->custom_execute(
+        request => "SELECT host_id, host_address, host_name, nagios_server_id as poller_id
+            FROM host_template_relation, host, ns_host_relation " . $join_table . "
+            WHERE " . $filter_host . $filter . " host_template_relation.host_host_id = host.host_id
+            AND " . $filter_poller . " host.host_id = ns_host_relation.host_host_id
+            AND `host_activate` = '1'
+            ",
+        mode => 1,
+        keys => 'host_id',
+    );
+    if ($status == -1) {
+        return (-1, 'cannot host list');
+    }
+
+    my $hosts = {};
+    foreach my $host_id (keys %$datas) {
+        if (defined($options{with_macro}) && $options{with_macro} == 1) {
+            if (defined($done_macro_host->{ $host_id })) {
+                $datas->{$host_id}->{macros} = $done_macro_host->{ $host_id };
+            } else {
+                ($status, my $message, my $macros) = get_macros_host(host_id => $host_id, class_object_centreon => $options{class_object_centreon});
+                if ($status == -1) {
+                    return (-1, $message);
+                }
+                $datas->{$host_id}->{macros} = $macros;
+                $done_macro_host->{ $host_id } = $macros;
+            }
+        }
+
+        push @{$hosts->{ $datas->{$host_id}->{poller_id} }}, $datas->{$host_id};
+    }
+
+    return (0, '', $hosts);
+}
+
+sub set_macro {
+    my ($macros, $name, $value) = @_;
+    
+    if (!defined($macros->{$name})) {
+        $macros->{$name} = $value;
+    }
+}
+
+sub get_macros_host {
+    my (%options) = @_;
+    my ($status, $datas);
+    my %macros = ();
+    my %loop_stop = ();
+    my @stack = ($options{host_id});
+    
+    while ((my $lhost_id = shift(@stack))) {
+        if (defined($loop_stop{$lhost_id})) {
+            # Already done the host
+            next;
+        }
+        $loop_stop{$lhost_id} = 1;
+
+        ($status, $datas) = $options{class_object_centreon}->custom_execute(
+            request => "SELECT host_snmp_community, host_snmp_version FROM host WHERE host_id = " . $lhost_id . " LIMIT 1",
+            mode => 2
+        );
+        if ($status == -1) {
+            return (-1, 'get macro: cannot get snmp information');
+        }
+
+        if (defined($datas->[0]->[0]) && $datas->[0]->[0] ne "") {
+            set_macro(\%macros, '$_HOSTSNMPCOMMUNITY$', $datas->[0]->[0]);
+        }
+        if (defined($datas->[0]->[1]) && $datas->[0]->[1] ne "") {
+            set_macro(\%macros, '$_HOSTSNMPVERSION$', $datas->[0]->[1]);
+        }
+
+        ($status, $datas) = $options{class_object_centreon}->custom_execute(
+            request => "SELECT host_macro_name, host_macro_value FROM on_demand_macro_host WHERE host_host_id = " . $lhost_id,
+            mode => 2
+        );
+        if ($status == -1) {
+            return (-1, 'get macro: cannot get on_demand_macro_host');
+        }
+        foreach (@$datas) {
+            set_macro(\%macros, $_->[0], $_->[1]);
+        }
+    
+        ($status, $datas) = $options{class_object_centreon}->custom_execute(
+            request => "SELECT host_tpl_id FROM host_template_relation WHERE host_host_id = " . $lhost_id . " ORDER BY `order` DESC",
+            mode => 2
+        );
+        if ($status == -1) {
+            return (-1, 'get macro: cannot get host_template_relation');
+        }
+        foreach (@$datas) {
+            unshift @stack, $_->[0];
+        }
+    }
+
+    return \%macros;
+}
+
+1;

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -324,7 +324,7 @@ sub get_hosts {
     
     my $filter_poller = '';
     my $join_table = '';
-    if (defined($options{poller_lookup}) && ref($options{host_lookup}) eq 'ARRAY' && scalar(@{$options{poller_lookup}}) > 0) {
+    if (defined($options{poller_lookup}) && ref($options{poller_lookup}) eq 'ARRAY' && scalar(@{$options{poller_lookup}}) > 0) {
         my $filter_append = '';
         foreach (@{$options{poller_lookup}}) {
             $filter_poller .= $filter_append . $options{class_object_centreon}->quote(value => $_);

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -59,6 +59,25 @@ sub get_pollers {
     return (0, '', $pollers);
 }
 
+sub get_audit {
+    my (%options) = @_;
+    my $audit = 0;
+
+    my ($status, $rows) = $options{class_object_centstorage}->custom_execute(
+        request =>
+            'SELECT audit_log_option FROM config LIMIT 1',
+        mode => 2
+    );
+    if ($status == -1) {
+        return (-1, 'cannot get audit configuration');
+    }
+    if (defined($rows->[0]->[0])) {
+        $audit = $rows->[0]->[0];
+    }
+
+    return (1, '', $audit);
+}
+
 sub get_audit_user_id {
     my (%options) = @_;
     my $user_id = 0;
@@ -252,7 +271,8 @@ sub get_contact {
 
     my ($status, $datas) = $options{class_object_centreon}->custom_execute(
         request => "SELECT contact_id, contact_email FROM contact WHERE contact_id = '" . $options{contact_id} . "' AND contact_activate = '1'",
-        mode => 1
+        mode => 1,
+        keys => 'contact_id'
     );
 
     if ($status == -1) {

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -246,10 +246,10 @@ sub get_rules {
             }
             foreach my $row (@$datas2) {
                 # Already add it
-                next if (defined($rules->{ $_->[0] }->{contact}->{ $row->[1] }));
-                if ((my $contact = get_contact(class_object_centreon => $options{class_object_centreon}, contact_id => $row->[1]))) {
+                next if (defined($rules->{ $_->[0] }->{contact}->{ $row->[0] }));
+                if ((my $contact = get_contact(class_object_centreon => $options{class_object_centreon}, contact_id => $row->[0]))) {
                     $rules->{ $_->[0] }->{contact} = {} if (!defined($rules->{ $_->[0] }->{contact}));
-                    $rules->{ $_->[0] }->{contact}->{$contact->{contact_id}} = { contact_email => $contact->{contact_email} };
+                    $rules->{ $_->[0] }->{contact}->{ $contact->{contact_id} } = { contact_email => $contact->{contact_email} };
                 }
             }
         }

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -586,10 +586,10 @@ sub check_exinc {
             attributes => $options{discovery_svc}->{attributes}
         );
         if ($exinc->{exinc_type} == 1 && $value =~ /$exinc->{exinc_regexp}/) {
-            $options{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> inclusion '$exinc->{exinc_regexp}'");
+            $options{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> inclusion '$exinc->{exinc_regexp}'");
             return 0;
         } elsif ($exinc->{exinc_type} == 0 && $value =~ /$exinc->{exinc_regexp}/) {
-            $options{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> exclusion '$exinc->{exinc_regexp}'");
+            $options{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> exclusion '$exinc->{exinc_regexp}'");
             return 1;
         }
     }

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -533,20 +533,6 @@ sub change_bytes {
     return (sprintf("%.2f", $options{value}), $unit . (defined($options{network}) ? 'b' : 'B'));
 }
 
-sub custom_variables {
-    my (%options) = @_;
-
-    if (defined($options{rule}->{rule_variable_custom}) && $options{rule}->{rule_variable_custom} ne '') {
-        my $error;
-        local $SIG{__DIE__} = sub { $error = $_[0]; };
-
-        eval "$options{rule}->{rule_variable_custom}";
-        if (defined($error)) {
-            $options{logger}->writeLogError("$options{logger_pre_message} custom variable code execution problem: " . $error);
-        }  
-    }
-}
-
 sub check_exinc {
     my (%options) = @_;
     

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -85,7 +85,7 @@ sub get_audit_user_id {
 
     my ($status, $contacts) = $options{class_object_centreon}->custom_execute(
         request => 'SELECT contact_id FROM contact WHERE contact_alias = ?',
-        bind_values => [$options{clapi_user}],
+        bind_values => [$options{user}],
         mode => 2
     );
     if ($status == -1) {

--- a/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -458,7 +458,7 @@ sub get_macros_host {
             my $macro_value = $_->[1];
             my $is_password = $_->[2];
             # Replace macro value if a vault is used
-            if ($options{vault_count} > 0 && defined($is_password) && $is_password == 1) {
+            if (defined($options{vault_count}) && defined($is_password) && $is_password == 1) {
                 set_macro(\%macros, $macro_name, "{" . $macro_name . "::secret::" . $macro_value . "}");
             } else {
                 set_macro(\%macros, $macro_name, $macro_value);
@@ -498,7 +498,7 @@ sub substitute_service_discovery_command {
     $command =~ s/\$HOSTADDRESS\$/$options{host}->{host_address}/g;
     $command =~ s/\$HOSTNAME\$/$options{host}->{host_name}/g;
 
-    if ($options{vault_count} > 0) {
+    if (defined($options{vault_count}) && $options{vault_count} > 0) {
         $command .= ' --pass-manager="centreonvault"';
     }
     


### PR DESCRIPTION
## Description

Migrated from https://github.com/centreon/centreon/pull/3880

Removes the use of CLAPI in the service discovery part of the autodiscovery module that can be painful to use with complicated passwords. It's also the aim of all Gorgone's modules.
Also maps settings in configuration file to be able to change the frequency of the discoveries.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Have some discovery rules configured and enabled,
2. Make sure to have something to be discovered and added to configuration,
3. Look at the logs for configuration generation:

```
2024-04-16 13:48:50 - INFO - [autodiscovery] -servicediscovery- 005cfc72:41 generate poller config '8'
2024-04-16 13:48:50 - DEBUG - == Info: Found bundle for host mycentral.domain.com: 0x558400333ec0 [can pipeline]
2024-04-16 13:48:50 - DEBUG - == Info: Re-using existing connection! (#746) with host mycentral.domain.com
2024-04-16 13:48:50 - DEBUG - == Info: Connected to mycentral.domain.com (10.2.3.4) port 443 (#746)
2024-04-16 13:48:50 - DEBUG - == Info: TLSv1.3 (OUT), TLS app data, [no content] (0):
2024-04-16 13:48:50 - DEBUG - => Send header: GET /centreon/api/latest/configuration/monitoring-servers/8/generate-and-reload?limit=10000&page=1 HTTP/1.1
Host: mycentral.domain.com
Accept: */*
Accept-Type: application/json; charset=utf-8
Content-Type: application/json; charset=utf-8
X-AUTH-TOKEN: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
2024-04-16 13:48:54 - DEBUG - == Info: TLSv1.3 (IN), TLS app data, [no content] (0):
2024-04-16 13:48:54 - DEBUG - => Recv header: HTTP/1.1 204 No Content
2024-04-16 13:48:54 - DEBUG - => Recv header: Date: Tue, 16 Apr 2024 11:48:53 GMT
2024-04-16 13:48:54 - DEBUG - => Recv header: Server: Apache
2024-04-16 13:48:54 - DEBUG - => Recv header: Cache-Control: no-cache, private
2024-04-16 13:48:54 - DEBUG - => Recv header: Api-Version: 23.04
2024-04-16 13:48:54 - DEBUG - => Recv header: X-Robots-Tag: noindex
2024-04-16 13:48:54 - DEBUG - => Recv header: Strict-Transport-Security: max-age=31536000; includeSubDomains
2024-04-16 13:48:54 - DEBUG - => Recv header: X-Frame-Options: sameorigin
2024-04-16 13:48:54 - DEBUG - => Recv header:
2024-04-16 13:48:54 - DEBUG - == Info: Connection #746 to host mycentral.domain.com left intact
```

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Autodiscovery module with new configuration directives for service discovery.
	- Introduced a method to trigger a reload for a monitoring server.

- **Bug Fixes**
	- Resolved a formatting issue in the `get_platform_versions` method.
	- Adjusted timeouts in service command executions to align with new configurations.

- **Documentation**
	- Updated documentation for the Autodiscovery module with new configuration directives and default values.

- **Refactor**
	- Updated the usage of internal APIs and methods across several modules for improved robustness and efficiency.
	- Renamed and refactored code for clearer understanding and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->