### PR TITLE
feat(gorgone): when pushing engine conf, push centreon_vmware daemon configuration

### DIFF
--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -130,118 +130,121 @@ jobs:
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-version.outputs.stability }}
 
-  # test-gorgone:
-  #   needs: [get-version, package]
+  test-gorgone:
+    needs: [get-version, package]
 
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       distrib: [el8, el9, bookworm, jammy]
-  #       include:
-  #         - package_extension: rpm
-  #           image: gorgone-testing-alma8
-  #           distrib: el8
-  #         - package_extension: rpm
-  #           image: gorgone-testing-alma9
-  #           distrib: el9
-  #         - package_extension: deb
-  #           image: gorgone-testing-jammy
-  #           distrib: jammy
-  #         - package_extension: deb
-  #           image: gorgone-testing-bookworm
-  #           distrib: bookworm
+    strategy:
+      fail-fast: false
+      matrix:
+        distrib: [el8, el9, bullseye, bookworm, jammy]
+        include:
+          - package_extension: rpm
+            image: gorgone-testing-alma8
+            distrib: el8
+          - package_extension: rpm
+            image: gorgone-testing-alma9
+            distrib: el9
+          - package_extension: deb
+            image: gorgone-testing-bullseye
+            distrib: bullseye
+          - package_extension: deb
+            image: gorgone-testing-jammy
+            distrib: jammy
+          - package_extension: deb
+            image: gorgone-testing-bookworm
+            distrib: bookworm
 
-  #   runs-on: ubuntu-22.04
-  #   container:
-  #     image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:${{ needs.get-version.outputs.gorgone_docker_version }}
-  #     credentials:
-  #       username: ${{ secrets.DOCKER_REGISTRY_ID }}
-  #       password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}
+    runs-on: ubuntu-22.04
+    container:
+      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:${{ needs.get-version.outputs.gorgone_docker_version }}
+      credentials:
+        username: ${{ secrets.DOCKER_REGISTRY_ID }}
+        password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}
 
-  #   services:
-  #     mariadb:
-  #       image: mariadb:latest
-  #       ports:
-  #         - 3306
-  #       env:
-  #         MYSQL_USER: centreon
-  #         MYSQL_PASSWORD: password
-  #         MYSQL_ROOT_PASSWORD: password
+    services:
+      mariadb:
+        image: mariadb:latest
+        ports:
+          - 3306
+        env:
+          MYSQL_USER: centreon
+          MYSQL_PASSWORD: password
+          MYSQL_ROOT_PASSWORD: password
 
