### PR TITLE
fix(gorgone): Die (as expected by caller) when config file is not readable in mbi (MON-51697)

### DIFF
--- a/gorgone/gorgone/modules/centreon/mbi/etl/class.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/etl/class.pm
@@ -126,7 +126,7 @@ sub db_parse_xml {
     my ($self, %options) = @_;
 
     my ($rv, $message, $content) = gorgone::standard::misc::slurp(file => $options{file});
-    return (0, $message) if (!$rv);
+    die $message if (!$rv);
     eval {
         $SIG{__WARN__} = sub {};
         $content = XMLin($content, ForceArray => [], KeyAttr => []);

--- a/gorgone/tests/unit/modules/centreon/mbi/etl/class.t
+++ b/gorgone/tests/unit/modules/centreon/mbi/etl/class.t
@@ -1,0 +1,22 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test2::V0;
+use Test2::Plugin::NoWarnings echo => 1;
+use Test2::Tools::Compare qw{is like match};
+use FindBin;
+use lib "$FindBin::Bin/../../../../../../";
+use gorgone::modules::centreon::mbi::etl::class;
+sub main {
+        eval {
+            gorgone::modules::centreon::mbi::etl::class::db_parse_xml(undef, 'file', 'FileThatDoesNotExist.xml');
+
+        };
+        if ($@) {
+            like($@, qr/FileThatDoesNotExist.xml/, 'FileThatDoesNotExist.xml does not exist');
+        }else {
+            fail('FileThatDoesNotExist.xml should not exist and send an error.');
+        }
+    done_testing();
+}
+main;


### PR DESCRIPTION
## Description

**Fixes** #MON-51697

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] master