### PR TITLE
fix(gorgone): move centreon-common dependency (#1792)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,15 @@
 *                              @centreon/owners-cpp
 
-.github/**                     @centreon/owners-pipelines
-packaging/**                   @centreon/owners-pipelines
-selinux/**                     @centreon/owners-pipelines
-
-tests/**                       @centreon/owners-robot-e2e
+*.pm                           @centreon/owners-perl
+*.pl                           @centreon/owners-perl
 
 gorgone/                       @centreon/owners-perl
 gorgone/docs/                  @centreon/owners-doc
 
+.github/**                     @centreon/owners-pipelines
+**/packaging/**                @centreon/owners-pipelines
+**/selinux/**                  @centreon/owners-pipelines
+
+tests/**                       @centreon/owners-robot-e2e
+
 gorgone/tests/robot/config/    @centreon/owners-perl
-*.pm                           @centreon/owners-perl
-*.pl                           @centreon/owners-perl

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -214,11 +214,9 @@ jobs:
         run: |
           if [[ "${{ matrix.package_extension }}" == "deb" ]]; then
             apt update
-            apt install -y ./centreon-gorgone*${{ steps.parse-distrib.outputs.package_distrib_name }}*
+            apt install -y ./centreon-gorgone*.deb
           else
-            dnf install -y ./centreon-gorgone*${{ steps.parse-distrib.outputs.package_distrib_name }}* ./centreon-gorgone-centreon-config*${{ steps.parse-distrib.outputs.package_distrib_name }}*
-            # in el8 at least, there is a package for the configuration and a package for the actual code.
-            # this is not the case for debian, and for now I don't know why it was made any different between the 2 Os.
+            dnf install -y ./centreon-gorgone*.rpm
           fi
 
       - name: Create databases

--- a/gorgone/packaging/centreon-gorgone-centreon-config.yaml
+++ b/gorgone/packaging/centreon-gorgone-centreon-config.yaml
@@ -53,9 +53,11 @@ overrides:
   rpm:
     depends:
       - centreon-gorgone = ${VERSION}-${RELEASE}${DIST}
+      - centreon-common
   deb:
     depends:
       - centreon-gorgone (= ${VERSION}-${RELEASE}${DIST})
+      - centreon-common
     replaces:
       - centreon-gorgone (<< 24.10.0)
 

--- a/gorgone/packaging/centreon-gorgone.yaml
+++ b/gorgone/packaging/centreon-gorgone.yaml
@@ -156,7 +156,6 @@ scripts:
 overrides:
   rpm:
     depends:
-      - centreon-common
       - bzip2
       - perl-Libssh-Session >= 0.8
       - perl-CryptX
@@ -194,8 +193,7 @@ overrides:
       - perl(lib)
       - perl(Safe)
   deb:
-    depends:   # those dependencies are taken from centreon-gorgone/packaging/debian/control
-      - centreon-common
+    depends:
       - libdatetime-perl
       - libtime-parsedate-perl
       - libtry-tiny-perl


### PR DESCRIPTION
## Description

fix(gorgone): move centreon-common dependency (#1792)

**Fixes** MON-151877

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)