-  #   steps:
-  #     - name: Get linked branch of centreon repository
-  #       id: centreon_repo_linked_branch
-  #       run: |
-  #         CENTREON_REPO_LINKED_BRANCH=$(git ls-remote -h https://github.com/centreon/centreon.git | grep -E "refs/heads/dev-${{ needs.get-version.outputs.major_version }}\.x$" >/dev/null 2>&1 && echo "dev-${{ needs.get-version.outputs.major_version }}.x" || echo develop)
+    steps:
+      - name: Get linked branch of centreon repository
+        id: centreon_repo_linked_branch
+        run: |
+          CENTREON_REPO_LINKED_BRANCH=$(git ls-remote -h https://github.com/centreon/centreon.git | grep -E "refs/heads/dev-${{ needs.get-version.outputs.major_version }}\.x$" >/dev/null 2>&1 && echo "dev-${{ needs.get-version.outputs.major_version }}.x" || echo develop)
 
-  #         GIT_BRANCH_EXISTS=$(git ls-remote -h https://github.com/centreon/centreon.git | grep -E "refs/heads/${{ github.head_ref || github.ref_name }}$" >/dev/null 2>&1 && echo yes || echo no)
-  #         if [[ "$GIT_BRANCH_EXISTS" == "yes" ]]; then
-  #           CENTREON_REPO_LINKED_BRANCH="${{ github.head_ref || github.ref_name }}"
-  #         fi
+          GIT_BRANCH_EXISTS=$(git ls-remote -h https://github.com/centreon/centreon.git | grep -E "refs/heads/${{ github.head_ref || github.ref_name }}$" >/dev/null 2>&1 && echo yes || echo no)
+          if [[ "$GIT_BRANCH_EXISTS" == "yes" ]]; then
+            CENTREON_REPO_LINKED_BRANCH="${{ github.head_ref || github.ref_name }}"
+          fi
 
-  #         echo "linked_branch=$CENTREON_REPO_LINKED_BRANCH" >> $GITHUB_OUTPUT
-  #       shell: bash
+          echo "linked_branch=$CENTREON_REPO_LINKED_BRANCH" >> $GITHUB_OUTPUT
+        shell: bash
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: Checkout sources
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
-  #     - name: Checkout sources
-  #       uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-  #       with:
-  #         repository: centreon/centreon
-  #         path: centreon
-  #         ref: ${{ steps.centreon_repo_linked_branch.outputs.linked_branch }}
-  #         sparse-checkout: |
-  #           centreon/www/install/createTables.sql
-  #           centreon/www/install/createTablesCentstorage.sql
+      - name: Checkout sources
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          repository: centreon/centreon
+          path: centreon
+          ref: ${{ steps.centreon_repo_linked_branch.outputs.linked_branch }}
+          sparse-checkout: |
+            centreon/www/install/createTables.sql
+            centreon/www/install/createTablesCentstorage.sql
 
-  #     - name: get cached gorgone package
-  #       uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-  #       with:
-  #         path: ./*.${{ matrix.package_extension }}
-  #         key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
-  #         fail-on-cache-miss: true
+      - name: get cached gorgone package
+        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: ./*.${{ matrix.package_extension }}
+          key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+          fail-on-cache-miss: true
 
-  #     - name: Parse distrib name
-  #       id: parse-distrib
-  #       uses: ./.github/actions/parse-distrib
-  #       with:
-  #         distrib: ${{ matrix.distrib }}
+      - name: Parse distrib name
+        id: parse-distrib
+        uses: ./.github/actions/parse-distrib
+        with:
+          distrib: ${{ matrix.distrib }}
 
-  #     - name: Install gorgone from just built package
-  #       shell: bash
-  #       run: |
-  #         if [[ "${{ matrix.package_extension }}" == "deb" ]]; then
-  #           apt update
-  #           apt install -y ./centreon-gorgone*${{ steps.parse-distrib.outputs.package_distrib_name }}*
-  #         else
-  #           dnf install -y ./centreon-gorgone*${{ steps.parse-distrib.outputs.package_distrib_name }}* ./centreon-gorgone-centreon-config*${{ steps.parse-distrib.outputs.package_distrib_name }}*
-  #           # in el8 at least, there is a package for the configuration and a package for the actual code.
-  #           # this is not the case for debian, and for now I don't know why it was made any different between the 2 Os.
-  #         fi
+      - name: Install gorgone from just built package
+        shell: bash
+        run: |
+          if [[ "${{ matrix.package_extension }}" == "deb" ]]; then
+            apt update
+            apt install -y ./centreon-gorgone*${{ steps.parse-distrib.outputs.package_distrib_name }}*
+          else
+            dnf install -y ./centreon-gorgone*${{ steps.parse-distrib.outputs.package_distrib_name }}* ./centreon-gorgone-centreon-config*${{ steps.parse-distrib.outputs.package_distrib_name }}*
+            # in el8 at least, there is a package for the configuration and a package for the actual code.
+            # this is not the case for debian, and for now I don't know why it was made any different between the 2 Os.
+          fi
 
-  #     - name: Create databases
-  #       run: |
-  #         mysql -h mariadb -u root -ppassword -e "CREATE DATABASE \`centreon\`"
-  #         mysql -h mariadb -u root -ppassword -e "CREATE DATABASE \`centreon-storage\`"
-  #         mysql -h mariadb -u root -ppassword -e "GRANT ALL PRIVILEGES ON centreon.* TO 'centreon'@'%'"
-  #         mysql -h mariadb -u root -ppassword -e "GRANT ALL PRIVILEGES ON  \`centreon-storage\`.* TO 'centreon'@'%'"
-  #         mysql -h mariadb -u root -ppassword 'centreon' < centreon/centreon/www/install/createTables.sql
-  #         mysql -h mariadb -u root -ppassword 'centreon-storage' < centreon/centreon/www/install/createTablesCentstorage.sql
+      - name: Create databases
+        run: |
+          mysql -h mariadb -u root -ppassword -e "CREATE DATABASE \`centreon\`"
+          mysql -h mariadb -u root -ppassword -e "CREATE DATABASE \`centreon-storage\`"
+          mysql -h mariadb -u root -ppassword -e "GRANT ALL PRIVILEGES ON centreon.* TO 'centreon'@'%'"
+          mysql -h mariadb -u root -ppassword -e "GRANT ALL PRIVILEGES ON  \`centreon-storage\`.* TO 'centreon'@'%'"
+          mysql -h mariadb -u root -ppassword 'centreon' < centreon/centreon/www/install/createTables.sql
+          mysql -h mariadb -u root -ppassword 'centreon-storage' < centreon/centreon/www/install/createTablesCentstorage.sql
 
-  #     - name: Run tests
-  #       run: robot -v 'DBHOST:mariadb' -v 'DBNAME:centreon' -v 'DBNAME_STORAGE:centreon-storage' -v 'DBUSER:centreon' gorgone/tests
+      - name: Run tests
+        run: robot -v 'DBHOST:mariadb' -v 'DBNAME:centreon' -v 'DBNAME_STORAGE:centreon-storage' -v 'DBUSER:centreon' gorgone/tests
 
-  #     - name: Upload gorgone and robot debug artifacts
-  #       if: failure()
-  #       uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
-  #       with:
-  #         name: gorgone-debug-${{ matrix.distrib }}
-  #         path: |
-  #           log.html
-  #           /var/log/centreon-gorgone
-  #           /etc/centreon-gorgone
-  #         retention-days: 1
+      - name: Upload gorgone and robot debug artifacts
+        if: failure()
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        with:
+          name: gorgone-debug-${{ matrix.distrib }}
+          path: |
+            log.html
+            /var/log/centreon-gorgone
+            /etc/centreon-gorgone
+          retention-days: 1
 
   deliver-sources:
     runs-on: [self-hosted, common]

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -136,7 +136,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el8, el9, bullseye, bookworm, jammy]
+        distrib: [el8, el9, bookworm, jammy]
         include:
           - package_extension: rpm
             image: gorgone-testing-alma8
@@ -144,9 +144,6 @@ jobs:
           - package_extension: rpm
             image: gorgone-testing-alma9
             distrib: el9
-          - package_extension: deb
-            image: gorgone-testing-bullseye
-            distrib: bullseye
           - package_extension: deb
             image: gorgone-testing-jammy
             distrib: jammy

--- a/gorgone/contrib/named_pipe_reader.pl
+++ b/gorgone/contrib/named_pipe_reader.pl
@@ -1,0 +1,68 @@
+#!/usr/bin/perl
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+use strict;
+use warnings;
+use Getopt::Long;
+use POSIX qw(mkfifo);
+use DateTime;
+use File::Basename;
+use File::Path qw(make_path);
+# global variable for easier verb() usage, don't need to pass the verbose argument.
+my $args = {};
+sub main {
+
+    GetOptions("pipename=s" => \$args->{pipename},
+               "logfile=s"   => \$args->{logfile},    # string
+               "verbose"  => \$args->{verbose}) # flag
+    or die("Error in command line arguments\n");
+    make_path(basename($args->{pipename}));
+
+    verb("pipe to create is : " . $args->{pipename});
+    unlink($args->{pipename});
+    mkfifo($args->{pipename}, 0777) || die "can't mkfifo $args->{pipename} : $!";
+    open(my $fh_log, '>>', $args->{logfile}) or die "can't open log file $args->{logfile} : $!";
+    {
+        my $ofh = select $fh_log;
+        $|      = 1; # work only on current filehandle, so we select our log fh and make it hot, and continue after.
+        select $ofh
+    }
+    while (1) {
+        open(my $fh_pipe, '<', $args->{pipename}) or die "can't open pipe $args->{pipename}";
+        my $val = <$fh_pipe>;
+        verb("pipe gave value : " . $val);
+        my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime(time());
+        my $date =  sprintf(
+            '%04d-%02d-%02d %02d:%02d:%02d',
+            $year+1900, $mon+1, $mday, $hour, $min, $sec
+        );
+        print $fh_log $date . " - " . $val;
+
+        close $fh_pipe;
+        sleep(0.1);
+    }
+
+}
+sub verb {
+    return if !$args->{verbose};
+    print DateTime->now() . " - ";
+    print shift ;
+    print "\n";
+}
+main;

--- a/gorgone/gorgone/modules/core/proxy/class.pm
+++ b/gorgone/gorgone/modules/core/proxy/class.pm
@@ -465,9 +465,6 @@ sub event {
 
     my $socket;
     if (defined($options{channel})) {
-        if (defined($self->{clients}->{ $options{channel} })) {
-            $self->{logger}->writeLogDebug("[proxy] event channel $options{channel} delete: $self->{clients}->{ $options{channel} }->{delete} com_read_internal: $self->{clients}->{ $options{channel} }->{com_read_internal}");
-        }
         return if (defined($self->{clients}->{ $options{channel} })
                    && ( $self->{clients}->{ $options{channel} }->{com_read_internal} == 0
                         || $self->{clients}->{ $options{channel} }->{delete} == 1)

--- a/gorgone/packaging/configuration/whitelist.conf.d/centreon.yaml
+++ b/gorgone/packaging/configuration/whitelist.conf.d/centreon.yaml
@@ -1,6 +1,6 @@
 # Configuration brought by Centreon Gorgone package.
 # SHOULD NOT BE EDITED! CREATE YOUR OWN FILE IN WHITELIST.CONF.D DIRECTORY!
-- ^sudo\s+(/bin/|/usr/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+- ^sudo\s+(/bin/|/usr/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd|centreon_vmware)(\.service)?\s*$
 - ^(sudo\s+)?(/usr/bin/)?service\s+(centengine|centreontrapd|cbd|cbd-sql)\s+(reload|restart)\s*$
 - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/+centengine\.cfg\s*$
 - ^cat\s+/var/lib/centreon-engine/+[a-zA-Z0-9\-]+-stats\.json\s*$

--- a/gorgone/tests/robot/Readme.md
+++ b/gorgone/tests/robot/Readme.md
@@ -1,0 +1,80 @@
+## Robot tests for Gorgone
+
+RobotFramework is an end to end test framework, used here to test Gorgone.
+
+### setup containers
+
+You need to have docker daemon up and running.
+
+Every command consider you are at the racine of the centreon-collect repository, 
+and there is an up to date centreon/centreon repository next to this one.
+(this is used to set up the database, you need it only for the first start of the mariadb container, or when you purge it)
+
+First you need to build the test image, we use bookworm and will tag it 'gorgone-bookworm', see .github/docker for other supported OS :
+```
+docker build --no-cache --file ./.github/docker/Dockerfile.gorgone-testing-bookworm --progress=plain -t gorgone-bookworm . 
+```
+
+Now you can launch it with a mariadb container, this is where you will run all tests.
+
+Create the 2 container with a network for easy communication :
+```
+docker network create robot-gorgone-bookworm
+docker run --env MYSQL_USER=centreon --env MYSQL_PASSWORD=password --env MARIADB_ROOT_PASSWORD=password --detach --network robot-gorgone-bookworm --name mariadb mariadb
+# update the path to reflect where your repository are, this should only work on linux.
+docker run --network robot-gorgone-bookworm --name 'gorgone-bookworm' -v $(pwd):/centreon-collect/:rw  -v $(pwd)/../centreon:/centreon/:rw -it  gorgone-bookworm bash
+```
+
+Connect to the robot bookworm container, go to the mount point, and create the database needed : 
+```
+cd /
+
+# please check .github/workflows/gorgone.yml file for any update on this.
+
+mysql -h mariadb -u root -ppassword -e "CREATE DATABASE \`centreon\`"
+mysql -h mariadb -u root -ppassword -e "CREATE DATABASE \`centreon-storage\`"
+mysql -h mariadb -u root -ppassword -e "GRANT ALL PRIVILEGES ON centreon.* TO 'centreon'@'%'"
+mysql -h mariadb -u root -ppassword -e "GRANT ALL PRIVILEGES ON  \`centreon-storage\`.* TO 'centreon'@'%'"
+mysql -h mariadb -u root -ppassword 'centreon' < centreon/centreon/www/install/createTables.sql
+mysql -h mariadb -u root -ppassword 'centreon-storage' < centreon/centreon/www/install/createTablesCentstorage.sql
+# we install gorgone because we want all dependancy to come from the package manager to be sure they work.
+# locally you should use the code in the repository, which is controlled in robot execution by the argument -v 'gorgone_binary:...'
+# by default and on the CI the binary used is the one installed by the package manager (from freshly built package)
+apt update
+apt install -y centreon-gorgone
+cd /centreon-collect/
+```
+
+### Execute all tests
+Launch robot tests with parameters to connect to the db and use the local gorgone binary : 
+```
+robot -v 'gorgone_binary:/centreon-collect/gorgone/gorgoned' -v 'DBHOST:mariadb' -v 'DBNAME:centreon' -v 'DBNAME_STORAGE:centreon-storage' -v 'DBUSER:centreon' gorgone/tests
+```
+
+### Filter tests by tags
+
+You can use tag to run only some test with, for exemple running only the test that are considered to long to be executed on each PR :  `--include long_tests`
+Or to filter them instead : `--exclude long_tests`.
+
+
+### Restart the host
+
+After a reboot, you don't have to redo everything before running tests again : 
+```
+docker start mariadb
+docker start gorgone-bookworm
+docker exec  -it gorgone-bookworm  bash
+```
+
+### debug robot tests
+No magic here, but you want at least to install the following binary to look at the file and see gorgone status : 
+```
+apt install -y vim nano htop top
+```
+
+Maybe you installed an old version of centreon-gorgone which don't have all the dependency, for exemple rrd and Mojo-ioloop-signal : 
+```
+apt install -y lib-rrds-perl lib-mojo-ioloop-signal-perl
+```
+
+You can add trace to robot with `--loglevel TRACE`, and check the log.html robot add in your current folder for the detail of robot execution.

--- a/gorgone/tests/robot/config/db_add_1_poller.sql
+++ b/gorgone/tests/robot/config/db_add_1_poller.sql
@@ -1,4 +1,11 @@
-INSERT IGNORE INTO `nagios_server`
+INSERT IGNORE INTO `nagios_server` (
+       id, name, localhost, is_default, last_restart, ns_ip_address,
+       ns_activate, ns_status, engine_start_command,
+       engine_stop_command,engine_restart_command,
+       engine_reload_command, nagios_bin,
+       nagiostats_bin, nagios_perfdata,
+       broker_reload_command, centreonbroker_cfg_path, centreonbroker_module_path, centreonconnector_path, ssh_port,gorgone_communication_type,gorgone_port,
+       init_script_centreontrapd, snmp_trapd_path_conf, engine_name, engine_version, centreonbroker_logs_path, remote_id, remote_server_use_as_proxy,updated)
   VALUES
   (
     1, 'Central', '1', 1, 1711560733, '127.0.0.1',
@@ -25,7 +32,10 @@ INSERT IGNORE INTO `nagios_server`
     NULL, NULL, '/var/log/centreon-broker/',
     NULL, '1', '0'
   );
-INSERT IGNORE INTO `cfg_nagios`
+
+INSERT IGNORE INTO `cfg_nagios` (
+       nagios_id, nagios_name, use_timezone, log_file, cfg_dir, status_file, status_update_interval, enable_notifications, execute_service_checks, accept_passive_service_checks, execute_host_checks, accept_passive_host_checks, enable_event_handlers, check_external_commands, external_command_buffer_slots, command_check_interval, command_file, retain_state_information, state_retention_file, retention_update_interval, use_retained_program_state, use_retained_scheduling_info, use_syslog, log_notifications, log_service_retries, log_host_retries, log_event_handlers, log_initial_states, log_external_commands, log_passive_checks, global_host_event_handler, global_service_event_handler, sleep_time, service_inter_check_delay_method, host_inter_check_delay_method, service_interleave_factor, max_concurrent_checks, max_service_check_spread, max_host_check_spread, check_result_reaper_frequency, auto_reschedule_checks, auto_rescheduling_interval, auto_rescheduling_window, enable_flap_detection, low_service_flap_threshold, high_service_flap_threshold, low_host_flap_threshold, high_host_flap_threshold, soft_state_dependencies, service_check_timeout, host_check_timeout, event_handler_timeout, notification_timeout, check_for_orphaned_services, check_for_orphaned_hosts, check_service_freshness, service_freshness_check_interval, freshness_check_interval, check_host_freshness, host_freshness_check_interval, date_format, instance_heartbeat_interval, illegal_object_name_chars, illegal_macro_output_chars, use_regexp_matching, use_true_regexp_matching, admin_email, admin_pager, nagios_comment, nagios_activate, event_broker_options, nagios_server_id, enable_predictive_host_dependency_checks, enable_predictive_service_dependency_checks, cached_host_check_horizon, cached_service_check_horizon, passive_host_checks_are_soft, enable_environment_macros, additional_freshness_latency, debug_file, debug_level, debug_level_opt, debug_verbosity, max_debug_file_size, cfg_file, log_pid, enable_macros_filter, macros_filter, logger_version
+       )
   VALUES
   (
     1, 'Centreon Engine Central', NULL,

--- a/gorgone/tests/robot/config/engine.yaml
+++ b/gorgone/tests/robot/config/engine.yaml
@@ -1,0 +1,6 @@
+gorgone:
+  modules:
+    - name: engine
+      package: "gorgone::modules::centreon::engine::hooks"
+      enable: true
+      command_file: "/var/lib/centreon-engine/rw/centengine.cmd"

--- a/gorgone/tests/robot/config/legacycmd.yaml
+++ b/gorgone/tests/robot/config/legacycmd.yaml
@@ -1,0 +1,10 @@
+gorgone:
+  modules:
+    - name: legacycmd
+      package: "gorgone::modules::centreon::legacycmd::hooks"
+      enable: true
+      cmd_dir: "/var/lib/centreon/centcore/"
+      cmd_file: "/var/lib/centreon/centcore.cmd"
+      cache_dir: "/var/cache/centreon/"
+      cache_dir_trap: "/etc/snmp/centreon_traps"
+      remote_dir: "/var/cache/centreon//config/remote-data/"

--- a/gorgone/tests/robot/tests/centreon/legacycmd.robot
+++ b/gorgone/tests/robot/tests/centreon/legacycmd.robot
@@ -1,0 +1,96 @@
+*** Settings ***
+Documentation       test gorgone legacycmd module
+Resource            ${CURDIR}${/}..${/}..${/}resources${/}import.resource
+Test Timeout        220s
+
+
+*** Test Cases ***
+Legacycmd with ${communication_mode} communication
+    [Documentation]    Check Legacycmd module work.
+    ${tmp}=    Set Variable    ${communication_mode}
+    [Teardown]    Legacycmd Teardown    comm=${tmp}
+    
+    @{central_config}    Create List    ${ROOT_CONFIG}legacycmd.yaml    ${ROOT_CONFIG}engine.yaml    ${ROOT_CONFIG}actions.yaml
+    @{poller_config}    Create List     ${ROOT_CONFIG}actions.yaml    ${ROOT_CONFIG}engine.yaml
+    Setup Two Gorgone Instances
+    ...    central_config=${central_config}
+    ...    communication_mode=${communication_mode}
+    ...    central_name=${communication_mode}_gorgone_central
+    ...    poller_name=${communication_mode}_gorgone_poller_2
+    ...    poller_config=${poller_config}
+    Run    mkdir /var/lib/centreon/centcore/ -p
+
+    Force Check Execution On Poller    comm=${communication_mode}
+    Push Engine And vmware Configuration    comm=${communication_mode}
+    Examples:    communication_mode   --
+        ...    push_zmq
+        ...    pullwss
+        ...    pull
+        
+*** Keywords ***
+Legacycmd Teardown
+    [Arguments]    ${comm}
+    @{process_list}    Create List    ${comm}_gorgone_central    ${comm}_gorgone_poller_2
+
+    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}db_delete_poller.sql
+    Terminate Process    pipeWatcher_${comm}
+    Run    rm -rf /var/cache/centreon/config
+    Run    rm -rf /etc/centreon/centreon_vmware.json
+    
+Push Engine And vmware Configuration
+    [Arguments]    ${comm}=    ${poller_id}=2
+
+    Copy File    ${CURDIR}${/}legacycmd${/}centreon_vmware.json    /var/cache/centreon/config/vmware/${poller_id}/
+    Copy File    ${CURDIR}${/}legacycmd${/}broker.cfg    /var/cache/centreon/config/broker/${poller_id}/
+    Copy File    ${CURDIR}${/}legacycmd${/}engine-hosts.cfg    /var/cache/centreon/config/engine/${poller_id}/
+    # we change all the configuration files to be sure it was copied in this run and not a rest of another test.
+    Run    sed -i -e 's/@COMMUNICATION_MODE@/${comm}/g' /var/cache/centreon/config/vmware/${poller_id}/centreon_vmware.json
+    Run    sed -i -e 's/@COMMUNICATION_MODE@/${comm}/g' /var/cache/centreon/config/broker/${poller_id}/broker.cfg
+    Run    sed -i -e 's/@COMMUNICATION_MODE@/${comm}/g' /var/cache/centreon/config/engine/${poller_id}/engine-hosts.cfg
+    Run    chown www-data:www-data /var/cache/centreon/config/*/${poller_id}/*
+    Run    chmod 644 /var/cache/centreon/config/*/${poller_id}/*
+    
+    # gorgone central should get these files, and send it to poller in /etc/centreon/, /etc/centreon-broker/, /etc/centreon-engine/
+    ${log_query}    Create List    centreon_vmware.json
+    # SENDCFGFILE say to gorgone to push conf to poller for a poller id.
+    Run    echo SENDCFGFILE:${poller_id} > /var/lib/centreon/centcore/random.cmd
+    ${log_status}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${comm}_gorgone_central/gorgoned.log    content=${log_query}    regex=0    timeout=20
+    Should Be True    ${log_status}    Didn't found the logs : ${log_status}
+    Log To Console    File should be set in /etc/centreon/ now
+
+    ${res}=    Run    cat /etc/centreon/centreon_vmware.json
+    Should Be Equal As Strings    ${res}    {"communication mode": "${comm}"}    data in /etc/centreon/centreon_vmware.json is not correct.
+    # check the user/group and permission are right. as gorgone run as root in the tests and as centreon-gorgone in prod, this might be different from real life.
+    ${vmware_stat}=    Run    stat -c "%a %U %G" /etc/centreon/centreon_vmware.json
+    Should Be Equal As Strings    ${vmware_stat}    644 centreon-gorgone centreon    for vmware file
+
+    # check engine conf file
+    # for now gorgone don't set user/group after it untar, it's only done when copying single files.
+    ${res}=    Run    cat /etc/centreon-engine/engine-hosts.cfg
+    Should Be Equal As Strings    ${res}    Engine conf, communicationmode:${comm}    data in /etc/centreon-engine/engine-hosts.cfg is not correct.
+
+    #check Broker conf file
+    ${res}=    Run    cat /etc/centreon-broker/broker.cfg
+    Should Be Equal As Strings    ${res}    Broker conf, communication mode:${comm}    data in /etc/centreon-broker/broker.cfg is not correct.
+
+Force Check Execution On Poller
+    [Arguments]    ${comm}=
+    # @TODO: This pipe name seem hard coded somewhere in gorgone, changing it is the engine.yaml configuration don't work.
+    # this should be investigated, maybe some other configuration have the same problem too ?
+    ${process}    Start Process
+    ...    /usr/bin/perl
+    ...    ${CURDIR}${/}..${/}..${/}..${/}..${/}contrib${/}named_pipe_reader.pl
+    ...    --pipename
+    ...    /var/lib/centreon-engine/rw/centengine.cmd
+    ...    --logfile
+    ...    /var/log/centreon-gorgone/${comm}_gorgone_central/legacycmd-pipe-poller.log
+    ...    alias=pipeWatcher_${comm}
+
+    Sleep    0.5
+    ${date}=    Get Time
+    ${forced_check_command}=    Set Variable    SCHEDULE_FORCED_SVC_CHECK;local2_${comm};Cpu;${date}
+    Run    echo "EXTERNALCMD:2:[1724242926] ${forced_check_command}" > /var/lib/centreon/centcore/random.cmd
+    Sleep    0.5
+    ${log_query}    Create List    ${forced_check_command}
+    ${log_status}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${comm}_gorgone_central/legacycmd-pipe-poller.log    content=${log_query}    regex=0    timeout=20
+    Should Be True    ${log_status}    Didn't found the logs : ${log_status}

--- a/gorgone/tests/robot/tests/centreon/legacycmd.robot
+++ b/gorgone/tests/robot/tests/centreon/legacycmd.robot
@@ -29,7 +29,6 @@ Legacycmd with ${communication_mode} communication
     Examples:    communication_mode   --
         ...    push_zmq
         ...    pullwss
-        ...    pull
         
 *** Keywords ***
 Legacycmd Teardown

--- a/gorgone/tests/robot/tests/centreon/legacycmd/broker.cfg
+++ b/gorgone/tests/robot/tests/centreon/legacycmd/broker.cfg
@@ -1,0 +1,1 @@
+Broker conf, communication mode:@COMMUNICATION_MODE@

--- a/gorgone/tests/robot/tests/centreon/legacycmd/centreon_vmware.json
+++ b/gorgone/tests/robot/tests/centreon/legacycmd/centreon_vmware.json
@@ -1,0 +1,1 @@
+{"communication mode": "@COMMUNICATION_MODE@"}

--- a/gorgone/tests/robot/tests/centreon/legacycmd/engine-hosts.cfg
+++ b/gorgone/tests/robot/tests/centreon/legacycmd/engine-hosts.cfg
@@ -1,0 +1,1 @@
+Engine conf, communicationmode:@COMMUNICATION_MODE@

--- a/gorgone/tests/robot/tests/centreon/statistics.robot
+++ b/gorgone/tests/robot/tests/centreon/statistics.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Documentation       test gorgone statistics module
+Library             DatabaseLibrary
 Resource            ${CURDIR}${/}..${/}..${/}resources${/}import.resource
 Test Timeout        220s
 Suite Setup         Suite Setup Statistics Module
@@ -8,37 +9,37 @@ Suite Teardown      Suite Teardown Statistic Module
 *** Test Cases ***
 check statistic module add all centengine data in db ${communication_mode}
     [Documentation]    Check engine statistics are correctly added in sql Database
-    @{process_list}    Create List    ${communication_mode}_gorgone_central    ${communication_mode}_gorgone_poller_2
+    ${central}=    Set Variable    ${communication_mode}_gorgone_central_statistics
+    ${poller}=    Set Variable    ${communication_mode}_gorgone_poller2_statistics
+    @{process_list}    Create List    ${central}    ${poller}
     [Teardown]    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}db_delete_poller.sql
 
     ${date}    Get Current Date    increment=-1s
     @{central_config}    Create List    ${ROOT_CONFIG}statistics.yaml    ${ROOT_CONFIG}actions.yaml
     @{poller_config}    Create List    ${ROOT_CONFIG}actions.yaml
-    Setup Two Gorgone Instances    central_config=${central_config}    communication_mode=${communication_mode}    central_name=${communication_mode}_gorgone_central    poller_name=${communication_mode}_gorgone_poller_2    poller_config=${poller_config}
+    Setup Two Gorgone Instances    central_config=${central_config}    communication_mode=${communication_mode}    central_name=${central}    poller_name=${poller}    poller_config=${poller_config}
 
     # we first test the module when there is no data in the table, we will test it again when
     # there is data in the table to be sure the data are correctly updated.
     Execute SQL String    DELETE FROM nagios_stats    alias=storage
-    Check If Not Exists In Database    SELECT * FROM nagios_stats    alias=storage
+    Check Row Count    SELECT * FROM nagios_stats    ==    0    alias=storage    assertion_message=there is still data in the nagios_stats table after the delete.
 
     Ctn Gorgone Force Engine Statistics Retrieve
     # statistics module send the GORGONE_ACTION_FINISH_OK once messages for the action module are sent.
     # It don't wait for the action module to send back data or for the processing of the response to be finished.
     # So I added a log each time a poller stat have finished to be processed. In this test I know
     # I have 2 log because there is the central and one poller.
-    Ctn Wait For Log    ${communication_mode}    ${date}
+    Ctn Wait For Log    /var/log/centreon-gorgone/${central}/gorgoned.log    ${date}
     
     Ctn Gorgone Check Poller Engine Stats Are Present    poller_id=1
     Ctn Gorgone Check Poller Engine Stats Are Present    poller_id=2
 
     # As the value we set in db are fake and hardcoded, we need to change the data before
     # running again the module to be sure data are correctly updated, instead of letting the last value persist.
-    Query    UPDATE nagios_stats SET stat_value=999;    alias=storage
+    Execute SQL String    UPDATE nagios_stats SET stat_value=999;    alias=storage
     ${date2}    Get Current Date    increment=-1s
-
     Ctn Gorgone Force Engine Statistics Retrieve
-
-    Ctn Wait For Log    ${communication_mode}    ${date2}
+    Ctn Wait For Log    /var/log/centreon-gorgone/${central}/gorgoned.log    ${date2}
     Ctn Gorgone Check Poller Engine Stats Are Present    poller_id=1
     Ctn Gorgone Check Poller Engine Stats Are Present    poller_id=2
 
@@ -53,15 +54,15 @@ Ctn Wait For Log
     ...    (even if it will often be the central node). So we check first for the central log, then for the poller node
     ...    from the starting point of the log. In the search, the lib search for the first log, and once it's found
     ...    start searching the second log from the first log position.
-    [Arguments]    ${communication_mode}    ${date}
+    [Arguments]    ${logfile}    ${date}
 
     ${log_central}    Create List    poller 1 engine data was integrated in rrd and sql database.
-    ${result_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${communication_mode}_gorgone_central/gorgoned.log    content=${log_central}    date=${date}    regex=1    timeout=60
+    ${result_central}    Ctn Find In Log With Timeout    log=${logfile}    content=${log_central}    date=${date}    regex=1    timeout=60
     Should Be True    ${result_central}    Didn't found the logs : ${result_central}
 
     ${log_poller2}    Create List    poller 2 engine data was integrated in rrd and sql database.
-    ${result_poller2}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${communication_mode}_gorgone_central/gorgoned.log    content=${log_poller2}    date=${date}    regex=1    timeout=60
-    Should Be True    ${result_poller2}    Didn't found the Central logs : ${result_poller2}
+    ${result_poller2}    Ctn Find In Log With Timeout    log=${logfile}    content=${log_poller2}    date=${date}    regex=1    timeout=60
+    Should Be True    ${result_poller2}    Didn't found the poller log on Central : ${result_poller2}
 
 Ctn Gorgone Check Poller Engine Stats Are Present
     [Arguments]    ${poller_id}=
@@ -76,7 +77,7 @@ Ctn Gorgone Check Poller Engine Stats Are Present
     FOR    ${stat_label}    ${stat_data}    IN    &{data_check}
         
         FOR    ${stat_key}    ${stat_value}    IN    &{stat_data}
-            Check If Exists In Database    SELECT instance_id FROM nagios_stats WHERE stat_key = '${stat_key}' AND stat_value = '${stat_value}' AND stat_label = '${stat_label}' AND instance_id='${poller_id}';    alias=storage
+            Check Row Count    SELECT instance_id FROM nagios_stats WHERE stat_key = '${stat_key}' AND stat_value = '${stat_value}' AND stat_label = '${stat_label}' AND instance_id='${poller_id}';    equal    1    alias=storage
 
         END
     END

--- a/gorgone/tests/robot/tests/core/action.robot
+++ b/gorgone/tests/robot/tests/core/action.robot
@@ -27,6 +27,7 @@ action module with ${communication_mode} communcation mode
     [Documentation]    test action on distant node, no whitelist configured
     @{process_list}    Create List    ${communication_mode}_gorgone_central    ${communication_mode}_gorgone_poller_2
     [Teardown]    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}db_delete_poller.sql
+    Run    rm /tmp/actionLogs
 
     @{central_config}    Create List    ${ROOT_CONFIG}actions.yaml
     @{poller_config}    Create List     ${ROOT_CONFIG}actions.yaml
@@ -64,8 +65,6 @@ action module with ${communication_mode} communcation mode
     ${log_poller2_query_sync}    Create List    Robot test write with param:${get_params} for node nodes/2/
     ${logs_poller}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${communication_mode}_gorgone_poller_2/gorgoned.log    content=${log_poller2_query_sync}    date=${start_date}    timeout=10
     Should Be True    ${logs_poller}    Didn't found the logs in the poller file: ${logs_poller}
-
-    Run    rm /tmp/actionLogs
 
     Examples:    communication_mode   --
         ...    push_zmq

--- a/gorgone/tests/robot/tests/core/action.robot
+++ b/gorgone/tests/robot/tests/core/action.robot
@@ -69,6 +69,7 @@ action module with ${communication_mode} communcation mode
     Examples:    communication_mode   --
         ...    push_zmq
         ...    pullwss
+        ...    pull
 
 *** Keywords ***
 Test Sync Action Module

--- a/gorgone/tests/robot/tests/core/pull.robot
+++ b/gorgone/tests/robot/tests/core/pull.robot
@@ -1,0 +1,16 @@
+*** Settings ***
+Documentation       Start and stop Gorgone with pull configuration
+
+Resource            ${CURDIR}${/}..${/}..${/}resources${/}import.resource
+Test Timeout        300s
+
+*** Variables ***
+@{process_list}    pull_gorgone_central    pull_gorgone_poller_2
+
+*** Test Cases ***
+connect 1 poller to a central with pull configuration
+    [Teardown]    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}db_delete_poller.sql
+
+    Log To Console    \nStarting the Gorgone setup with pull configuration
+    Setup Two Gorgone Instances    communication_mode=pull    central_name=pull_gorgone_central    poller_name=pull_gorgone_poller_2
+    Log To Console    End of tests.


### PR DESCRIPTION
## Description

As we want vault support, the centreon_vmware daemon configuration now have to be managed by the central.
This PR aim to push a centreon_vmware.json conf file to each poller with the vmware authentication configured by the user in the webapp.
This file can contain vault path instead of clear text password, to be decided by the webapp when exporting the conf.
Another ticket aim to upgrade the centreon_vmware daemon to read this file.

**Fixes** # MON-144643

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] master

<h2> How this pull request can be tested ? </h2>

Add an ACC for vmware in the webapp for a poller.
Export the configuration to this poller from the webapplication.
Check on the poller the file /etc/centreon/centreon_vmware.json exist, and contain the correct data configured in the webapp.

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

