### PR TITLE
Mon 144271 multiple identical metrics

### DIFF
--- a/common/src/perfdata.cc
+++ b/common/src/perfdata.cc
@@ -16,6 +16,7 @@
  * For more information : contact@centreon.com
  */
 
+#include <absl/container/flat_hash_set.h>
 #include <cmath>
 
 #include "perfdata.hh"
@@ -203,6 +204,8 @@ std::list<perfdata> perfdata::parse_perfdata(
     uint32_t service_id,
     const char* str,
     const std::shared_ptr<spdlog::logger>& logger) {
+  absl::flat_hash_set<std::string_view> metric_name;
+  std::string_view current_name;
   std::list<perfdata> retval;
   auto id = [host_id, service_id] {
     if (host_id || service_id)
@@ -280,6 +283,15 @@ std::list<perfdata> perfdata::parse_perfdata(
 
     if (end - s + 1 > 0) {
       p._name.assign(s, end - s + 1);
+      current_name = std::string_view(s, end - s + 1);
+
+      if (metric_name.contains(current_name)) {
+        logger->warn(
+            "storage: The metric '{}' appears several times in the output "
+            "\"{}\": you will lose any new occurence of this metric",
+            p.name(), str);
+        error = true;
+      }
     } else {
       logger->error("In service {}, metric name empty before '{}...'", id(),
                     fmt::string_view(s, 10));
@@ -363,7 +375,8 @@ std::list<perfdata> perfdata::parse_perfdata(
         p.max());
 
     // Append to list.
-    retval.emplace_back(std::move(p));
+    metric_name.insert(current_name);
+    retval.push_back(std::move(p));
 
     // Skip whitespaces.
     while (isspace(*tmp))

--- a/common/tests/perfdata_test.cc
+++ b/common/tests/perfdata_test.cc
@@ -246,6 +246,58 @@ TEST_F(PerfdataParser, Simple2) {
   ASSERT_TRUE(expected == *it);
 }
 
+TEST_F(PerfdataParser, SeveralIdenticalMetrics) {
+  // Parse perfdata.
+  std::list<common::perfdata> list{common::perfdata::parse_perfdata(
+      0, 0, "'et'=18.00%;15:;10:;0;100 other=15 et=13.00%", _logger)};
+
+  // Assertions.
+  ASSERT_EQ(list.size(), 2u);
+  std::list<perfdata>::const_iterator it = list.begin();
+  perfdata expected;
+  expected.name("et");
+  expected.value_type(perfdata::gauge);
+  expected.value(18.0);
+  expected.unit("%");
+  expected.warning(std::numeric_limits<double>::infinity());
+  expected.warning_low(15.0);
+  expected.critical(std::numeric_limits<double>::infinity());
+  expected.critical_low(10.0);
+  expected.min(0.0);
+  expected.max(100.0);
+  ASSERT_TRUE(expected == *it);
+  ++it;
+  ASSERT_EQ(it->name(), std::string_view("other"));
+  ASSERT_EQ(it->value(), 15);
+  ASSERT_EQ(it->value_type(), perfdata::gauge);
+}
+
+TEST_F(PerfdataParser, ComplexSeveralIdenticalMetrics) {
+  // Parse perfdata.
+  std::list<common::perfdata> list{common::perfdata::parse_perfdata(
+      0, 0, "'d[foo]'=18.00%;15:;10:;0;100 other=15 a[foo]=13.00%", _logger)};
+
+  // Assertions.
+  ASSERT_EQ(list.size(), 2u);
+  std::list<perfdata>::const_iterator it = list.begin();
+  perfdata expected;
+  expected.name("foo");
+  expected.value_type(perfdata::derive);
+  expected.value(18.0);
+  expected.unit("%");
+  expected.warning(std::numeric_limits<double>::infinity());
+  expected.warning_low(15.0);
+  expected.critical(std::numeric_limits<double>::infinity());
+  expected.critical_low(10.0);
+  expected.min(0.0);
+  expected.max(100.0);
+  ASSERT_TRUE(expected == *it);
+  ++it;
+  ASSERT_EQ(it->name(), std::string_view("other"));
+  ASSERT_EQ(it->value(), 15);
+  ASSERT_EQ(it->value_type(), perfdata::gauge);
+}
+
 TEST_F(PerfdataParser, Complex1) {
   // Parse perfdata.
   std::list<perfdata> list{perfdata::parse_perfdata(

--- a/tests/broker-engine/rrd.robot
+++ b/tests/broker-engine/rrd.robot
@@ -482,6 +482,47 @@ BRRDSTATUS
     Should Be Equal    ${result}    ${False}    We shouldn't have any error about empty value in RRD
 
 
+#BRRDSTATUSRETENTION   We need the fix for this test: MON-139747
+#    [Documentation]    We are working with BBDO3. This test checks status are not sent twice after Engine reload.
+#    [Tags]    rrd    status    bbdo3
+#    Ctn Config Engine    ${1}
+#    Ctn Config Broker    rrd
+#    Ctn Config Broker    central
+#    Ctn Config Broker    module
+#    Ctn Config BBDO3    ${1}
+#    Ctn Broker Config Log    central    sql    info
+#    Ctn Broker Config Log    rrd    rrd    debug
+#    Ctn Broker Config Log    rrd    core    error
+#    Ctn Broker Config Flush Log    central    0
+#    Ctn Broker Config Flush Log    rrd    0
+#
+#    ${start}    Get Current Date
+#    Ctn Start Broker
+#    Ctn Start Engine
+#    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+#
+#    Ctn Schedule Forced Svc Check    host_1    service_1    ${VarRoot}/lib/centreon-engine/config0/rw/centengine.cmd
+#    Log To Console    Engine works during 20s
+#    Sleep    20s
+#
+#    Log To Console    We modify the check_interval of the service service_1
+#    Ctn Engine Config Replace Value In Services    0    service_1    check_interval    1
+#
+#    ${start}    Ctn Get Round Current Date
+#    Log To Console    Reloading Engine and waiting for 20s again
+#    Ctn Reload Engine
+#    Sleep    20s
+#
+#    Log To Console    Find in logs if there is an error in rrd.
+#    ${index}    Ctn Get Service Index    1    1
+#    ${content}    Create List    RRD: ignored update error in file '${VarRoot}/lib/centreon/status/${index}.rrd': ${VarRoot}/lib/centreon/status/${index}.rrd: illegal attempt to update using time
+#    ${result}    Ctn Find In Log With Timeout    ${rrdLog}    ${start}    ${content}    1
+#    Should Be Equal
+#    ...    ${result}    ${False}
+#    ...    No message about an illegal attempt to update the rrd files should appear
+#    Log To Console    Test finished
+
+
 *** Keywords ***
 Ctn Test Clean
     Ctn Stop Engine

--- a/tests/resources/Engine.py
+++ b/tests/resources/Engine.py
@@ -857,7 +857,7 @@ def ctn_engine_config_set_value_in_services(idx: int, desc: str, key: str, value
         key (str): The key whose value needs to change.
         value (str): The new value to set.
     """
-    filename = ETC_ROOT + "/centreon-engine/config{}/services.cfg".format(idx)
+    filename = f"{ETC_ROOT}/centreon-engine/config{idx}/services.cfg"
     with open(filename, "r") as f:
         lines = f.readlines()
 


### PR DESCRIPTION
REFS: MON-144271

When perfdata are parsed, if some metric appear more than once, a warning log is raised by broker to explain the issue but only the first metric is kept in the output.