### PR TITLE
fix(gorgone): remove dependency to centreon-common

### DIFF
--- a/gorgone/packaging/centreon-gorgone-centreon-config.yaml
+++ b/gorgone/packaging/centreon-gorgone-centreon-config.yaml
@@ -47,6 +47,7 @@ contents:
       mode: 0770
 
 scripts:
+  preinstall: ./scripts/centreon-gorgone-centreon-config-preinstall.sh
   postinstall: ./scripts/centreon-gorgone-centreon-config-postinstall.sh
 
 overrides:

--- a/gorgone/packaging/centreon-gorgone.yaml
+++ b/gorgone/packaging/centreon-gorgone.yaml
@@ -156,7 +156,6 @@ scripts:
 overrides:
   rpm:
     depends:
-      - centreon-common
       - bzip2
       - perl-Libssh-Session >= 0.8
       - perl-CryptX
@@ -194,8 +193,7 @@ overrides:
       - perl(lib)
       - perl(Safe)
   deb:
-    depends:   # those dependencies are taken from centreon-gorgone/packaging/debian/control
-      - centreon-common
+    depends:
       - libdatetime-perl
       - libtime-parsedate-perl
       - libtry-tiny-perl

--- a/gorgone/packaging/scripts/centreon-gorgone-centreon-config-preinstall.sh
+++ b/gorgone/packaging/scripts/centreon-gorgone-centreon-config-preinstall.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if ! getent passwd centreon > /dev/null 2>&1; then
+  useradd -g centreon -m -d /var/spool/centreon -r centreon 2> /dev/null
+fi
+
 if ! getent group centreon > /dev/null 2>&1; then
   groupadd -r centreon
 fi

--- a/gorgone/packaging/scripts/centreon-gorgone-centreon-config-preinstall.sh
+++ b/gorgone/packaging/scripts/centreon-gorgone-centreon-config-preinstall.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-if ! getent passwd centreon > /dev/null 2>&1; then
-  useradd -g centreon -m -d /var/spool/centreon -r centreon 2> /dev/null
-fi
-
 if ! getent group centreon > /dev/null 2>&1; then
   groupadd -r centreon
+fi
+
+if ! getent passwd centreon > /dev/null 2>&1; then
+  useradd -g centreon -m -d /var/spool/centreon -r centreon 2> /dev/null
 fi

--- a/gorgone/packaging/scripts/centreon-gorgone-centreon-config-preinstall.sh
+++ b/gorgone/packaging/scripts/centreon-gorgone-centreon-config-preinstall.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if ! getent group centreon > /dev/null 2>&1; then
+  groupadd -r centreon
+fi


### PR DESCRIPTION
## Description

fix(gorgone): remove dependency to centreon-common

**Fixes** MON-151261

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)