### PR TITLE
fix(gorgone) correctly handle gorgone pullwss module shutdown

### DIFF
--- a/gorgone/gorgone/modules/core/pullwss/class.pm
+++ b/gorgone/gorgone/modules/core/pullwss/class.pm
@@ -84,9 +84,6 @@ sub handle_TERM {
 
     if ($self->{connected} == 1) {
         $self->{tx}->send({text => $message });
-        $self->{tx}->on(drain => sub { Mojo::IOLoop->stop_gracefully(); });
-    } else {
-        Mojo::IOLoop->stop_gracefully();
     }
 }
 

--- a/gorgone/gorgone/standard/library.pm
+++ b/gorgone/gorgone/standard/library.pm
@@ -705,7 +705,7 @@ sub connect_com {
     if ($options{type} eq 'tcp') {
         $socket->set(ZMQ_TCP_KEEPALIVE, 'int', defined($options{zmq_tcp_keepalive}) ? $options{zmq_tcp_keepalive} : -1);
     }
-
+    $options{logger}->writeLogInfo("connection to zmq socket : " . $options{type} . '://' . $options{path});
     $socket->connect($options{type} . '://' . $options{path});
     return $socket;
 }

--- a/gorgone/packaging/centreon-gorgone.yaml
+++ b/gorgone/packaging/centreon-gorgone.yaml
@@ -161,6 +161,7 @@ overrides:
       - perl-Libssh-Session >= 0.8
       - perl-CryptX
       - perl-Mojolicious
+      - perl(Mojo::IOLoop::Signal)
       - perl(Archive::Tar)
       - perl(Schedule::Cron)
       - perl(ZMQ::FFI)
@@ -211,6 +212,7 @@ overrides:
       - libhash-merge-perl
       - libcryptx-perl
       - libmojolicious-perl
+      - libmojo-ioloop-signal-perl
       - libauthen-simple-perl
       - libauthen-simple-net-perl
       - libnet-curl-perl

--- a/gorgone/tests/robot/resources/resources.resource
+++ b/gorgone/tests/robot/resources/resources.resource
@@ -99,7 +99,7 @@ Check Poller Communicate
     [Arguments]    ${poller_id}
     ${response}     Set Variable    ${EMPTY}
     Log To Console    checking Gorgone see poller in rest api response...
-    FOR    ${i}    IN RANGE    10
+    FOR    ${i}    IN RANGE    20
         Sleep    5
         ${response}=    GET  http://127.0.0.1:8085/api/internal/constatus
         Log    ${response.json()}
@@ -111,7 +111,7 @@ Check Poller Communicate
         END
     END
     Log To Console    json response : ${response.json()}
-    Should Be True    ${i} < 9    timeout after ${i} time waiting for poller status in gorgone rest api (/api/internal/constatus) : ${response.json()}
+    Should Be True    ${i} < 19    timeout after ${i} time waiting for poller status in gorgone rest api (/api/internal/constatus) : ${response.json()}
     Should Be True    0 == ${response.json()}[data][${poller_id}][ping_failed]    there was failed ping between the central and the poller ${poller_id}
     Should Be True    0 < ${response.json()}[data][${poller_id}][ping_ok]    there was no successful ping between the central and the poller ${poller_id}
 

--- a/gorgone/tests/robot/resources/resources.resource
+++ b/gorgone/tests/robot/resources/resources.resource
@@ -5,6 +5,7 @@ Library            Process
 Library            RequestsLibrary
 Library            OperatingSystem
 
+Library             DatabaseLibrary
 *** Variables ***
 ${gorgone_binary}             /usr/bin/gorgoned
 ${ROOT_CONFIG}                ${CURDIR}${/}..${/}config${/}
@@ -44,7 +45,7 @@ Stop Gorgone And Remove Gorgone Config
 
     FOR    ${process}    IN    @{process_alias}
         ${result}    Terminate Process    ${process}
-        BuiltIn.Run Keyword And Continue On Failure    Should Be True    ${result.rc} == -15 or ${result.rc} == -9 or ${result.rc} == 0    Engine badly stopped alias = ${process} - code returned ${result.rc}.
+        BuiltIn.Run Keyword And Continue On Failure    Should Be True    ${result.rc} == -15 or ${result.rc} == 0    Gorgone ${process} badly stopped, code returned is ${result.rc}.
     END
 
 Gorgone Execute Sql
