### PR TITLE
MON-147699 check_exec doesn't lock on recursion

### DIFF
--- a/agent/inc/com/centreon/agent/check_exec.hh
+++ b/agent/inc/com/centreon/agent/check_exec.hh
@@ -37,14 +37,14 @@ namespace detail {
  * ensure that completion is called for the right process and not for the
  * previous one
  */
-class process : public common::process {
+class process : public common::process<false> {
   bool _process_ended;
   bool _stdout_eof;
   std::string _stdout;
   unsigned _running_index;
   std::weak_ptr<check_exec> _parent;
 
-  void _on_completion(absl::ReleasableMutexLock& yet_locked);
+  void _on_completion();
 
  public:
   process(const std::shared_ptr<asio::io_context>& io_context,
@@ -54,22 +54,21 @@ class process : public common::process {
 
   void start(unsigned running_index);
 
-  void kill() { common::process::kill(); }
+  void kill() { common::process<false>::kill(); }
 
-  int get_exit_status() const { return common::process::get_exit_status(); }
+  int get_exit_status() const {
+    return common::process<false>::get_exit_status();
+  }
 
   const std::string& get_stdout() const { return _stdout; }
 
  protected:
-  void on_stdout_read(absl::ReleasableMutexLock& yet_locked,
-                      const boost::system::error_code& err,
+  void on_stdout_read(const boost::system::error_code& err,
                       size_t nb_read) override;
-  void on_stderr_read(absl::ReleasableMutexLock& yet_locked,
-                      const boost::system::error_code& err,
+  void on_stderr_read(const boost::system::error_code& err,
                       size_t nb_read) override;
 
-  void on_process_end(absl::ReleasableMutexLock& yet_locked,
-                      const boost::system::error_code& err,
+  void on_process_end(const boost::system::error_code& err,
                       int raw_exit_status) override;
 };
 

--- a/agent/inc/com/centreon/agent/check_exec.hh
+++ b/agent/inc/com/centreon/agent/check_exec.hh
@@ -44,7 +44,7 @@ class process : public common::process {
   unsigned _running_index;
   std::weak_ptr<check_exec> _parent;
 
-  void _on_completion();
+  void _on_completion(absl::ReleasableMutexLock& yet_locked);
 
  public:
   process(const std::shared_ptr<asio::io_context>& io_context,
@@ -61,12 +61,15 @@ class process : public common::process {
   const std::string& get_stdout() const { return _stdout; }
 
  protected:
-  void on_stdout_read(const boost::system::error_code& err,
+  void on_stdout_read(absl::ReleasableMutexLock& yet_locked,
+                      const boost::system::error_code& err,
                       size_t nb_read) override;
-  void on_stderr_read(const boost::system::error_code& err,
+  void on_stderr_read(absl::ReleasableMutexLock& yet_locked,
+                      const boost::system::error_code& err,
                       size_t nb_read) override;
 
-  void on_process_end(const boost::system::error_code& err,
+  void on_process_end(absl::ReleasableMutexLock& yet_locked,
+                      const boost::system::error_code& err,
                       int raw_exit_status) override;
 };
 

--- a/agent/src/main.cc
+++ b/agent/src/main.cc
@@ -81,6 +81,8 @@ static std::string read_file(const std::string& file_path) {
       ss << file.rdbuf();
       file.close();
       return ss.str();
+    } else {
+      SPDLOG_LOGGER_ERROR(g_logger, "fail to open {}", file_path);
     }
   } catch (const std::exception& e) {
     SPDLOG_LOGGER_ERROR(g_logger, "fail to read {}: {}", file_path, e.what());

--- a/common/process/inc/com/centreon/common/process/process.hh
+++ b/common/process/inc/com/centreon/common/process/process.hh
@@ -26,6 +26,33 @@ namespace detail {
 struct boost_process;
 }  // namespace detail
 
+namespace detail {
+template <bool use_mutex>
+class mutex;
+
+template <bool use_mutex>
+class lock;
+
+template <>
+class mutex<true> : public absl::Mutex {};
+
+template <>
+class lock<true> : public absl::MutexLock {
+ public:
+  lock(absl::Mutex* mut) : absl::MutexLock(mut) {}
+};
+
+template <>
+class mutex<false> {};
+
+template <>
+class lock<false> {
+ public:
+  lock(mutex<false>* dummy_mut) {}
+};
+
+}  // namespace detail
+
 /**
  * @brief This class allow to exec a process asynchronously.
  * It's a base class. If you want to get stdin and stdout returned data, you
@@ -37,22 +64,23 @@ struct boost_process;
  * When completion methods like on_stdout_read are called, _protect is already
  * locked
  */
-class process : public std::enable_shared_from_this<process> {
+
+template <bool use_mutex = true>
+class process : public std::enable_shared_from_this<process<use_mutex>> {
+  using std::enable_shared_from_this<process<use_mutex>>::shared_from_this;
   std::string _exe_path;
   std::vector<std::string> _args;
 
-  std::deque<std::shared_ptr<std::string>> _stdin_write_queue
-      ABSL_GUARDED_BY(_protect);
-  bool _write_pending ABSL_GUARDED_BY(_protect) = false;
+  std::deque<std::shared_ptr<std::string>> _stdin_write_queue;
+  bool _write_pending;
 
-  std::shared_ptr<detail::boost_process> _proc ABSL_GUARDED_BY(_protect);
+  std::shared_ptr<detail::boost_process> _proc;
 
   int _exit_status = 0;
 
-  absl::Mutex _protect;
+  detail::mutex<use_mutex> _protect;
 
-  void stdin_write_no_lock(const std::shared_ptr<std::string>& data)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(_protect);
+  void stdin_write_no_lock(const std::shared_ptr<std::string>& data);
   void stdin_write(const std::shared_ptr<std::string>& data);
 
   void stdout_read();
@@ -62,26 +90,18 @@ class process : public std::enable_shared_from_this<process> {
   std::shared_ptr<asio::io_context> _io_context;
   std::shared_ptr<spdlog::logger> _logger;
 
-  char _stdout_read_buffer[0x1000] ABSL_GUARDED_BY(_protect);
-  char _stderr_read_buffer[0x1000] ABSL_GUARDED_BY(_protect);
+  char _stdout_read_buffer[0x1000];
+  char _stderr_read_buffer[0x1000];
 
-  virtual void on_stdout_read(absl::ReleasableMutexLock& yet_locked,
-                              const boost::system::error_code& err,
-                              size_t nb_read)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(_protect);
-  virtual void on_stderr_read(absl::ReleasableMutexLock& yet_locked,
-                              const boost::system::error_code& err,
-                              size_t nb_read)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(_protect);
+  virtual void on_stdout_read(const boost::system::error_code& err,
+                              size_t nb_read);
+  virtual void on_stderr_read(const boost::system::error_code& err,
+                              size_t nb_read);
 
-  virtual void on_process_end(absl::ReleasableMutexLock& yet_locked,
-                              const boost::system::error_code& err,
-                              int raw_exit_status)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(_protect);
+  virtual void on_process_end(const boost::system::error_code& err,
+                              int raw_exit_status);
 
-  virtual void on_stdin_write(absl::ReleasableMutexLock& yet_locked,
-                              const boost::system::error_code& err)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(_protect);
+  virtual void on_stdin_write(const boost::system::error_code& err);
 
  public:
   template <typename string_iterator>
@@ -130,12 +150,13 @@ class process : public std::enable_shared_from_this<process> {
  * @param arg_begin iterator to first argument
  * @param arg_end iterator after the last argument
  */
+template <bool use_mutex>
 template <typename string_iterator>
-process::process(const std::shared_ptr<asio::io_context>& io_context,
-                 const std::shared_ptr<spdlog::logger>& logger,
-                 const std::string_view& exe_path,
-                 string_iterator arg_begin,
-                 string_iterator arg_end)
+process<use_mutex>::process(const std::shared_ptr<asio::io_context>& io_context,
+                            const std::shared_ptr<spdlog::logger>& logger,
+                            const std::string_view& exe_path,
+                            string_iterator arg_begin,
+                            string_iterator arg_end)
     : _exe_path(exe_path),
       _args(arg_begin, arg_end),
       _io_context(io_context),
@@ -150,11 +171,13 @@ process::process(const std::shared_ptr<asio::io_context>& io_context,
  * @param exe_path path of executable without argument
  * @param args container of arguments
  */
+template <bool use_mutex>
 template <typename args_container>
-process::process(const std::shared_ptr<boost::asio::io_context>& io_context,
-                 const std::shared_ptr<spdlog::logger>& logger,
-                 const std::string_view& exe_path,
-                 const args_container& args)
+process<use_mutex>::process(
+    const std::shared_ptr<boost::asio::io_context>& io_context,
+    const std::shared_ptr<spdlog::logger>& logger,
+    const std::string_view& exe_path,
+    const args_container& args)
     : _exe_path(exe_path),
       _args(args),
       _io_context(io_context),
@@ -170,11 +193,13 @@ process::process(const std::shared_ptr<boost::asio::io_context>& io_context,
  * @param exe_path path of executable without argument
  * @param args brace of arguments {"--flag1", "arg1", "-c", "arg2"}
  */
+template <bool use_mutex>
 template <typename string_type>
-process::process(const std::shared_ptr<boost::asio::io_context>& io_context,
-                 const std::shared_ptr<spdlog::logger>& logger,
-                 const std::string_view& exe_path,
-                 const std::initializer_list<string_type>& args)
+process<use_mutex>::process(
+    const std::shared_ptr<boost::asio::io_context>& io_context,
+    const std::shared_ptr<spdlog::logger>& logger,
+    const std::string_view& exe_path,
+    const std::initializer_list<string_type>& args)
     : _exe_path(exe_path), _io_context(io_context), _logger(logger) {
   _args.reserve(args.size());
   for (const auto& str : args) {
@@ -189,8 +214,9 @@ process::process(const std::shared_ptr<boost::asio::io_context>& io_context,
  * can be used to construct a std::string
  * @param content
  */
+template <bool use_mutex>
 template <typename string_class>
-void process::write_to_stdin(const string_class& content) {
+void process<use_mutex>::write_to_stdin(const string_class& content) {
   stdin_write(std::make_shared<std::string>(content));
 }
 

--- a/common/process/inc/com/centreon/common/process/process.hh
+++ b/common/process/inc/com/centreon/common/process/process.hh
@@ -65,18 +65,22 @@ class process : public std::enable_shared_from_this<process> {
   char _stdout_read_buffer[0x1000] ABSL_GUARDED_BY(_protect);
   char _stderr_read_buffer[0x1000] ABSL_GUARDED_BY(_protect);
 
-  virtual void on_stdout_read(const boost::system::error_code& err,
+  virtual void on_stdout_read(absl::ReleasableMutexLock& yet_locked,
+                              const boost::system::error_code& err,
                               size_t nb_read)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(_protect);
-  virtual void on_stderr_read(const boost::system::error_code& err,
+  virtual void on_stderr_read(absl::ReleasableMutexLock& yet_locked,
+                              const boost::system::error_code& err,
                               size_t nb_read)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(_protect);
 
-  virtual void on_process_end(const boost::system::error_code& err,
+  virtual void on_process_end(absl::ReleasableMutexLock& yet_locked,
+                              const boost::system::error_code& err,
                               int raw_exit_status)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(_protect);
 
-  virtual void on_stdin_write(const boost::system::error_code& err)
+  virtual void on_stdin_write(absl::ReleasableMutexLock& yet_locked,
+                              const boost::system::error_code& err)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(_protect);
 
  public:

--- a/common/tests/process_test.cc
+++ b/common/tests/process_test.cc
@@ -44,7 +44,7 @@ class process_test : public ::testing::Test {
   }
 };
 
-class process_wait : public process {
+class process_wait : public process<> {
   std::mutex _cond_m;
   std::condition_variable _cond;
   std::string _stdout;
@@ -61,8 +61,7 @@ class process_wait : public process {
     _process_ended = false;
   }
 
-  void on_stdout_read(absl::ReleasableMutexLock& yet_locked,
-                      const boost::system::error_code& err,
+  void on_stdout_read(const boost::system::error_code& err,
                       size_t nb_read) override {
     if (!err) {
       std::string_view line(_stdout_read_buffer, nb_read);
@@ -74,11 +73,10 @@ class process_wait : public process {
       l.unlock();
       _cond.notify_one();
     }
-    process::on_stdout_read(yet_locked, err, nb_read);
+    process::on_stdout_read(err, nb_read);
   }
 
-  void on_stderr_read(absl::ReleasableMutexLock& yet_locked,
-                      const boost::system::error_code& err,
+  void on_stderr_read(const boost::system::error_code& err,
                       size_t nb_read) override {
     if (!err) {
       std::string_view line(_stderr_read_buffer, nb_read);
@@ -90,13 +88,12 @@ class process_wait : public process {
       l.unlock();
       _cond.notify_one();
     }
-    process::on_stderr_read(yet_locked, err, nb_read);
+    process::on_stderr_read(err, nb_read);
   }
 
-  void on_process_end(absl::ReleasableMutexLock& yet_locked,
-                      const boost::system::error_code& err,
+  void on_process_end(const boost::system::error_code& err,
                       int raw_exit_status) override {
-    process::on_process_end(yet_locked, err, raw_exit_status);
+    process::on_process_end(err, raw_exit_status);
     SPDLOG_LOGGER_DEBUG(_logger, "process end");
     std::unique_lock l(_cond_m);
     _process_ended = true;


### PR DESCRIPTION
REFS;MON-147699

## Description

In CMA, When a check is too long completion of process object call start method of this object witch goes to a deadlock 

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

