### PR TITLE
Mon 144663 gorgone pull tests fail some time on the ci

### DIFF
--- a/gorgone/tests/robot/Readme.md
+++ b/gorgone/tests/robot/Readme.md
@@ -48,7 +48,7 @@ cd /centreon-collect/
 ### Execute all tests
 Launch robot tests with parameters to connect to the db and use the local gorgone binary : 
 ```
-robot -v 'gorgone_binary:/centreon-collect/gorgone/gorgoned' -v 'DBHOST:mariadb' -v 'DBNAME:centreon' -v 'DBNAME_STORAGE:centreon-storage' -v 'DBUSER:centreon' gorgone/tests
+robot --loglevel TRACE -v 'gorgone_binary:/centreon-collect/gorgone/gorgoned' -v 'DBHOST:mariadb' -v 'DBNAME:centreon' -v 'DBNAME_STORAGE:centreon-storage' -v 'DBUSER:centreon' gorgone/tests/robot/tests
 ```
 
 ### Filter tests by tags
@@ -74,7 +74,5 @@ apt install -y vim nano htop top
 
 Maybe you installed an old version of centreon-gorgone which don't have all the dependency, for exemple rrd and Mojo-ioloop-signal : 
 ```
-apt install -y lib-rrds-perl lib-mojo-ioloop-signal-perl
+apt install -y librrds-perl libmojo-ioloop-signal-perl
 ```
-
-You can add trace to robot with `--loglevel TRACE`, and check the log.html robot add in your current folder for the detail of robot execution.

--- a/gorgone/tests/robot/resources/resources.resource
+++ b/gorgone/tests/robot/resources/resources.resource
@@ -98,23 +98,23 @@ Check Poller Is Connected
 
 Check Poller Communicate
     [Documentation]    Ask the central Gorgone rest api if it have communicated with the poller using a given ID.
-    [Arguments]    ${poller_id}
+    [Arguments]    ${poller_id}    ${max_failed_attempt}=0
     ${response}     Set Variable    ${EMPTY}
     Log To Console    checking Gorgone see poller in rest api response...
-    FOR    ${i}    IN RANGE    20
+    FOR    ${i}    IN RANGE    25
         Sleep    5
         ${response}=    GET  http://127.0.0.1:8085/api/internal/constatus
         Log    ${response.json()}
         IF    not ${response.json()}[data]
             CONTINUE
         END
-        IF    ${response.json()}[data][${poller_id}][ping_failed] > 0 or ${response.json()}[data][${poller_id}][ping_ok] > 0
+        IF    ${response.json()}[data][${poller_id}][ping_failed] > ${max_failed_attempt} or ${response.json()}[data][${poller_id}][ping_ok] > 0
             BREAK
         END
     END
     Log To Console    json response : ${response.json()}
-    Should Be True    ${i} < 19    timeout after ${i} time waiting for poller status in gorgone rest api (/api/internal/constatus) : ${response.json()}
-    Should Be True    0 == ${response.json()}[data][${poller_id}][ping_failed]    there was failed ping between the central and the poller ${poller_id}
+    Should Be True    ${i} < 24    timeout after ${i} time waiting for poller status in gorgone rest api (/api/internal/constatus) : ${response.json()}
+    Should Be True    ${max_failed_attempt} >= ${response.json()}[data][${poller_id}][ping_failed]    there was failed ping between the central and the poller ${poller_id}
     Should Be True    0 < ${response.json()}[data][${poller_id}][ping_ok]    there was no successful ping between the central and the poller ${poller_id}
 
 Setup Two Gorgone Instances
@@ -166,12 +166,12 @@ Setup Two Gorgone Instances
         Setup Gorgone Config    ${central_pull_config}    gorgone_name=${central_name}    sql_file=${ROOT_CONFIG}db_add_1_poller.sql
         Setup Gorgone Config    ${poller_pull_config}     gorgone_name=${poller_name}
 
-        Start Gorgone    debug    ${poller_name}
         Start Gorgone    debug    ${central_name}
         Wait Until Port Is Bind    5556
+        Start Gorgone    debug    ${poller_name}
 
         Check Poller Is Connected    port=5556    expected_nb=2
-        Check Poller Communicate     2
+        Check Poller Communicate     2    max_failed_attempt=1
     END
 
 Wait Until Port Is Bind

--- a/gorgone/tests/robot/tests/centreon/legacycmd.robot
+++ b/gorgone/tests/robot/tests/centreon/legacycmd.robot
@@ -29,6 +29,7 @@ Legacycmd with ${communication_mode} communication
     Examples:    communication_mode   --
         ...    push_zmq
         ...    pullwss
+        ...    pull
         
 *** Keywords ***
 Legacycmd Teardown


### PR DESCRIPTION
## Description

Add a workaround in the gorgone test for the pull connection method, allowing one failed ping while waiting for the poller to connect to the central.

**Fixes** # MON-144663

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>
The automated test should always pass.

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