@@ -90,7 +91,6 @@ Check Poller Is Connected
           BREAK
         END
     END
-    Log To Console    TCP connection establishing after ${i} attempt
     Should Be True    ${i} < 39    Gorgone did not establish tcp connection in 160 seconds.
     Log To Console    TCP connection established after ${i} attempt (4 seconds each)
 
@@ -99,7 +99,7 @@ Check Poller Communicate
     [Arguments]    ${poller_id}
     ${response}     Set Variable    ${EMPTY}
     Log To Console    checking Gorgone see poller in rest api response...
-    FOR    ${i}    IN RANGE    20
+    FOR    ${i}    IN RANGE    10
         Sleep    5
         ${response}=    GET  http://127.0.0.1:8085/api/internal/constatus
         Log    ${response.json()}
@@ -111,7 +111,7 @@ Check Poller Communicate
         END
     END
     Log To Console    json response : ${response.json()}
-    Should Be True    ${i} < 20    timeout after ${i} time waiting for poller status in gorgone rest api (/api/internal/constatus) : ${response.json()}
+    Should Be True    ${i} < 9    timeout after ${i} time waiting for poller status in gorgone rest api (/api/internal/constatus) : ${response.json()}
     Should Be True    0 == ${response.json()}[data][${poller_id}][ping_failed]    there was failed ping between the central and the poller ${poller_id}
     Should Be True    0 < ${response.json()}[data][${poller_id}][ping_ok]    there was no successful ping between the central and the poller ${poller_id}
 
@@ -159,5 +159,13 @@ Wait Until Port Is Bind
           BREAK
         END
     END
-    Should Be True    ${i} < 10    Gorgone did not listen on port ${port} on time.
+    Should Be True    ${i} < 9    Gorgone did not listen on port ${port} on time.
     Log To Console    tcp port ${port} bind after ${i} attempt (0.5 seconds each)
+
+Ctn Check No Error In Logs
+    [Arguments]    ${gorgone_id}
+    ${cmd}=    Set Variable     grep -vP '^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2} ' /var/log/centreon-gorgone/${gorgone_id}/gorgoned.log
+    Log To Console    \n\n${cmd}\n\n
+
+    ${log_line_wrong}    RUN    ${cmd}
+    Should Be Empty     ${log_line_wrong}    There is Log in ${gorgone_id} not mathcing the standard gorgone format : ${log_line_wrong}

--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -8,9 +8,19 @@ Test Timeout        220s
 @{process_list}    pullwss_gorgone_poller_2    pullwss_gorgone_central
 
 *** Test Cases ***
-check one poller can connect to a central gorgone 
-    [Teardown]    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}db_delete_poller.sql
-
+check one poller can connect to a central and gorgone central stop first
+    [Teardown]    Stop Gorgone And Remove Gorgone Config    @{process_list}
+    @{process_list}    Set Variable    pullwss_gorgone_central    pullwss_gorgone_poller_2
     Log To Console    \nStarting the gorgone setup
     Setup Two Gorgone Instances    communication_mode=pullwss    central_name=pullwss_gorgone_central    poller_name=pullwss_gorgone_poller_2
+    Ctn Check No Error In Logs    pullwss_gorgone_poller_2
+    Log To Console    End of tests.
+
+check one poller can connect to a central and gorgone poller stop first
+    [Teardown]    Stop Gorgone And Remove Gorgone Config    @{process_list}
+    @{process_list}    Set Variable    pullwss_gorgone_poller_2    pullwss_gorgone_central
+    Log To Console    \nStarting the gorgone setup
+
+    Setup Two Gorgone Instances    communication_mode=pullwss    central_name=pullwss_gorgone_central    poller_name=pullwss_gorgone_poller_2
+    Ctn Check No Error In Logs    pullwss_gorgone_poller_2
     Log To Console    End of tests.


### PR DESCRIPTION
## Description

Migrated from https://github.com/centreon/centreon/pull/4178

This PR remove some C++ stack trace present when pullwss module unload by closing the zmq socket before the global destruction of the module.
It also use a new library Mojo::IOLoop::Signal to correctly handle sigterm signal, which was not always handled.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] master

<h2> How this pull request can be tested ? </h2>
See the robot tests, connecting a poller to a central and disconecting them should not add any C++ level error in the poller logs.
you should test both when the poller go down first (with a sigterm) and when the central go down first.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
