### PR TITLE
enh(engine/gRPC): the GetHostgroup function to return all about the Hostgroups.

### DIFF
--- a/common/engine_conf/parser.cc
+++ b/common/engine_conf/parser.cc
@@ -526,6 +526,10 @@ void parser::_resolve_template(State* pb_config, error_cnt& err) {
     _resolve_template(_pb_helper[&he],
                       _pb_templates[message_helper::hostescalation]);
 
+  for (Hostgroup& hg : *pb_config->mutable_hostgroups())
+    _resolve_template(_pb_helper[&hg],
+                      _pb_templates[message_helper::hostgroup]);
+
   for (const Command& c : pb_config->commands())
     _pb_helper.at(&c)->check_validity(err);
 

--- a/engine/enginerpc/engine.proto
+++ b/engine/enginerpc/engine.proto
@@ -35,6 +35,7 @@ service Engine {
   rpc GetHost(HostIdentifier) returns (EngineHost) {}
   rpc GetContact(ContactIdentifier) returns (EngineContact) {}
   rpc GetService(ServiceIdentifier) returns (EngineService) {}
+  rpc GetHostGroup(HostGroupIdentifier) returns (EngineHostGroup) {}
   rpc GetHostsCount(google.protobuf.Empty) returns (GenericValue) {}
   rpc GetContactsCount(google.protobuf.Empty) returns (GenericValue) {}
   rpc GetServicesCount(google.protobuf.Empty) returns (GenericValue) {}
@@ -673,6 +674,20 @@ message EngineService {
     ANOMALY_DETECTION = 5;
   }
   ServiceType service_type = 117;
+}
+
+message HostGroupIdentifier {
+    string name = 1;
+}
+
+message EngineHostGroup {
+  uint32 id = 1;
+  string name = 2;
+  string alias = 3;
+  repeated string members = 4;
+  string notes = 5;
+  string notes_url = 6;
+  string action_url = 7;
 }
 
 message EngineComment {

--- a/engine/inc/com/centreon/engine/engine_impl.hh
+++ b/engine/inc/com/centreon/engine/engine_impl.hh
@@ -57,6 +57,9 @@ class engine_impl final : public Engine::Service {
   grpc::Status GetService(grpc::ServerContext* context,
                           const ServiceIdentifier* request,
                           EngineService* response) override;
+  grpc::Status GetHostGroup(grpc::ServerContext* context,
+                            const HostGroupIdentifier*,
+                            EngineHostGroup*) override;
   grpc::Status AddHostComment(grpc::ServerContext* context,
                               const EngineComment* request,
                               CommandSuccess* response) override;

--- a/tests/engine/hostgroup_inheritance.robot
+++ b/tests/engine/hostgroup_inheritance.robot
@@ -1,0 +1,288 @@
+*** Settings ***
+Documentation       Centreon Broker and Engine Verify hostgroup inheritance.
+
+Resource            ../resources/import.resource
+
+Suite Setup         Ctn Clean Before Suite
+Suite Teardown      Ctn Clean After Suite
+Test Setup          Ctn Stop Processes
+Test Teardown       Ctn Save Logs If Failed
+
+
+*** Test Cases ***
+EBSN5
+    [Documentation]    Verify hostgroup inheritance : hostgroup(empty) inherit from template (full) , on Start Engine
+    [Tags]    engine    hostgroup    MON-151323
+    Ctn Config Engine    ${1}    ${5}    ${5}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module
+    Ctn Config BBDO3    1
+    Ctn Clear Retention
+
+    # Create files :
+    Ctn Create Template File    ${0}    hostgroup    alias    ["hostgroup_template_1_alias"]
+    
+    # Delete unnecessary fields in templates:
+    Ctn Engine Config Delete Key In Cfg    0    hostgroup_template_1    active_checks_enabled    hostgroupTemplates.cfg
+    Ctn Engine Config Delete Key In Cfg    0    hostgroup_template_1    passive_checks_enabled    hostgroupTemplates.cfg
+    
+    # Add necessarily files :
+    Ctn Config Engine Add Cfg File    ${0}    hostgroupTemplates.cfg
+
+    # Create host group
+    Ctn Add Host Group    ${0}    ${1}    ["host_1"]
+
+    # Delete unnecessary fields in hostgroup:
+    Ctn Engine Config Delete Key In Cfg    0    hostgroup_1    alias    hostgroups.cfg
+    Ctn Engine Config Delete Key In Cfg    0    hostgroup_1    members    hostgroups.cfg
+    
+    # Set hostgroup_1 to use hostgroup_template_1
+    Ctn Engine Config Set Key Value In Cfg    0    hostgroup_1    use    hostgroup_template_1    hostgroups.cfg
+
+    # Operation in hostgroupTemplates
+    ${config_values}    Create Dictionary
+...    members    host_2
+...    notes    note_tmpl
+...    notes_url    note_url_tmpl
+...    action_url    action_url_tmpl
+
+    FOR    ${key}    ${value}    IN    &{config_values}
+        Ctn Engine Config Set Key Value In Cfg    0    hostgroup_template_1    ${key}    ${value}    hostgroupTemplates.cfg
+    END
+
+    ${start}    Get Current Date
+    Ctn Clear Retention
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+
+    ${output}    Ctn Get Hostgroup Info Grpc    hostgroup_1
+
+    Should Be Equal As Strings     ${output}[name]    hostgroup_1
+    Should Be Equal As Strings     ${output}[alias]    hostgroup_template_1_alias
+    Should Not Contain    ${output}[members]    host_1
+    Should Contain    ${output}[members]    host_2
+    Should Be Equal As Strings    ${output}[notes]    note_tmpl
+    Should Be Equal As Strings    ${output}[notesUrl]    note_url_tmpl
+    Should Be Equal As Strings    ${output}[actionUrl]    action_url_tmpl
+
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker
+
+EBSN6
+    [Documentation]    Verify hostgroup inheritance : hostgroup(full) inherit from template (full) , on Start Engine
+    [Tags]    engine    hostgroup    MON-151323
+    Ctn Config Engine    ${1}    ${5}    ${5}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module
+    Ctn Config BBDO3    1
+    Ctn Clear Retention
+
+    # Create files :
+    Ctn Create Template File    ${0}    hostgroup    alias    ["hostgroup_template_1_alias"]
+    
+    # Delete unnecessary fields in templates:
+    Ctn Engine Config Delete Key In Cfg    0    hostgroup_template_1    active_checks_enabled    hostgroupTemplates.cfg
+    Ctn Engine Config Delete Key In Cfg    0    hostgroup_template_1    passive_checks_enabled    hostgroupTemplates.cfg
+    
+    # Add necessarily files :
+    Ctn Config Engine Add Cfg File    ${0}    hostgroupTemplates.cfg
+
+    # Create host groups
+    Ctn Add Host Group    ${0}    ${1}    ["host_1"]
+    
+    # Set hostgroup_1 to use hostgroup_template_1
+    Ctn Engine Config Set Key Value In Cfg    0    hostgroup_1    use    hostgroup_template_1    hostgroups.cfg
+
+    # Operation in hostgroup
+    ${config_values}    Create Dictionary
+...    notes    note
+...    notes_url    note_url
+...    action_url    action_url
+
+    FOR    ${key}    ${value}    IN    &{config_values}
+        Ctn Engine Config Set Key Value In Cfg    0    hostgroup_1    ${key}    ${value}    hostgroups.cfg
+    END
+
+    # Operation in hostgroupTemplates
+    ${config_values}    Create Dictionary
+...    members    host_2
+...    notes    note_tmpl
+...    notes_url    note_url_tmpl
+...    action_url    action_url_tmpl
+
+    FOR    ${key}    ${value}    IN    &{config_values}
+        Ctn Engine Config Set Key Value In Cfg    0    hostgroup_template_1    ${key}    ${value}    hostgroupTemplates.cfg
+    END
+
+    ${start}    Get Current Date
+    Ctn Clear Retention
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+
+    ${output}    Ctn Get Hostgroup Info Grpc    hostgroup_1
+
+    Should Be Equal As Strings     ${output}[name]    hostgroup_1
+    Should Be Equal As Strings     ${output}[alias]    hostgroup_1
+    Should Contain    ${output}[members]    host_1
+    Should Not Contain    ${output}[members]    host_2
+    Should Be Equal As Strings    ${output}[notes]    note
+    Should Be Equal As Strings    ${output}[notesUrl]    note_url
+    Should Be Equal As Strings    ${output}[actionUrl]    action_url
+
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker
+
+EBSN7
+    [Documentation]    Verify hostgroup inheritance : hostgroup(empty) inherit from template (full) , on Reload Engine
+    [Tags]    engine    hostgroup    MON-151323
+    Ctn Config Engine    ${1}    ${5}    ${5}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module
+    Ctn Config BBDO3    1
+    Ctn Clear Retention
+
+    # Create files :
+    Ctn Create Template File    ${0}    hostgroup    alias    ["hostgroup_template_1_alias"]
+    
+    # Delete unnecessary fields in templates:
+    Ctn Engine Config Delete Key In Cfg    0    hostgroup_template_1    active_checks_enabled    hostgroupTemplates.cfg
+    Ctn Engine Config Delete Key In Cfg    0    hostgroup_template_1    passive_checks_enabled    hostgroupTemplates.cfg
+    
+    # Add necessarily files :
+    Ctn Config Engine Add Cfg File    ${0}    hostgroupTemplates.cfg
+
+    # Create host groups
+    Ctn Add Host Group    ${0}    ${1}    ["host_1"]
+
+    ${start}    Get Current Date
+    Ctn Clear Retention
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+
+    # Delete unnecessary fields in hostgroup:
+    Ctn Engine Config Delete Key In Cfg    0    hostgroup_1    alias    hostgroups.cfg
+    Ctn Engine Config Delete Key In Cfg    0    hostgroup_1    members    hostgroups.cfg
+    
+    # Set hostgroup_1 to use hostgroup_template_1
+    Ctn Engine Config Set Key Value In Cfg    0    hostgroup_1    use    hostgroup_template_1    hostgroups.cfg
+
+    # Operation in hostgroupTemplates
+    ${config_values}    Create Dictionary
+...    members    host_2
+...    notes    note_tmpl
+...    notes_url    note_url_tmpl
+...    action_url    action_url_tmpl
+
+    FOR    ${key}    ${value}    IN    &{config_values}
+        Ctn Engine Config Set Key Value In Cfg    0    hostgroup_template_1    ${key}    ${value}    hostgroupTemplates.cfg
+    END
+
+    ${start}    Get Current Date
+    Ctn Reload Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+    ${content}    Create List    Reload configuration finished
+    ${result}    Ctn Find In Log With Timeout
+    ...    ${ENGINE_LOG}/config0/centengine.log
+    ...    ${start}
+    ...    ${content}
+    ...    60
+    ...    verbose=False
+    Should Be True    ${result}    Engine is Not Ready after 60s!!
+
+    ${output}    Ctn Get Hostgroup Info Grpc    hostgroup_1
+
+    Should Be Equal As Strings     ${output}[name]    hostgroup_1
+    Should Be Equal As Strings     ${output}[alias]    hostgroup_template_1_alias
+    Should Not Contain    ${output}[members]    host_1
+    Should Contain    ${output}[members]    host_2
+    Should Be Equal As Strings    ${output}[notes]    note_tmpl
+    Should Be Equal As Strings    ${output}[notesUrl]    note_url_tmpl
+    Should Be Equal As Strings    ${output}[actionUrl]    action_url_tmpl
+
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker
+
+EBSN8
+    [Documentation]    Verify hostgroup inheritance : hostgroup(full) inherit from template (full) , on Reload Engine
+    [Tags]    engine    hostgroup    MON-151323
+    Ctn Config Engine    ${1}    ${5}    ${5}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module
+    Ctn Config BBDO3    1
+    Ctn Clear Retention
+
+    # Create files :
+    Ctn Create Template File    ${0}    hostgroup    alias    ["hostgroup_template_1_alias"]
+    
+    # Delete unnecessary fields in templates:
+    Ctn Engine Config Delete Key In Cfg    0    hostgroup_template_1    active_checks_enabled    hostgroupTemplates.cfg
+    Ctn Engine Config Delete Key In Cfg    0    hostgroup_template_1    passive_checks_enabled    hostgroupTemplates.cfg
+    
+    # Add necessarily files :
+    Ctn Config Engine Add Cfg File    ${0}    hostgroupTemplates.cfg
+
+    # Create host groups
+    Ctn Add Host Group    ${0}    ${1}    ["host_1"]
+
+    ${start}    Get Current Date
+    Ctn Clear Retention
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+    
+    # Set hostgroup_1 to use hostgroup_template_1
+    Ctn Engine Config Set Key Value In Cfg    0    hostgroup_1    use    hostgroup_template_1    hostgroups.cfg
+
+    # Operation in hostgroup
+    ${config_values}    Create Dictionary
+...    members    host_3
+...    notes    note
+...    notes_url    note_url
+...    action_url    action_url
+
+    FOR    ${key}    ${value}    IN    &{config_values}
+        Ctn Engine Config Set Key Value In Cfg    0    hostgroup_1    ${key}    ${value}    hostgroups.cfg
+    END
+
+    # Operation in hostgroupTemplates
+    ${config_values}    Create Dictionary
+...    members    host_2
+...    notes    note_tmpl
+...    notes_url    note_url_tmpl
+...    action_url    action_url_tmpl
+
+    FOR    ${key}    ${value}    IN    &{config_values}
+        Ctn Engine Config Set Key Value In Cfg    0    hostgroup_template_1    ${key}    ${value}    hostgroupTemplates.cfg
+    END
+
+    ${start}    Get Current Date
+    Ctn Reload Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+    ${content}    Create List    Reload configuration finished
+    ${result}    Ctn Find In Log With Timeout
+    ...    ${ENGINE_LOG}/config0/centengine.log
+    ...    ${start}
+    ...    ${content}
+    ...    60
+    ...    verbose=False
+    Should Be True    ${result}    Engine is Not Ready after 60s!!
+
+    ${output}    Ctn Get Hostgroup Info Grpc    hostgroup_1
+
+    Should Be Equal As Strings     ${output}[name]    hostgroup_1
+    Should Be Equal As Strings     ${output}[alias]    hostgroup_1
+    Should Contain    ${output}[members]    host_1
+    Should Not Contain    ${output}[members]    host_2
+    Should Be Equal As Strings    ${output}[notes]    note
+    Should Be Equal As Strings    ${output}[notesUrl]    note_url
+    Should Be Equal As Strings    ${output}[actionUrl]    action_url
+
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker


### PR DESCRIPTION
On the gRPC API of Engine, there is a GetHostgroups function that returns some informations about a Hostgroups. We can specify the group by its name.

REFS: MON-151323