### PR TITLE
fix(ci): remove lua-curl delivery to bookworm and jammy

### DIFF
--- a/.github/workflows/lua-curl.yml
+++ b/.github/workflows/lua-curl.yml
@@ -197,10 +197,6 @@ jobs:
             arch: amd64
           - distrib: bullseye
             arch: arm64
-          - distrib: bookworm
-            arch: amd64
-          - distrib: jammy
-            arch: amd64
     name: deliver ${{ matrix.distrib }} ${{ matrix.arch }}
 
     steps:
@@ -225,7 +221,7 @@ jobs:
     runs-on: [self-hosted, common]
     strategy:
       matrix:
-        distrib: [el8, el9, bullseye, bookworm]
+        distrib: [el8, el9, bullseye]
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
## Description

fix(ci): remove lua-curl delivery to bookworm and jammy

**Fixes** MON-35026

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x
- [ ] master