### PR TITLE
Mon 143223 dev 23 10 x gorgone autodisco nmap provider will not work due to gorgone whitelist migrate

### DIFF
--- a/gorgone/packaging/whitelist.conf.d/centreon.yaml
+++ b/gorgone/packaging/whitelist.conf.d/centreon.yaml
@@ -4,7 +4,7 @@
 - ^(sudo\s+)?(/usr/bin/)?service\s+(centengine|centreontrapd|cbd|cbd-sql)\s+(reload|restart)\s*$
 - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/+centengine\.cfg\s*$
 - ^cat\s+/var/lib/centreon-engine/+[a-zA-Z0-9\-]+-stats\.json\s*$
-- ^/usr/lib/centreon/plugins/.*$
+- ^(sudo\s+)?/usr/lib/centreon/plugins/.*$
 - ^/bin/perl /usr/share/centreon/bin/anomaly_detection --seasonality >> /var/log/centreon/anomaly_detection\.log 2>&1\s*$
 - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
 - ^centreon


### PR DESCRIPTION
## Description

add whitelist to fix nmap host discovery provider on 23.10 version

**Fixes** MON-143224

Migrated from https://github.com/centreon/centreon/pull/4642