### PR TITLE
Mon-106121 move centreon perl libs packages

### DIFF
--- a/perl-libs/lib/README.md
+++ b/perl-libs/lib/README.md
@@ -1,0 +1,33 @@
+# centreon-perl-libs / centreon-perl-libs-common
+
+This directory contains the common Perl libraries used by Centreon.
+
+## centreon-perl-libs-common
+
+This package contain libraries located in centreon::common namespace.
+they are generic library used by multiples centreon modules.
+
+### tests
+
+to execute the test, see t/ directory in the package.
+First install the dependency : 
+```bash
+# distro package to install :  
+openssl-dev
+# cpan package to install :
+Test2::V0 Test2::Plugin::NoWarnings Crypt::OpenSSL::AES
+```
+
+run the following command passing the path to t/ folder as argument :
+```bash
+prove -r t/
+```
+
+
+## centreon-perl-libs
+
+This package contain libraries associated to specific binary, they are located in centreon::[area] namespace.
+
+for exemple the package centreon-trap contain a binary calling centreon::trap namespace which contain all the logic.
+
+

--- a/perl-libs/lib/centreon/common/centreonvault.pm
+++ b/perl-libs/lib/centreon/common/centreonvault.pm
@@ -1,0 +1,428 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::common::centreonvault;
+
+use strict;
+use warnings;
+
+use MIME::Base64;
+use Crypt::OpenSSL::AES;
+use Net::Curl::Easy qw(:constants);
+use JSON::XS;
+
+my $VAULT_PATH_REGEX = qr/^secret::hashicorp_vault::([^:]+)::(.+)$/;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self  = bless \%options, $class;
+    # mandatory options:
+    # - logger: logger object
+    # - config_file: either path of a JSON vault config file or the configuration as a perl hash.
+
+    $self->{enabled} = 1;
+    $self->{crypted_credentials} = 1;
+
+    if ( !$self->init() ) {
+        $self->{enabled} = 0;
+        $self->{logger}->writeLogWarning("Something happened during init() method that makes Centreonvault not usable. Ignore this if you don't use Centreonvault");
+    }
+    return $self;
+}
+
+
+sub init {
+    my ($self, %options) = @_;
+
+    $self->check_options() or return undef;
+
+    # for unit test purpose, if the config is given as an hash, we don't try to read the config file.
+    if (ref $self->{config_file} eq ref {}) {
+        $self->{vault_config} = $self->{config_file};
+    } else {
+        # check if the following information is available
+        $self->{logger}->writeLogDebug("Reading Vault configuration from file " . $self->{config_file} . ".");
+        $self->{vault_config} = parse_json_file('json_file' => $self->{config_file});
+        if (defined($self->{vault_config}->{error_message})) {
+            $self->{logger}->writeLogInfo("Error while parsing " . $self->{config_file} . ": "
+                . $self->{vault_config}->{error_message});
+            return undef;
+        }
+    }
+    $self->check_configuration() or return undef;
+
+    $self->{logger}->writeLogDebug("Vault configuration read. Name: " . $self->{vault_config}->{name}
+        . ". Url: " . $self->{vault_config}->{url} . ".");
+
+    # Create the Curl object, it will be used several times
+    $self->{curl_easy} = Net::Curl::Easy->new();
+    $self->{curl_easy}->setopt( CURLOPT_USERAGENT, "Centreon VMware daemon's centreonvault.pm");
+
+    return 1;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+
+    if ( !defined($self->{logger}) ) {
+        die "FATAL: No logger given to the constructor. Centreonvault cannot be used.";
+    }
+    if ( !defined($self->{config_file})) {
+        $self->{logger}->writeLogNotice("No config file given to the constructor. Centreonvault cannot be used.");
+        return undef;
+    }
+    if ( ! -f $self->{config_file} and ref $self->{config_file} ne ref {}) {
+        $self->{logger}->writeLogNotice("The given configuration file " . $self->{config_file}
+            . " does not exist. Passwords won't be retrieved from Centreonvault. Ignore this if you don't use Centreonvault.");
+        return undef;
+    }
+
+    return 1;
+}
+
+sub check_configuration {
+    my ($self, %options) = @_;
+
+    if ( !defined($self->{vault_config}->{url}) || $self->{vault_config}->{url} eq '') {
+        $self->{logger}->writeLogDebug("Vault url is missing from configuration.");
+        $self->{vault_config}->{url} = '127.0.0.1';
+    }
+    if ( !defined($self->{vault_config}->{port}) || $self->{vault_config}->{port} eq '') {
+        $self->{logger}->writeLogDebug("Vault port is missing from configuration.");
+        $self->{vault_config}->{port} = '443';
+    }
+
+    # Normally, the role_id and secret_id data are encrypted using AES wit the following information:
+    # firstKey = APP_SECRET (environment variable)
+    # secondKey = 'salt' (hashing) key given by vault.json configuration file
+    # both are base64 encoded
+    if ( !defined($self->{vault_config}->{salt}) || $self->{vault_config}->{salt} eq '') {
+        $self->{logger}->writeLogNotice("Vault environment does not seem complete: 'salt' attribute missing from "
+            . $self->{config_file}
+            . ". 'role_id' and 'secret_id' won't be decrypted, so they'll be used as they're stored in the vault config file.");
+        $self->{crypted_credentials} = 0;
+        $self->{hash_key} = '';
+    } else {
+        $self->{hash_key} = $self->{vault_config}->{salt}; # key for sha3-512 hmac
+    }
+    $self->{encryption_key} = get_app_secret();
+    if ( !defined($self->{encryption_key}) or $self->{encryption_key} eq '' ) {
+        $self->{logger}->writeLogInfo("Vault environment does not seem complete. 'APP_SECRET' environment variable missing."
+            . " 'role_id' and 'secret_id' won't be decrypted, so they'll be used as they're stored in the vault config file.");
+        $self->{crypted_credentials} = 0;
+        $self->{encryption_key} = '';
+    }
+
+    return 1;
+}
+
+sub get_app_secret {
+    if (defined($ENV{'APP_SECRET'}) && $ENV{'APP_SECRET'} ne '' ) {
+        return $ENV{'APP_SECRET'};
+    }
+    if (-r '/usr/share/centreon/.env'){
+        open(my $fh, '<', '/usr/share/centreon/.env') or return '';
+        while (my $line = <$fh>) {
+            chomp $line;
+            if ($line =~ /^APP_SECRET=(.+)$/) {
+                return $1;
+            }
+        }
+    }
+    return ''; # if no app_secret found return empty string so caller don't try to use it.
+}
+
+sub extract_and_decrypt {
+    my ($self, %options) = @_;
+
+    my $input = decode_base64($options{data});
+    $self->{logger}->writeLogDebug("data to extract and decrypt: '" . $options{data} . "'");
+
+    # with AES-256, the IV length must 16 bytes
+    my $iv_length = 16;
+    # extract the IV, the hashed data, the encrypted data
+    my $iv             = substr($input, 0, $iv_length);     # initialization vector
+    my $hashed_data    = substr($input, $iv_length, 64);    # hmac of the original data, for integrity control
+    my $encrypted_data = substr($input, $iv_length + 64);   # data to decrypt
+
+    # create the AES object
+    $self->{logger}->writeLogDebug(
+            "Creating the AES decryption object for initialization vector (IV) of length "
+            . length($iv) . "B, key of length " . length($self->{encryption_key}) . "B."
+    );
+    my $cipher;
+    eval {
+        $cipher = Crypt::OpenSSL::AES->new(
+            decode_base64( $self->{encryption_key} ),
+            {
+                'cipher'  => 'AES-256-CBC',
+                'iv'      => $iv,
+                'padding' => 1
+            }
+        );
+    };
+    if ($@) {
+        $self->{logger}->writeLogNotice("There was an error while creating the AES object: " . $@);
+        return undef;
+    }
+
+    # decrypt
+    $self->{logger}->writeLogDebug("Decrypting the data of length " . length($encrypted_data) . "B.");
+    my $decrypted_data;
+    eval {$decrypted_data = $cipher->decrypt($encrypted_data);};
+    if ($@) {
+        $self->{logger}->writeLogNotice("There was an error while decrypting one of the AES-encrypted data: " . $@);
+        return undef;
+    }
+
+    return $decrypted_data;
+}
+
+sub authenticate {
+    my ($self) = @_;
+
+    # initial value: assuming the role and secret id might not be encrypted
+    my $role_id   = $self->{vault_config}->{role_id};
+    my $secret_id = $self->{vault_config}->{secret_id};
+
+
+    if ($self->{crypted_credentials}) {
+        # Then decrypt using https://github.com/perl-openssl/perl-Crypt-OpenSSL-AES
+        # keep the decrypted data in local variables so that they stay in memory for as little time as possible
+        $self->{logger}->writeLogDebug("Decrypting the credentials needed to authenticate to the vault.");
+        $role_id   = $self->extract_and_decrypt( ('data' => $role_id ));
+        $secret_id = $self->extract_and_decrypt( ('data' => $secret_id ));
+        $self->{logger}->writeLogDebug("role_id and secret_id have been decrypted.");
+    } else {
+        $self->{logger}->writeLogDebug("role_id and secret_id are not crypted");
+    }
+
+
+    # Authenticate to get the token
+    my $url = "https://" . $self->{vault_config}->{url} . ":" . $self->{vault_config}->{port} . "/v1/auth/approle/login";
+    $self->{logger}->writeLogDebug("Authenticating to the vault server at URL: $url");
+    $self->{curl_easy}->setopt( CURLOPT_URL, $url );
+
+    my $post_data = "role_id=$role_id&secret_id=$secret_id";
+    my $auth_result_json;
+    # to get more details (in STDERR)
+    #$self->{curl_easy}->setopt(CURLOPT_VERBOSE, 1);
+    $self->{curl_easy}->setopt(CURLOPT_POST, 1);
+    $self->{curl_easy}->setopt(CURLOPT_POSTFIELDS, $post_data);
+    $self->{curl_easy}->setopt(CURLOPT_POSTFIELDSIZE, length($post_data));
+    $self->{curl_easy}->setopt(CURLOPT_WRITEDATA(), \$auth_result_json);
+
+    eval {
+        $self->{curl_easy}->perform();
+    };
+    if ($@) {
+        $self->{logger}->writeLogError("Error while authenticating to the vault: " . $@);
+        return undef;
+    }
+
+    $self->{logger}->writeLogInfo("Authentication to the vault passed." );
+
+    my $auth_result_obj = transform_json_to_object($auth_result_json);
+    if (defined($auth_result_obj->{error_message})) {
+        $self->{logger}->writeLogError("Error while decoding JSON '$auth_result_json'. Message: "
+                . $auth_result_obj->{error_message});
+        return undef;
+    }
+
+    # store the token (.auth.client_token) and its expiration date (current date + .lease_duration)
+    my $expiration_epoch = -1;
+    my $lease_duration = $auth_result_obj->{auth}->{lease_duration};
+    if ( defined($lease_duration)
+            && $lease_duration =~ /\d+/
+            && $lease_duration > 0 ) {
+        $expiration_epoch = time() + $lease_duration;
+    }
+    $self->{auth} = {
+        'token'            => $auth_result_obj->{auth}->{client_token},
+        'expiration_epoch' => $expiration_epoch
+    };
+    $self->{logger}->writeLogInfo("Authenticating worked. Token valid until "
+        . localtime($self->{auth}->{expiration_epoch}));
+
+    return 1;
+}
+
+sub is_token_still_valid {
+    my ($self) = @_;
+    if (
+            !defined($self->{auth})
+            || !defined($self->{auth}->{token})
+            || $self->{auth}->{token} eq ''
+            || $self->{auth}->{expiration_epoch} <= time()
+    ) {
+        $self->{logger}->writeLogInfo("The token has expired or is invalid.");
+        return undef;
+    }
+    $self->{logger}->writeLogDebug("The token is still valid.");
+    return 1;
+}
+
+sub get_secret {
+    my ($self, $secret) = @_;
+
+    # if vault not enabled, return the secret unchanged
+    return $secret if ( ! $self->{enabled});
+
+    my ($secret_path, $secret_name) = $secret =~ $VAULT_PATH_REGEX;
+    if (!defined($secret_path) || !defined($secret_name)) {
+        return $secret;
+    }
+    $self->{logger}->writeLogDebug("Secret path: $secret_path - Secret name: $secret_name");
+
+    if (!defined($self->{auth}) || !$self->is_token_still_valid() ) {
+        $self->authenticate() or return $secret;
+    }
+
+    # prepare the GET statement
+    my $get_result_json;
+    my $url = "https://" . $self->{vault_config}->{url} . ":" . $self->{vault_config}->{port} . "/v1/" . $secret_path;
+    $self->{logger}->writeLogDebug("Requesting URL: $url");
+
+    #$self->{curl_easy}->setopt( CURLOPT_VERBOSE, 1 );
+    $self->{curl_easy}->setopt( CURLOPT_URL, $url );
+    $self->{curl_easy}->setopt( CURLOPT_POST, 0 );
+    $self->{curl_easy}->setopt( CURLOPT_WRITEDATA(), \$get_result_json );
+    $self->{curl_easy}->setopt( CURLOPT_HTTPHEADER(), ["X-Vault-Token: " . $self->{auth}->{token}]);
+
+    eval {
+        $self->{curl_easy}->perform();
+    };
+    if ($@) {
+        $self->{logger}->writeLogError("Error while getting a secret from the vault: " . $@);
+        return $secret;
+    }
+
+    $self->{logger}->writeLogDebug("Request passed.");
+    # request_id
+
+    # the result is a json string, convert it into an object
+    my $get_result_obj = transform_json_to_object($get_result_json);
+    if (defined($get_result_obj->{error_message})) {
+        $self->{logger}->writeLogError("Error while decoding JSON '$get_result_json'. Message: "
+                . $get_result_obj->{error_message});
+        return $secret;
+    }
+    $self->{logger}->writeLogDebug("Request id is " . $get_result_obj->{request_id});
+
+    # .data.data will contain the stored macros
+    if ( !defined($get_result_obj->{data})
+            || !defined($get_result_obj->{data}->{data})
+            || !defined($get_result_obj->{data}->{data}->{$secret_name}) ) {
+        $self->{logger}->writeLogError("Could not get secret '$secret_name' from path '$secret_path' from the vault. Enable debug for more details.");
+        $self->{logger}->writeLogDebug("Response: " . $get_result_json);
+        return $secret;
+    }
+    $self->{logger}->writeLogInfo("Secret '$secret_name' from path '$secret_path' retrieved from the vault.");
+    return $get_result_obj->{data}->{data}->{$secret_name};
+}
+
+sub transform_json_to_object {
+    my ($json_data) = @_;
+
+    my $json_as_object;
+    eval {
+        $json_as_object = decode_json($json_data);
+    };
+    if ($@) {
+        return ({'error_message' => "Could not decode JSON from '$json_data'. Reason: " . $@});
+    };
+    return($json_as_object);
+}
+
+sub parse_json_file {
+    my (%options) = @_;
+
+    my $fh;
+    my $json_data = '';
+
+    my $json_file = $options{json_file};
+
+    open($fh, '<', $json_file) or return ('error_message' => "parse_json_file: Cannot open " . $json_file);
+    for my $line (<$fh>) {
+        chomp $line;
+        $json_data .= $line;
+    }
+    close($fh);
+    return transform_json_to_object($json_data);
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Centreon Vault password manager
+
+=head1 SYNOPSIS
+
+Allows to retrieve secrets (usually username and password) from a Hashicorp vault compatible api given a config file as constructor.
+
+    use centreon::common::logger;
+    use centreon::script::centreonvault;
+    my $vault = centreon::script::centreonvault->new(
+        (
+            'logger'      => centreon::common::logger->new(),
+            'config_file' =>  '/var/lib/centreon/vault/vault.json'
+        )
+    );
+    my $password = $vault->get_secret('secret::hashicorp_vault::mypath/to/mysecrets::password');
+
+=head1 METHODS
+
+=head2 new(\%options)
+
+Constructor of the vault object.
+
+%options must provide:
+
+- logger: an object of the centreon::common::logger class.
+
+- config_file: full path and file name of the Centreon Vault JSON config file.
+
+The default config_file path should be '/var/lib/centreon/vault/vault.json'.
+The expected file format for Centreon Vault is:
+
+    {
+      "name": "hashicorp_vault",
+      "url": "vault-server.mydomain.com",
+      "salt": "<base64 encoded(<32 bytes long key used to hash the crypted data)>",
+      "port": 443,
+      "root_path": "vmware_daemon",
+      "role_id": "<base64 encoded(<iv><hmac_hash><encrypted_role_id>)",
+      "secret_id": "<base64 encoded(<iv><hmac_hash><encrypted_secret_id>)"
+    }
+
+This sub will not emit Error logs (only Notice and inferior) as it can be called on environment where the Vault is not used.
+get_secret() can emit Error logs if vault is considered enabled.
+
+=head2 get_secret($secret)
+
+Returns the secret stored in the Centreon Vault at the given path.
+If the format of the secret does not match the regular expression
+C</^secret::hashicorp_vault::([^:]+)::(.+)$/>
+or in case of any failure in the process, the method will return the secret unchanged.
+
+=cut

--- a/perl-libs/lib/centreon/common/db.pm
+++ b/perl-libs/lib/centreon/common/db.pm
@@ -1,0 +1,302 @@
+################################################################################
+# Copyright 2005-2013 Centreon
+# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+# 
+# This program is free software; you can redistribute it and/or modify it under 
+# the terms of the GNU General Public License as published by the Free Software 
+# Foundation ; either version 2 of the License.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with 
+# this program; if not, see <http://www.gnu.org/licenses>.
+# 
+# Linking this program statically or dynamically with other modules is making a 
+# combined work based on this program. Thus, the terms and conditions of the GNU 
+# General Public License cover the whole combination.
+# 
+# As a special exception, the copyright holders of this program give Centreon 
+# permission to link this program with independent modules to produce an executable, 
+# regardless of the license terms of these independent modules, and to copy and 
+# distribute the resulting executable under terms of Centreon choice, provided that 
+# Centreon also meet, for each linked independent module, the terms  and conditions 
+# of the license of that module. An independent module is a module which is not 
+# derived from this program. If you modify this program, you may extend this 
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+# 
+#
+####################################################################################
+
+package centreon::common::db;
+
+use strict;
+use warnings;
+use DBI;
+
+sub new {
+    my ($class, %options) = @_;
+    my %defaults =
+      (
+       logger => undef,
+       db => undef,
+       host => "localhost",
+       user => undef,
+       password => undef,
+       port => 3306,
+       force => 0,
+       type => "mysql"
+      );
+    my $self = {%defaults, %options};
+    $self->{type} = 'mysql' if (!defined($self->{type}));
+
+    $self->{instance} = undef;
+    $self->{args} = [];
+    bless $self, $class;
+    return $self;
+}
+
+# Getter/Setter DB name
+sub type {
+    my $self = shift;
+    if (@_) {
+        $self->{type} = shift;
+    }
+    return $self->{type};
+}
+
+# Getter/Setter DB name
+sub db {
+    my $self = shift;
+    if (@_) {
+        $self->{db} = shift;
+    }
+    return $self->{db};
+}
+
+# Getter/Setter DB host
+sub host {
+    my $self = shift;
+    if (@_) {
+        $self->{host} = shift;
+    }
+    return $self->{host};
+}
+
+# Getter/Setter DB port
+sub port {
+    my $self = shift;
+    if (@_) {
+        $self->{port} = shift;
+    }
+    return $self->{port};
+}
+
+# Getter/Setter DB user
+sub user {
+    my $self = shift;
+    if (@_) {
+        $self->{user} = shift;
+    }
+    return $self->{user};
+}
+
+# Getter/Setter DB force
+sub force {
+    my $self = shift;
+    if (@_) {
+        $self->{force} = shift;
+    }
+    return $self->{force};
+}
+
+# Getter/Setter DB password
+sub password {
+    my $self = shift;
+    if (@_) {
+        $self->{password} = shift;
+    }
+    return $self->{password};
+}
+
+sub last_insert_id {
+    my $self = shift;
+    return $self->{instance}->last_insert_id(undef, undef, undef, undef);
+}
+
+sub quote {
+    my $self = shift;
+
+    if (defined($self->{instance})) {
+        return $self->{instance}->quote($_[0]);
+    }
+    my $num = scalar(@{$self->{args}});
+    push @{$self->{args}}, $_[0];
+    return "##__ARG__$num##";
+}
+
+sub set_inactive_destroy {
+    my $self = shift;
+
+    if (defined($self->{instance})) {
+        $self->{instance}->{InactiveDestroy} = 1;
+    }
+}
+
+sub transaction_mode {
+    my ($self, $status) = @_;
+
+    if ($status) {
+        $self->{instance}->begin_work;
+        $self->{instance}->{RaiseError} = 1;
+    } else {
+        $self->{instance}->{AutoCommit} = 1;
+        $self->{instance}->{RaiseError} = 0;
+    }
+}
+
+sub commit { shift->{instance}->commit; }
+
+sub rollback { shift->{instance}->rollback; }
+
+sub kill {
+    my $self = shift;
+
+    if (defined($self->{instance})) {
+        $self->{logger}->writeLogInfo("KILL QUERY\n");
+        my $rv = $self->{instance}->do("KILL QUERY " . $self->{instance}->{'mysql_thread_id'});
+        if (!$rv) {
+            my ($package, $filename, $line) = caller;
+            $self->{logger}->writeLogError("MySQL error : " . $self->{instance}->errstr . " (caller: $package:$filename:$line)");
+        }
+    }
+}
+
+# Connection initializer
+sub connect {
+    my ($self, %options) = @_;
+    my $logger = $self->{logger};
+    my $status = 0;
+
+    my $connect_options = {};
+    $connect_options = $options{connect_options} if (defined($options{connect_options}) && ref($options{connect_options}) eq "HASH");
+    while (1) {
+        $self->{port} = 3306 if (!defined($self->{port}) && $self->{type} eq 'mysql');
+        if ($self->{type} =~ /SQLite/i) {
+            $self->{instance} = DBI->connect(
+                "DBI:".$self->{type} 
+                    .":".$self->{db},
+                $self->{user},
+                $self->{password},
+                { "RaiseError" => 0, "PrintError" => 0, "AutoCommit" => 1, %{$connect_options} }
+            );
+        } else {
+            $self->{instance} = DBI->connect(
+                "DBI:".$self->{type} 
+                    .":".$self->{db}
+                    .":".$self->{host}
+                    .":".$self->{port},
+                $self->{user},
+                $self->{password},
+                { "RaiseError" => 0, "PrintError" => 0, "AutoCommit" => 1, %{$connect_options} }
+            );
+        }
+        if (defined($self->{instance})) {
+            last;
+        }
+
+        my ($package, $filename, $line) = caller;
+        $logger->writeLogError("MySQL error : cannot connect to database " . $self->{db} . ": " . $DBI::errstr . " (caller: $package:$filename:$line)");
+        if ($self->{force} == 0) {
+            $status = -1;
+            last;
+        }
+        sleep(5);
+    }
+    return $status;
+}
+
+# Destroy connection
+sub disconnect {
+    my $self = shift;
+    my $instance = $self->{instance};
+    if (defined($instance)) {
+        $instance->disconnect;
+        $self->{instance} = undef;
+    }
+}
+
+sub do {
+    my ($self, $query) = @_;
+
+    if (!defined $self->{instance}) {
+        if ($self->connect() == -1) {
+            $self->{logger}->writeLogError("Can't connect to the database");
+            return -1;
+        }
+    }
+    my $numrows = $self->{instance}->do($query);
+    die $self->{instance}->errstr if !defined $numrows;
+    return $numrows;
+}
+
+sub error {
+    my ($self, $error, $query) = @_;
+    my ($package, $filename, $line) = caller 1;
+
+    chomp($query);
+    $self->{logger}->writeLogError(<<"EOE");
+MySQL error: $error (caller: $package:$filename:$line)
+Query: $query
+EOE
+    $self->disconnect();
+    $self->{instance} = undef;
+}
+
+sub query {
+    my $self = shift;
+    my $query = shift;
+    my $logger = $self->{logger};
+    my $status = 0;
+    my $statement_handle;
+
+    while (1) {
+        if (!defined($self->{instance})) {
+            $status = $self->connect();
+            if ($status != -1) {
+                for (my $i = 0; $i < scalar(@{$self->{args}}); $i++) {
+                    my $str_quoted = $self->quote(${$self->{args}}[$i]);
+                    $query =~ s/##__ARG__$i##/$str_quoted/;
+                }
+                $self->{args} = [];
+            }
+            if ($status == -1 && $self->{force} == 0) {
+                $self->{args} = [];
+                last;
+            }
+        }
+
+        $statement_handle = $self->{instance}->prepare($query);
+        if (!defined $statement_handle) {
+            $self->error($self->{instance}->errstr, $query);
+            $status = -1;
+            last if $self->{force} == 0;
+            next;
+        }
+
+        my $rv = $statement_handle->execute;
+        if (!$rv) {
+            $self->error($statement_handle->errstr, $query);
+            $status = -1;
+            last if $self->{force} == 0;
+            next;
+        }
+        last;
+    }
+    return ($status, $statement_handle);
+}
+
+1;

--- a/perl-libs/lib/centreon/common/lock.pm
+++ b/perl-libs/lib/centreon/common/lock.pm
@@ -1,0 +1,181 @@
+################################################################################
+# Copyright 2005-2013 Centreon
+# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+# 
+# This program is free software; you can redistribute it and/or modify it under 
+# the terms of the GNU General Public License as published by the Free Software 
+# Foundation ; either version 2 of the License.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with 
+# this program; if not, see <http://www.gnu.org/licenses>.
+# 
+# Linking this program statically or dynamically with other modules is making a 
+# combined work based on this program. Thus, the terms and conditions of the GNU 
+# General Public License cover the whole combination.
+# 
+# As a special exception, the copyright holders of this program give Centreon 
+# permission to link this program with independent modules to produce an executable, 
+# regardless of the license terms of these independent modules, and to copy and 
+# distribute the resulting executable under terms of Centreon choice, provided that 
+# Centreon also meet, for each linked independent module, the terms  and conditions 
+# of the license of that module. An independent module is a module which is not 
+# derived from this program. If you modify this program, you may extend this 
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+# 
+#
+####################################################################################
+
+package centreon::common::lock;
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, $name, %options) = @_;
+    my %defaults = (name => $name, pid => $$, timeout => 10);
+    my $self = {%defaults, %options};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub is_set {
+    die "Not implemented";
+}
+
+sub set {
+    my $self = shift;
+
+    for (my $i = 0; $i < $self->{timeout}; $i++) {
+        return if (!$self->is_set());
+        sleep 1;
+    }
+
+    die "Failed to set lock for $self->{name}";
+}
+
+package centreon::common::lock::file;
+
+use base qw(centreon::common::lock);
+
+sub new {
+    my $class = shift;
+    my $self = $class->SUPER::new(@_);
+
+    if (!defined $self->{storagedir}) {
+        die "Can't build lock, required arguments not provided";
+    }
+    bless $self, $class;
+    $self->{pidfile} = "$self->{storagedir}/$self->{name}.lock";
+    return $self;
+}
+
+sub is_set {
+    return -e shift->{pidfile};
+}
+
+sub set {
+    my $self = shift;
+
+    $self->SUPER::set();
+    open LOCK, ">", $self->{pidfile};
+    print LOCK $self->{pid};
+    close LOCK;
+}
+
+sub DESTROY {
+    my $self = shift;
+
+    if (defined $self->{pidfile} && -e $self->{pidfile}) {
+        unlink $self->{pidfile};
+    }
+}
+
+package centreon::common::lock::sql;
+
+use base qw(centreon::common::lock);
+
+sub new {
+    my $class = shift;
+    my $self = $class->SUPER::new(@_);
+
+    if (!defined $self->{dbc}) {
+        die "Can't build lock, required arguments not provided";
+    }
+    bless $self, $class;
+    $self->{launch_time} = time();
+    return $self;
+}
+
+sub is_set {
+    my $self = shift;
+    my ($status, $sth) = $self->{dbc}->query(
+        "SELECT `id`,`running`,`pid`,`time_launch` FROM `cron_operation` WHERE `name` LIKE '$self->{name}'"
+    );
+
+    return 1 if ($status == -1);
+    my $data = $sth->fetchrow_hashref();
+
+    if (!defined $data->{id}) {
+        $self->{not_created_yet} = 1;
+        $self->{previous_launch_time} = 0;
+        return 0;
+    }
+    $self->{id} = $data->{id};
+	my $pid = defined($data->{pid}) ? $data->{pid} : -1;
+    $self->{previous_launch_time} = $data->{time_launch};
+    if (defined $data->{running} && $data->{running} == 1) {
+        my $line = `ps -ef | grep -v grep | grep -- $pid | grep $self->{name}`;
+        return 0 if !length $line;
+        return 1;
+    }
+    return 0;
+}
+
+sub set {
+    my $self = shift;
+    my $status;
+
+    $self->SUPER::set();
+    if (defined $self->{not_created_yet}) {
+        $status = $self->{dbc}->do(<<"EOQ");
+INSERT INTO `cron_operation`
+(`name`, `system`, `activate`)
+VALUES ('$self->{name}', '1', '1')
+EOQ
+        goto error if $status == -1;
+        $self->{id} = $self->{dbc}->last_insert_id();
+        return;
+    }
+    $status = $self->{dbc}->do(<<"EOQ");
+UPDATE `cron_operation`
+SET `running` = '1', `time_launch` = '$self->{launch_time}', `pid` = '$self->{pid}'
+WHERE `id` = '$self->{id}'
+EOQ
+    goto error if $status == -1;
+    return;
+
+  error:
+    die "Failed to set lock for $self->{name}";
+}
+
+sub DESTROY {
+    my $self = shift;
+
+    if (defined $self->{dbc}) {
+        my $exectime = time() - $self->{launch_time};
+        $self->{dbc}->do(<<"EOQ");
+UPDATE `cron_operation`
+SET `last_execution_time` = '$exectime'
+WHERE `id` = '$self->{id}'
+EOQ
+    }
+}
+
+1;

--- a/perl-libs/lib/centreon/common/logger.pm
+++ b/perl-libs/lib/centreon/common/logger.pm
@@ -1,0 +1,288 @@
+################################################################################
+# Copyright 2005-2013 Centreon
+# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+# 
+# This program is free software; you can redistribute it and/or modify it under 
+# the terms of the GNU General Public License as published by the Free Software 
+# Foundation ; either version 2 of the License.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with 
+# this program; if not, see <http://www.gnu.org/licenses>.
+# 
+# Linking this program statically or dynamically with other modules is making a 
+# combined work based on this program. Thus, the terms and conditions of the GNU 
+# General Public License cover the whole combination.
+# 
+# As a special exception, the copyright holders of this program give Centreon 
+# permission to link this program with independent modules to produce an executable, 
+# regardless of the license terms of these independent modules, and to copy and 
+# distribute the resulting executable under terms of Centreon choice, provided that 
+# Centreon also meet, for each linked independent module, the terms  and conditions 
+# of the license of that module. An independent module is a module which is not 
+# derived from this program. If you modify this program, you may extend this 
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+# 
+#
+####################################################################################
+# updated by Evan ADAM on 10/2024
+
+package centreon::common::logger;
+=head1 NOM
+
+centreon::common::logger - Simple logging module
+
+=head1 SYNOPSIS
+
+ #!/usr/bin/perl -w
+
+ use strict;
+ use warnings;
+ use centreon::common::logger;
+
+ my $logger = new centreon::common::logger();
+
+ $logger->writeLogInfo("information");
+
+=head1 DESCRIPTION
+
+This module offers a simple interface to write log messages to various output:
+
+* standard output
+* file
+* syslog
+
+=cut
+
+use strict;
+use warnings;
+use Sys::Syslog qw(:standard :macros);
+use IO::Handle;
+
+# Fixed the severity internal representation to be
+my %human_severities = (
+    2 => 'FATAL',
+    3 => 'ERROR',
+    4 => 'WARNING',
+    5 => 'NOTICE',
+    6 => 'INFO',
+    7 => 'DEBUG'
+);
+
+sub new {
+    my $class = shift;
+
+    my $self = bless
+      {
+       file => 0,
+       filehandler => undef,
+       # warning by default, see %human_severities for the available possibilty
+       severity => 4,
+       old_severity => 4,
+       # 0 = stdout, 1 = file, 2 = syslog
+       log_mode => 0,
+       # Output pid of current process
+        withpid => 0,
+       # Output date of log
+        withdate => 1,
+       # syslog
+       log_facility => undef,
+       log_option => LOG_PID,
+      }, $class;
+    return $self;
+}
+
+sub file_mode($$) {
+    my ($self, $file) = @_;
+
+    if (defined($self->{filehandler})) {
+        $self->{filehandler}->close();
+    }
+    if (open($self->{filehandler}, ">>", $file)){
+        $self->{log_mode} = 1;
+        $self->{filehandler}->autoflush(1);
+        $self->{file_name} = $file;
+        return 1;
+    }
+    $self->{filehandler} = undef;
+    print STDERR "Cannot open file $file: $!\n";
+    return 0;
+}
+
+sub is_file_mode {
+    my $self = shift;
+    
+    if ($self->{log_mode} == 1) {
+        return 1;
+    }
+    return 0;
+}
+
+sub is_debug {
+    my $self = shift;
+
+    if ($self->{severity} == 7) {
+        return 1;
+    }
+    return 0;
+}
+
+sub syslog_mode($$$) {
+    my ($self, $logopt, $facility) = @_;
+
+    $self->{log_mode} = 2;
+    openlog($0, $logopt, $facility);
+    return 1;
+}
+
+# For daemons
+sub redirect_output {
+    my $self = shift;
+
+    if ($self->is_file_mode()) {
+        open my $lfh, '>>', $self->{file_name};
+        open STDOUT, '>&', $lfh;
+        open STDERR, '>&', $lfh;
+    }
+}
+# Bypass the buffers set up by the kernel/file system and always write the log
+# as soon as it is sent.
+sub flush_output {
+    my ($self, %options) = @_;
+
+    $| = 1 if (defined($options{enabled}));
+}
+
+sub force_default_severity {
+    my ($self, %options) = @_;
+
+    $self->{old_severity} = defined($options{severity}) ? $options{severity} : $self->{severity};
+}
+
+sub set_default_severity {
+    my $self = shift;
+
+    $self->{severity} = $self->{old_severity};
+}
+
+# Getter/Setter Log severity
+sub severity {
+    my $self = shift;
+    if (@_) {
+        my $input_severity = lc($_[0]);
+        my $save_severity = $self->{severity};
+        if ($input_severity =~ /^[0234567]$/) {
+            $self->{severity} = $input_severity;
+        } elsif ($input_severity eq "none") {
+            $self->{severity} = 0;
+        } elsif ($input_severity eq "fatal") {
+            $self->{severity} = 2;
+        } elsif ($input_severity eq "error") {
+            $self->{severity} = 3;
+        } elsif ($input_severity eq "warning") {
+            $self->{severity} = 4;
+        } elsif ($input_severity eq "notice") {
+            $self->{severity} = 5;
+        } elsif ($input_severity eq "info") {
+            $self->{severity} = 6;
+        } elsif ($input_severity eq "debug") {
+            $self->{severity} = 7;
+        } else {
+            $self->writeLogError("Wrong severity value set.");
+            return -1;
+        }
+        $self->{old_severity} = $save_severity;
+    }
+    return $human_severities{$self->{severity}};
+}
+
+sub withpid {
+    my $self = shift;
+    if (@_) {
+        if ($_[0]){
+        $self->{withpid} = 1;
+        }else{
+        $self->{withpid} = 0;
+        }
+
+    }
+    return $self->{withpid};
+}
+
+sub withdate {
+    my $self = shift;
+    if (@_) {
+        $self->{withdate} = $_[0];
+    }
+    return $self->{withdate};
+}
+
+sub get_date {
+    my $self = shift;
+    my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime(time());
+    return sprintf("%04d-%02d-%02d %02d:%02d:%02d",
+                   $year+1900, $mon+1, $mday, $hour, $min, $sec);
+}
+
+sub writeLog($$$%) {
+    my ($self, $severity, $msg, %options) = @_;
+
+    # do nothing if the configured severity does not imply logging this message
+    return if ($self->{severity} < $severity);
+
+    $msg = ($self->withpid()) ? "[$$] $msg" : $msg;
+
+    my $datedmsg = "[" . $human_severities{$severity} . "] " . $msg . "\n";
+    if ($self->withdate()) {
+        $datedmsg = "[" . $self->get_date . "] " . $datedmsg;
+    }
+    if ($self->{log_mode} == 1 and defined($self->{filehandler})) {
+        print {$self->{filehandler}} $datedmsg;
+    } elsif ($self->{log_mode} == 0) {
+        print $datedmsg;
+    } elsif ($self->{log_mode} == 2) {
+        syslog($severity, $msg);
+    } else {
+        print STDERR "Unknown log mode '$self->{log_mode}' or log file unavailable for the following log :\n $datedmsg\n";
+    }
+}
+
+sub writeLogDebug {
+    shift->writeLog(7, @_);
+}
+
+sub writeLogInfo {
+    shift->writeLog(6, @_);
+}
+
+sub writeLogNotice {
+    shift->writeLog(5, @_);
+}
+
+sub writeLogWarning {
+    shift->writeLog(4, @_);
+}
+
+sub writeLogError {
+    shift->writeLog(3, @_);
+}
+
+sub writeLogFatal {
+    shift->writeLog(2, @_);
+    die("FATAL: " . $_[0] . "\n");
+}
+
+sub DESTROY {
+    my $self = shift;
+    
+    if (defined $self->{filehandler}) {
+        $self->{filehandler}->close();
+    }
+}
+
+1;

--- a/perl-libs/lib/centreon/common/misc.pm
+++ b/perl-libs/lib/centreon/common/misc.pm
@@ -1,0 +1,275 @@
+################################################################################
+# Copyright 2005-2013 Centreon
+# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+# 
+# This program is free software; you can redistribute it and/or modify it under 
+# the terms of the GNU General Public License as published by the Free Software 
+# Foundation ; either version 2 of the License.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with 
+# this program; if not, see <http://www.gnu.org/licenses>.
+# 
+# Linking this program statically or dynamically with other modules is making a 
+# combined work based on this program. Thus, the terms and conditions of the GNU 
+# General Public License cover the whole combination.
+# 
+# As a special exception, the copyright holders of this program give Centreon 
+# permission to link this program with independent modules to produce an executable, 
+# regardless of the license terms of these independent modules, and to copy and 
+# distribute the resulting executable under terms of Centreon choice, provided that 
+# Centreon also meet, for each linked independent module, the terms  and conditions 
+# of the license of that module. An independent module is a module which is not 
+# derived from this program. If you modify this program, you may extend this 
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+# 
+#
+####################################################################################
+
+package centreon::common::misc;
+
+use strict;
+use warnings;
+use vars qw($centreon_config);
+use POSIX ":sys_wait_h";
+
+my $read_size = 1*1024*1024*10; # 10Mo
+
+sub reload_db_config {
+    my ($logger, $config_file, $cdb, $csdb) = @_;
+    my ($cdb_mod, $csdb_mod) = (0, 0);
+    
+    unless (my $return = do $config_file) {
+        $logger->writeLogError("couldn't parse $config_file: $@") if $@;
+        $logger->writeLogError("couldn't do $config_file: $!") unless defined $return;
+        $logger->writeLogError("couldn't run $config_file") unless $return;
+        return -1;
+    }
+    
+    if (defined($cdb)) {
+        if ($centreon_config->{centreon_db} ne $cdb->db() ||
+            $centreon_config->{db_host} ne $cdb->host() ||
+            $centreon_config->{db_user} ne $cdb->user() ||
+            $centreon_config->{db_passwd} ne $cdb->password() ||
+            (defined($centreon_config->{db_port}) && $centreon_config->{db_port} ne $cdb->port())) {
+            $logger->writeLogInfo("Database centreon config had been modified");
+            $cdb->db($centreon_config->{centreon_db});
+            $cdb->host($centreon_config->{db_host});
+            $cdb->user($centreon_config->{db_user});
+            $cdb->password($centreon_config->{db_passwd});
+            $cdb->port($centreon_config->{db_port});
+            $cdb_mod = 1;
+        }
+    }
+    
+    if (defined($csdb)) {
+        if ($centreon_config->{centstorage_db} ne $csdb->db() ||
+            $centreon_config->{db_host} ne $csdb->host() ||
+            $centreon_config->{db_user} ne $csdb->user() ||
+            $centreon_config->{db_passwd} ne $csdb->password() ||
+            (defined($centreon_config->{db_port}) && $centreon_config->{db_port} ne $csdb->port())) {
+            $logger->writeLogInfo("Database centstorage config had been modified");
+            $csdb->db($centreon_config->{centstorage_db});
+            $csdb->host($centreon_config->{db_host});
+            $csdb->user($centreon_config->{db_user});
+            $csdb->password($centreon_config->{db_passwd});
+            $csdb->port($centreon_config->{db_port});
+            $csdb_mod = 1;
+        }
+    }
+   
+    return (0, $cdb_mod, $csdb_mod);
+}
+
+sub get_all_options_config {
+    my ($extra_config, $centreon_db_centreon, $prefix) = @_;
+
+    my $save_force = $centreon_db_centreon->force();
+    $centreon_db_centreon->force(0);
+    
+    my ($status, $stmt) = $centreon_db_centreon->query("SELECT `key`, `value` FROM options WHERE `key` LIKE " . $centreon_db_centreon->quote($prefix . "_%") . " LIMIT 1");
+    if ($status == -1) {
+        $centreon_db_centreon->force($save_force);
+        return ;
+    }
+    while ((my $data = $stmt->fetchrow_hashref())) {
+        if (defined($data->{value}) && length($data->{value}) > 0) {
+            $data->{key} =~ s/^${prefix}_//;
+            $extra_config->{$data->{key}} = $data->{value};
+        }
+    }
+    
+    $centreon_db_centreon->force($save_force);
+}
+
+sub get_option_config {
+    my ($extra_config, $centreon_db_centreon, $prefix, $key) = @_;
+    my $data;
+ 
+    my $save_force = $centreon_db_centreon->force();
+    $centreon_db_centreon->force(0);
+    
+    my ($status, $stmt) = $centreon_db_centreon->query("SELECT value FROM options WHERE `key` = " . $centreon_db_centreon->quote($prefix . "_" . $key) . " LIMIT 1");
+    if ($status == -1) {
+        $centreon_db_centreon->force($save_force);
+        return ;
+    }
+    if (($data = $stmt->fetchrow_hashref()) && defined($data->{value})) {
+        $extra_config->{$key} = $data->{value};
+    }
+    
+    $centreon_db_centreon->force($save_force);
+}
+
+sub check_debug {
+    my ($logger, $key, $cdb, $name) = @_;
+    
+    my $request = "SELECT value FROM options WHERE `key` = " . $cdb->quote($key);
+    my ($status, $sth) =  $cdb->query($request);
+    return -1 if ($status == -1);
+    my $data = $sth->fetchrow_hashref();
+    if (defined($data->{'value'}) && $data->{'value'} == 1) {
+        if (!$logger->is_debug()) {
+            $logger->severity("debug");
+            $logger->writeLogInfo("Enable Debug in $name");
+        }
+    } else {
+        if ($logger->is_debug()) {
+            $logger->set_default_severity();
+            $logger->writeLogInfo("Disable Debug in $name");
+        }
+    }
+    return 0;
+}
+
+sub get_line_file {
+    my ($fh, $datas, $readed) = @_;
+    my $line;
+    my $size = scalar(@$datas);
+
+    return (1, shift(@$datas)) if ($size > 1);
+    while ((my $eof = sysread($fh, $line, $read_size))) {
+        my @result = split("\n", $line);
+        if ($line =~ /\n$/) {
+            push @result, "";
+        }
+        if ($size == 1) {
+            $$datas[0] .= shift(@result);
+        }
+        push @$datas, @result;
+        $$readed += $eof;
+        $size = scalar(@$datas);
+        if ($size > 1) {
+            return (1, shift(@$datas));
+        }
+    }
+    return (1, shift(@$datas)) if ($size > 1);
+    return -1;
+}
+
+sub get_line_pipe {
+    my ($fh, $datas, $read_done) = @_;
+    my $line;
+    my $size = scalar(@$datas);
+
+    if ($size > 1) {
+        return (1, shift(@$datas));
+    } elsif ($size == 1 && $$read_done == 1) {
+        return 0;
+    }
+    while ((my $eof = sysread($fh, $line, 10000))) {
+        $$read_done = 1;
+        my @result = split("\n", $line);
+        if ($line =~ /\n$/) {
+            push @result, "";
+        }
+        if ($size == 1) {
+            $$datas[0] .= shift(@result);
+        }
+        push @$datas, @result;
+        $size = scalar(@$datas);
+        if ($size > 1) {
+            return (1, shift(@$datas));
+        } else {
+            return 0;
+        }
+    }
+    return -1;
+}
+
+sub backtick {
+    my %arg = (
+        command => undef,
+        logger => undef,
+        timeout => 30,
+        wait_exit => 0,
+        @_,
+    );
+    my @output;
+    my $pid;
+    my $return_code;
+    
+    my $sig_do;
+    if ($arg{wait_exit} == 0) {
+        $sig_do = 'IGNORE';
+        $return_code = undef;
+    } else {
+        $sig_do = 'DEFAULT';
+    }
+    local $SIG{CHLD} = $sig_do;
+    if (!defined($pid = open( KID, "-|" ))) {
+        $arg{logger}->writeLogError("Cant fork: $!");
+        return -1;
+    }
+    
+    if ($pid) {
+        eval {
+           local $SIG{ALRM} = sub { die "Timeout by signal ALARM\n"; };
+           alarm( $arg{timeout} );
+           while (<KID>) {
+               chomp;
+               push @output, $_;
+           }
+
+           alarm(0);
+        };
+        if ($@) {
+            $arg{logger}->writeLogInfo($@);
+
+            $arg{logger}->writeLogInfo("Killing child process [$pid] ...");
+            if ($pid != -1) {
+                kill -9, $pid;
+            }
+            $arg{logger}->writeLogInfo("Killed");
+
+            alarm(0);
+            close KID;
+            return (-1, join("\n", @output), -1);
+        } else {
+            if ($arg{wait_exit} == 1) {
+                # We're waiting the exit code                
+                waitpid($pid, 0);
+                $return_code = ($? >> 8);
+            }
+            close KID;
+        }
+    } else {
+        # child
+        # set the child process to be a group leader, so that
+        # kill -9 will kill it and all its descendents
+        setpgrp(0, 0);
+
+        exec($arg{command});
+        # Exec is in error. No such command maybe.
+        exit(127);
+    }
+
+    return (0, join("\n", @output), $return_code);
+}
+        
+1;

--- a/perl-libs/lib/centreon/health/checkbroker.pm
+++ b/perl-libs/lib/centreon/health/checkbroker.pm
@@ -1,0 +1,103 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::checkbroker;
+
+use strict;
+use warnings;
+use JSON;
+use POSIX qw(strftime);
+use centreon::common::misc;
+use centreon::health::ssh;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{output} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub json_parsing {
+    my ($self, %options) = @_;
+    
+    my $json_content = JSON->new->decode($options{json_content});
+    foreach my $key (keys %$json_content) {
+	if ($key =~ m/^endpoint/) {
+	foreach my $broker_metric (keys %{$json_content->{$key}}) {
+		next if ($broker_metric !~ m/version|event_processing|last_connection|queued|state/);
+		$self->{output}->{$options{poller_name}}->{$options{file_name}}->{$broker_metric} = ($broker_metric =~ m/^last_connection/ && $json_content->{$key}->{$broker_metric} != -1) 
+										? strftime("%m/%d/%Y %H:%M:%S",localtime($json_content->{$key}->{$broker_metric}))
+										: $json_content->{$key}->{$broker_metric} ;
+	    }
+	} elsif ($key =~ m/version/) {
+	    $self->{output}->{$options{poller_name}}->{$options{file_name}}->{$key} = $json_content->{$key};
+	}
+
+    }
+
+    return $self->{output} 
+
+}
+
+sub run {
+    my $self = shift;
+    my ($centreon_db, $server_list, $centreon_version) = @_;
+
+    my $sth;
+
+    if ($centreon_version ne "2.8") {
+	$self->{output}->{not_compliant} = "Incompatible file format, work only with JSON format";
+	return $self->{output}
+    }
+
+    return if ($centreon_version ne "2.8");
+    foreach my $server (keys %$server_list) {
+	$sth = $centreon_db->query("SELECT config_name, cache_directory 
+					FROM cfg_centreonbroker 
+					WHERE stats_activate='1' 
+					AND ns_nagios_server=".$centreon_db->quote($server)."");
+
+	if ($server_list->{$server}->{localhost} eq "YES") {
+            while (my $row = $sth->fetchrow_hashref()) {
+	        my ($lerror, $stdout) = centreon::common::misc::backtick(command => "cat " . $row->{cache_directory} . "/" . $row->{config_name} . "-stats.json");
+		$self->{output} = $self->json_parsing(json_content => $stdout,
+						      poller_name => $server_list->{$server}->{name},
+						      file_name => $row->{config_name}. "-stats.json");
+	    }
+	} else {
+            while (my $row = $sth->fetchrow_hashref()) {
+		my $stdout = centreon::health::ssh->new->main(host => $server_list->{$server}->{address},
+                                                              port => $server_list->{$server}->{ssh_port},
+                                                              userdata => $row->{cache_directory} . "/" . $row->{config_name} . "-stats.json",
+                                                              command => "cat " . $row->{cache_directory} . "/" . $row->{config_name} . "-stats.json");
+                $self->{output} = $self->json_parsing(json_content => $stdout,
+                                                      poller_name => $server_list->{$server}->{name},
+                                                      file_name => $row->{config_name}. "-stats.json");
+
+            }
+        }
+       
+    }
+    return $self->{output}
+}
+
+1;

--- a/perl-libs/lib/centreon/health/checkdb.pm
+++ b/perl-libs/lib/centreon/health/checkdb.pm
@@ -1,0 +1,95 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::checkdb;
+
+use strict;
+use warnings;
+use POSIX qw(strftime);
+use centreon::health::misc;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{output} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub run {
+    my $self = shift;
+    my ($centreon_db, $centstorage_db, $centstorage_db_name, $flag, $logger) = @_;
+    my $size = 0;
+    my ($sth, $status);
+
+    foreach my $db_name ('centreon', $centstorage_db_name) {
+        $sth = $centreon_db->query("SELECT table_schema AS db_name, SUM(data_length+index_length) AS db_size 
+                                    FROM information_schema.tables
+				    WHERE table_schema=".$centreon_db->quote($db_name)."");
+        while (my $row = $sth->fetchrow_hashref) {
+            $self->{output}->{db_size}->{$row->{db_name}} = centreon::health::misc::format_bytes(bytes_value => $row->{db_size});
+        }
+        next if $db_name !~ /$centstorage_db_name/;
+        foreach my $table ('data_bin', 'logs', 'log_archive_host', 'log_archive_service', 'downtimes') {
+
+            $sth = $centreon_db->query("SELECT table_name, SUM(data_length+index_length) AS table_size
+                                        FROM information_schema.tables
+                                        WHERE table_schema=".$centreon_db->quote($db_name)."
+	    			        AND table_name=".$centreon_db->quote($table)."");
+
+            while (my $row = $sth->fetchrow_hashref()) {
+                $self->{output}->{table_size}->{$row->{table_name}} = centreon::health::misc::format_bytes(bytes_value =>$row->{table_size});
+            }
+	    
+	    next if ($table =~ m/downtimes/);
+            $sth = $centreon_db->query("SELECT MAX(CONVERT(PARTITION_DESCRIPTION, SIGNED INTEGER)) as lastPart 
+					FROM INFORMATION_SCHEMA.PARTITIONS 
+					WHERE TABLE_NAME='" . $table . "' 
+					AND TABLE_SCHEMA='" . $db_name . "' GROUP BY TABLE_NAME;");
+
+            while (my $row = $sth->fetchrow_hashref()) {
+	        $self->{output}->{partitioning_last_part}->{$table} = defined($row->{lastPart}) ? strftime("%m/%d/%Y %H:%M:%S",localtime($row->{lastPart})) : $table . " has no partitioning !";
+	    }
+	}
+    
+    }
+
+    my $var_list = { 'innodb_file_per_table' => 0,
+		     'open_files_limit' => 0,
+		     'read_only' => 0,
+                     'key_buffer_size' => 1,
+                     'sort_buffer_size' => 1,
+                     'join_buffer_size' => 1,
+                     'read_buffer_size' => 1,
+                     'read_rnd_buffer_size' => 1,
+                     'max_allowed_packet' => 1 };
+
+    foreach my $var (keys %{$var_list}) {
+	my $sth = $centreon_db->query("SHOW GLOBAL VARIABLES LIKE " . $centreon_db->quote($var));
+	my $value = $sth->fetchrow();
+	$self->{output}->{interesting_variables}->{$var} = ($var_list->{$var} == 1) ? centreon::health::misc::format_bytes(bytes_value => $value) : $value;
+    }
+
+    return $self->{output};
+    
+}
+
+1;

--- a/perl-libs/lib/centreon/health/checklogs.pm
+++ b/perl-libs/lib/centreon/health/checklogs.pm
@@ -1,0 +1,102 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::checklogs;
+
+use strict;
+use warnings;
+use POSIX qw(strftime);
+use centreon::common::misc;
+use centreon::health::ssh;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{logs_path_broker} = {};
+    $self->{logs_path_engine} = {};
+    $self->{output} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub run {
+    my $self = shift;
+    my ($centreon_db, $server_list, $centreon_version, $logger) = @_;
+
+    my $sth;
+    my ($lerror, $stdout);
+
+    foreach my $server (keys %$server_list) {
+        $sth = $centreon_db->query("SELECT log_file
+                                     FROM cfg_nagios
+                                     WHERE nagios_id=" . $centreon_db->quote($server));
+
+        while (my $row = $sth->fetchrow_hashref) {
+            push @{$self->{logs_path_engine}->{engine}->{$server_list->{$server}->{name}}}, $row->{log_file};
+        }
+
+        foreach my $log_file (@{$self->{logs_path_engine}->{engine}->{$server_list->{$server}->{name}}}) {
+            if ($server_list->{$server}->{localhost} eq "YES") {
+                ($lerror, $self->{output}->{$server_list->{$server}->{name}}->{engine}->{$log_file}) = centreon::common::misc::backtick(command => "tail -n20 " . $log_file);
+            } else {
+                $self->{output}->{$server_list->{$server}->{name}}->{engine}->{$log_file} = centreon::health::ssh->new->main(host => $server_list->{$server}->{address},
+ 	 	                                                                                                             port => $server_list->{$server}->{ssh_port},
+           	   	                                                                                                     userdata => $log_file,
+                             		                                                                                     command => "tail -n20 " . $log_file);
+            }
+        }
+
+        $sth = $centreon_db->query("SELECT DISTINCT(config_value) FROM cfg_centreonbroker, cfg_centreonbroker_info
+                                            WHERE config_group='logger' AND config_key='name'
+                                            AND cfg_centreonbroker.config_id=cfg_centreonbroker_info.config_id
+                                            AND cfg_centreonbroker.ns_nagios_server=" . $centreon_db->quote($server));
+
+        while (my $row = $sth->fetchrow_hashref) {
+            push @{$self->{logs_path_broker}->{broker}->{$server_list->{$server}->{name}}}, $row->{config_value};
+        }
+
+        foreach my $log_file (@{$self->{logs_path_broker}->{broker}->{$server_list->{$server}->{name}}}) {
+            if ($server_list->{$server}->{localhost} eq "YES") {
+                ($lerror, $self->{output}->{$server_list->{$server}->{name}}->{broker}->{$log_file}) = centreon::common::misc::backtick(command => "tail -n20 " . $log_file);
+            } else {
+                $self->{output}->{$server_list->{$server}->{name}}->{broker}->{$log_file} = centreon::health::ssh->new->main(host => $server_list->{$server}->{address},
+                                                                              			                             port => $server_list->{$server}->{ssh_port},
+                                                                                                		             userdata => $log_file,
+                                                                                                         		     command => "tail -n20 " . $log_file);
+            }
+        }
+
+	if ($server_list->{$server}->{localhost} eq "YES") {
+             $sth = $centreon_db->query("SELECT `value` FROM options WHERE `key`='debug_path'");
+
+	     my $centreon_log_path = $sth->fetchrow();
+	     ($lerror, $stdout) = centreon::common::misc::backtick(command => "find " . $centreon_log_path . " -type f -name *.log");
+
+	     foreach my $log_file (split '\n', $stdout) {
+	         ($lerror, $self->{output}->{$server_list->{$server}->{name}}->{centreon}->{$log_file}) = centreon::common::misc::backtick(command => "tail -n10 " . $log_file);
+	     }
+	}
+    }
+ 
+    return $self->{output}
+}
+
+1;

--- a/perl-libs/lib/centreon/health/checkmodules.pm
+++ b/perl-libs/lib/centreon/health/checkmodules.pm
@@ -1,0 +1,53 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::checkmodules;
+
+use strict;
+use warnings;
+use centreon::health::misc;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{output} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub run {
+    my $self = shift;
+    my ($centreon_db, $logger) = @_;
+    my $size = 0;
+    my ($sth, $status);
+
+    $sth = $centreon_db->query("SELECT name, rname, author, mod_release FROM  modules_informations");
+    while (my $row = $sth->fetchrow_hashref) {
+        $self->{output}->{$row->{name}}{full_name} = $row->{rname};
+        $self->{output}->{$row->{name}}{author} = $row->{author};
+        $self->{output}->{$row->{name}}{version} = $row->{mod_release};
+    }
+
+    return $self->{output};
+    
+}
+
+1;

--- a/perl-libs/lib/centreon/health/checkrrd.pm
+++ b/perl-libs/lib/centreon/health/checkrrd.pm
@@ -1,0 +1,94 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::checkrrd;
+
+use strict;
+use warnings;
+use centreon::common::misc;
+use centreon::health::misc;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{rrd_metrics} = undef;
+    $self->{rrd_status} = undef;
+    $self->{output} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub get_rrd_path {
+    my ($self, %options) = @_;
+    my ($sth, $status);
+
+    $sth = $options{csdb}->query("SELECT RRDdatabase_path, RRDdatabase_status_path FROM config");
+
+    while (my $row = $sth->fetchrow_hashref()) {
+        $self->{rrd_metrics} = $row->{RRDdatabase_path};
+        $self->{rrd_status} = $row->{RRDdatabase_status_path};
+    }
+    
+}
+     
+sub get_rrd_infos {
+    my $self = shift;
+
+    my ($lerror, $size_metrics, $size_status, $count_last_written, $count_outdated_rrd, $count_metrics, $count_status);
+
+    if (-d $self->{rrd_metrics}) {
+        ($lerror, $size_metrics) = centreon::common::misc::backtick(command => "du -sb " . $self->{rrd_metrics});
+        ($lerror, $count_metrics) = centreon::common::misc::backtick(command => "ls -l " . $self->{rrd_metrics} . " | wc -l");
+        ($lerror, $count_last_written) = centreon::common::misc::backtick(command => "find " . $self->{rrd_metrics} . " -type f -mmin 5 | wc -l");
+        ($lerror, $count_outdated_rrd) = centreon::common::misc::backtick(command => "find " . $self->{rrd_metrics} . " -type f -mmin +288000 | wc -l");
+    } else {
+        $count_metrics = 0;
+        $size_metrics = 0;
+	$count_last_written = "ERROR, Directory " . $self->{rrd_metrics} . " does not exist !\n";
+        $count_outdated_rrd = "ERROR, Directory " . $self->{rrd_metrics} . " does not exist !\n";
+    }
+    if (-d $self->{rrd_status}) {
+        ($lerror, $size_status) = centreon::common::misc::backtick(command => "du -sb " . $self->{rrd_status});
+        ($lerror, $count_status) = centreon::common::misc::backtick(command => "ls -l " . $self->{rrd_status} . " | wc -l");
+    } else {
+	$count_status = 0;
+	$size_status = 0;
+    }
+
+    $self->{output}->{$self->{rrd_metrics}}{size} = centreon::health::misc::format_bytes(bytes_value => $size_metrics);
+    $self->{output}->{$self->{rrd_status}}{size} = centreon::health::misc::format_bytes(bytes_value => $size_status);
+    $self->{output}->{rrd_written_last_5m} = $count_last_written;
+    $self->{output}->{rrd_not_updated_since_180d} = $count_outdated_rrd;
+    $self->{output}->{$self->{rrd_metrics}}{count} = $count_metrics;
+    $self->{output}->{$self->{rrd_status}}{count} = $count_status;
+}
+
+sub run {
+    my $self = shift;
+    my ($centstorage_db, $flag, $logger) = @_;
+ 
+    $self->get_rrd_path(csdb => $centstorage_db);
+    $self->get_rrd_infos();
+
+    return $self->{output}
+}
+
+1;

--- a/perl-libs/lib/centreon/health/checkservers.pm
+++ b/perl-libs/lib/centreon/health/checkservers.pm
@@ -1,0 +1,137 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::checkservers;
+
+use strict;
+use warnings;
+use integer;
+use POSIX qw(strftime);
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{output} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub query_misc {
+    my ($self, %options) = @_;
+    my ($sth, $status);
+
+    ($status, $sth) = $options{cdb}->query($options{query});
+
+    if ($status == -1) {
+        return "Query error - information is not available\n";
+    } else {
+       return $sth->fetchrow()
+    }
+
+}
+
+sub get_servers_informations {
+    my ($self, %options) = @_;
+
+    my $sth = $options{cdb}->query("SELECT id, name, localhost, ns_ip_address, ssh_port
+                                   FROM nagios_server WHERE ns_activate='1'");
+    while (my $row = $sth->fetchrow_hashref()) {
+        $self->{output}->{poller}->{$row->{id}}{name} = $row->{name};
+        $self->{output}->{poller}->{$row->{id}}{localhost} = ($row->{localhost} == 1) ? "YES" : "NO";
+        $self->{output}->{poller}->{$row->{id}}{address} = $row->{ns_ip_address};
+        $self->{output}->{poller}->{$row->{id}}{ssh_port} = (defined($row->{ssh_port})) ? $row->{ssh_port} : "-";
+        $self->{output}->{poller}->{$row->{id}}{id} = $row->{id};
+    }
+
+    foreach my $id (keys %{$self->{output}->{poller}}) {
+        $self->{output}->{global}->{count_poller}++;
+        $sth = $options{csdb}->query("SELECT COUNT(DISTINCT hosts.host_id) as num_hosts, count(DISTINCT services.host_id, services.service_id) as num_services
+                                     FROM hosts, services WHERE services.host_id=hosts.host_id
+                                     AND hosts.enabled=1
+                                     AND services.enabled=1
+                                     AND hosts.instance_id=".$options{cdb}->quote($id)."
+                                     AND hosts.name NOT LIKE '%Module%'");
+
+        while (my $row = $sth->fetchrow_hashref()) {
+            $self->{output}->{poller}{$id}{hosts} = $row->{num_hosts};
+            $self->{output}->{poller}{$id}{services} = $row->{num_services};
+            $self->{output}->{global}{count_hosts} += $row->{num_hosts};
+            $self->{output}->{global}{count_services} += $row->{num_services};
+        }
+
+        $sth = $options{csdb}->query("SELECT COUNT(DISTINCT hosts.host_id) as num_hosts, count(DISTINCT services.host_id, services.service_id) as num_services
+                                     FROM hosts, services WHERE services.host_id=hosts.host_id
+                                     AND hosts.enabled=1
+                                     AND services.enabled=1
+                                     AND hosts.instance_id=".$options{cdb}->quote($id)."");
+
+        $sth = $options{csdb}->query("SELECT *
+                                     FROM instances
+                                     WHERE instance_id = " . $options{cdb}->quote($id) . "");
+
+        while (my $row = $sth->fetchrow_hashref()) {
+            $self->{output}->{poller}{$row->{instance_id}}{uptime} = centreon::health::misc::change_seconds(value => $row->{last_alive} - $row->{start_time});
+            $self->{output}->{poller}{$row->{instance_id}}{running} = ($row->{running} == 1) ? "YES" : "NO";
+            $self->{output}->{poller}{$row->{instance_id}}{start_time} = strftime("%m/%d/%Y %H:%M:%S",localtime($row->{start_time}));
+            $self->{output}->{poller}{$row->{instance_id}}{last_alive} = strftime("%m/%d/%Y %H:%M:%S",localtime($row->{last_alive}));
+            $self->{output}->{poller}{$row->{instance_id}}{last_command_check} = strftime("%m/%d/%Y %H:%M:%S",localtime($row->{last_command_check}));
+            $self->{output}->{poller}{$row->{instance_id}}{engine} = $row->{engine};
+            $self->{output}->{poller}{$row->{instance_id}}{version} = $row->{version};
+        }
+
+        $sth = $options{csdb}->query("SELECT stat_key, stat_value, stat_label 
+                                      FROM nagios_stats
+                                      WHERE instance_id = " . $options{cdb}->quote($id) . "");
+
+        while (my $row = $sth->fetchrow_hashref()) {
+	        $self->{output}->{poller}->{$id}->{engine_stats}->{$row->{stat_label}}->{$row->{stat_key}} = $row->{stat_value}; 
+        }
+
+        $self->{output}->{global}->{hosts_by_poller_avg} = ($self->{output}->{global}->{count_poller} != 0) ? $self->{output}->{global}->{count_hosts} / $self->{output}->{global}->{count_poller} : '0';
+        $self->{output}->{global}->{services_by_poller_avg} = ($self->{output}->{global}->{count_poller} != 0) ? $self->{output}->{global}->{count_services} / $self->{output}->{global}->{count_poller} : '0';
+        $self->{output}->{global}->{services_by_host_avg} = ($self->{output}->{global}->{count_hosts} != 0) ? $self->{output}->{global}->{count_services} / $self->{output}->{global}->{count_hosts} : '0';
+        $self->{output}->{global}->{metrics_by_service_avg} = ($self->{output}->{global}->{count_services} != 0) ? $self->{output}->{global}->{count_metrics} / $self->{output}->{global}->{count_services} : '0';
+    }
+}
+     
+
+sub run {
+    my $self = shift;
+    my ($centreon_db, $centstorage_db, $centreon_version) = @_;
+
+    my $query_misc = {   count_pp => [$centreon_db, $centreon_version eq '2.7' ? "SELECT count(*) FROM mod_pluginpack" : "SELECT count(*) FROM mod_ppm_pluginpack"],
+                            count_downtime => [$centreon_db, "SELECT count(*) FROM downtime"],
+                            count_modules => [$centreon_db, "SELECT count(*) FROM modules_informations"],
+                            centreon_version => [$centreon_db, "SELECT value FROM informations LIMIT 1"],
+                            count_metrics => [$centstorage_db, "SELECT count(*) FROM metrics"] };
+
+    foreach my $info (keys %$query_misc) {
+        my $result = $self->query_misc(cdb => $query_misc->{$info}[0],
+                                        query => $query_misc->{$info}[1] );
+        $self->{output}->{global}->{$info} = $result;
+    }
+
+    $self->get_servers_informations(cdb => $centreon_db, csdb => $centstorage_db);
+
+    return $self->{output}
+}
+
+1;

--- a/perl-libs/lib/centreon/health/checksystems.pm
+++ b/perl-libs/lib/centreon/health/checksystems.pm
@@ -1,0 +1,133 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::checksystems;
+
+use strict;
+use warnings;
+use centreon::common::misc;
+use centreon::health::ssh;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{cmd_system_health} = [];
+    $self->{output} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub build_command_hash {
+    my ($self, %options) = @_;
+
+    if ($options{medium} eq "snmp") {
+        $self->{cmd_system_health} = [ { cmd => "/usr/lib/" . $options{plugin_path} . "/plugins/" . $options{plugins} . " --plugin os::linux::snmp::plugin --mode cpu-detailed \\
+							 --hostname localhost \\
+							 --statefile-suffix='_diag-cpu' \\
+							 --filter-perfdata='^(?!(wait|guest|user|softirq|kernel|interrupt|guestnice|idle|steal|system|nice))' \\
+							 --snmp-community " . $options{community} ,
+                                         callback => \&centreon::health::ssh::ssh_callback,
+					 userdata => "cpu_usage" },
+                                       { cmd => "/usr/lib/" . $options{plugin_path} . "/plugins/" . $options{plugins} . " --plugin os::linux::snmp::plugin --mode load \\
+							 --hostname localhost \\
+							 --filter-perfdata='^(?!(load))' \\
+							 --snmp-community " . $options{community},
+                                         callback => \&centreon::health::ssh::ssh_callback,
+                                         userdata => "load" },
+                                       { cmd => "/usr/lib/" . $options{plugin_path} . "/plugins/" . $options{plugins} . " --plugin os::linux::snmp::plugin --mode memory \\
+							 --hostname localhost \\
+							 --filter-perfdata='^(?!(cached|buffer|used))' \\
+							 --snmp-community " . $options{community},
+                                         callback => \&centreon::health::ssh::ssh_callback,
+                                         userdata => "mem_usage" },
+                                       { cmd => "/usr/lib/" . $options{plugin_path} . "/plugins/" . $options{plugins} . " --plugin os::linux::snmp::plugin --mode swap \\
+							 --hostname localhost \\
+							 --filter-perfdata='^(?!(used))' \\
+							 --snmp-community " . $options{community},
+                                         callback => \&centreon::health::ssh::ssh_callback,
+                                         userdata => "swap_usage" },
+                                       { cmd => "/usr/lib/" . $options{plugin_path} . "/plugins/" . $options{plugins} . " --plugin os::linux::snmp::plugin --mode storage \\
+							 --hostname localhost \\
+							 --storage='^(?!(/dev/shm|/sys/fs/cgroup|/boot|/run.*))' --name --regexp \\
+							 --filter-perfdata='^(?!(used))' --statefile-suffix='_diag-storage' \\
+							 --verbose \\
+							 --snmp-community " . $options{community},
+                                        callback => \&centreon::health::ssh::ssh_callback,
+                                        userdata => "storage_usage" },
+                                     ];
+    } else {
+	return -1
+    }
+
+
+}
+
+sub get_remote_infos {
+    my ($self, %options) = @_;
+  
+    
+    return centreon::health::ssh::new->main(host => $options{host}, port => $options{ssh_port}, command_pool => $self->{cmd_system_health}); 
+    
+}
+     
+sub get_local_infos {
+    my ($self, %options) = @_;
+    my ($lerror, $stdout);    
+    
+    my $results;
+
+    foreach my $command (@{$self->{cmd_system_health}}) {
+        ($lerror, $stdout) = centreon::common::misc::backtick(command => $command->{cmd});
+	$results->{$command->{userdata}} = $stdout;
+	while ($stdout =~ m/Buffer creation/) {
+	    # Replay command to bypass cache creation
+	    sleep 1;
+	    ($lerror, $stdout) = centreon::common::misc::backtick(command => $command->{cmd});
+	    $results->{$command->{userdata}} = $stdout;
+	}
+    }
+
+    return $results 
+    
+}
+
+sub run {
+    my $self = shift;
+    my ($server_list, $medium, $community, $centreon_ver) = @_;
+
+    $self->build_command_hash(medium => $medium,
+			      plugins => ($centreon_ver eq 2.8) ? 'centreon_linux_snmp.pl' : 'centreon_plugins.pl',
+			      plugin_path => ($centreon_ver eq 2.8) ? 'centreon' : 'nagios',
+			      community => $community);
+
+    foreach my $server (keys %$server_list) {
+	my $name = $server_list->{$server}->{name};
+	if ($server_list->{$server}->{localhost} eq "NO") {
+	    $self->{output}->{$name} = $self->get_remote_infos(host => $server_list->{$server}->{address}, ssh_port => $server_list->{$server}->{ssh_port});
+        } else {
+	    $self->{output}->{$name} = $self->get_local_infos(poller_name => $name);
+	}
+    }
+    
+    return $self->{output}
+}
+
+1;

--- a/perl-libs/lib/centreon/health/misc.pm
+++ b/perl-libs/lib/centreon/health/misc.pm
@@ -1,0 +1,103 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::misc;
+
+use strict;
+use warnings;
+use Libssh::Session qw(:all);
+
+sub get_ssh_connection {
+    my %options = @_;
+
+    my $session = Libssh::Session->new();
+    if ($session->options(host => $options{host}, port => $options{port}, user => $options{user}) != SSH_OK) {
+        print $session->error() . "\n";
+        return 1
+    }
+
+    if ($session->connect() != SSH_OK) {
+        print $session->error() . "\n";
+        return 1
+    }
+
+    if ($session->auth_publickey_auto() != SSH_AUTH_SUCCESS) {
+        printf("auth issue pubkey: %s\n", $session->error(GetErrorSession => 1));
+        if ($session->auth_password(password => $options{password}) != SSH_AUTH_SUCCESS) {
+            printf("auth issue: %s\n", $session->error(GetErrorSession => 1));
+            return 1
+        }
+    }
+
+    return $session
+
+}
+
+sub change_seconds {
+    my %options = @_;
+    my ($str, $str_append) = ('', '');
+    my $periods = [
+                    { unit => 'y', value => 31556926 },
+                    { unit => 'M', value => 2629743 },
+                    { unit => 'w', value => 604800 },
+                    { unit => 'd', value => 86400 },
+                    { unit => 'h', value => 3600 },
+                    { unit => 'm', value => 60 },
+                    { unit => 's', value => 1 },
+    ];
+    my %values = ('y' => 1, 'M' => 2, 'w' => 3, 'd' => 4, 'h' => 5, 'm' => 6, 's' => 7);
+
+    foreach (@$periods) {
+        next if (defined($options{start}) && $values{$_->{unit}} < $values{$options{start}});
+        my $count = int($options{value} / $_->{value});
+
+        next if ($count == 0);
+        $str .= $str_append . $count . $_->{unit};
+        $options{value} = $options{value} % $_->{value};
+        $str_append = ' ';
+    }
+
+    return $str;
+}
+
+sub format_bytes {
+    my (%options) = @_;
+    my $size = $options{bytes_value};
+    $size =~ s/\D//g;
+
+    if ($size > 1099511627776) {
+        return sprintf("%.0fT", $size / 1099511627776);
+    }
+    elsif ($size > 1073741824) {
+        return sprintf("%.0fG", $size / 1073741824);
+    }
+    elsif ($size > 1048576) {
+        return sprintf("%.0fM", $size / 1048576);
+    }
+    elsif ($size > 1024) {
+        return sprintf("%.0fK", $size / 1024);
+    }
+    else {
+        return sprintf("%.0fB", $size);
+    }
+}
+
+        
+1;

--- a/perl-libs/lib/centreon/health/output.pm
+++ b/perl-libs/lib/centreon/health/output.pm
@@ -1,0 +1,307 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::output;
+
+use strict;
+use warnings;
+use JSON;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub output_text {
+    my ($self, %options) = @_;
+
+    my $output; 
+
+    $output = "\t ===CENTREON_HEALTH TEXT OUTPUT=== \n\n";
+    $output .=  "\t\t CENTREON OVERVIEW\n\n";
+    $output .=  "Centreon Version: " . $options{data}->{server}->{global}->{centreon_version} . "\n";
+    $output .=  "Number of pollers: " . $options{data}->{server}->{global}->{count_poller} . "\n";
+    $output .=  "Number of hosts: " . $options{data}->{server}->{global}->{count_hosts} . "\n";
+    $output .=  "Number of services: " . $options{data}->{server}->{global}->{count_services} . "\n";
+    $output .=  "Number of metrics: " . $options{data}->{server}->{global}->{count_metrics} . "\n";
+    $output .=  "Number of modules: " . $options{data}->{server}->{global}->{count_modules} . "\n";
+    $output .=  defined($options{data}->{server}->{global}->{count_pp}) ? "Number of plugin-packs: " . $options{data}->{server}->{global}->{count_pp} . "\n" : " Number of plugin-packs: N/A\n";
+    $output .=  "Number of recurrent downtimes: " . $options{data}->{server}->{global}->{count_downtime} . "\n\n";
+
+    $output .=  "\t\t AVERAGE METRICS\n\n";
+    $output .=  "Host / poller (avg): " . $options{data}->{server}->{global}->{hosts_by_poller_avg} . "\n";
+    $output .=  "Service / poller (avg): " . $options{data}->{server}->{global}->{services_by_poller_avg} . "\n";
+    $output .=  "Service / host (avg): " . $options{data}->{server}->{global}->{services_by_host_avg} . "\n";
+    $output .=  "Metrics / service (avg): " . $options{data}->{server}->{global}->{metrics_by_service_avg} . "\n\n";
+
+    if ($options{flag_rrd} != 1 || $options{flag_db} eq "") {
+        $output .=  "\t\t RRD INFORMATIONS\n\n";
+        $output .= "RRD not updated since more than 180 days: " .  $options{data}->{rrd}->{rrd_not_updated_since_180d} . "\n";
+        $output .= "RRD written during last 5 five minutes: " .  $options{data}->{rrd}->{rrd_written_last_5m} . "\n";
+        foreach my $key (sort keys %{$options{data}->{rrd}}) {
+	    next if ($key =~ m/^rrd_/);
+            $output .= "RRD files Count/Size in " . $key . " directory: " . $options{data}->{rrd}->{$key}->{count} . "/" . $options{data}->{rrd}->{$key}->{size} . "\n";
+        }
+	$output .= "\n";
+    }
+
+    if ($options{flag_db} != 1 || $options{flag_db} eq "") {
+        $output .=  "\t\t DATABASES INFORMATIONS\n\n";
+        $output .= "\tDatabases size\n\n";
+        foreach my $database (keys %{$options{data}->{database}->{db_size}}) { 
+	    $output .= "Size of " . $database . " database: " . $options{data}->{database}->{db_size}->{$database} . "\n";
+        }
+        $output .= "\n";
+        $output .= "\tTables size (centreon_storage db)\n\n";
+        foreach my $database (keys %{$options{data}->{database}->{table_size}}) {
+            $output .= "Size of " . $database . " table: " . $options{data}->{database}->{table_size}->{$database} . "\n";
+        }
+        $output .= "\n";
+        $output .= "\tPartitioning check\n\n";
+        foreach my $table (keys %{$options{data}->{database}->{partitioning_last_part}}) {
+            $output .= "Last partition date for " . $table . " table: " . $options{data}->{database}->{partitioning_last_part}->{$table} . "\n";
+        }
+        $output .= "\n";
+    }
+   
+    $output .= "\t\t MODULE INFORMATIONS\n\n";
+    foreach my $module_key (keys %{$options{data}->{module}}) {
+	$output .= "Module " . $options{data}->{module}->{$module_key}->{full_name} . " is installed. (Author: " . $options{data}->{module}->{$module_key}->{author} . " # Codename: " . $module_key . " # Version: " . $options{data}->{module}->{$module_key}->{version} . ")\n";
+    }
+    $output .= "\n";
+
+    $output .= "\t\t CENTREON NODES INFORMATIONS\n\n";
+    
+    foreach my $poller_id (keys %{$options{data}->{server}->{poller}}) {
+        $output .= "\t" . $options{data}->{server}->{poller}->{$poller_id}->{name} . "\n\n";
+	$output .= "Identity: \n";
+	if (defined($options{data}->{server}->{poller}->{$poller_id}->{engine}) && defined($options{data}->{server}->{poller}->{$poller_id}->{version})) { 
+  	    $output .= "    Engine (version): " . $options{data}->{server}->{poller}->{$poller_id}->{engine} . " (" . $options{data}->{server}->{poller}->{$poller_id}->{version} . ")\n";
+            $output .= "    IP Address (SSH port): " . $options{data}->{server}->{poller}->{$poller_id}->{address} . " (" . $options{data}->{server}->{poller}->{$poller_id}->{ssh_port} . ")\n";
+	    $output .= "    Localhost: " . $options{data}->{server}->{poller}->{$poller_id}->{localhost} . "\n"; 
+            $output .= "    Running: " . $options{data}->{server}->{poller}->{$poller_id}->{running} . "\n";
+            $output .= "    Start time: " . $options{data}->{server}->{poller}->{$poller_id}->{start_time} . "\n";
+            $output .= "    Last alive: " . $options{data}->{server}->{poller}->{$poller_id}->{last_alive} . "\n";
+            $output .= "    Uptime: " . $options{data}->{server}->{poller}->{$poller_id}->{uptime} . "\n";
+            $output .= "    Count Hosts/Services - (Last command check): " . $options{data}->{server}->{poller}->{$poller_id}->{hosts} . "/" . $options{data}->{server}->{poller}->{$poller_id}->{services} . " - (" . $options{data}->{server}->{poller}->{$poller_id}->{last_command_check} . ")\n\n";
+        } else {
+	    $output .= "    SKIP Identity for this poller, enabled but does not seems to work correctly ! \n\n";
+        }
+
+        $output .= "Engine stats: \n";
+	foreach my $stat_key (sort keys %{$options{data}->{server}->{poller}->{$poller_id}->{engine_stats}}) {
+	    foreach my $stat_value (sort keys %{$options{data}->{server}->{poller}->{$poller_id}->{engine_stats}->{$stat_key}}) {
+            $output .= "    " . $stat_key . "(" . $stat_value . "): " . $options{data}->{server}->{poller}->{$poller_id}->{engine_stats}->{$stat_key}->{$stat_value} . "\n";
+	    }
+	}
+	$output .= "\n";
+
+        $output .= "Broker stats: \n";
+        foreach my $broker_stat_file (sort keys %{$options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}}) {
+   	    $output .= "    \tFile: " . $broker_stat_file . "\n";
+            $output .= "    Version: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{version} . "\n";
+	    $output .= "    State: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{state} . "\n";
+	    $output .= "    Event proecessing speed " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{event_processing_speed} . "\n";
+            $output .= "    Queued events: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{queued_events} . "\n";
+            $output .= "    Last connection attempts: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{last_connection_attempt} . "\n";
+            $output .= "    Last connection success: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{last_connection_success} . "\n\n";
+	}
+
+	$output .= "System stats: \n"; 
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{cpu_usage}) ? 
+			"    CPU => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{cpu_usage} . "\n" :
+                        "    CPU => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{load}) ? 
+			"    LOAD => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{load} . "\n" :
+			"    LOAD => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{mem_usage}) ?
+			"    MEMORY => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{mem_usage} . "\n" :
+                        "    MEMORY => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{swap_usage}) ? 
+			"    SWAP => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{swap_usage} . "\n" :
+			"    SWAP => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{storage_usage}) ? 
+			"    STORAGE => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{storage_usage} . "\n\n" :
+                        "    STORAGE => Could not gather data \n\n";
+
+	if ($options{flag_logs} != 1 || $options{flag_logs} eq "") {
+            $output .= "\t\t LOGS LAST LINES: \n\n";
+            foreach my $log_topic (sort keys %{$options{data}->{logs}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}}) {
+	        foreach my $log_file (keys %{$options{data}->{logs}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$log_topic}}) {
+	            $output .= "    " . $log_file . " (" . $log_topic . ")\n\n";
+		    $output .= $options{data}->{logs}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$log_topic}->{$log_file} . "\n\n"; 
+	        }
+	        $output .= "\n";
+	    }
+        }
+    }
+    return $output;
+}
+
+sub output_markdown {
+    my ($self, %options) = @_;
+
+    my $output;
+
+    $output = "# CENTREON_HEALTH TEXT OUTPUT\n";
+    $output .=  "## CENTREON OVERVIEW\n\n";
+    $output .=  "  + Centreon Version: " . $options{data}->{server}->{global}->{centreon_version} . "\n";
+    $output .=  "  + Number of pollers: " . $options{data}->{server}->{global}->{count_poller} . "\n";
+    $output .=  "  + Number of hosts: " . $options{data}->{server}->{global}->{count_hosts} . "\n";
+    $output .=  "  + Number of services: " . $options{data}->{server}->{global}->{count_services} . "\n";
+    $output .=  "  + Number of metrics: " . $options{data}->{server}->{global}->{count_metrics} . "\n";
+    $output .=  "  + Number of modules: " . $options{data}->{server}->{global}->{count_modules} . "\n";
+    $output .=  defined($options{data}->{server}->{global}->{count_pp}) ? "  + Number of plugin-packs: " . $options{data}->{server}->{global}->{count_pp} . "\n" : "  + Number of plugin-packs: N/A\n";
+    $output .=  "  + Number of recurrent downtimes: " . $options{data}->{server}->{global}->{count_downtime} . "\n\n";
+    $output .=  "## AVERAGE METRICS\n\n";
+    $output .=  "  + Host / poller (avg): " . $options{data}->{server}->{global}->{hosts_by_poller_avg} . "\n";
+    $output .=  "  + Service / poller (avg): " . $options{data}->{server}->{global}->{services_by_poller_avg} . "\n";
+    $output .=  "  + Service / host (avg): " . $options{data}->{server}->{global}->{services_by_host_avg} . "\n";
+    $output .=  "  + Metrics / service (avg): " . $options{data}->{server}->{global}->{metrics_by_service_avg} . "\n\n";
+
+    if ($options{flag_rrd} != 1 || $options{flag_db} eq "") {
+        $output .=  "## RRD INFORMATIONS\n\n";
+        $output .= "  + RRD not updated since more than 180 days: " .  $options{data}->{rrd}->{rrd_not_updated_since_180d} . "\n";
+        $output .= "  + RRD written during last 5 five minutes: " .  $options{data}->{rrd}->{rrd_written_last_5m} . "\n";
+        foreach my $key (sort keys %{$options{data}->{rrd}}) {
+            next if ($key =~ m/^rrd_/);
+            $output .= "  + RRD files Count/Size in " . $key . " directory: " . $options{data}->{rrd}->{$key}->{count} . "/" . $options{data}->{rrd}->{$key}->{size} . "\n";
+        }
+        $output .= "\n";
+    }
+
+    if ($options{flag_db} != 1 || $options{flag_db} eq "") {
+        $output .=  "## DATABASES INFORMATIONS\n\n";
+        $output .= "### Databases size\n\n";
+        foreach my $database (keys %{$options{data}->{database}->{db_size}}) {
+            $output .= "  + Size of " . $database . " database: " . $options{data}->{database}->{db_size}->{$database} . "\n";
+        }
+        $output .= "\n";
+        $output .= "### Tables size (centreon_storage db)\n\n";
+        foreach my $database (keys %{$options{data}->{database}->{table_size}}) {
+            $output .= "  + Size of " . $database . " table: " . $options{data}->{database}->{table_size}->{$database} . "\n";
+        }
+        $output .= "\n";
+        $output .= "### Partitioning check\n\n";
+        foreach my $table (keys %{$options{data}->{database}->{partitioning_last_part}}) {
+            $output .= "  + Last partition date for " . $table . " table: " . $options{data}->{database}->{partitioning_last_part}->{$table} . "\n";
+        }
+        $output .= "\n";
+    }
+
+    $output .= "## MODULE INFORMATIONS\n\n";
+    foreach my $module_key (keys %{$options{data}->{module}}) {
+        $output .= "  + Module " . $options{data}->{module}->{$module_key}->{full_name} . " is installed. (Author: " . $options{data}->{module}->{$module_key}->{author} . " # Codename: " . $module_key . " # Version: " . $options{data}->{module}->{$module_key}->{version} . ")\n";
+    }
+    $output .= "\n";
+
+    $output .= "## CENTREON NODES INFORMATIONS\n\n";
+
+    foreach my $poller_id (keys %{$options{data}->{server}->{poller}}) {
+        $output .= "### " . $options{data}->{server}->{poller}->{$poller_id}->{name} . "\n\n";
+        $output .= "#### Identity: \n";
+        if (defined($options{data}->{server}->{poller}->{$poller_id}->{engine}) && defined($options{data}->{server}->{poller}->{$poller_id}->{version})) {
+            $output .= "  + Engine (version): " . $options{data}->{server}->{poller}->{$poller_id}->{engine} . " (" . $options{data}->{server}->{poller}->{$poller_id}->{version} . ")\n";
+            $output .= "  + IP Address (SSH port): " . $options{data}->{server}->{poller}->{$poller_id}->{address} . " (" . $options{data}->{server}->{poller}->{$poller_id}->{ssh_port} . ")\n";
+            $output .= "  + Localhost: " . $options{data}->{server}->{poller}->{$poller_id}->{localhost} . "\n";
+            $output .= "  + Running: " . $options{data}->{server}->{poller}->{$poller_id}->{running} . "\n";
+            $output .= "  + Start time: " . $options{data}->{server}->{poller}->{$poller_id}->{start_time} . "\n";
+            $output .= "  + Last alive: " . $options{data}->{server}->{poller}->{$poller_id}->{last_alive} . "\n";
+            $output .= "  + Uptime: " . $options{data}->{server}->{poller}->{$poller_id}->{uptime} . "\n";
+            $output .= "  + Count Hosts/Services - (Last command check): " . $options{data}->{server}->{poller}->{$poller_id}->{hosts} . "/" . $options{data}->{server}->{poller}->{$poller_id}->{services} . " - (" . $options{data}->{server}->{poller}->{$poller_id}->{last_command_check} . ")\n\n";
+
+        } else {
+            $output .= "  + SKIP Identity for this poller, enabled but does not seems to work correctly ! \n\n";
+        }
+
+        $output .= "#### Engine stats: \n";
+        foreach my $stat_key (sort keys %{$options{data}->{server}->{poller}->{$poller_id}->{engine_stats}}) {
+            foreach my $stat_value (sort keys %{$options{data}->{server}->{poller}->{$poller_id}->{engine_stats}->{$stat_key}}) {
+            $output .= "  + " . $stat_key . "(" . $stat_value . "): " . $options{data}->{server}->{poller}->{$poller_id}->{engine_stats}->{$stat_key}->{$stat_value} . "\n";
+            }
+        }
+        $output .= "\n";
+
+        $output .= "#### Broker stats: \n";
+        foreach my $broker_stat_file (sort keys %{$options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}}) {
+            $output .= "##### File: " . $broker_stat_file . "\n";
+            $output .= "  + Version: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{version} . "\n";
+            $output .= "  + State: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{state} . "\n";
+            $output .= "  + Event proecessing speed " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{event_processing_speed} . "\n";
+            $output .= "  + Queued events: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{queued_events} . "\n";
+            $output .= "  + Last connection attempts: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{last_connection_attempt} . "\n";
+            $output .= "  + Last connection success: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{last_connection_success} . "\n\n";
+        }
+
+        $output .= "#### System stats: \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{cpu_usage}) ?
+                        "  + CPU => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{cpu_usage} . "\n" :
+                        "  + CPU => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{load}) ?
+                        "  + LOAD => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{load} . "\n" :
+                        "  + LOAD => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{mem_usage}) ?
+                        "  + MEMORY => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{mem_usage} . "\n" :
+                        "  + MEMORY => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{swap_usage}) ?
+                        "  + SWAP => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{swap_usage} . "\n" :
+                        "  + SWAP => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{storage_usage}) ?
+                        "  + STORAGE => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{storage_usage} . "\n\n" :
+                        "  + STORAGE => Could not gather data \n\n";
+
+        if ($options{flag_logs} != 1 || $options{flag_logs} eq "") {
+            $output .= "## LOGS LAST LINES: \n\n";
+            foreach my $log_topic (sort keys %{$options{data}->{logs}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}}) {
+                foreach my $log_file (keys %{$options{data}->{logs}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$log_topic}}) {
+                    $output .= "  + " . $log_file . " (" . $log_topic . ")\n\n";
+                    $output .= $options{data}->{logs}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$log_topic}->{$log_file} . "\n\n";
+                }
+                $output .= "\n";
+            }
+        }
+    }
+    return $output;
+}
+
+
+sub run {
+    my $self = shift;
+    my ($data, $format, $flag_rrd, $flag_db, $flash_logs) = @_;
+
+    if ($format eq "JSON") {
+	my $output = JSON->new->encode($data);
+	print $output;
+    } elsif ($format eq "TEXT") {
+	my $output = $self->output_text(data => $data, flag_rrd => $flag_rrd, flag_db => $flag_db, flag_logs => $flash_logs);
+	print $output;
+    } elsif ($format eq "MARKDOWN") {
+        my $output = $self->output_markdown(data => $data, flag_rrd => $flag_rrd, flag_db => $flag_db, flag_logs => $flash_logs);
+        print $output;
+    } elsif ($format eq "DUMPER") {
+	use Data::Dumper;
+	print Dumper($data);
+    }
+}
+        
+1;

--- a/perl-libs/lib/centreon/health/ssh.pm
+++ b/perl-libs/lib/centreon/health/ssh.pm
@@ -1,0 +1,93 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::ssh;
+
+use strict;
+use warnings;
+use Libssh::Session qw(:all);
+
+my $command_results = {};
+
+sub new {
+    my $class = shift @_ || __PACKAGE__;
+    my $self; 
+    $self->{session} = undef;
+    $self->{host} = undef;
+    $self->{port} = undef;
+    $self->{logger} = undef;
+    $self->{data} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub ssh_callback {
+    my (%options) = @_;
+
+    if ($options{exit} == SSH_OK || $options{exit} == SSH_AGAIN) { # AGAIN means timeout
+	chomp($options{stdout});
+        $command_results->{multiple}->{$options{userdata}} = $options{stdout};
+    } else {
+        $command_results->{multiple}->{failed_action} = "Failed action on ssh or plugin";
+	return -1
+    }
+    return 0
+}
+
+sub create_ssh_channel {
+    my ($self, %options) = @_;
+
+    $self->{session} = Libssh::Session->new();
+    if ($self->{session}->options(host => $options{host}, port => $options{port}, user => $options{user}) != SSH_OK) {
+        return 1
+    }
+
+    if ($self->{session}->connect() != SSH_OK) {
+        return 1
+    }
+
+    if ($self->{session}->auth_publickey_auto() != SSH_AUTH_SUCCESS) {
+        printf("auth issue pubkey: %s\n", $self->{session}->error(GetErrorSession => 1));
+        if ($self->{session}->auth_password(password => $options{password}) != SSH_AUTH_SUCCESS) {
+            printf("auth issue: %s\n", $self->{session}->error(GetErrorSession => 1));
+            return 1
+        }
+    }
+    return 0
+}
+
+sub main {
+    my ($self, %options) = @_;
+
+    $self->create_ssh_channel(host => $options{host}, port => $options{port}, user => 'centreon');
+    if (defined($options{command_pool})) {
+        $self->{session}->execute(commands => $options{command_pool}, timeout => 5000, timeout_nodata => 10, parallel => 5);
+	 $self->{data} = $command_results->{multiple};
+    } else {
+    	my $return = $self->{session}->execute_simple(cmd => $options{command}, userdata => $options{userdata}, timeout => 10, timeout_nodata => 5);
+	$command_results->{simple} = $return->{stdout};
+	$self->{data} = $command_results->{simple};
+    }
+
+    return $self->{data}
+}
+        
+1;

--- a/perl-libs/lib/centreon/reporting/CentreonAck.pm
+++ b/perl-libs/lib/centreon/reporting/CentreonAck.pm
@@ -1,0 +1,114 @@
+################################################################################
+# Copyright 2005-2020 Centreon
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation ; either version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see <http://www.gnu.org/licenses>.
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
+# General Public License cover the whole combination.
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+#
+#
+####################################################################################
+
+use strict;
+use warnings;
+
+package centreon::reporting::CentreonAck;
+
+# Constructor
+# parameters:
+# $logger: instance of class CentreonLogger
+# $centreon: Instance of centreonDB class for connection to Centreon database
+# $centstorage: (optionnal) Instance of centreonDB class for connection to Centstorage database
+sub new {
+    my $class = shift;
+    my $self  = {};
+    $self->{logger} = shift;
+    $self->{centstatus} = shift;
+    if (@_) {
+        $self->{centstorage}  = shift;
+    }
+    bless $self, $class;
+    return $self;
+}
+
+# returns first ack time for a service or a host event
+sub getServiceAckTime {
+    my $self = shift;
+    my $centreon = $self->{centstatus};
+    my $start = shift;
+    my $end = shift;
+    my $hostId = shift;
+    my $serviceId = shift;
+    my $query;
+
+    $query = "SELECT `entry_time` as ack_time, sticky ".
+    " FROM `acknowledgements`" .
+    " WHERE `host_id` = " . $hostId .
+    " AND `service_id` = ". $serviceId .
+    " AND `type` = 1" .
+    " AND `entry_time` >= " . $start .
+    " AND `entry_time` <= " . $end .
+    " ORDER BY `entry_time` ASC";
+
+    my ($status, $sth) = $centreon->query($query);
+    my $ackTime = "NULL";
+    my $sticky = 0;
+    if (my $row = $sth->fetchrow_hashref()) {
+        $ackTime = $row->{ack_time};
+        $sticky = $row->{sticky};
+    }
+    $sth->finish();
+    return ($ackTime, $sticky);
+}
+
+# returns first ack time for a service or a host event
+sub getHostAckTime {
+    my $self = shift;
+    my $centreon = $self->{centstatus};
+    my $start = shift;
+    my $end = shift;
+    my $hostId = shift;
+    my $query;
+
+    $query = "SELECT entry_time as ack_time, sticky ".
+        " FROM `acknowledgements`".
+        " WHERE `type` = 0".
+        " AND `entry_time` >= " . $start .
+        " AND `entry_time` <= " . $end .
+        " AND `host_id` = " . $hostId .
+        " ORDER BY `entry_time` ASC";
+
+    my ($status, $sth) = $centreon->query($query);
+    my $ackTime = "NULL";
+    my $sticky = 0;
+    if (my $row = $sth->fetchrow_hashref()) {
+        $ackTime = $row->{ack_time};
+        $sticky = $row->{sticky};
+    }
+    $sth->finish();
+    return ($ackTime, $sticky);
+}
+
+1;

--- a/perl-libs/lib/centreon/reporting/CentreonDashboard.pm
+++ b/perl-libs/lib/centreon/reporting/CentreonDashboard.pm
@@ -1,0 +1,208 @@
+################################################################################
+# Copyright 2005-2020 Centreon
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation ; either version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see <http://www.gnu.org/licenses>.
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
+# General Public License cover the whole combination.
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+#
+#
+####################################################################################
+
+use strict;
+use warnings;
+
+package centreon::reporting::CentreonDashboard;
+
+use POSIX;
+use Getopt::Long;
+use Time::Local;
+
+# Constructor
+# parameters:
+# $logger: instance of class CentreonLogger
+# $centreon: Instance of centreonDB class for connection to Centreon database
+# $centstorage: (optionnal) Instance of centreonDB class for connection to Centstorage database
+sub new {
+    my $class = shift;
+    my $self  = {};
+    $self->{"logger"} = shift;
+    $self->{"centstorage"} = shift;
+    bless $self, $class;
+    return $self;
+}
+
+# Insert data in log_archive_host
+sub insertHostStats {
+    my $self = shift;
+    my $centstorage = $self->{"centstorage"};
+    my $names = shift;
+    my $stateDurations = shift;
+    my $start = shift;
+    my $end = shift;
+    my $dayDuration = $end - $start;
+    my $query_start = "INSERT INTO `log_archive_host` (`host_id`,".
+        " `UPTimeScheduled`,".
+        " `DOWNTimeScheduled`,".
+        " `UNREACHABLETimeScheduled`,".
+        " `MaintenanceTime`,".
+        " `UNDETERMINEDTimeScheduled`,".
+        " `UPnbEvent`,".
+        " `DOWNnbEvent`,".
+        " `UNREACHABLEnbEvent`,".
+        " `date_start`, `date_end`) VALUES ";
+    my $query_end = "";
+    my $firstHost = 1;
+    my $count = 0;
+    my ($status, $sth);
+    while (my ($key, $value) = each %$names) {
+        if ($firstHost == 1) {
+            $firstHost = 0;
+        } else {
+            $query_end .= ",";
+        }
+        $query_end .= "(".$key.",";
+        if (defined($stateDurations->{$key})) {
+            my $stats = $stateDurations->{$key};
+            my @tab = @$stats;
+            foreach (@tab) {
+                $query_end .= $_.",";
+            }
+            $query_end .= $start.",".$end.")";
+        } else {
+            $query_end .= "0,0,0,0,".$dayDuration.",0,0,0,".$start.",".$end.")";
+        }
+        $count++;
+        if ($count == 5000) {
+            ($status, $sth) = $centstorage->query($query_start.$query_end);
+            $firstHost = 1;
+            $query_end = "";
+            $count = 0;
+        }
+    }
+    if ($count) {
+        ($status, $sth) = $centstorage->query($query_start.$query_end);
+    }
+}
+
+# Insert data in log_archive_service
+sub insertServiceStats {
+    my $self = shift;
+    my $centstorage = $self->{"centstorage"};
+    my $names = shift;
+    my $stateDurations = shift;
+    my $start = shift;
+    my $end = shift;
+    my $dayDuration = $end - $start;
+    my $query_start = "INSERT INTO `log_archive_service` (`host_id`, `service_id`,".
+        " `OKTimeScheduled`,".
+        " `WARNINGTimeScheduled`,".
+        " `CRITICALTimeScheduled`,".
+        " `UNKNOWNTimeScheduled`,".
+        " `MaintenanceTime`,".
+        " `UNDETERMINEDTimeScheduled`,".
+        " `OKnbEvent`,".
+        " `WARNINGnbEvent`,".
+        " `CRITICALnbEvent`,".
+        " `UNKNOWNnbEvent`,".
+        " `date_start`, `date_end`) VALUES ";
+    my $query_end = "";
+    my $firstService = 1;
+    my $count = 0;
+    my ($status, $sth);
+    while (my ($key, $value) = each %$names) {
+        if ($firstService == 1) {
+            $firstService = 0;
+        } else {
+            $query_end .= ",";
+        }
+        my ($host_id, $service_id) = split(";;", $key);
+        $query_end .= "(".$host_id.",".$service_id.",";
+        if (defined($stateDurations->{$key})) {
+            my $stats = $stateDurations->{$key};
+            my @tab = @$stats;
+            foreach (@tab) {
+                $query_end .= $_.",";
+            }
+            $query_end .= $start.",".$end.")";
+        } else {
+            $query_end .= "0,0,0,0,0,".$dayDuration.",0,0,0,0,".$start.",".$end.")";
+        }
+        $count++;
+        if ($count == 5000) {
+            ($status, $sth) = $centstorage->query($query_start.$query_end);
+            $firstService = 1;
+            $query_end = "";
+            $count = 0;
+        }
+    }
+    if ($count) {
+        ($status, $sth) = $centstorage->query($query_start.$query_end);
+    }
+}
+
+# Truncate service dashboard stats table
+sub truncateServiceStats {
+    my $self = shift;
+    my $centstorage = $self->{"centstorage"};
+
+    my $query = "TRUNCATE TABLE `log_archive_service`";
+    $centstorage->query($query);
+}
+
+# Truncate host dashboard stats table
+sub truncateHostStats {
+    my $self = shift;
+    my $centstorage = $self->{"centstorage"};
+
+    my $query = "TRUNCATE TABLE `log_archive_host`";
+    $centstorage->query($query);
+}
+
+# Delete service dashboard stats for a given period
+sub deleteServiceStats {
+    my $self = shift;
+    my $centstorage = $self->{"centstorage"};
+
+    my ($start, $end) = (shift, shift);
+    my ($day, $month, $year) = (localtime($end))[3,4,5];
+    $end = mktime(0, 0, 0, $day + 1, $month, $year);
+    my $query = "DELETE FROM `log_archive_service` WHERE `date_start`>= " . $start . " AND `date_end` <= " . $end;
+    $centstorage->query($query);
+}
+
+# Delete host dashboard stats for a given period
+sub deleteHostStats {
+    my $self = shift;
+    my $centstorage = $self->{"centstorage"};
+
+    my ($start, $end) = (shift, shift);
+    my ($day, $month, $year) = (localtime($end))[3,4,5];
+    $end = mktime(0, 0, 0, $day + 1, $month, $year);
+    my $query = "DELETE FROM `log_archive_host` WHERE `date_start`>= " . $start . " AND `date_end` <= " . $end;
+    $centstorage->query($query);
+}
+
+1;

--- a/perl-libs/lib/centreon/reporting/CentreonDownTime.pm
+++ b/perl-libs/lib/centreon/reporting/CentreonDownTime.pm
@@ -1,0 +1,239 @@
+################################################################################
+# Copyright 2005-2020 Centreon
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation ; either version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see <http://www.gnu.org/licenses>.
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
+# General Public License cover the whole combination.
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+#
+#
+####################################################################################
+
+use strict;
+use warnings;
+
+package centreon::reporting::CentreonDownTime;
+
+# Constructor
+# parameters:
+# $logger: instance of class CentreonLogger
+# $centreon: Instance of centreonDB class for connection to Centreon database
+# $centstorage: (optionnal) Instance of centreonDB class for connection to Centstorage database
+sub new {
+    my $class = shift;
+    my $self  = {};
+    $self->{"logger"}    = shift;
+    $self->{"centstatus"} = shift;
+    if (@_) {
+        $self->{"centstorage"}  = shift;
+    }
+    bless $self, $class;
+    return $self;
+}
+
+# returns two references to two hash tables => hosts indexed by id and hosts indexed by name
+sub getDowntimes {
+    my $self = shift;
+    my $centreon = $self->{"centstatus"};
+    my $allIds = shift;
+    my $start = shift;
+    my $end = shift;
+    my $type = shift; # if 1 => host, if 2 => service
+    my $query;
+
+    $query = "SELECT DISTINCT h.host_id, s.service_id, " .
+             "d.actual_start_time, d.actual_end_time " .
+             "FROM `hosts` h, `downtimes` d " .
+             "LEFT JOIN services s ON s.service_id = d.service_id " .
+             "WHERE started = 1 " .
+             "AND d.host_id = h.host_id ";
+    if ($type == 1) {
+        $query .= "AND d.type = 2 "; # That can be confusing, but downtime_type 2 is for host
+    } elsif ($type == 2) {
+        $query .= "AND d.type = 1 "; # That can be confusing, but downtime_type 1 is for service
+    }
+    $query .= "AND (actual_start_time < " . $end . " AND actual_start_time IS NOT NULL) " .
+             "AND (actual_end_time > " . $start . " OR actual_end_time IS NULL) " .
+             "ORDER BY h.host_id ASC, actual_start_time ASC, actual_end_time ASC";
+
+    my ($status, $sth) = $centreon->query($query);
+
+    my @periods = ();
+    while (my $row = $sth->fetchrow_hashref()) {
+        my $id = $row->{"host_id"};
+        if ($type == 2) {
+            $id .= ";;" . $row->{"service_id"}
+        }
+        if (defined($allIds->{$id})) {
+            if ($row->{"actual_start_time"} < $start) {
+                $row->{"actual_start_time"} = $start;
+            }
+            if (!defined $row->{"actual_end_time"} || $row->{"actual_end_time"} > $end) {
+                $row->{"actual_end_time"} = $end;
+            }
+
+            my $insert = 1;
+            for (my $i = 0; $i < scalar(@periods) && $insert; $i++) {
+                my $checkTab = $periods[$i];
+                if ($checkTab->[0] eq $id){
+                    if ($row->{"actual_start_time"} <= $checkTab->[2] && $row->{"actual_end_time"} <= $checkTab->[2]) {
+                        $insert = 0;
+                    } elsif ($row->{"actual_start_time"} <= $checkTab->[2] && $row->{"actual_end_time"} > $checkTab->[2]) {
+                        $checkTab->[2] = $row->{"actual_end_time"};
+                        $periods[$i] = $checkTab;
+                        $insert = 0;
+                    }
+                }
+            }
+            if ($insert) {
+                my @tab = ($id, $row->{"actual_start_time"}, $row->{"actual_end_time"});
+                $periods[scalar(@periods)] = \@tab;
+            }
+        }
+    }
+    $sth->finish();
+    return (\@periods);
+}
+
+sub splitInsertEventDownTime {
+    my $self = shift;
+
+    my $objectId = shift;
+    my $start = shift;
+    my $end = shift;
+    my $downtimes = shift;
+    my $state = shift;
+
+    my @events = ();
+    my $total = 0;
+    if ($state ne "" && defined($downtimes) && defined($state) && $state != 0) {
+        $total = scalar(@$downtimes);
+    }
+    for (my $i = 0; $i < $total && $start < $end; $i++) {
+         my $tab = $downtimes->[$i];
+         my $id = $tab->[0];
+         my $downTimeStart = $tab->[1];
+         my $downTimeEnd = $tab->[2];
+
+         if ($id eq $objectId) {
+             if ($downTimeStart < $start) {
+                 $downTimeStart = $start;
+             }
+             if ($downTimeEnd > $end) {
+                 $downTimeEnd = $end;
+             }
+             if ($downTimeStart < $end && $downTimeEnd > $start) {
+                 if ($downTimeStart > $start) {
+                     my @tab = ($start, $downTimeStart, 0);
+                     $events[scalar(@events)] = \@tab;
+                 }
+                 my @tab = ($downTimeStart, $downTimeEnd, 1);
+                 $events[scalar(@events)] = \@tab;
+                 $start = $downTimeEnd;
+             }
+         }
+    }
+    if ($start < $end) {
+        my @tab = ($start, $end, 0);
+        $events[scalar(@events)] = \@tab;
+    }
+    return (\@events);
+}
+
+sub splitUpdateEventDownTime {
+    my $self = shift;
+
+    my $objectId = shift;
+    my $start = shift;
+    my $end = shift;
+    my $downTimeFlag = shift;
+    my $downTimes = shift;
+    my $state = shift;
+
+    my $updated = 0;
+    my @events = ();
+    my $updateTime = 0;
+    my $total = 0;
+    if (defined($downTimes) && $state != 0) {
+        $total = scalar(@$downTimes);
+    }
+    for (my $i = 0; $i <  $total && $start < $end; $i++) {
+        my $tab = $downTimes->[$i];
+         my $id = $tab->[0];
+         my $downTimeStart = $tab->[1];
+         my $downTimeEnd = $tab->[2];
+
+         if ($id eq $objectId) {
+             if ($downTimeStart < $start) {
+                 $downTimeStart = $start;
+             }
+             if ($downTimeEnd > $end) {
+                 $downTimeEnd = $end;
+             }
+             if ($downTimeStart < $end && $downTimeEnd > $start) {
+                 if ($updated == 0) {
+                    $updated = 1;
+                    if ($downTimeStart > $start) {
+                        if ($downTimeFlag == 1) {
+                            my @tab = ($start, $downTimeStart, 0);
+                            $events[scalar(@events)] = \@tab;
+                        }else {
+                            $updateTime = $downTimeStart;
+                        }
+                        my @tab = ($downTimeStart, $downTimeEnd, 1);
+                        $events[scalar(@events)] = \@tab;
+                    }else {
+                        if ($downTimeFlag == 1) {
+                            $updateTime = $downTimeEnd;
+                        }else {
+                            my @tab = ($downTimeStart, $downTimeEnd, 1);
+                            $events[scalar(@events)] = \@tab;
+                        }
+                    }
+                }else {
+                    if ($downTimeStart > $start) {
+                        my @tab = ($start, $downTimeStart, 0);
+                        $events[scalar(@events)] = \@tab;
+                    }
+                    my @tab = ($downTimeStart, $downTimeEnd, 1);
+                    $events[scalar(@events)] = \@tab;
+                }
+                $start = $downTimeEnd;
+            }
+         }
+    }
+    if ($start < $end && scalar(@events)) {
+        my @tab = ($start, $end, 0);
+        $events[scalar(@events)] = \@tab;
+    } else {
+        $updateTime = $end;
+        if (scalar(@events) && $end > $events[0][0]) {
+            $updateTime = $events[0][0];
+        }
+    }
+    return ($updateTime, \@events);
+}
+
+1;

--- a/perl-libs/lib/centreon/reporting/CentreonHost.pm
+++ b/perl-libs/lib/centreon/reporting/CentreonHost.pm
@@ -1,0 +1,80 @@
+################################################################################
+# Copyright 2005-2020 Centreon
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation ; either version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see <http://www.gnu.org/licenses>.
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
+# General Public License cover the whole combination.
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+#
+#
+####################################################################################
+
+use strict;
+use warnings;
+
+package centreon::reporting::CentreonHost;
+
+# Constructor
+# parameters:
+# $logger: instance of class CentreonLogger
+# $centreon: Instance of centreonDB class for connection to Centreon database
+# $centstorage: (optionnal) Instance of centreonDB class for connection to Centstorage database
+sub new {
+    my $class = shift;
+    my $self  = {};
+    $self->{logger} = shift;
+    $self->{centreon} = shift;
+    if (@_) {
+        $self->{centstorage}  = shift;
+    }
+    bless $self, $class;
+    return $self;
+}
+
+# returns two references to two hash tables => hosts indexed by id and hosts indexed by id
+sub getAllHostIds {
+    my $self = shift;
+    my $centreon = $self->{centreon};
+    my $activated = 1;
+    if (@_) {
+        $activated  = 0;
+    }
+    my %hostIds;
+
+    my $query = "SELECT `host_id`" .
+                " FROM `host`".
+                " WHERE `host_register` = '1'";
+    if ($activated == 1) {
+        $query .= " AND `host_activate` = '1'";
+    }
+    my ($status, $sth) = $centreon->query($query);
+    while (my $row = $sth->fetchrow_hashref()) {
+        $hostIds{$row->{host_id}} = 1;
+    }
+    $sth->finish();
+    return \%hostIds;
+}
+
+1;

--- a/perl-libs/lib/centreon/reporting/CentreonHostStateEvents.pm
+++ b/perl-libs/lib/centreon/reporting/CentreonHostStateEvents.pm
@@ -1,0 +1,278 @@
+################################################################################
+# Copyright 2005-2020 Centreon
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation ; either version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see <http://www.gnu.org/licenses>.
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
+# General Public License cover the whole combination.
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+#
+#
+####################################################################################
+
+use strict;
+use warnings;
+
+package centreon::reporting::CentreonHostStateEvents;
+
+# Constructor
+# parameters:
+# $logger: instance of class CentreonLogger
+# $centreon: Instance of centreonDB class for connection to Centreon database
+# $centstorage: (optionnal) Instance of centreonDB class for connection to Centstorage database
+sub new {
+    my $class = shift;
+    my $self  = {};
+    $self->{logger} = shift;
+    $self->{centstorage} = shift;
+    $self->{centreonAck} = shift;
+    $self->{centreonDownTime} = shift;
+    bless $self, $class;
+    return $self;
+}
+
+# Get events in given period
+# Parameters:
+# $start: period start
+# $end: period end
+sub getStateEventDurations {
+    my $self = shift;
+    my $centstorage = $self->{centstorage};
+    my $start = shift;
+    my $end = shift;
+    my %hosts;
+    my $query = "SELECT `host_id`, `state`,  `start_time`, `end_time`, `in_downtime`".
+                " FROM `hoststateevents`".
+                " WHERE `start_time` < ".$end.
+                    " AND `end_time` > ".$start.
+                    " AND `state` < 3"; # STATE PENDING AND UNKNOWN NOT HANDLED
+    my ($status, $sth) = $centstorage->query($query);
+    while (my $row = $sth->fetchrow_hashref()) {
+        if ($row->{start_time} < $start) {
+            $row->{start_time} = $start;
+        }
+        if ($row->{end_time} > $end) {
+            $row->{end_time} = $end;
+        }
+        if (!defined($hosts{$row->{host_id}})) {
+            my @tab = (0, 0, 0, 0, 0, 0, 0, 0);
+            # index 0: UP, index 1: DOWN, index 2: UNREACHABLE, index 3: DOWNTIME, index 4: UNDETERMINED
+            # index 5: UP alerts, index 6: Down alerts, , index 7: Unreachable alerts
+            $hosts{$row->{host_id}} = \@tab;
+        }
+
+        my $stats = $hosts{$row->{host_id}};
+        if ($row->{in_downtime} == 0) {
+            $stats->[$row->{state}] += $row->{end_time} - $row->{start_time};
+
+            # We count UP alert like a recovery (don't put it otherwise)
+            if ($row->{state} != 0 || ($row->{state} == 0 && $row->{start_time} > $start)) {
+                $stats->[$row->{state} + 5] += 1;
+            }
+        } else {
+            $stats->[3] += $row->{end_time} - $row->{start_time};
+        }
+        $hosts{$row->{host_id}} = $stats;
+    }
+    my %results;
+    while (my ($key, $value) = each %hosts) {
+        $value->[4] = ($end - $start) - ($value->[0] + $value->[1] + $value->[2] + $value->[3]);
+        $results{$key} = $value;
+    }
+    return (\%results);
+}
+
+# Get last events for each host
+# Parameters:
+# $start: max date possible for each event
+# $hostIds: references a hash table containing a list of host ids
+sub getLastStates {
+    my $self = shift;
+    my $centstorage = $self->{centstorage};
+    my $hostIds = shift;
+
+    my %currentStates;
+
+    my $query = "SELECT `host_id`, `state`, `hoststateevent_id`, `end_time`, `in_downtime`, `in_ack`".
+                " FROM `hoststateevents`".
+                " WHERE `last_update` = 1";
+    my ($status, $sth) = $centstorage->query($query);
+    while (my $row = $sth->fetchrow_hashref()) {
+        if (defined($hostIds->{$row->{host_id}})) {
+            my @tab = ($row->{end_time}, $row->{state}, $row->{hoststateevent_id}, $row->{in_downtime}, $row->{in_ack});
+            $currentStates{$row->{host_id}} = \@tab;
+        }
+    }
+    $sth->finish();
+
+    return (\%currentStates);
+}
+
+# update a specific host incident end time
+# Parameters
+# $endTime: incident end time
+# $eventId: ID of event to update
+sub updateEventEndTime {
+    my $self = shift;
+    my $centstorage = $self->{centstorage};
+    my $centreonDownTime = $self->{centreonDownTime};
+    my $centreonAck = $self->{centreonAck};
+
+    my ($hostId, $start, $end, $state, $eventId, $downTimeFlag, $lastUpdate, $downTime, $inAck) = @_;
+    my $return = {};
+
+    my ($events, $updateTime);
+    ($updateTime, $events) = $centreonDownTime->splitUpdateEventDownTime($hostId, $start, $end, $downTimeFlag,$downTime, $state);
+
+    my $totalEvents = 0;
+    if (defined($events)) {
+        $totalEvents = scalar(@$events);
+    }
+    my ($ack, $sticky) = $centreonAck->getHostAckTime($start, $updateTime, $hostId);
+    if (defined($ack) && $sticky == 1) {
+        $inAck = 1;
+    }
+    if (!$totalEvents && $updateTime) {
+        my $query = "UPDATE `hoststateevents` SET `end_time` = ".$updateTime.", `ack_time`= IFNULL(ack_time,$ack), `in_ack` = '$inAck', `last_update` = ".$lastUpdate.
+            " WHERE `hoststateevent_id` = ".$eventId;
+        $centstorage->query($query);
+    } else {
+        if ($updateTime) {
+            my $query = "UPDATE `hoststateevents` SET `end_time` = ".$updateTime.", `ack_time`= IFNULL(ack_time,$ack), `in_ack` = '$inAck', `last_update` = 0".
+                " WHERE `hoststateevent_id` = ".$eventId;
+            $centstorage->query($query);
+        }
+        return $self->insertEventTable($hostId, $state, $lastUpdate, $events, $inAck);
+    }
+
+    $return->{in_ack} = $inAck;
+    return $return;
+}
+
+# insert a new incident for host
+# Parameters
+# $hostId : host ID
+# $serviceId: service ID
+# $state: incident state
+# $start: incident start time
+# $end: incident end time
+sub insertEvent {
+    my $self = shift;
+    my $centreonDownTime = $self->{centreonDownTime};
+
+    my ($hostId, $state, $start, $end, $lastUpdate, $downtimes, $inAck) = @_;
+    my $return = { in_ack => $inAck };
+
+    my $events = $centreonDownTime->splitInsertEventDownTime($hostId, $start, $end, $downtimes, $state);
+    if ($state ne "") {
+        return $self->insertEventTable($hostId, $state, $lastUpdate, $events, $inAck);
+    }
+
+    return $return;
+}
+
+sub insertEventTable {
+    my $self = shift;
+    my $centstorage = $self->{centstorage};
+    my $centreonAck = $self->{centreonAck};
+
+    my ($hostId, $state, $lastUpdate, $events, $inAck) =  @_;
+    my $return = {};
+
+    my $query_start = "INSERT INTO `hoststateevents`".
+        " (`host_id`, `state`, `start_time`, `end_time`, `last_update`, `in_downtime`, `ack_time`, `in_ack`)" .
+        " VALUES (";
+    my $count = 0;
+    my $totalEvents = 0;
+
+    # Stick ack is removed
+    if ($state == 0) {
+        $inAck = 0;
+    }
+    for($count = 0; $count < scalar(@$events) - 1; $count++) {
+        my $tab = $events->[$count];
+        my ($ack, $sticky) = $centreonAck->getHostAckTime($tab->[0], $tab->[1], $hostId);
+        if ($inAck == 1) {
+            $sticky = 1;
+            $ack = $tab->[0];
+        }
+        if (defined($ack) && $sticky == 1) {
+            $inAck = 1;
+        }
+        my $query_end = $hostId.", ".$state.", ".$tab->[0].", ".$tab->[1].", 0, ".$tab->[2].", ".$ack.", '$sticky')";
+        $centstorage->query($query_start.$query_end);
+    }
+    if (scalar(@$events)) {
+        my $tab = $events->[$count];
+        if (defined($hostId) && defined($state)) {
+            my ($ack, $sticky) = $centreonAck->getHostAckTime($tab->[0], $tab->[1], $hostId);
+            if ($inAck == 1) {
+                $sticky = 1;
+                $ack = $tab->[0];
+            }
+            if (defined($ack) && $sticky == 1) {
+                $inAck = 1;
+            }
+            my $query_end = $hostId . ", " . $state . ", " . $tab->[0] . ", " . $tab->[1] . ", " .
+                $lastUpdate . ", " . $tab->[2] . ", " . $ack . ", '$sticky')";
+            $centstorage->query($query_start.$query_end);
+        }
+    }
+
+    $return->{in_ack} = $inAck;
+    return $return;
+}
+
+# Truncate service incident table
+sub truncateStateEvents {
+    my ($self, %options) = @_;
+    my $centstorage = $self->{centstorage};
+
+    if (defined($options{start})) {
+        my $query = "DELETE FROM hoststateevents WHERE start_time > $options{start}";
+        $centstorage->query($query);
+        $query = "UPDATE hoststateevents SET end_time = $options{midnight} WHERE end_time > $options{midnight}";
+        $centstorage->query($query);
+    } else {
+        my $query = "TRUNCATE TABLE hoststateevents";
+        $centstorage->query($query);
+    }
+}
+
+# Get first and last events date
+sub getFirstLastIncidentTimes {
+    my $self = shift;
+    my $centstorage = $self->{centstorage};
+
+    my $query = "SELECT min(`start_time`) as minc, max(`end_time`) as maxc FROM `hoststateevents`";
+    my ($status, $sth) = $centstorage->query($query);
+    my ($start, $end) = (0,0);
+    if (my $row = $sth->fetchrow_hashref()) {
+        ($start, $end) = ($row->{minc}, $row->{maxc});
+    }
+    $sth->finish;
+    return ($start, $end);
+}
+
+1;

--- a/perl-libs/lib/centreon/reporting/CentreonLog.pm
+++ b/perl-libs/lib/centreon/reporting/CentreonLog.pm
@@ -1,0 +1,119 @@
+################################################################################
+# Copyright 2005-2020 Centreon
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation ; either version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see <http://www.gnu.org/licenses>.
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
+# General Public License cover the whole combination.
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+#
+#
+####################################################################################
+
+use strict;
+use warnings;
+
+package centreon::reporting::CentreonLog;
+
+# Constructor
+# parameters:
+# $logger: instance of class CentreonLogger
+# $centreon: Instance of centreonDB class for connection to Centreon database
+# $centstorage: (optionnal) Instance of centreonDB class for connection to Centstorage database
+sub new {
+    my $class = shift;
+    my $self  = {};
+    $self->{"logger"} = shift;
+    $self->{"centstorage"} = shift;
+    if (@_) {
+        $self->{"centreon"} = shift;
+    }
+    bless $self, $class;
+    return $self;
+}
+
+# Get all service logs between two dates
+# Parameters:
+# $start: period start date in timestamp
+# $end: period start date in timestamp
+sub getLogOfServices {
+    my $self = shift;
+    my $centstorage = $self->{"centstorage"};
+    my ($start, $end);
+    if (@_) {
+        $start = shift;
+        $end = shift;
+    }
+    my $query = "SELECT `status`, `ctime`, `host_id`, `service_id`" .
+        " FROM `logs`" .
+        " WHERE `ctime` >= " . $start .
+        " AND `ctime` < " . $end .
+        " AND (`type` = 1 OR (`status` = 0 AND `type` = 0))" .
+        " AND ((`service_id` != 0 AND `service_id` IS NOT NULL) OR `service_description` IS NOT NULL) " .
+        " AND `msg_type` IN ('0', '1', '6', '7', '8', '9')" .
+        " ORDER BY `ctime`";
+    my ($status, $result) = $centstorage->query($query);
+    return $result;
+}
+
+# Get all hosts logs between two dates
+# Parameters:
+# $start: period start date in timestamp
+# $end: period start date in timestamp
+sub getLogOfHosts {
+    my $self = shift;
+    my $centstorage = $self->{"centstorage"};
+    my ($start, $end);
+    if (@_) {
+        $start = shift;
+        $end = shift;
+    }
+    my $query = "SELECT `status`, `ctime`, `host_id`" .
+            " FROM `logs`" .
+            " WHERE `ctime` >= " . $start .
+            " AND `ctime` < " . $end .
+            " AND (`type` = 1 OR (`status` = 0 AND `type` = 0))" .
+            " AND `msg_type` IN ('0', '1', '6', '7', '8', '9')" .
+            " AND (`service_id` = 0 OR `service_id` IS NULL) AND (service_description = '' OR service_description IS NULL) ".
+            " ORDER BY `ctime`";
+    my ($status, $result) = $centstorage->query($query);
+    return $result;
+}
+
+# Get First log date and last log date
+sub getFirstLastLogTime {
+    my $self = shift;
+    my $centstorage = $self->{centstorage};
+
+    my $query = "SELECT min(`ctime`) as minc, max(`ctime`) as maxc FROM `logs`";
+    my ($status, $sth) = $centstorage->query($query);
+    my ($start, $end) = (0,0);
+    if (my $row = $sth->fetchrow_hashref()) {
+        ($start, $end) = ($row->{minc}, $row->{maxc});
+    }
+    $sth->finish;
+    return ($start, $end);
+}
+
+1;

--- a/perl-libs/lib/centreon/reporting/CentreonProcessStateEvents.pm
+++ b/perl-libs/lib/centreon/reporting/CentreonProcessStateEvents.pm
@@ -1,0 +1,277 @@
+################################################################################
+# Copyright 2005-2020 Centreon
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation ; either version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see <http://www.gnu.org/licenses>.
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
+# General Public License cover the whole combination.
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+#
+#
+####################################################################################
+
+use strict;
+use warnings;
+
+package centreon::reporting::CentreonProcessStateEvents;
+
+# Constructor
+# parameters:
+# $logger: instance of class CentreonLogger
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{"logger"} = shift;
+    $self->{"host"} = shift;
+    $self->{"service"} = shift;
+    $self->{"nagiosLog"} = shift;
+    $self->{"hostEvents"} = shift;
+    $self->{"serviceEvents"} = shift;
+    $self->{"centreonDownTime"} = shift;
+    bless $self, $class;
+
+    return $self;
+}
+
+# Parse services logs for given period
+# Parameters:
+# $start: period start
+# $end: period end
+sub parseServiceLog {
+    my $self = shift;
+    # parameters:
+    my ($start ,$end) = (shift,shift);
+    my $service = $self->{"service"};
+    my $nagiosLog = $self->{"nagiosLog"};
+    my $events = $self->{"serviceEvents"};
+    my $centreonDownTime = $self->{"centreonDownTime"};
+
+    my $serviceIds = $service->getAllServiceIds();
+    my $currentEvents = $events->getLastStates($serviceIds);
+    my $logs = $nagiosLog->getLogOfServices($start, $end);
+    my $downtimes = $centreonDownTime->getDowntimes($serviceIds, $start, $end, 2);
+
+    while (my $row = $logs->fetchrow_hashref()) {
+        my $fullId  = $row->{host_id} . ";;" . $row->{service_id};
+        if (defined($serviceIds->{$fullId})) {
+            my $statusCode = $row->{status};
+
+            # manage initial states (no entry in state events table)
+            if (!defined($currentEvents->{$fullId})) {
+                my @tab = ($row->{ctime}, $statusCode, 0, 0, 0);
+                $currentEvents->{$fullId} = \@tab;
+            }
+
+            my $eventInfos =  $currentEvents->{$fullId};
+            # $eventInfos is a reference to a table containing : incident start time | status | state_event_id | in_downtime. The last one is optional
+            if ($statusCode ne "" && defined($eventInfos->[1]) && $eventInfos->[1] ne "" && $eventInfos->[1] != $statusCode) {
+                my ($hostId, $serviceId) = split(";;", $fullId);
+                my $result = {};
+                if ($eventInfos->[2] != 0) {
+                    # If eventId of log is defined, update the last day event
+                    $result = $events->updateEventEndTime(
+                        $hostId,
+                        $serviceId,
+                        $eventInfos->[0],
+                        $row->{ctime},
+                        $eventInfos->[1],
+                        $eventInfos->[2],
+                        $eventInfos->[3],
+                        0,
+                        $downtimes,
+                        $eventInfos->[4]
+                    );
+                } else {
+                    if ($row->{ctime} > $eventInfos->[0]) {
+                        $result = $events->insertEvent(
+                            $hostId,
+                            $serviceId,
+                            $eventInfos->[1],
+                            $eventInfos->[0],
+                            $row->{ctime},
+                            0,
+                            $downtimes,
+                            $eventInfos->[4]
+                        );
+                    }
+                }
+                $eventInfos->[0] = $row->{ctime};
+                $eventInfos->[1] = $statusCode;
+                $eventInfos->[2] = 0;
+                $eventInfos->[3] = 0;
+                $eventInfos->[4] = defined($result->{in_ack}) ? $result->{in_ack} : 0;
+                $currentEvents->{$fullId} = $eventInfos;
+            }
+        }
+    }
+    $self->insertLastServiceEvents($end, $currentEvents, $downtimes);
+}
+
+# Parse host logs for given period
+# Parameters:
+# $start: period start
+# $end: period end
+sub parseHostLog {
+    my $self = shift;
+
+    # parameters:
+    my ($start ,$end) = (shift,shift);
+
+    my $host = $self->{"host"};
+    my $nagiosLog = $self->{"nagiosLog"};
+    my $events = $self->{"hostEvents"};
+    my $centreonDownTime = $self->{"centreonDownTime"};
+
+    my $hostIds = $host->getAllHostIds();
+    my $currentEvents = $events->getLastStates($hostIds);
+    my $logs = $nagiosLog->getLogOfHosts($start, $end);
+    my $downtimes = $centreonDownTime->getDowntimes($hostIds, $start, $end, 1);
+
+    while (my $row = $logs->fetchrow_hashref()) {
+        my $hostId  = $row->{host_id};
+
+        if (defined($hostIds->{$hostId})) {
+            my $statusCode = $row->{status};
+
+            # manage initial states (no entry in state events table)
+            if (!defined($currentEvents->{$hostId})) {
+                my @tab = ($row->{'ctime'}, $statusCode, 0, 0, 0);
+                $currentEvents->{$hostId} = \@tab;
+            }
+
+            my $eventInfos =  $currentEvents->{$hostId}; # $eventInfos is a reference to a table containing : incident start time | status | state_event_id. The last one is optionnal
+            if ($statusCode ne "" && defined($eventInfos->[1]) && $eventInfos->[1] ne "" && $eventInfos->[1] != $statusCode) {
+                my $result = {};
+                if ($eventInfos->[2] != 0) {
+                    # If eventId of log is defined, update the last day event
+                    $result = $events->updateEventEndTime(
+                        $hostId,
+                        $eventInfos->[0],
+                        $row->{'ctime'},
+                        $eventInfos->[1],
+                        $eventInfos->[2],
+                        $eventInfos->[3],
+                        0,
+                        $downtimes,
+                        $eventInfos->[4]
+                    );
+                } else {
+                    if ($row->{ctime} > $eventInfos->[0]) {
+                        $result = $events->insertEvent(
+                            $hostId,
+                            $eventInfos->[1],
+                            $eventInfos->[0],
+                            $row->{'ctime'},
+                            0,
+                            $downtimes,
+                            $eventInfos->[4]
+                        );
+                    }
+                }
+                $eventInfos->[0] = $row->{'ctime'};
+                $eventInfos->[1] = $statusCode;
+                $eventInfos->[2] = 0;
+                $eventInfos->[3] = 0;
+                $eventInfos->[4] = defined($result->{in_ack}) ? $result->{in_ack} : 0;
+                $currentEvents->{$hostId} = $eventInfos;
+            }
+        }
+    }
+    $self->insertLastHostEvents($end, $currentEvents, $downtimes);
+}
+
+
+# Insert in DB last service incident of day currently processed
+# Parameters:
+# $end: period end
+# $currentEvents: reference to a hash table that contains last incident details
+# $serviceIds: reference to a hash table that returns host/service ids for host/service ids
+sub insertLastServiceEvents {
+    my $self = shift;
+    my $events = $self->{"serviceEvents"};
+
+    # parameters:
+    my ($end, $currentEvents, $downtimes)  = (shift, shift, shift, shift);
+
+    while (my ($id, $eventInfos) = each (%$currentEvents)) {
+        my ($hostId, $serviceId) = split(";;", $id);
+        if ($eventInfos->[2] != 0) {
+            $events->updateEventEndTime(
+                $hostId,
+                $serviceId,
+                $eventInfos->[0],
+                $end,
+                $eventInfos->[1],
+                $eventInfos->[2],
+                $eventInfos->[3],
+                1,
+                $downtimes,
+                $eventInfos->[4]
+            );
+        } else {
+            $events->insertEvent(
+                $hostId,
+                $serviceId,
+                $eventInfos->[1],
+                $eventInfos->[0],
+                $end,
+                1,
+                $downtimes,
+                $eventInfos->[4]
+            );
+        }
+    }
+}
+
+# Insert in DB last host incident of day currently processed
+# Parameters:
+# $end: period end
+# $currentEvents: reference to a hash table that contains last incident details
+sub insertLastHostEvents {
+    my $self = shift;
+    my $events = $self->{"hostEvents"};
+
+    # parameters:
+    my ($end, $currentEvents, $downtimes)  = (shift, shift, shift);
+
+    while (my ($hostId, $eventInfos) = each (%$currentEvents)) {
+        if ($eventInfos->[2] != 0) {
+            $events->updateEventEndTime(
+                $hostId,
+                $eventInfos->[0],
+                $end,
+                $eventInfos->[1],
+                $eventInfos->[2],
+                $eventInfos->[3],
+                1,
+                $downtimes,
+                $eventInfos->[4]
+            );
+        } else {
+            $events->insertEvent($hostId, $eventInfos->[1], $eventInfos->[0], $end, 1, $downtimes, $eventInfos->[4]);
+        }
+    }
+}
+
+1;

--- a/perl-libs/lib/centreon/reporting/CentreonService.pm
+++ b/perl-libs/lib/centreon/reporting/CentreonService.pm
@@ -1,0 +1,105 @@
+################################################################################
+# Copyright 2005-2020 Centreon
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation ; either version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see <http://www.gnu.org/licenses>.
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
+# General Public License cover the whole combination.
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+#
+#
+####################################################################################
+
+use strict;
+use warnings;
+
+package centreon::reporting::CentreonService;
+
+# Constructor
+# parameters:
+# $logger: instance of class CentreonLogger
+# $centreon: Instance of centreonDB class for connection to Centreon database
+# $centstorage: (optional) Instance of centreonDB class for connection to Centstorage database
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{"logger"} = shift;
+    $self->{"centreon"} = shift;
+    if (@_) {
+        $self->{"centstorage"}  = shift;
+    }
+    bless $self, $class;
+    return $self;
+}
+
+# returns two references to two hash tables => services indexed by id and services indexed by id
+sub getAllServiceIds {
+    my $self = shift;
+    my $centreon = $self->{"centreon"};
+    my $activated = 1;
+    if (@_) {
+        $activated  = 0;
+    }
+
+    my %serviceIds;
+    # getting services linked to hosts
+    my $query = "SELECT host_host_id as host_id, service_id" .
+                " FROM host, service, host_service_relation" .
+                " WHERE host_host_id = host_id" .
+                " AND service_service_id = service_id" .
+                " AND service_register = '1'";
+    if ($activated == 1) {
+        $query .= " AND `service_activate`='1'";
+    }
+
+    my ($status, $sth) = $centreon->query($query);
+    while (my $row = $sth->fetchrow_hashref()) {
+        $serviceIds{$row->{'host_id'} . ";;" . $row->{'service_id'}} = 1;
+    }
+
+    # getting services linked to hostgroup
+    $query = "SELECT host_id, service_id" .
+        " FROM host, service, host_service_relation hr, hostgroup_relation hgr, hostgroup hg" .
+        " WHERE hr.hostgroup_hg_id IS NOT NULL" .
+        " AND hr.service_service_id = service_id" .
+        " AND hr.hostgroup_hg_id = hgr.hostgroup_hg_id" .
+        " AND hgr.host_host_id = host_id" .
+        " AND service_register = '1'";
+    if ($activated == 1) {
+        $query .= " AND service_activate='1'" .
+                  " AND host_activate = '1'" .
+                  " AND hg.hg_activate = '1'";
+    }
+    $query .= " AND hg.hg_id = hgr.hostgroup_hg_id";
+
+    ($status, $sth) = $centreon->query($query);
+    while (my $row = $sth->fetchrow_hashref()) {
+        $serviceIds{$row->{'host_id'} . ";;" . $row->{'service_id'}} = 1;
+    }
+    $sth->finish();
+
+    return \%serviceIds;
+}
+
+1;

--- a/perl-libs/lib/centreon/reporting/CentreonServiceStateEvents.pm
+++ b/perl-libs/lib/centreon/reporting/CentreonServiceStateEvents.pm
@@ -1,0 +1,276 @@
+################################################################################
+# Copyright 2005-2020 Centreon
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation ; either version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see <http://www.gnu.org/licenses>.
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
+# General Public License cover the whole combination.
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+#
+#
+####################################################################################
+
+use strict;
+use warnings;
+
+package centreon::reporting::CentreonServiceStateEvents;
+
+# Constructor
+# parameters:
+# $logger: instance of class CentreonLogger
+# $centreon: Instance of centreonDB class for connection to Centreon database
+# $centstorage: (optional) Instance of centreonDB class for connection to Centstorage database
+sub new {
+    my $class = shift;
+    my $self  = {};
+    $self->{logger} = shift;
+    $self->{centstorage} = shift;
+    $self->{centreonAck} = shift;
+    $self->{centreonDownTime}  = shift;
+    bless $self, $class;
+    return $self;
+}
+
+# Get events in given period
+# Parameters:
+# $start: period start
+# $end: period end
+sub getStateEventDurations {
+    my $self = shift;
+    my $centstorage = $self->{centstorage};
+    my $start = shift;
+    my $end = shift;
+
+    my %services;
+    my $query = "SELECT `host_id`, `service_id`, `state`,  `start_time`, `end_time`, `in_downtime`".
+                " FROM `servicestateevents`".
+                " WHERE `start_time` < ".$end.
+                    " AND `end_time` > ".$start.
+                    " AND `state` < 4"; # NOT HANDLING PENDING STATE
+    my ($status, $sth) = $centstorage->query($query);
+    while (my $row = $sth->fetchrow_hashref()) {
+        if ($row->{start_time} < $start) {
+            $row->{start_time} = $start;
+        }
+        if ($row->{end_time} > $end) {
+            $row->{end_time} = $end;
+        }
+        if (!defined($services{$row->{host_id}.";;".$row->{service_id}})) {
+            my @tab = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            # index 0: OK, index 1: WARNING, index 2: CRITICAL, index 3: UNKNOWN, index 4: DOWNTIME, index 5: UNDETERMINED
+            # index 6: OK alerts, index 7: WARNING alerts, index 8: CRITICAL alerts, index 9: UNKNOWN alerts
+            $services{$row->{host_id}.";;".$row->{service_id}} = \@tab;
+        }
+
+        my $stats = $services{$row->{host_id}.";;".$row->{service_id}};
+        if ($row->{in_downtime} == 0) {
+            $stats->[$row->{state}] += $row->{end_time} - $row->{start_time};
+            if ($row->{state} != 0 || ($row->{state} == 0 && $row->{start_time} > $start)) {
+                $stats->[$row->{state} + 6] += 1;
+            }
+        } else {
+            $stats->[4] += $row->{end_time} - $row->{start_time};
+        }
+        $services{$row->{host_id}.";;".$row->{service_id}} = $stats;
+    }
+    my %results;
+    while (my ($key, $value) = each %services) {
+        $value->[5] = ($end - $start) - ($value->[0] + $value->[1] + $value->[2] + $value->[3] + $value->[4]);
+        $results{$key} = $value;
+    }
+    return (\%results);
+}
+
+
+# Get last events for each service
+# Parameters:
+# $start: max date possible for each event
+# $serviceIds: references a hash table containing a list of services
+sub getLastStates {
+    my $self = shift;
+    my $centstorage = $self->{centstorage};
+
+    my $serviceIds = shift;
+
+    my $currentStates = {};
+
+    my $query = "SELECT `host_id`, `service_id`, `state`, `servicestateevent_id`, `end_time`, `in_downtime`, `in_ack`".
+                " FROM `servicestateevents`".
+                " WHERE `last_update` = 1";
+    my ($status, $sth) = $centstorage->query($query);
+    while (my $row = $sth->fetchrow_hashref()) {
+        my $serviceId = $row->{host_id} . ";;" . $row->{service_id};
+        if (defined($serviceIds->{$serviceId})) {
+            my @tab = ($row->{end_time}, $row->{state}, $row->{servicestateevent_id}, $row->{in_downtime}, $row->{in_ack});
+            $currentStates->{$serviceId} = \@tab;
+        }
+    }
+    $sth->finish();
+
+    return ($currentStates);
+}
+
+# update a specific service incident end time
+# Parameters
+# $endTime: incident end time
+# $eventId: ID of event to update
+sub updateEventEndTime {
+    my $self = shift;
+    my $centstorage = $self->{centstorage};
+    my $centstatus = $self->{centstatus};
+    my $centreonAck = $self->{centreonAck};
+    my $centreonDownTime = $self->{centreonDownTime};
+    my ($hostId, $serviceId, $start, $end, $state, $eventId, $downTimeFlag, $lastUpdate, $downtimes, $inAck) = @_;
+    my $return = {};
+
+    my ($events, $updateTime);
+    ($updateTime, $events) = $centreonDownTime->splitUpdateEventDownTime($hostId . ";;" . $serviceId, $start, $end, $downTimeFlag, $downtimes, $state);
+    my $totalEvents = 0;
+    if (defined($events)) {
+        $totalEvents = scalar(@$events);
+    }
+    my ($ack, $sticky) = $centreonAck->getServiceAckTime($start, $updateTime, $hostId, $serviceId);
+    if (defined($ack) && $sticky == 1) {
+        $inAck = 1;
+    }
+    if (!$totalEvents && $updateTime) {
+        my $query = "UPDATE `servicestateevents` SET `end_time` = ".$updateTime.", `ack_time`= IFNULL(ack_time,$ack), `in_ack` = '$inAck', `last_update`=".$lastUpdate.
+                    " WHERE `servicestateevent_id` = ".$eventId;
+        $centstorage->query($query);
+    } else {
+        if ($updateTime) {
+            my $query = "UPDATE `servicestateevents` SET `end_time` = ".$updateTime.", `ack_time`= IFNULL(ack_time,$ack), `in_ack` = '$inAck', `last_update`= 0".
+                    " WHERE `servicestateevent_id` = ".$eventId;
+            $centstorage->query($query);
+        }
+        return $self->insertEventTable($hostId, $serviceId, $state, $lastUpdate, $events, $inAck);
+    }
+
+    $return->{in_ack} = $inAck;
+    return $return;
+}
+
+# insert a new incident for service
+# Parameters
+# $hostId : host ID
+# $serviceId: service ID
+# $state: incident state
+# $start: incident start time
+# $end: incident end time
+sub insertEvent {
+    my $self = shift;
+    my $centreonDownTime = $self->{centreonDownTime};
+    my ($hostId, $serviceId, $state, $start, $end, $lastUpdate, $downtimes, $inAck) = @_;
+    my $events = $centreonDownTime->splitInsertEventDownTime($hostId . ";;" . $serviceId, $start, $end, $downtimes, $state);
+    my $return = { in_ack => $inAck };
+
+    if ($state ne "") {
+        return $self->insertEventTable($hostId, $serviceId, $state, $lastUpdate, $events, $inAck);
+    }
+
+    return $return;
+}
+
+sub insertEventTable {
+    my $self = shift;
+    my $centstorage = $self->{centstorage};
+    my $centreonAck = $self->{centreonAck};
+    my ($hostId, $serviceId, $state, $lastUpdate, $events, $inAck) =  @_;
+    my $return = {};
+
+    my $query_start = "INSERT INTO `servicestateevents`".
+                      " (`host_id`, `service_id`, `state`, `start_time`, `end_time`, `last_update`, `in_downtime`, `ack_time`, `in_ack`)".
+                      " VALUES (";
+
+    # Stick ack is removed
+    if ($state == 0) {
+        $inAck = 0;
+    }
+    my $count = 0;
+    for ($count = 0; $count < scalar(@$events) - 1; $count++) {
+        my $tab = $events->[$count];
+
+        my ($ack, $sticky) = $centreonAck->getServiceAckTime($tab->[0], $tab->[1], $hostId, $serviceId);
+        if ($inAck == 1) {
+            $sticky = 1;
+            $ack = $tab->[0];
+        }
+        if (defined($ack) && $sticky == 1) {
+            $inAck = 1;
+        }
+        my $query_end = $hostId.", ".$serviceId.", ".$state.", ".$tab->[0].", ".$tab->[1].", 0, ".$tab->[2].", ".$ack.", '$sticky')";
+        $centstorage->query($query_start.$query_end);
+    }
+    if (scalar(@$events)) {
+        my $tab = $events->[$count];
+        if (defined($hostId) && defined($serviceId) && defined($state)) {
+            my ($ack, $sticky) = $centreonAck->getServiceAckTime($tab->[0], $tab->[1], $hostId, $serviceId);
+            if ($inAck == 1) {
+                $sticky = 1;
+                $ack = $tab->[0];
+            }
+            if (defined($ack) && $sticky == 1) {
+                $inAck = 1;
+            }
+            my $query_end = $hostId.", ".$serviceId.", ".$state.", ".$tab->[0].", ".$tab->[1].", ".$lastUpdate.", ".$tab->[2].", ".$ack.", '$sticky')";
+            $centstorage->query($query_start.$query_end);
+        }
+    }
+
+    $return->{in_ack} = $inAck;
+    return $return;
+}
+
+# Truncate service incident table
+sub truncateStateEvents {
+    my ($self, %options) = @_;
+    my $centstorage = $self->{centstorage};
+
+    if (defined($options{start})) {
+        my $query = "DELETE FROM servicestateevents WHERE start_time > $options{start}";
+        $centstorage->query($query);
+        $query = "UPDATE servicestateevents SET end_time = $options{midnight} WHERE end_time > $options{midnight}";
+        $centstorage->query($query);
+    } else {
+        my $query = "TRUNCATE TABLE servicestateevents";
+        $centstorage->query($query);
+    }
+}
+
+# Get first and last events date
+sub getFirstLastIncidentTimes {
+    my $self = shift;
+    my $centstorage = $self->{centstorage};
+
+    my $query = "SELECT min(`start_time`) as minc, max(`end_time`) as maxc FROM `servicestateevents`";
+    my ($status, $sth) = $centstorage->query($query);
+    my ($start, $end) = (0,0);
+    if (my $row = $sth->fetchrow_hashref()) {
+        ($start, $end) = ($row->{minc}, $row->{maxc});
+    }
+    $sth->finish;
+    return ($start, $end);
+}
+
+1;

--- a/perl-libs/lib/centreon/script.pm
+++ b/perl-libs/lib/centreon/script.pm
@@ -1,0 +1,159 @@
+################################################################################
+# Copyright 2005-2013 Centreon
+# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+# 
+# This program is free software; you can redistribute it and/or modify it under 
+# the terms of the GNU General Public License as published by the Free Software 
+# Foundation ; either version 2 of the License.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with 
+# this program; if not, see <http://www.gnu.org/licenses>.
+# 
+# Linking this program statically or dynamically with other modules is making a 
+# combined work based on this program. Thus, the terms and conditions of the GNU 
+# General Public License cover the whole combination.
+# 
+# As a special exception, the copyright holders of this program give Centreon 
+# permission to link this program with independent modules to produce an executable, 
+# regardless of the license terms of these independent modules, and to copy and 
+# distribute the resulting executable under terms of Centreon choice, provided that 
+# Centreon also meet, for each linked independent module, the terms  and conditions 
+# of the license of that module. An independent module is a module which is not 
+# derived from this program. If you modify this program, you may extend this 
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+# 
+#
+####################################################################################
+
+package centreon::script;
+
+use strict;
+use warnings;
+use FindBin;
+use Getopt::Long;
+use Pod::Usage;
+use centreon::common::logger;
+use centreon::common::db;
+use centreon::common::lock;
+
+use vars qw($centreon_config);
+use vars qw($mysql_user $mysql_passwd $mysql_host $mysql_database_oreon $mysql_database_ods $mysql_database_ndo $instance_mode);
+
+$SIG{__DIE__} = sub {
+    return unless defined $^S and $^S == 0; # Ignore errors in eval
+    my $error = shift;
+    print "Error: $error";
+    exit 1;
+};
+
+sub new {
+    my ($class, $name, %options) = @_;
+    my %defaults = 
+      (
+       config_file => "/etc/centreon/conf.pm",
+       log_file => undef,
+       centreon_db_conn => 0,
+       centstorage_db_conn => 0,
+       severity => "info",
+       noconfig => 0,
+       noroot => 0,
+       instance_mode => "central"
+      );
+    my $self = {%defaults, %options};
+
+    bless $self, $class;
+    $self->{name} = $name;
+    $self->{logger} = centreon::common::logger->new();
+    $self->{options} = {
+        "config=s" => \$self->{config_file},
+        "logfile=s" => \$self->{log_file},
+        "severity=s" => \$self->{severity},
+        "help|?" => \$self->{help}
+    };
+    return $self;
+}
+
+sub init {
+    my $self = shift;
+
+    if (defined $self->{log_file}) {
+        $self->{logger}->file_mode($self->{log_file});
+    }
+    $self->{logger}->severity($self->{severity});
+
+    if ($self->{noroot} == 1) {
+        # Stop exec if root
+        if ($< == 0) {
+            $self->{logger}->writeLogError("Can't execute script as root.");
+            die("Quit");
+        }
+    }
+    
+    if ($self->{centreon_db_conn}) {
+        $self->{cdb} = centreon::common::db->new
+          (db => $self->{centreon_config}->{centreon_db},
+           host => $self->{centreon_config}->{db_host},
+           port => $self->{centreon_config}->{db_port},
+           user => $self->{centreon_config}->{db_user},
+           password => $self->{centreon_config}->{db_passwd},
+           logger => $self->{logger});
+        $self->{lock} = centreon::common::lock::sql->new($self->{name}, dbc => $self->{cdb});
+        $self->{lock}->set();
+    }
+    if ($self->{centstorage_db_conn}) {
+        $self->{csdb} = centreon::common::db->new
+          (db => $self->{centreon_config}->{centstorage_db},
+           host => $self->{centreon_config}->{db_host},
+           port => $self->{centreon_config}->{db_port},
+           user => $self->{centreon_config}->{db_user},
+           password => $self->{centreon_config}->{db_passwd},
+           logger => $self->{logger});
+    }
+    $self->{instance_mode} = $instance_mode;
+}
+
+sub DESTROY {
+    my $self = shift;
+
+    if (defined $self->{cdb}) {
+        $self->{cdb}->disconnect();
+    }
+    if (defined $self->{csdb}) {
+        $self->{csdb}->disconnect();
+    }
+}
+
+sub add_options {
+    my ($self, %options) = @_;
+
+    $self->{options} = {%{$self->{options}}, %options};
+}
+
+sub parse_options {
+    my $self = shift;
+
+    Getopt::Long::Configure('bundling');
+    die "Command line error" if !GetOptions(%{$self->{options}});
+    pod2usage(-exitval => 1, -input => $FindBin::Bin . "/" . $FindBin::Script) if $self->{help};
+    if ($self->{noconfig} == 0) {
+        if (-e "$self->{config_file}" && -s "$self->{config_file}") {
+            require $self->{config_file};
+            $self->{centreon_config} = $centreon_config;
+        }
+    }
+}
+
+sub run {
+    my $self = shift;
+
+    $self->parse_options();
+    $self->init();
+}
+
+1;

--- a/perl-libs/lib/centreon/script/centFillTrapDB.pm
+++ b/perl-libs/lib/centreon/script/centFillTrapDB.pm
@@ -1,0 +1,779 @@
+################################################################################
+# Copyright 2005-2013 Centreon
+# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+# 
+# This program is free software; you can redistribute it and/or modify it under 
+# the terms of the GNU General Public License as published by the Free Software 
+# Foundation ; either version 2 of the License.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with 
+# this program; if not, see <http://www.gnu.org/licenses>.
+# 
+# Linking this program statically or dynamically with other modules is making a 
+# combined work based on this program. Thus, the terms and conditions of the GNU 
+# General Public License cover the whole combination.
+# 
+# As a special exception, the copyright holders of this program give Centreon 
+# permission to link this program with independent modules to produce an executable, 
+# regardless of the license terms of these independent modules, and to copy and 
+# distribute the resulting executable under terms of Centreon choice, provided that 
+# Centreon also meet, for each linked independent module, the terms  and conditions 
+# of the license of that module. An independent module is a module which is not 
+# derived from this program. If you modify this program, you may extend this 
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+# 
+#
+####################################################################################
+
+package centreon::script::centFillTrapDB;
+
+use strict;
+use warnings;
+use centreon::script;
+use File::Basename;
+use File::Spec;
+
+use base qw(centreon::script);
+
+sub new {
+    my $class = shift;
+    my $self = $class->SUPER::new("centFillTrapDB",
+        centreon_db_conn => 0,
+        centstorage_db_conn => 0,
+    );
+
+    bless $self, $class;
+    
+    $self->{no_description} = 0;
+    $self->{no_variables} = 0;
+    $self->{no_format_summary} = 0;
+    $self->{no_format_desc} = 0;
+    $self->{format} = 0;
+    $self->{format_desc} = 0;
+    $self->{no_desc_wildcard} = 0;
+    $self->{no_severity} = 0;
+    $self->{severity} = 'Normal';
+    
+    # Set this to 1 to have the --TYPE string prepended to the --SUMMARY string.
+    # Set to 0 to disable
+    $self->{prepend_type} = 1;
+    $self->{net_snmp_perl} = 0;
+    $self->{total_translations} = 0;
+    $self->{successful_translations} = 0;
+    $self->{failed_translations} = 0;
+    
+    $self->add_options(
+        "f=s" => \$self->{opt_f}, "file=s" => \$self->{opt_f},
+        "m=s" => \$self->{opt_m}, "man=s" => \$self->{opt_m}
+    );
+    
+    return $self;
+}
+
+sub check_snmptranslate_version {
+    my $self = shift;
+    $self->{snmptranslate_use_On} = 1;
+    
+    if (open SNMPTRANSLATE, "snmptranslate -V 2>&1|") {
+        my $snmptranslatever = <SNMPTRANSLATE>;
+        close SNMPTRANSLATE;
+
+        chomp ($snmptranslatever);
+
+        $self->{logger}->writeLogInfo("snmptranslate version: " . $snmptranslatever);
+
+        if ($snmptranslatever =~ /UCD/i || $snmptranslatever =~ /NET-SNMP version: 5.0.1/i) {
+            $self->{snmptranslate_use_On} = 0;
+            $self->{logger}->writeLogDebug("snmptranslate is either UCD-SNMP, or NET-SNMP v5.0.1, so do not use the -On switch.  Version found: $snmptranslatever");
+        }
+    }
+}
+
+sub existsInDB {
+    my $self = shift;
+
+    my ($status, $sth) = $self->{centreon_dbc}->query("SELECT `traps_id` FROM `traps` WHERE `traps_oid` = " . $self->{centreon_dbc}->quote($self->{trap_oid}) . " AND `traps_name` = " . $self->{centreon_dbc}->quote($self->{trap_name}) . " LIMIT 1");
+    if ($status == -1) {
+        return 0;
+    }
+    if (defined($sth->fetchrow_array())) {
+		return 1;
+    }
+    return 0;
+}
+
+sub getStatus {
+    my ($self) = @_;
+
+    if ($self->{trap_severity} =~ /up/i) {
+        return 0;
+    } elsif ($self->{trap_severity} =~ /warning|degraded|minor/i) {
+        return 1;
+    } elsif ($self->{trap_severity} =~ /critical|major|failure|error|down/i) {
+        return 2;
+    } else {
+        if ($self->{trap_name} =~ /normal|up/i || $self->{trap_name} =~ /on$/i) {
+            return 0;
+        } elsif ($self->{trap_name} =~ /warning|degraded|minor/i) {
+            return 1;
+        } elsif ($self->{trap_name} =~ /critical|major|fail|error|down|bad/i || $self->{trap_name} =~ /off|low$/i) {
+            return 2;
+        }
+    }
+    return 3;
+}
+
+sub insert_into_centreon {
+    my $self = shift;
+    my $last_oid = "";
+    my ($status, $sth);
+
+    if (!$self->existsInDB()) {
+        ($status, $sth) = $self->{centreon_dbc}->query(
+            "INSERT INTO `traps` (`traps_name`, `traps_oid`, `traps_status`, `manufacturer_id`, `traps_submit_result_enable`) VALUES ("
+            . $self->{centreon_dbc}->quote($self->{trap_name}) . ", " 
+            . $self->{centreon_dbc}->quote($self->{trap_oid}) . ", " 
+            . $self->{centreon_dbc}->quote($self->getStatus()) . ", " 
+            . $self->{centreon_dbc}->quote($self->{opt_m}) . ", '1')"
+        );
+    }
+    ($status, $sth) = $self->{centreon_dbc}->query(
+        "UPDATE `traps` SET `traps_args` = " . $self->{centreon_dbc}->quote($self->{trap_format})
+        . ", `traps_comments` = " . $self->{centreon_dbc}->quote($self->{trap_description})
+        . " WHERE `traps_oid` = " . $self->{centreon_dbc}->quote($self->{trap_oid})
+    );
+}
+
+################
+## MAIN FUNCTION
+#
+sub main {
+    my $self = shift;
+    
+    if (!open(FILE, $self->{opt_f})) {
+		$self->{logger}->writeLogError("Cannot get mib file : $self->{opt_f}");
+		exit(1);
+    }
+    
+    # From snmpconvertmib
+    # Copyright 2002-2013 Alex Burger
+    # alex_b@users.sourceforge.net
+    
+    # Get complete path of input file (MIB) in a portable way (needed for -m switch for snmptranslate)
+    my $dirname = dirname $self->{opt_f};
+    my $basename = basename $self->{opt_f};
+    my $input = File::Spec->catfile($dirname, $basename);
+    $ENV{MIBS} = $input;
+    
+    $self->check_snmptranslate_version();
+    my @mibfile;
+    while (<FILE>) {
+        chomp;			# remove <cr> at end of line
+        s/\015//;			# Remove any DOS carriage returns
+        push(@mibfile, $_);		# add to each line to @trapconf array
+    }
+
+    my $currentline = 0;
+    # A mib file can contain multiple BEGIN definitions.  This finds the first one
+    # to make sure we have at least one definition.
+    # Determine name of MIB file
+    my $mib_name = '';
+    while ($currentline <= $#mibfile) {
+        my $line = $mibfile[$currentline];
+
+        # Sometimes DEFINITIONS ::= BEGIN will appear on the line following the mib name.
+        # Look for DEFINITIONS ::= BEGIN with nothing (white space allowed) around it and a previous line with 
+        # only a single word with whitespace around it.
+        if ($currentline > 0 && $line =~ /^\s*DEFINITIONS\s*::=\s*BEGIN\s*$/ && $mibfile[$currentline-1] =~ /^\s*(\S+)\s*$/) {
+            # We should have found the mib name
+            $mib_name = $1;
+            $self->{logger}->writeLogInfo("Split line DEFINITIONS ::= BEGIN found ($1).");
+            $mib_name =~ s/\s+//g;
+            last;
+        } elsif ($line =~ /(.*)DEFINITIONS\s*::=\s*BEGIN/) {
+            $mib_name = $1;
+            $mib_name =~ s/\s+//g;
+            last;
+        }
+        $currentline++;
+    }
+    $self->{logger}->writeLogInfo("mib name: $mib_name");
+    if ($mib_name eq '') {
+        $self->{logger}->writeLogError("Could not find DEFINITIONS ::= BEGIN statement in MIB file!");
+        exit (1);
+    }
+    
+    while ($currentline <= $#mibfile) {
+        my $line = $mibfile[$currentline];
+
+        # Sometimes DEFINITIONS ::= BEGIN will appear on the line following the mib name.
+        # Look for DEFINITIONS ::= BEGIN with nothing (white space allowed) around it and a previous line with 
+        # only a single word with whitespace around it.
+        if ($currentline > 0 && $line =~ /^\s*DEFINITIONS\s*::=\s*BEGIN\s*$/ && $mibfile[$currentline-1] =~ /^\s*(\S+)\s*$/) {
+            # We should have found the mib name
+            $self->{logger}->writeLogInfo("Split line DEFINITIONS ::= BEGIN found ($1).");
+
+            $mib_name = $1;
+            $mib_name =~ s/\s+//g;
+            $self->{logger}->writeLogInfo("Processing MIB:         $mib_name");
+
+            $currentline++; # Increment to the next line
+            next;
+        } elsif ($line =~ /(.*)DEFINITIONS\s*::=\s*BEGIN/) {
+            $mib_name = $1;
+            $mib_name =~ s/\s+//g;
+            $self->{logger}->writeLogInfo("Processing MIB:         $mib_name");
+
+            $currentline++; # Increment to the next line
+            next;
+        }
+
+        # TRAP-TYPE (V1) / NOTIFICATION-TYPE (V2)
+        #
+        # eg: 'mngmtAgentTrap-23003 TRAP-TYPE';
+        # eg: 'ciscoSystemClockChanged NOTIFICATION-TYPE';
+        if ($line =~ /(.*)\s*TRAP-TYPE.*/ || 
+            $line =~ /(.*)\s*(?<!--)NOTIFICATION-TYPE.*/) {
+            my $trapname = $1;
+
+            my $trapversion;
+            if ( $line =~ /TRAP-TYPE/ ) {
+                $trapversion = 'TRAP';
+            } else {
+                $trapversion = 'NOTIFICATION';
+            }
+
+            # Make sure it doesn't start with a --.  If it does, it's a comment line..  Skip it
+            if ($line =~/.*--.*TRAP-TYPE/ || $line =~/.*--.*NOTIFICATION-TYPE/) {
+                # Comment line
+
+                $currentline++; # Increment to the next line
+                $line = $mibfile[$currentline]; # Get next line
+                next;
+            }
+            my $enterprisefound = 0;
+
+            my @variables = ();
+
+            $self->{logger}->writeLogInfo("#");
+
+            # Sometimes the TRAP-TYPE / NOTIFICATION-TYPE will appear on the line following the trap name
+            # Look for xxx-TYPE with nothing (white space allowed) around it and a previous line with only a single word
+            # with whitespace around it.
+            if ( ($currentline > 0 && $line =~ /^\s*TRAP-TYPE\s*$/ && $mibfile[$currentline-1] =~ /^\s*(\S+)\s*$/) ||
+            ($currentline > 0 && $line =~ /^\s*NOTIFICATION-TYPE\s*$/ && $mibfile[$currentline-1] =~ /^\s*(\S+)\s*$/) ) {
+                # We should have found the trap name
+                $trapname = $1;
+                $self->{logger}->writeLogInfo("Split line TRAP-TYPE / NOTIFICATION-TYPE found ($1).");
+            } elsif ( $line =~ /^\s+TRAP-TYPE.*/ || $line =~ /^\s+NOTIFICATION-TYPE.*/  || $line =~ /^.*,.*NOTIFICATION-TYPE.*/ ) {
+                # If the TRAP-TYPE / NOTIFICATION-TYPE line starts with white space, it's probably a import line, so ignore
+                $self->{logger}->writeLogInfo("skipping a TRAP-TYPE / NOTIFICATION-TYPE line - probably an import line.");
+                $currentline++; # Increment to the next line
+                $line = $mibfile[$currentline]; # Get next line
+                next;
+            }
+
+            # Remove beginning and trailing white space
+            $trapname =~ /\s*([A-Za-z0-9_-]+)\s*/;
+            $trapname = $1;
+
+            $self->{logger}->writeLogInfo("Line: $currentline");
+            if ($trapversion eq 'TRAP') {
+                $self->{logger}->writeLogInfo("TRAP-TYPE: $1");		# If trapsummary blank, use trapsummary line for FORMAT and EXEC
+            } else {
+                $self->{logger}->writeLogInfo("NOTIFICATION-TYPE: $1");	# If trapsummary blank, use trapsummary line for FORMAT and EXEC
+            }
+
+            $currentline++; # Increment to the next line
+            my $line3 = $mibfile[$currentline];
+
+            my $end_of_definition = 0;
+
+            $self->{trap_name} = '';
+            $self->{trap_oid} = '';
+            $self->{trap_severity} = '';
+            $self->{trap_format} = '';
+            $self->{trap_description} = '';
+            
+            
+            my $traptype = "";
+            my $trapsummary = "";
+            my @description = ();
+            my $trap_severity = $self->{severity};
+            my $enterprise;
+            my @arguments;
+            my $formatexec;
+
+            while ( ($currentline <= $#mibfile) && !($line3 =~ /\s+END\s+/) && !($line3 =~ /(.*)\s+TRAP-TYPE.*/ )
+                    && !($line3 =~ /(.*)\s+NOTIFICATION-TYPE.*/) && ($end_of_definition == 0) ) {
+                # Keep going through the file until the next TRAP-TYPE / NOTIFICATION-TYPE or the end of the mib file
+                # is reached, or the end of the section (between BEGIN and END)
+
+                # Look for DESCRIPTION and anything after (including newline with /s)
+                # and capture that anything in $1
+
+                # If line starts with ENTERPRISE, pull it out
+                # Only applies to SNMPv1 TRAPs
+                # (SNMPv2 NOTIFICATIONS have the enterprise in the ::= line)
+
+                $traptype = "";
+                $trapsummary = "";
+                @description = ();
+                $trap_severity = $self->{severity};
+
+                if ($line3 =~ /ENTERPRISE\s+(.*)/) {
+                    $enterprise = $1;
+                    $enterprisefound =1;
+                }
+
+                if ( ($line3 =~ /VARIABLES(.*)/s) || ($line3 =~ /OBJECTS(.*)/s) ) {
+                    # If there is more text after the word VARIABLES or OBJECTS, assume it's the start of
+                    # the variable list
+                    my $templine = "";
+                    if ($1 ne "") {
+                        $templine = $templine . $1;
+                        $templine =~ s/--.*//; # Remove any trailing comments
+                    }
+
+                    if ($templine =~ /\}/) { # Contains a }, so we're done
+                        # DONE!
+                    } else {
+                        $currentline++; # Increment to the next line
+                        my $line4 = $mibfile[$currentline];
+                        $line4 =~ s/--.*//; # Remove any trailing comments
+                        my $keepdigging = 1;
+                        while (($currentline <= $#mibfile) && ($keepdigging == 1)) {
+                            $templine = $templine . $line4;
+                            if ($line4 =~ /\}/)	{ # Contains a }, so we're done
+                                $keepdigging = 0;
+                            } else {
+                                $currentline++; # Increment to the next line
+                                $line4 = $mibfile[$currentline];
+                                $line4 =~ s/--.*//; # Remove any trailing comments
+                            }
+                        }
+                    }
+                    $templine =~ s/\s//g;	# Remove any white space
+                    $templine =~ /\{(.*)\}/; # Remove brackets
+                    @variables = split /\,/, $1;
+                    $self->{logger}->writeLogInfo("Variables: @variables");
+                }
+
+                if ($line3 =~ /DESCRIPTION(.*)/s) {
+                    my $temp1 = 0;
+
+                    # Start of DESCRIPTION
+
+                    #print "SDESC\n";
+
+                    # If there is more text after the word DESCRIPTION, assume it's the start of
+                    # the description.
+                    if ($1 ne "") {
+                        # Pull out text and remove beginning and trailing white space
+                        if ($1 =~ /\s*(.*)\s*/) {
+                            # Remove any quotes
+                            $_ = $1;
+                            s(\")()g;
+                            # "
+                            push (@description, "$_\n");
+                        }
+                    }
+
+                    $currentline++; # Increment to the next line
+                    my $line4 = $mibfile[$currentline];
+
+                    # Assume the rest is the description up until a ::= or end of the file
+                    while (! ($line4 =~ /::=/)) {
+                        # If next line is a --#TYPE, pull out the information and place in $traptype
+                        if ($line4 =~ /--#TYPE(.*)/) {
+                            # Pull out text and remove beginning and trailing white space and quotes
+                            if ($line4 =~ /\s*--#TYPE\s*(.*)\s*/) {
+                                # Remove any quotes
+                                $_ = $1;
+                                s(\")()g;
+                                # "
+
+                                #print ("2\n");
+                                $traptype = $_;
+                                #print "Type: $traptype \n";
+                            }
+
+                            # Increment to next line and continue with the loop
+                            $currentline++; # Increment to the next line
+                            $line4 = $mibfile[$currentline];
+                            next;
+                        }
+
+                        # If next line is a --#SUMMARY, pull out the information and place in $summary
+                        if ($line4 =~ /--#SUMMARY(.*)/) {
+                            # Pull out text and remove beginning and trailing white space and quotes
+                            if ($line4 =~ /\s*--#SUMMARY\s*(.*)\s*/) {
+                                # Remove any quotes
+                                $_ = $1;
+                                s(\")()g;
+                                # "
+
+                                #print ("2\n");
+                                $trapsummary .= $_;
+                                #print "Summary: $trapsummary \n";
+                            }
+
+                            # Increment to next line and continue with the loop
+                            $currentline++; # Increment to the next line
+                            $line4 = $mibfile[$currentline];
+                            next;
+                        }
+                        
+                        # If next line is a --#ARGUMENTS, pull out the information and place in $arguments
+                        if ($line4 =~ /--#ARGUMENTS\s*{(.*)}/) {
+                            @arguments = split /,/, $1;
+
+                            for(my $i=0;$i <= $#arguments;$i++) {
+                                # Most ARGUMENTS lines have %n where n is a number starting 
+                                # at 0, but some MIBS have an ARGUMENTS line that have $1, $2,
+                                # etc and start at 1.  These need to have the $ removed and 
+                                # the number downshifted so the FORMAT will be generated 
+                                # properly.
+                                if ($arguments[$i] =~ /^\s*\$\d+/) {
+                                    $arguments[$i] =~ s/^\s*\$(\d+)/$1/;
+                                    $arguments[$i]--;
+                                }
+                                #print "argument $i: $arguments[$i]\n";
+                            }
+
+                            #for(my $i=0;$i <= $#arguments;$i++)
+                            #{
+                            #print "argument $i: $arguments[$i]\n";
+                            #}
+
+                            # Increment to next line and continue with the loop
+                            $currentline++; # Increment to the next line
+                            $line4 = $mibfile[$currentline];
+                            next;
+                        }
+
+                        # If next line is a --#SEVERITY, pull out the information and place in $trap_severity
+                        if ($line4 =~ /--#SEVERITY\s+(.*)/ && ! ($line4 =~ /--#SEVERITYMAP/)) {
+                            # Pull out text and remove beginning and trailing white space and quotes
+                            if ($line4 =~ /\s*--#SEVERITY\s+(.*)\s*/) {
+                                # Remove any quotes
+                                $_ = $1;
+                                s(\")()g;
+                                # "
+
+                                #print ("2\n");
+                                if ($self->{no_severity} == 0) {
+                                    $trap_severity = $_;
+                                }
+                                #print "Severity: $trap_severity \n";
+                            }
+                            # Increment to next line and continue with the loop
+                            $currentline++; # Increment to the next line
+                            $line4 = $mibfile[$currentline];
+                            next;
+                        }
+                        # If next line starts with a --#, ignore it and continue with the loop
+                        # (we already got the SUMMARY line above)
+                        if ($line4 =~ /--#/) {
+                            $currentline++; # Increment to the next line
+                            $line4 = $mibfile[$currentline];
+                            next;
+                        }
+
+                        # If we did not find text after the word DESCRIPTION, then the NEXT
+                        # line must be the first line of description.
+
+                        # Remove beginning and trailing white space
+                        $line4 =~ (/\s*(.*)\s*/);
+                        if ($1 ne "") {
+                            # Remove any quotes
+                            $_ = $1;
+                            s(\")()g;
+                            # "
+
+                            push (@description, "$_\n");
+                            #print "c:$_\n";
+                        }
+
+                        $currentline++; # Increment to the next line
+                        $line4 = $mibfile[$currentline];
+                    }
+                    #print "EDESC\n";
+
+                    if ($line4 =~ /::=/) {
+                        $end_of_definition = 1;		# Move on to the next one
+
+                        if ($enterprisefound == 0) {
+                            # $line4 should now contain ::= line
+                            # # Pull out enterprise from { }
+                            # # Would only apply to SNMPv2 NOTIFICATIONS
+                            # #print "Line4: $line4\n";
+                            $line4 =~ /{(.*)\s\d.*/;
+
+                            #print "\$1=$1\n";
+                            $enterprisefound =1;
+
+                            # Remove any spaces
+                            $_ = $1;
+                            s( )()g;
+                            $enterprise = $_;
+                            $self->{logger}->writeLogInfo("Enterprise: $enterprise");
+                        }
+                    }
+                }
+                $currentline++; # Increment to the next line
+                $line3 = $mibfile[$currentline];
+            }
+
+            # Combine Trap type and summary together to make new summary
+            if ($traptype ne "" && $self->{prepend_type} == 1) {
+                $trapsummary = $traptype . ": " . $trapsummary;
+            }
+
+            my $trap_lookup;
+            if ($mib_name eq '' || $mib_name !~ m/(^[A-Za-z0-9_-]+$)/) {
+                $trap_lookup = $trapname;
+            } else {
+                $trap_lookup = "$mib_name\:\:$trapname";
+            }
+            $self->{logger}->writeLogInfo("Looking up via snmptranslate: $trap_lookup");
+
+            my $trapoid;
+            if ($self->{snmptranslate_use_On} == 1) {
+                $trapoid = `snmptranslate -IR -Ts -On $trap_lookup`;
+            } else {
+                $trapoid = `snmptranslate -IR -Ts $trap_lookup`;
+            }
+
+            chomp $trapoid;
+            if ($trapoid ne "") {
+                $self->{trap_name} = $trapname;
+                $self->{trap_oid} = $trapoid;
+                $self->{trap_severity} = $trap_severity;
+                #print OUTPUTFILE "EVENT $trapname $trapoid \"Status Events\" $trap_severity\n";
+
+                # Loop through trapsummary and replace the %s and %d etc with %1 to %n
+
+                #$j = $#arguments; # j is last element number
+                #print "j is $j\n";
+
+                # Change the %s or %d etc into $1 etc (starts at $1)
+                $_ = $trapsummary;
+                for (my $j=0; $j<= $#arguments; $j++) {
+                    my $variable = ($arguments[$j])+1;
+                    s(%[a-zA-Z])(\$$variable);
+                }
+
+                #print "new summary: $_\n";
+
+                $trapsummary = $_;
+
+                my $descriptionline1 = '';
+
+                # Build description line for FORMAT / EXEC
+                if ($self->{format_desc} == 0) { # First line of description
+                    $descriptionline1 = $description[0];
+                    chomp ($descriptionline1);
+                } else {                 # n sentence(s) of description
+                    # Build single line copy of description
+                    my $description_temp;
+                    foreach my $a (@description) {
+                        my $b = $a;
+                        chomp($b);
+                        $description_temp = $description_temp . $b . " ";
+                    }
+                    chop $description_temp;
+
+                    # Split up based on sentences
+                    my @description_temp2 = split /\./, $description_temp;
+
+                    # Remove white space around each sentence and add a trailing .
+                    for (my $i=0 ; $i <= $#description_temp2; $i++) {
+                        $description_temp2[$i] =~ /\s*(.*)\s*/;
+                        $description_temp2[$i] = $1 . ".";
+                    }
+
+                    # Build description line based on the number of sentences requested.
+                    for (my $i=1 ; $i <= $self->{format_desc}; $i++) {
+                        if ($description_temp2[$i-1] ne '') {
+                            $descriptionline1 = $descriptionline1 . $description_temp2[$i-1] . " " ;
+                        }
+                    }
+                    chop $descriptionline1;	# Remove last space
+                }
+
+                if ($descriptionline1 ne "") {
+                    if ($descriptionline1 =~ /%[a-zA-Z]/) {
+                        # Sometimes the variables are in the first line of the description
+                        # Change the %s or %d etc into $1 etc (starts at $1)
+                        # There is no list of variables, so just put them in order starting at 1 and
+                        # going up to 20
+                        $_ = $descriptionline1;
+                        for (my $j=1; $j<= 20; $j++) {
+                            s(%[a-zA-Z])(\$$j);
+                        }
+                        $descriptionline1 = $_;
+                        #$descriptionlinehadvariables = 1;
+                    } else {
+                        if ($self->{no_desc_wildcard} == 0) {
+                            $descriptionline1 = "$descriptionline1 \$*";
+                        }
+                    }
+                }
+
+                $formatexec = '';
+
+                if ($self->{format} == 0) {         # --#SUMMARY or description
+                    if ($trapsummary ne '' && $self->{no_format_summary} == 0) {
+                        $formatexec = $trapsummary;
+                    } elsif ($descriptionline1 ne '' && $self->{no_format_desc} == 0) {
+                        $formatexec = $descriptionline1;
+                    }
+                } elsif ($self->{format} == 1) {    # description or --#SUMMARY
+                    if ($descriptionline1 ne '' && $self->{no_format_desc} == 0) {
+                        $formatexec = $descriptionline1;
+                    } elsif ($trapsummary ne '' && $self->{no_format_summary} == 0) {
+                        $formatexec = $trapsummary;
+                    }
+                } elsif ($self->{format} == 2) {    # --#SUMMARY and description
+                    if ($trapsummary ne '' && $self->{no_format_summary} == 0) {
+                        $formatexec = $trapsummary;
+                    }
+                    if ($descriptionline1 ne '' && $self->{no_format_desc} == 0) {
+                        if ($formatexec =~ /\.$/) { # If it already ends in a .
+                            $formatexec = $formatexec . " " . $descriptionline1;
+                        } else {
+                            $formatexec = $formatexec . ". " . $descriptionline1;
+                        }
+                    }
+                } elsif ($self->{format} == 3) {    # description and --#SUMMARY
+                    if ($descriptionline1 ne '' && $self->{no_format_desc} == 0) {
+                        $formatexec = $descriptionline1;
+                    }
+                    if ($trapsummary ne '' && $self->{no_format_summary} == 0) {
+                        $formatexec = $formatexec . " " . $trapsummary;
+                    }
+                } elsif ($self->{format} == 4) {    # -- trap name and variables
+                    $formatexec = "$trapname - ";
+                    for (my $i=1; $i < $#variables+2; $i++) {
+                        $formatexec .= "$variables[$i-1]:\$$i ";
+                    }
+                }
+
+                if ($formatexec ne '') {
+                    $self->{trap_format} = $formatexec;
+                    #print OUTPUTFILE "FORMAT $formatexec\n";
+                } else {
+                    $self->{trap_format} = '$*';
+                    #print OUTPUTFILE "FORMAT \$*\n";
+                }
+
+                if ($self->{no_description} == 0) {
+                    #print OUTPUTFILE "SDESC\n";
+                    #print OUTPUTFILE "$descriptionline1\n";
+                    for (my $i=0; $i <= $#description; $i++) {
+                        $self->{trap_description} .= "$description[$i]";
+                        #print OUTPUTFILE "$description[$i]";
+                    }
+
+                    # If net_snmp_perl is enabled, lookup each variable
+                    if (@variables && $self->{no_variables} == 0 && $self->{net_snmp_perl} == 1) {
+                        $self->{trap_description} .= "Variables:\n";
+                        #print OUTPUTFILE "Variables:\n";
+                        for (my $i=0; $i <= $#variables; $i++) {
+                            $self->{trap_description} .= sprintf("%3d: %s\n",$i+1,$variables[$i]);
+                            $self->{trap_description} .= "     Syntax=\"" . $SNMP::MIB{$variables[$i]}{type} . "\"\n";
+                            #printf OUTPUTFILE "%3d: %s\n",$i+1,$variables[$i];
+                            #printf OUTPUTFILE "     Syntax=\"" . $SNMP::MIB{$variables[$i]}{type} . "\"\n";
+                            if (uc $SNMP::MIB{$variables[$i]}{type} =~ /INTEGER/) {
+                                my $b = $SNMP::MIB{$variables[$i]}{enums};
+                                my %hash = %$b;
+                                my $i = 1;
+
+                                # Create a new copy of the hash swapping the key and the value
+                                my %temphash = ();
+                                while ((my $key, my $value) = each %hash) {
+                                    $temphash{$value} = $key;
+                                }
+                                # Print out the entries in the hash
+                                foreach my $c (sort keys %temphash) {
+                                    $self->{trap_description} .= "       " . $c . ": $temphash{$c}\n";
+                                    #print OUTPUTFILE "       " . $c . ": $temphash{$c}\n";
+                                }
+                            }
+                            if ($SNMP::MIB{$variables[$i]}{description}) {
+                                $self->{trap_description} .= "     Descr=\"" . $SNMP::MIB{$variables[$i]}{description} . "\"\n";
+                                #print OUTPUTFILE "     Descr=\"" . $SNMP::MIB{$variables[$i]}{description} . "\"\n";
+                            }
+                        }
+                    } elsif (@variables ne "" && $self->{no_variables} == 0  && $self->{net_snmp_perl} == 0) {
+                        $self->{trap_description} .= "Variables:\n";
+                        #print OUTPUTFILE "Variables:\n";
+                        for (my $i=0; $i <= $#variables; $i++) {
+                            $self->{trap_description} .= "  " . ($i+1) . ": " . $variables[$i] . "\n";
+                            #print OUTPUTFILE "  " . ($i+1) . ": " . $variables[$i] . "\n";
+                        }
+                    }
+                    #print OUTPUTFILE "EDESC\n";
+                }
+                #print "Name= " . $self->{trap_name} . "==\n";
+                #print "OID= " . $self->{trap_oid} . "==\n";
+                #print "Severity= " . $self->{trap_severity} . "==\n";
+                #print "Format= " . $self->{trap_format} . "==\n";
+                #print "Description= " . $self->{trap_description} . "==\n";
+                $currentline--;
+            }
+
+            $self->{logger}->writeLogInfo("OID: $trapoid");
+
+            $self->{total_translations}++;
+            if ($trapoid eq '') {
+                $self->{failed_translations}++;
+            } else {
+                $self->insert_into_centreon();
+                $self->{successful_translations}++;
+            }
+
+            #print "\@description is ", $#description,"\n";
+            #print "going to next trap / notification\n\n";
+        }
+
+        $currentline++; # Increment to the next line
+    }
+    
+    $self->{logger}->writeLogInfo("Done");
+    $self->{logger}->writeLogInfo("Total translations:        $self->{total_translations}");
+    $self->{logger}->writeLogInfo("Successful translations:   $self->{successful_translations}");
+    $self->{logger}->writeLogInfo("Failed translations:       $self->{failed_translations}");
+}
+
+sub run {
+    my $self = shift;
+
+    $self->SUPER::run();
+    if (!defined($self->{opt_f}) || !defined($self->{opt_m})) {
+        $self->{logger}->writeLogError("Arguments missing.");
+        exit(1);
+    }
+    $self->{centreon_dbc} = centreon::common::db->new(db => $self->{centreon_config}->{centreon_db},
+                                                      host => $self->{centreon_config}->{db_host},
+                                                      port => $self->{centreon_config}->{db_port},
+                                                      user => $self->{centreon_config}->{db_user},
+                                                      password => $self->{centreon_config}->{db_passwd},
+                                                      force => 0,
+                                                      logger => $self->{logger});
+    if ($self->{centreon_dbc}->connect() == -1) {
+        exit(1);
+    }
+    
+    $self->main();
+    exit(0);
+}
+
+1;

--- a/perl-libs/lib/centreon/script/centreonSyncArchives.pm
+++ b/perl-libs/lib/centreon/script/centreonSyncArchives.pm
@@ -1,0 +1,86 @@
+################################################################################
+# Copyright 2005-2013 Centreon
+# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+# 
+# This program is free software; you can redistribute it and/or modify it under 
+# the terms of the GNU General Public License as published by the Free Software 
+# Foundation ; either version 2 of the License.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with 
+# this program; if not, see <http://www.gnu.org/licenses>.
+# 
+# Linking this program statically or dynamically with other modules is making a 
+# combined work based on this program. Thus, the terms and conditions of the GNU 
+# General Public License cover the whole combination.
+# 
+# As a special exception, the copyright holders of this program give Centreon 
+# permission to link this program with independent modules to produce an executable, 
+# regardless of the license terms of these independent modules, and to copy and 
+# distribute the resulting executable under terms of Centreon choice, provided that 
+# Centreon also meet, for each linked independent module, the terms  and conditions 
+# of the license of that module. An independent module is a module which is not 
+# derived from this program. If you modify this program, you may extend this 
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+# 
+#
+####################################################################################
+
+package centreon::script::centreonSyncArchives;
+
+use strict;
+use warnings;
+use centreon::script;
+
+use base qw(centreon::script);
+
+sub new {
+    my $class = shift;
+    my $self = $class->SUPER::new("centreonSyncArchives",
+        centreon_db_conn => 0,
+        centstorage_db_conn => 0
+    );
+    bless $self, $class;
+    $self->{rsync} = "rsync";
+    return $self;
+}
+
+sub run {
+    my $self = shift;
+
+    $self->SUPER::run();
+    my $cdb = centreon::common::db->new(db => $self->{centreon_config}->{centreon_db},
+                                        host => $self->{centreon_config}->{db_host},
+                                        port => $self->{centreon_config}->{db_port},
+                                        user => $self->{centreon_config}->{db_user},
+                                        password => $self->{centreon_config}->{db_passwd},
+                                        force => 0,
+                                        logger => $self->{logger});
+    my ($status, $sth) = $cdb->query("SELECT nagios_server.id, nagios_server.ns_ip_address, nagios_server.ssh_port, cfg_nagios.log_file FROM nagios_server, cfg_nagios
+                                      WHERE nagios_server.ns_activate = '1' AND nagios_server.localhost = '0' AND nagios_server.id = cfg_nagios.nagios_server_id");
+    die("Error SQL Quit") if ($status == -1);
+    while ((my $data = $sth->fetchrow_hashref())) {
+        $data->{log_archive_path} = $data->{log_file};
+        $data->{log_archive_path} =~ s#(.*)/.*#$1/archives/#;
+		if (defined($data->{log_archive_path}) && $data->{log_archive_path} ne '') {
+			`$self->{rsync} -c -e "ssh -o port=$data->{'ssh_port'}" $data->{'ns_ip_address'}:$data->{'log_archive_path'}/* $self->{centreon_config}->{VarLib}/log/$data->{'id'}/archives/`;
+		} else {
+			$self->{logger}->writeLogError("Can't get archive path for service " . $data->{'id'} . " (" . $data->{'ns_address_ip'} . ")");
+		}		
+	}
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+    sample - Using GetOpt::Long and Pod::Usage
+
+=cut

--- a/perl-libs/lib/centreon/script/centreonSyncPlugins.pm
+++ b/perl-libs/lib/centreon/script/centreonSyncPlugins.pm
@@ -1,0 +1,94 @@
+################################################################################
+# Copyright 2005-2013 Centreon
+# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+# 
+# This program is free software; you can redistribute it and/or modify it under 
+# the terms of the GNU General Public License as published by the Free Software 
+# Foundation ; either version 2 of the License.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with 
+# this program; if not, see <http://www.gnu.org/licenses>.
+# 
+# Linking this program statically or dynamically with other modules is making a 
+# combined work based on this program. Thus, the terms and conditions of the GNU 
+# General Public License cover the whole combination.
+# 
+# As a special exception, the copyright holders of this program give Centreon 
+# permission to link this program with independent modules to produce an executable, 
+# regardless of the license terms of these independent modules, and to copy and 
+# distribute the resulting executable under terms of Centreon choice, provided that 
+# Centreon also meet, for each linked independent module, the terms  and conditions 
+# of the license of that module. An independent module is a module which is not 
+# derived from this program. If you modify this program, you may extend this 
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+# 
+#
+####################################################################################
+
+package centreon::script::centreonSyncPlugins;
+
+use strict;
+use warnings;
+use centreon::script;
+
+use base qw(centreon::script);
+
+sub new {
+    my $class = shift;
+    my $self = $class->SUPER::new("centreonSyncPlugins",
+        centreon_db_conn => 0,
+        centstorage_db_conn => 0
+    );
+    bless $self, $class;
+    $self->{rsync} = "rsync";
+    $self->{ssh} = "ssh";
+    return $self;
+}
+
+sub run {
+    my $self = shift;
+
+    $self->SUPER::run();
+    my $cdb = centreon::common::db->new(db => $self->{centreon_config}->{centreon_db},
+                                        host => $self->{centreon_config}->{db_host},
+                                        port => $self->{centreon_config}->{db_port},
+                                        user => $self->{centreon_config}->{db_user},
+                                        password => $self->{centreon_config}->{db_passwd},
+                                        force => 0,
+                                        logger => $self->{logger});
+    my ($status, $sth) = $cdb->query("SELECT `value` FROM `options` WHERE `key` LIKE 'nagios_path_plugins' LIMIT 1");
+    die("Error SQL Quit") if ($status == -1);
+    my $data = $sth->fetchrow_hashref();
+    if (!defined($data->{value}) || $data->{value} eq '') {
+        $self->{logger}->writeLogError("Plugin path is not set.");
+        die("Quit");
+    }
+    my $path_plugins = $data->{value};
+    
+    ($status, $sth) = $cdb->query("SELECT `id`, `ns_ip_address`, `ssh_port` FROM `nagios_server` WHERE `ns_activate` = '1' AND `localhost` = '0'");
+    die("Error SQL Quit") if ($status == -1);
+    while ((my $data = $sth->fetchrow_hashref())) {
+		my $ls = `$self->{ssh} -q -p $data->{'ssh_port'} $data->{'ns_ip_address'} ls -l $path_plugins/ 2>> /dev/null | wc -l`;
+        if ($ls > 1) {
+            `$self->{rsync} -e "ssh -o port=$data->{'ssh_port'}" -prc $path_plugins/* $data->{'ns_ip_address'}:$path_plugins/`;
+        } else {
+            $self->{logger}->writeLogError("Directory not present on remote server : " . $data->{'ns_ip_address'});
+        }
+	}
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+    sample - Using GetOpt::Long and Pod::Usage
+
+=cut

--- a/perl-libs/lib/centreon/script/centreon_health.pm
+++ b/perl-libs/lib/centreon/script/centreon_health.pm
@@ -1,0 +1,86 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::script::centreon_health;
+
+use strict;
+use warnings;
+use POSIX;
+use centreon::script;
+use base qw(centreon::script);
+
+use centreon::health::checkservers;
+use centreon::health::checkrrd;
+use centreon::health::checkdb;
+use centreon::health::checkmodules;
+use centreon::health::checksystems;
+use centreon::health::checkbroker;
+use centreon::health::checklogs;
+use centreon::health::output;
+
+sub new {
+    my $class = shift;
+    my $self = $class->SUPER::new("centreon_health",
+                                   centreon_db_conn => 1,
+                                   centstorage_db_conn => 1,
+				   noroot => 1,
+        			);
+    bless $self, $class;
+
+    $self->add_options(
+	"centstorage-db=s"	=> \$self->{opt_csdb},
+	"centreon-branch=s"	=> \$self->{opt_majorversion},
+	"check-protocol=s"	=> \$self->{opt_checkprotocol},
+	"output-format=s"	=> \$self->{opt_outputformat},
+	"snmp-community=s"	=> \$self->{opt_community},
+	"skip-rrd"		=> \$self->{opt_skiprrd},
+	"skip-db"		=> \$self->{opt_skipdb},
+	"skip-logs"		=> \$self->{opt_skiplogs},
+	"anonymous"		=> \$self->{opt_anonymous}
+    );
+	
+    $self->{data} = {};
+    $self->{final_output} = {};
+    $self->{opt_checkprotocol} = 'snmp';
+    $self->{opt_outputformat} = 'JSON' if (!defined$self->{opt_outputformat}); 
+    $self->{opt_community} = 'public' if (!defined $self->{opt_community});
+    $self->{opt_csdb} = 'centreon_storage' if (!defined $self->{opt_csdb});
+    $self->{opt_majorversion} = '2.8' if (!defined $self->{opt_majorversion});
+
+    return $self;
+}
+
+sub run {
+    my $self = shift;
+    $self->SUPER::run();
+
+    $self->{data}->{rrd} = centreon::health::checkrrd->new->run($self->{csdb}) if (!defined($self->{opt_skiprrd}));
+    $self->{data}->{database} = centreon::health::checkdb->new->run($self->{cdb}, $self->{csdb}, $self->{opt_csdb}) if (!defined($self->{opt_skipdb}));    
+    $self->{data}->{module} = centreon::health::checkmodules->new->run($self->{cdb});
+    $self->{data}->{server} = centreon::health::checkservers->new->run($self->{cdb}, $self->{csdb}, $self->{opt_majorversion});
+    $self->{data}->{systems} = centreon::health::checksystems->new->run($self->{data}->{server}->{poller}, $self->{opt_checkprotocol}, $self->{opt_community}, $self->{opt_majorversion});
+    $self->{data}->{broker} = centreon::health::checkbroker->new->run($self->{cdb}, $self->{data}->{server}->{poller}, $self->{opt_majorversion});
+    $self->{data}->{logs} = centreon::health::checklogs->new->run($self->{cdb}, $self->{data}->{server}->{poller}) if (!defined($self->{opt_skiplogs}));
+
+    centreon::health::output->new->run($self->{data}, $self->{opt_outputformat}, defined($self->{opt_skiprrd}), defined($self->{opt_skipdb}), defined($self->{opt_skiplogs}));
+
+}
+
+1;

--- a/perl-libs/lib/centreon/script/centreon_trap_send.pm
+++ b/perl-libs/lib/centreon/script/centreon_trap_send.pm
@@ -1,0 +1,105 @@
+################################################################################
+# Copyright 2005-2013 Centreon
+# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+# 
+# This program is free software; you can redistribute it and/or modify it under 
+# the terms of the GNU General Public License as published by the Free Software 
+# Foundation ; either version 2 of the License.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with 
+# this program; if not, see <http://www.gnu.org/licenses>.
+# 
+# Linking this program statically or dynamically with other modules is making a 
+# combined work based on this program. Thus, the terms and conditions of the GNU 
+# General Public License cover the whole combination.
+# 
+# As a special exception, the copyright holders of this program give Centreon 
+# permission to link this program with independent modules to produce an executable, 
+# regardless of the license terms of these independent modules, and to copy and 
+# distribute the resulting executable under terms of Centreon choice, provided that 
+# Centreon also meet, for each linked independent module, the terms  and conditions 
+# of the license of that module. An independent module is a module which is not 
+# derived from this program. If you modify this program, you may extend this 
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+# 
+#
+####################################################################################
+
+package centreon::script::centreon_trap_send;
+
+use strict;
+use warnings;
+use Net::SNMP;
+use centreon::script;
+
+use base qw(centreon::script);
+
+sub new {
+    my $class = shift;
+    my $self = $class->SUPER::new("centreon_trap_send",
+        centreon_db_conn => 0,
+        centstorage_db_conn => 0,
+        noconfig => 1
+    );
+
+    bless $self, $class;
+    $self->{opt_d} = 'localhost';
+    $self->{opt_snmpcommunity} = 'public';
+    $self->{opt_snmpversion} = 'snmpv2c';
+    $self->{opt_snmpport} = 162;
+    $self->{opt_oidtrap} = '.1.3.6.1.4.1.12182.1';
+    @{$self->{opt_args}} = ();
+    $self->add_options(
+        "d=s" => \$self->{opt_d}, "destination=s" => \$self->{opt_d},
+        "c=s" => \$self->{opt_snmpcommunity}, "community=s" => \$self->{opt_snmpcommunity},
+        "o=s" => \$self->{opt_oidtrap}, "oid=s" => \$self->{opt_oidtrap},
+        "snmpport=i" => \$self->{opt_snmpport},
+        "snmpversion=s" => \$self->{opt_snmpversion},
+        "a=s" => \@{$self->{opt_args}}, "arg=s" => \@{$self->{opt_args}}
+    );
+    $self->{timestamp} = time();
+    return $self;
+}
+
+sub run {
+    my $self = shift;
+
+    $self->SUPER::run();
+    my ($snmp_session, $error) = Net::SNMP->session(-hostname    => $self->{opt_d},
+                                                    -community    => $self->{opt_snmpcommunity},
+                                                    -port        => $self->{opt_snmpport},
+                                                    -version   => $self->{opt_snmpversion});
+    if (!defined($snmp_session)) {
+        $self->{logger}->writeLogError("UNKNOWN: SNMP Session : $error");
+        die("Quit");
+    }
+
+    my @oid_value = ();
+    foreach (@{$self->{opt_args}}) {
+        my ($oid, $type, $value) = split /:/, $_;
+        my $result;
+        my $ltmp = "\$result = Net::SNMP::$type;";
+        eval $ltmp;
+        push @oid_value,($oid, $result, $value);
+    }
+    unshift @oid_value,('1.3.6.1.6.3.1.1.4.1.0', OBJECT_IDENTIFIER, $self->{opt_oidtrap});
+    unshift @oid_value,('1.3.6.1.2.1.1.3.0', TIMETICKS, $self->{timestamp});
+    $snmp_session->snmpv2_trap(-varbindlist => \@oid_value);
+    $snmp_session->close();
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+    sample - Using GetOpt::Long and Pod::Usage
+
+=cut

--- a/perl-libs/lib/centreon/script/centreontrapd.pm
+++ b/perl-libs/lib/centreon/script/centreontrapd.pm
@@ -1,0 +1,1354 @@
+################################################################################
+# Copyright 2005-2013 Centreon
+# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+# 
+# This program is free software; you can redistribute it and/or modify it under 
+# the terms of the GNU General Public License as published by the Free Software 
+# Foundation ; either version 2 of the License.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with 
+# this program; if not, see <http://www.gnu.org/licenses>.
+# 
+# Linking this program statically or dynamically with other modules is making a 
+# combined work based on this program. Thus, the terms and conditions of the GNU 
+# General Public License cover the whole combination.
+# 
+# As a special exception, the copyright holders of this program give Centreon 
+# permission to link this program with independent modules to produce an executable, 
+# regardless of the license terms of these independent modules, and to copy and 
+# distribute the resulting executable under terms of Centreon choice, provided that 
+# Centreon also meet, for each linked independent module, the terms  and conditions 
+# of the license of that module. An independent module is a module which is not 
+# derived from this program. If you modify this program, you may extend this 
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+# 
+#
+####################################################################################
+
+package centreon::script::centreontrapd;
+
+use strict;
+use warnings;
+use POSIX;
+use Socket;
+use Storable;
+use centreon::script;
+use centreon::common::db;
+use centreon::common::misc;
+use centreon::trapd::lib;
+use centreon::trapd::Log;
+
+use base qw(centreon::script);
+use vars qw(%centreontrapd_config);
+
+my %handlers = ('TERM' => {}, 'HUP' => {}, 'DIE' => {}, 'CHLD' => {});
+
+sub new {
+    my $class = shift;
+    my $self = $class->SUPER::new('centreontrapd',
+        centreon_db_conn => 0,
+        centstorage_db_conn => 0
+    );
+
+    bless $self, $class;
+    $self->add_options(
+        "config-extra=s" => \$self->{opt_extra},
+    );
+
+    %{$self->{centreontrapd_default_config}} = (
+       timeout_end => 30,
+       spool_directory => "/var/spool/centreontrapd/",
+       sleep => 2,
+       use_trap_time => 1,
+       net_snmp_perl_enable => 1,
+       mibs_environment => '',
+       remove_backslash_from_quotes => 1,
+       dns_enable => 0,
+       separator => ' ',
+       strip_domain => 0,
+       strip_domain_list => [],
+       duplicate_trap_window => 1,
+       date_format => "",
+       time_format => "",
+       date_time_format => "",
+       cache_unknown_traps_retention => 600,
+       # secure mode: 1 => cannot use customcode option for traps
+       secure_mode => 1,
+       # 0 = central, 1 = poller
+       mode => 0,
+       cmd_timeout => 10,
+       centreon_user => "centreon",
+       # 0 => skip if MySQL error | 1 => dont skip (block) if MySQL error (and keep order)
+       policy_trap => 1,
+       # Log DB
+       log_trap_db => 0,
+       log_transaction_request_max => 500,
+       log_transaction_timeout => 10,
+       log_purge_time => 600,
+       # unknown
+       unknown_trap_enable => 0,
+       unknown_trap_mode => 0,
+       unknown_trap_file => '/var/log/centreon/centreontrapd_unknown.log',
+       unknown_trap_facility => undef,
+       # local_broker
+       local_broker => undef,
+    );
+   
+    # save trap_data
+    @{$self->{trap_data_save}} = ();
+   
+    $self->{trap_data} = {
+        var => [],                      # Variables of trap received by SNMPTRAPD
+        entvar => [],                   # Enterprise variable values of trap received by SNMPTRAPD
+        entvarname => [],               # Enterprise variable names of trap received by SNMPTRAPD
+        preexec => [],                  # Result from PREEXEC
+        agent_dns_name => undef,
+        trap_date => undef,
+        trap_time => undef,
+        trap_date_time => undef,
+        trap_date_time_epoch => undef,
+        
+        ref_oids => undef,
+        ref_hosts => undef,
+        ref_services => undef,
+        ref_macro_hosts => undef,
+        
+        current_trap_id => undef,
+        current_host_id => undef,
+        current_service_id => undef
+    };
+   
+    $self->{htmlentities} = 0;   
+    %{$self->{duplicate_traps}} = ();
+    $self->{timetoreload} = 0;
+    @{$self->{filenames}} = undef;
+    $self->{oids_cache} = undef;
+    $self->{last_cache_time} = undef;
+    $self->{whoami} = undef;
+
+ 
+    # Fork manage
+    $self->{return_child} = {};
+    $self->{running_processes} = {};
+    $self->{sequential_processes} = {
+        pid => {},
+        trap_id => {}
+    };
+    $self->{last_time_exec} = { oid => {}, host => {} };
+
+    # Current ID of working
+    $self->{current_host_id} = undef;
+    $self->{current_hostname} = undef;
+    $self->{current_server_id} = undef;
+    $self->{current_service_id} = undef;
+    $self->{current_server_ip_address} = undef;
+    $self->{current_service_desc} = undef;
+    $self->{current_trap_id} = undef;
+    $self->{current_ip} = undef;
+    $self->{current_oid} = undef;
+    # From centreon DB
+    $self->{current_trap_name} = undef;
+    $self->{current_trap_log} = undef;
+    $self->{current_vendor_name} = undef;
+    
+    $self->{current_alarm_timeout} = undef;
+    
+    # After in fork
+    $self->{traps_global_output} = undef;
+    $self->{traps_global_status} = undef;
+    $self->{traps_global_severity_id} = undef;
+    $self->{traps_global_severity_name} = undef;
+    $self->{traps_global_severity_level} = undef;
+    
+    # For policy_trap = 1 (temp). To avoid doing the same thing twice
+    # ID oid ===> Host ID ===> Service ID
+    %{$self->{policy_trap_skip}} = ();
+    $self->{digest_trap} = undef;
+    
+    $self->{cmdFile} = undef;
+    $self->{cmdDir} = undef;
+    
+    # Pipe for log DB 
+    %{$self->{logdb_pipes}} = (running => 0);
+    $self->{pid_logdb_child} = undef;
+    # For protocol
+    $self->{id_logdb} = 0;
+    
+    # redefine to avoid out when we try modules
+    $SIG{__DIE__} = 'IGNORE';
+    return $self;
+}
+
+sub init {
+    my $self = shift;
+    $self->SUPER::init();
+    
+    if (!defined($self->{opt_extra})) {
+        $self->{opt_extra} = "/etc/centreon/centreontrapd.pm";
+    }
+    if (-f $self->{opt_extra}) {
+        require $self->{opt_extra};
+    } else {
+        $self->{logger}->writeLogInfo("Can't find extra config file $self->{opt_extra}");
+    }
+    
+    $self->{logger}->withpid(1);
+
+    $self->{centreontrapd_config} = {%{$self->{centreontrapd_default_config}}, %centreontrapd_config};
+    
+    if ($self->{centreontrapd_config}->{unknown_trap_enable} == 1) {
+        $self->{logger_unknown} = centreon::common::logger->new();
+        if ($self->{centreontrapd_config}->{unknown_trap_mode} == 1) {
+            $self->{logger_unknown}->file_mode($self->{centreontrapd_config}->{unknown_trap_file});
+        }
+        $self->{logger_unknown}->severity("info");
+    }
+    
+    ($self->{centreontrapd_config}->{date_format}, $self->{centreontrapd_config}->{time_format}) = 
+        centreon::trapd::lib::manage_params_conf(
+            $self->{centreontrapd_config}->{date_format},
+            $self->{centreontrapd_config}->{time_format}
+        );
+    centreon::trapd::lib::init_modules(logger => $self->{logger}, config => $self->{centreontrapd_config}, htmlentities => \$self->{htmlentities});
+    
+    $self->set_signal_handlers;
+}
+
+sub set_signal_handlers {
+    my $self = shift;
+
+    $SIG{TERM} = \&class_handle_TERM;
+    $handlers{TERM}->{$self} = sub { $self->handle_TERM() };
+    $SIG{HUP} = \&class_handle_HUP;
+    $handlers{HUP}->{$self} = sub { $self->handle_HUP() };
+    $SIG{__DIE__} = \&class_handle_DIE;
+    $handlers{DIE}->{$self} = sub { $self->handle_DIE($_[0]) };
+    $SIG{CHLD} = \&class_handle_CHLD;
+    $handlers{CHLD}->{$self} = sub { $self->handle_CHLD() };
+}
+
+sub class_handle_TERM {
+    foreach (keys %{$handlers{TERM}}) {
+        &{$handlers{TERM}->{$_}}();
+    }
+}
+
+sub class_handle_HUP {
+    foreach (keys %{$handlers{HUP}}) {
+        &{$handlers{HUP}->{$_}}();
+    }
+}
+
+sub class_handle_CHLD {
+    foreach (keys %{$handlers{CHLD}}) {
+        &{$handlers{CHLD}->{$_}}();
+    }
+}
+
+sub class_handle_DIE {
+    my ($msg) = @_;
+
+    foreach (keys %{$handlers{DIE}}) {
+        &{$handlers{DIE}->{$_}}($msg);
+    }
+}
+
+sub handle_TERM {
+    my $self = shift;
+    $self->{logger}->writeLogInfo("$$ Receiving order to stop...");
+    die("Quit");
+}
+
+sub handle_HUP {
+    my $self = shift;
+    $self->{logger}->writeLogInfo("$$ Receiving order to reload...");
+    $self->{timetoreload} = 1;
+}
+
+sub handle_DIE {
+    my $self = shift;
+    my $msg = shift;
+
+    $self->{logger}->writeLogInfo($msg);
+
+    ###
+    # Send -TERM signal
+    ###
+    if (defined($self->{logdb_pipes}{running}) && $self->{logdb_pipes}{running} == 1) {
+        $self->{logger}->writeLogInfo("Send -TERM signal to logdb process..");
+        kill('TERM', $self->{pid_logdb_child});
+    }
+    
+    # We're waiting n seconds
+    for (my $i = 0; $i < $self->{centreontrapd_config}->{timeout_end}; $i++) {
+        $self->manage_pool(0);
+        if (keys %{$self->{running_processes}} == 0 && $self->{logdb_pipes}{running} == 0) {
+            $self->{logger}->writeLogInfo("Main process exit.");
+            exit(0);
+        }
+        sleep 1;
+    }
+
+    $self->{logger}->writeLogInfo("Dont handle gently. Send KILL Signals to childs");
+    # Last check before
+    $self->manage_pool(0);
+
+    # We are killing
+    foreach (keys %{$self->{running_processes}}) {
+        kill('KILL', $_);
+        $self->{logger}->writeLogInfo("Send -KILL signal to child process '$_'..");
+    }
+    if ($self->{logdb_pipes}{'running'} == 1) {
+        kill('KILL', $self->{pid_logdb_child});
+        $self->{logger}->writeLogInfo("Send -KILL signal to logdb process..");
+    }
+
+    exit(0);
+}
+
+sub handle_CHLD {
+    my $self = shift;
+    my $child_pid;
+
+    while (($child_pid = waitpid(-1, &WNOHANG)) > 0) {
+        $self->{return_child}{$child_pid} = {'exit_code' => $? >> 8};
+        $self->{logger}->writeLogInfo("SIGCHLD received: $child_pid");
+    }
+    $SIG{CHLD} = \&class_handle_CHLD;
+}
+
+sub reload_config {
+    my $self = shift;
+    my $file = $_[0];
+    
+    unless (my $return = do $file) {
+        $self->{logger}->writeLogError("couldn't parse $file: $@") if $@;
+        $self->{logger}->writeLogError("couldn't do $file: $!") unless defined $return;
+        $self->{logger}->writeLogError("couldn't run $file") unless $return;
+    }
+}
+
+sub reload {
+    my $self = shift;
+
+    $self->{logger}->writeLogInfo("Reload in progress for main process...");
+    
+    # reopen file
+    if ($self->{logger}->is_file_mode()) {
+        $self->{logger}->file_mode($self->{logger}->{file_name});
+    }
+    $self->{logger}->redirect_output();
+    if ($self->{centreontrapd_config}->{unknown_trap_enable} == 1 && $self->{centreontrapd_config}->{unknown_trap_mode} == 1) {
+        $self->{logger_unknown}->file_mode($self->{centreontrapd_config}->{unknown_trap_file});
+    }
+    
+    centreon::common::misc::reload_db_config($self->{logger}, $self->{config_file});
+    if ($self->{centreontrapd_config}->{mode} == 0) {
+    	centreon::common::misc::check_debug($self->{logger}, "debug_centreontrapd", $self->{cdb}, "centreontrapd main process");
+    }
+
+    if ($self->{cdb}->type() =~ /SQLite/i) {
+        $self->{logger}->writeLogInfo("Sqlite database. Need to disconnect and connect file.");
+        $self->{cdb}->disconnect();
+        $self->{cdb}->connect();
+    }
+    
+    if ($self->{logdb_pipes}{running} == 1) {
+        kill('HUP', $self->{pid_logdb_child});
+        $self->{logger}->writeLogInfo("Send -HUP signal to logdb process..");
+    }
+    
+    $self->reload_config($self->{opt_extra});
+    ($self->{centreontrapd_config}->{date_format}, $self->{centreontrapd_config}->{time_format}) = 
+        centreon::trapd::lib::manage_params_conf(
+            $self->{centreontrapd_config}->{date_format},
+            $self->{centreontrapd_config}->{time_format}
+        );
+    # redefine to avoid out when we try modules
+    $SIG{__DIE__} = 'IGNORE';
+    centreon::trapd::lib::init_modules(logger => $self->{logger}, config => $self->{centreontrapd_config}, htmlentities => \$self->{htmlentities});
+    $self->set_signal_handlers;
+
+    centreon::trapd::lib::get_cache_oids(cdb => $self->{cdb}, oids_cache => \$self->{oids_cache}, last_cache_time => \$self->{last_cache_time});
+    $self->{timetoreload} = 0;
+}
+
+sub create_logdb_child {
+    my $self = shift;
+    my ($reader_pipe, $writer_pipe);
+
+    pipe($reader_pipe, $writer_pipe);
+    $writer_pipe->autoflush(1);
+
+    $self->{logdb_pipes}{reader} = \*$reader_pipe;
+    $self->{logdb_pipes}{writer} = \*$writer_pipe;
+    
+    $self->{logger}->writeLogInfo("Create logdb child");
+    my $current_pid = fork();
+    if (!$current_pid) {
+        # Unhandle die in child
+        $SIG{CHLD} = 'IGNORE';
+        $SIG{__DIE__} = 'IGNORE';
+        $self->{cdb}->set_inactive_destroy();
+
+        close $self->{logdb_pipes}{writer};
+        my $centreon_db_centstorage;
+        if ($self->{centreontrapd_config}->{mode} == 0) { 
+            $centreon_db_centstorage = centreon::common::db->new(
+                db => $self->{centreon_config}->{centstorage_db},
+                host => $self->{centreon_config}->{db_host},
+                port => $self->{centreon_config}->{db_port},
+                user => $self->{centreon_config}->{db_user},
+                password => $self->{centreon_config}->{db_passwd},
+                force => 1,
+                logger => $self->{logger}
+            );
+        } elsif ($self->{centreontrapd_config}->{mode} == 1) {
+            $centreon_db_centstorage = centreon::common::db->new(
+                db => $self->{centreontrapd_config}->{centreon_db},
+                host => $self->{centreontrapd_config}->{db_host},
+                port => $self->{centreontrapd_config}->{db_port},
+                user => $self->{centreontrapd_config}->{db_user},
+                password => $self->{centreontrapd_config}->{db_passwd},
+                type => $self->{centreontrapd_config}->{db_type},
+                force => 1,
+                logger => $self->{logger}
+            );
+        }
+        $centreon_db_centstorage->connect();
+
+        my $centreontrapd_log = centreon::trapd::Log->new($self->{logger});
+        $centreontrapd_log->main(
+            $centreon_db_centstorage,
+            $self->{logdb_pipes}{reader},
+            $self->{config_file},
+            $self->{centreontrapd_config}
+        );
+        exit(0);
+    }
+    $self->{pid_logdb_child} = $current_pid;
+    close $self->{logdb_pipes}{reader};
+    $self->{logdb_pipes}{running} = 1;
+}
+
+sub manage_pool {
+    my $self = shift;
+    my ($create_pool) = @_;
+        
+    foreach my $child_pid (keys %{$self->{return_child}}) {
+    
+        if (defined($self->{sequential_processes}->{pid}->{$child_pid})) {
+            delete $self->{sequential_processes}->{trap_id}->{ $self->{sequential_processes}->{pid}->{$child_pid} };
+            delete $self->{sequential_processes}->{pid}->{$child_pid};
+        }
+    
+        if (defined($self->{running_processes}->{$child_pid})) {
+            delete $self->{running_processes}->{$child_pid};
+            delete $self->{return_child}->{$child_pid};
+        }
+        
+        if (defined($self->{pid_logdb_child}) && $child_pid == $self->{pid_logdb_child}) {
+            $self->{logger}->writeLogInfo("Logdb child is dead");
+            $self->{logdb_pipes}{running} = 0;
+            if ($self->{centreontrapd_config}->{log_trap_db} == 1 && defined($create_pool) && $create_pool == 1) {
+                $self->create_logdb_child();
+            }
+            delete $self->{return_child}{$child_pid};
+        }
+    }
+}
+
+###############################
+## Save and Play functions
+#
+
+sub set_current_values {
+    my $self = shift;
+    
+    $self->{current_trap_id} = $self->{trap_data}->{current_trap_id};
+    $self->{current_host_id} = $self->{trap_data}->{current_host_id};
+    $self->{current_service_id} = $self->{trap_data}->{current_service_id};
+    
+    $self->{current_ip} = $self->{trap_data}->{var}->[1];
+    $self->{current_oid} = $self->{trap_data}->{var}->[3];
+    $self->{current_trap_log} = $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_log};
+    $self->{current_trap_name} = $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_name};
+    $self->{current_vendor_name} = $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{name};
+    $self->{current_server_id} = $self->{trap_data}->{ref_hosts}->{ $self->{current_host_id} }->{nagios_server_id};
+    $self->{current_server_ip_address} = $self->{trap_data}->{ref_hosts}->{ $self->{current_host_id} }->{ns_ip_address};
+    $self->{current_hostname} = $self->{trap_data}->{ref_hosts}->{ $self->{current_host_id} }->{host_name};
+    $self->{current_service_desc} = $self->{trap_data}->{ref_services}->{ $self->{current_service_id} }->{service_description};
+    $self->{current_service_notes} = defined($self->{trap_data}->{ref_services}->{ $self->{current_service_id} }->{esi_notes}) ?
+        $self->{trap_data}->{ref_services}->{ $self->{current_service_id} }->{esi_notes} : '';
+    $self->{current_user_arg1} = defined($self->{user_arg1}) ? $self->{user_arg1} : '';
+    $self->{current_user_arg2} = defined($self->{user_arg2}) ? $self->{user_arg2} : '';
+}
+
+sub check_sequential_can_exec {
+    my $self = shift;
+
+    if (defined($self->{sequential_processes}->{trap_id}->{$self->{current_host_id} . "_" . $self->{current_trap_id}})) {
+        # We save data
+        $self->{logger}->writeLogInfo("Put trap " . $self->{current_trap_id} . " in queue...");
+        push @{$self->{trap_data_save}}, Storable::dclone($self->{trap_data});
+        return 1;
+    }
+    foreach (@{$self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_group}}) {
+        if (defined($self->{sequential_processes}->{trap_id}->{$self->{current_host_id} . "_" . $_})) {
+            # We save data
+            $self->{logger}->writeLogInfo("Put trap " . $self->{current_trap_id} . " in queue (trap_id $_ is in execution)...");
+            push @{$self->{trap_data_save}}, Storable::dclone($self->{trap_data});
+            return 1;
+        }
+    }
+        
+    return 0;
+}
+
+sub check_sequential_todo {
+    my $self = shift;
+    
+    for (my $i = 0; $i <= $#{$self->{trap_data_save}}; $i++) {
+        if (!defined($self->{sequential_processes}->{trap_id}->{ $self->{trap_data_save}->[$i]->{current_host_id} . "_" . $self->{trap_data_save}->[$i]->{current_trap_id} })) {
+            my $group = 0;
+            foreach (@{$self->{trap_data_save}->[$i]->{ref_oids}->{ $self->{trap_data_save}->[$i]->{current_trap_id} }->{traps_group}}) {
+                if (defined($self->{sequential_processes}->{trap_id}->{ $self->{trap_data_save}->[$i]->{current_host_id} . "_" . $_ })) {
+                    # still some running
+                    $group = 1;
+                    last;
+                }
+            }
+            next if ($group == 1);
+
+            $self->{logger}->writeLogInfo("Exec trap in queue (trap_id " . $self->{trap_data_save}->[$i]->{current_trap_id} . ") ...");
+            $self->{trap_data} = splice @{$self->{trap_data_save}}, $i, 1;
+            $i--;
+            $self->manage_exec();
+        }
+    }
+}
+
+###############################
+## Execute a command Nagios or Centcore
+#
+sub do_exec {
+    my $self = shift;
+    my $matching_result = 0;
+    
+    $self->{traps_global_status} = $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_status};
+    $self->{traps_global_severity_id} = $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{sc_id};
+    $self->{traps_global_severity_name} = $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{sc_name};
+    $self->{traps_global_severity_level} = $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{level};
+    
+    # PREEXEC commands
+    $self->execute_preexec();
+
+    $self->{traps_global_output} = $self->substitute_string($self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_args});
+    # Check if a transform is needed
+    if (defined($self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_output_transform}) &&
+        $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_output_transform} ne '') {
+        eval "\$self->{traps_global_output} =~ $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_output_transform};";
+        if ($@) {
+            $self->{logger}->writeLogError("Output transform not valid for " . $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_name});
+        }
+    }
+    
+    ######################################################################
+    # Advanced matching rules
+    if (defined($self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_advanced_treatment}) && 
+        $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_advanced_treatment} == 1) {
+        $matching_result = $self->checkMatchingRules();
+    }
+
+    #####################################################################
+    # Submit value to passive service
+    if (defined($self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_submit_result_enable}) && 
+        $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_submit_result_enable} == 1 &&
+        $matching_result == 0) {
+        $self->submitResult();
+    }
+
+    ######################################################################
+    # Force service execution with external command
+    if (defined($self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_reschedule_svc_enable}) && 
+        $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_reschedule_svc_enable} == 1) {
+        $self->forceCheck();
+    }
+
+    ######################################################################
+    # Execute special command
+    if (defined($self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_execution_command_enable}) && 
+        $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_execution_command_enable} == 1) {
+        $self->executeCommand();
+    }
+    
+    if ($self->{centreontrapd_config}->{log_trap_db} == 1 && $self->{current_trap_log} == 1) {
+        centreon::trapd::lib::send_logdb(
+            pipe => $self->{logdb_pipes}{writer},
+            id => $self->{id_logdb},
+            cdb => $self->{cdb},
+            trap_time => $self->{trap_data}->{trap_date_time_epoch},
+            timeout => 0,
+            host_name => $self->{trap_data}->{var}->[0],
+            ip_address => $self->{current_ip},
+            agent_host_name => $self->{trap_data}->{agent_dns_name},
+            agent_ip_address => $self->{trap_data}->{var}->[4],
+            trap_oid => $self->{current_oid},
+            trap_name => $self->{current_trap_name},
+            vendor => $self->{current_vendor_name},
+            status => $self->{traps_global_status},
+            severity_id => $self->{traps_global_severity_id},
+            severity_name => $self->{traps_global_severity_name},
+            output_message => $self->{traps_global_output},
+            entvar => \@{$self->{trap_data}->{entvar}},
+            entvarname => \@{$self->{trap_data}->{entvarname}}
+        );
+    }
+}
+
+sub manage_exec {
+    my $self = shift;
+
+    $self->set_current_values();
+    
+    #### Fork And manage exec ####
+    ####### Check Interval ######
+    if (defined($self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_exec_interval_type}) && 
+        $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_exec_interval_type} ne '' &&
+        defined($self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_exec_interval})) {
+        # OID type
+        if ($self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_exec_interval_type} == 1 &&
+            defined($self->{last_time_exec}->{oid}->{ $self->{current_oid} }) &&
+            $self->{trap_data}->{trap_date_time_epoch} < ($self->{last_time_exec}->{oid}->{ $self->{current_oid} } + $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_exec_interval})) {
+            $self->{logger}->writeLogInfo("Skipping trap '" . $self->{current_trap_id} . "': time interval");
+            return 1;
+        }
+        
+        # Host type
+        if ($self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_exec_interval_type} == 2 &&
+            defined($self->{last_time_exec}->{host}->{ $self->{current_host_id} . ";" . $self->{current_oid} }) &&
+            $self->{trap_data}->{trap_date_time_epoch} < ($self->{last_time_exec}->{host}->{ $self->{current_host_id} . ";" . $self->{current_oid} } + $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_exec_interval})) {
+            $self->{logger}->writeLogInfo("Skipping trap '" . $self->{current_trap_id} . "' for host ID '" . $self->{current_host_id} . "': time interval");
+            return 1;
+        }
+        
+        # Host/Service type
+        if ($self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_exec_interval_type} == 3 &&
+            defined($self->{last_time_exec}->{host}->{ $self->{current_host_id} . ";" . $self->{current_service_id} . ";" . $self->{current_oid} }) &&
+            $self->{trap_data}->{trap_date_time_epoch} < ($self->{last_time_exec}->{host}->{ $self->{current_host_id} . ";" . $self->{current_service_id} . ";" . $self->{current_oid} } + $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_exec_interval})) {
+            $self->{logger}->writeLogInfo("Skipping trap '" . $self->{current_trap_id} . "' for host ID '" . $self->{current_host_id} . "' and service ID '" . $self->{current_service_id} . "': time interval");
+            return 1;
+        }
+    }
+    
+    ### Check Sequential exec ###
+    return 1 if ($self->check_sequential_can_exec() == 1);
+    
+    $self->{id_logdb}++;
+    
+    my $current_pid = fork();
+    if (!$current_pid) {
+        # Unhandle die in child
+        $SIG{CHLD} = 'IGNORE';
+        $SIG{__DIE__} = 'IGNORE';
+        $self->{cdb}->set_inactive_destroy();
+        if (defined($self->{csdb})) {
+            $self->{csdb}->set_inactive_destroy();
+        }
+
+        $self->{current_alarm_timeout} = $self->{centreontrapd_config}->{cmd_timeout};
+        if (defined($self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_timeout}) && $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_timeout} != 0) {
+            $self->{current_alarm_timeout} = $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_timeout};
+        }
+        $self->do_exec();
+
+        exit(1);
+    }
+    
+    $self->{logger}->writeLogInfo("CHLD command launched: $current_pid");
+    
+    ####
+    # Save to say it's sequential
+    if (defined($self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_exec_method}) && 
+        $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_exec_method} == 1) {
+        $self->{sequential_processes}->{pid}->{$current_pid} = $self->{current_host_id} . "_" . $self->{current_trap_id};
+        $self->{sequential_processes}->{trap_id}->{ $self->{current_host_id} . "_" . $self->{current_trap_id} } = $current_pid;
+    }
+
+    $self->{running_processes}->{$current_pid} = 1;
+    $self->{last_time_exec}->{oid}->{$self->{current_oid}} = $self->{trap_data}->{trap_date_time_epoch};
+    $self->{last_time_exec}->{host}->{$self->{current_host_id} . ";" . $self->{current_oid}} = $self->{trap_data}->{trap_date_time_epoch};
+    $self->{last_time_exec}->{host}->{$self->{current_host_id} . ";" . $self->{current_service_id} . ";" . $self->{current_oid}} = $self->{trap_data}->{trap_date_time_epoch};
+    return 1;
+}
+
+######################################
+## Force a new check for selected services
+#
+sub forceCheck {
+    my $self = shift;
+    my $datetime = time();
+    my $submit;
+
+    my $str = "SCHEDULE_FORCED_SVC_CHECK;$self->{current_hostname};$self->{current_service_desc};$datetime";
+    my $prefix = "";
+    if ($self->{centreontrapd_config}->{mode} == 0) {
+        $prefix = "EXTERNALCMD:$self->{current_server_id}:";
+    }
+    
+    if ($self->{whoami} eq $self->{centreontrapd_config}->{centreon_user}) {
+        $str =~ s/"/\\"/g;
+        if (defined($self->{cmdDir})) {
+            $submit = '/bin/echo "' . $prefix .  "[$datetime] $str\" >> " . $self->{cmdDir} . "/" . $datetime . "-traps";
+        } else {
+            $submit = '/bin/echo "' . $prefix .  "[$datetime] $str\" >> " . $self->{cmdFile};
+        }
+    } else {
+        $str =~ s/'/'\\''/g;
+        $str =~ s/"/\\"/g;
+        if (defined($self->{cmdDir})) {
+            $submit = "su -l " . $self->{centreontrapd_config}->{centreon_user} . " -c '/bin/echo \"" . $prefix . "[$datetime] $str\" >> " . $self->{cmdDir} . "/" . $datetime . "-traps' 2>&1";
+        } else {
+            $submit = "su -l " . $self->{centreontrapd_config}->{centreon_user} . " -c '/bin/echo \"" . $prefix . "[$datetime] $str\" >> " . $self->{cmdFile} . "' 2>&1";
+        }
+    }
+    
+    my ($lerror, $stdout) = centreon::common::misc::backtick(
+        command => $submit,
+        logger => $self->{logger},
+        timeout => $self->{current_alarm_timeout}
+    );
+    $self->{logger}->writeLogInfo("FORCE: Reschedule linked service");
+    $self->{logger}->writeLogInfo("FORCE: Launched command: $submit");
+    if (defined($stdout) && $stdout ne "") {
+        $self->{logger}->writeLogError("FORCE stdout: $stdout");
+    }
+}
+
+#######################################
+## Submit result via external command
+#
+
+sub submitResult_do {
+    my $self = shift;
+    my $str = $_[0];
+    my $datetime = time();
+    my $submit;
+
+    my $prefix = "";
+    if ($self->{centreontrapd_config}->{mode} == 0) {
+        $prefix = "EXTERNALCMD:$self->{current_server_id}:";
+    }
+    
+    if ($self->{whoami} eq $self->{centreontrapd_config}->{centreon_user}) {
+        $str =~ s/"/\\"/g;
+        if (defined($self->{cmdDir})) {
+            $submit = '/bin/echo "' . $prefix . "[$datetime] $str\" >> " . $self->{cmdDir} . "/" . $datetime . "-traps";
+        } else {
+            $submit = '/bin/echo "' . $prefix . "[$datetime] $str\" >> " . $self->{cmdFile};
+        }
+    } else {
+        $str =~ s/'/'\\''/g;
+        $str =~ s/"/\\"/g;
+		if (defined($self->{cmdDir})) {
+            $submit = "su -l " . $self->{centreontrapd_config}->{centreon_user} . " -c '/bin/echo \"" . $prefix . "[$datetime] $str\" >> " . $self->{cmdDir} . "/" . $datetime . "-traps' 2>&1";
+        } else {
+            $submit = "su -l " . $self->{centreontrapd_config}->{centreon_user} . " -c '/bin/echo \"" . $prefix . "[$datetime] $str\" >> " . $self->{cmdFile} . "' 2>&1";
+        }
+    }
+    my ($lerror, $stdout) = centreon::common::misc::backtick(
+        command => $submit,
+        logger => $self->{logger},
+        timeout => $self->{current_alarm_timeout}
+    );
+    
+    $self->{logger}->writeLogInfo("SUBMIT: Force service status via passive check update");
+    $self->{logger}->writeLogInfo("SUBMIT: Launched command: $submit");
+    if (defined($stdout) && $stdout ne "") {
+        $self->{logger}->writeLogError("SUBMIT RESULT stdout: $stdout");
+    }
+}
+
+sub submitResult {
+    my $self = shift;
+    
+    my $str = "PROCESS_SERVICE_CHECK_RESULT;$self->{current_hostname};$self->{current_service_desc};" . $self->{traps_global_status} . ";" . $self->{traps_global_output};
+    $self->submitResult_do($str);
+    
+    #####
+    # Severity
+    #####
+    return if (!defined($self->{traps_global_severity_id}) || $self->{traps_global_severity_id} eq ''); 
+    $str = "CHANGE_CUSTOM_SVC_VAR;$self->{current_hostname};$self->{current_service_desc};CRITICALITY_ID;" . $self->{traps_global_severity_id};
+    $self->submitResult_do($str);
+    $str = "CHANGE_CUSTOM_SVC_VAR;$self->{current_hostname};$self->{current_service_desc};CRITICALITY_LEVEL;" . $self->{traps_global_severity_level};
+    $self->submitResult_do($str);
+}
+
+sub execute_preexec {
+    my $self = shift;
+
+    foreach my $row (@{$self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_preexec}}) {
+        my $tpe_string = $row->{tpe_string};
+        $tpe_string = $self->substitute_string($tpe_string);
+        $tpe_string = $self->substitute_centreon_var($tpe_string);
+        
+        my ($lerror, $output, $exit_code) = centreon::common::misc::backtick(
+            command => $tpe_string,
+            logger => $self->{logger},
+            timeout => $self->{current_alarm_timeout},
+            wait_exit => 1
+        );
+        if ($exit_code == -1) {
+            $self->{logger}->writeLogError("EXEC prexec: Execution error: $!");
+        } elsif (($exit_code >> 8) != 0) {
+            $self->{logger}->writeLogInfo("EXEC preexec: Exit command: " . ($exit_code >> 8));
+        }
+        if (defined($output)) {
+            chomp $output;
+            push @{$self->{trap_data}->{preexec}}, $output;
+            $self->{logger}->writeLogInfo("EXEC preexec: Output : $output");
+        } else {
+            push @{$self->{trap_data}->{preexec}}, "";
+        }
+    }
+}
+
+sub execute_customcode {
+    my ($self, %options) = @_;
+
+    if ($self->{centreontrapd_config}->{secure_mode} == 1) {
+        $self->{logger}->writeLogInfo("Cannot exec customcode with secure_mode option to '1'. Need to change the option.");
+        return ;
+    }
+    {
+        my $error;
+        local $SIG{__DIE__} = sub { $error = $_[0]; };
+        eval "$self->{trap_data}->{ref_oids}->{ $self->{trap_data}->{current_trap_id} }->{traps_customcode}";
+        if (defined($error)) {
+            $self->{logger}->writeLogError("Customcode execution problem: " . $error);
+        }
+    }    
+}
+
+##########################
+## REPLACE
+#
+sub substitute_host_macro {
+    my $self = shift;
+    my $str = $_[0];
+    
+    if (defined($self->{ref_macro_hosts})) {
+        foreach my $macro_name (keys %{$self->{ref_macro_hosts}}) {
+            $str =~ s/\Q$macro_name\E/\Q$self->{ref_macro_hosts}->{$macro_name}\E/g;
+        }
+    }
+
+    return $str;
+}
+
+sub substitute_string {
+    my $self = shift;
+    my $str = $_[0];
+
+    # Substitute @{oid_value} and $1, $2,...
+    for (my $i=0; $i <= $#{$self->{trap_data}->{entvar}}; $i++) {
+        my $x = $i + 1;
+        $str =~ s/\@\{$self->{trap_data}->{entvarname}->[$i]\}/$self->{trap_data}->{entvar}->[$i]/g;
+        $str =~ s/\$$x([^0-9]|$)/$self->{trap_data}->{entvar}->[$i]$1/g;
+    }
+
+    # Substitute preexec var
+    for (my $i=0; $i <= $#{$self->{trap_data}->{preexec}}; $i++) {
+        my $x = $i + 1;
+        $str =~ s/\$p$x([^0-9]|$)/$self->{trap_data}->{preexec}->[$i]$1/g;
+    }
+
+    # Substitute $*
+    my $sub_str = join($self->{centreontrapd_config}->{separator}, @{$self->{trap_data}->{entvar}});
+    $str =~ s/\$\*/$sub_str/g;
+
+    # $A
+    $str =~ s/\$A/$self->{trap_data}->{agent_dns_name}/g;
+
+    # $aA (Trap agent IP Adress)
+    $str =~ s/\$aA/$self->{trap_data}->{var}->[4]/g;
+    
+    # $R, $r (Trap Hostname)
+    $str =~ s/\$R/$self->{trap_data}->{var}->[0]/g;
+    $str =~ s/\$r/$self->{trap_data}->{var}->[0]/g;
+
+    # $aR, $ar (IP Adress)
+    $str =~ s/\$aR/$self->{trap_data}->{var}->[1]/g;
+    $str =~ s/\$ar/$self->{trap_data}->{var}->[1]/g;
+
+    # $o (Trap OID)
+    $str =~ s/\$o/$self->{trap_data}->{var}->[3]/g;
+
+    # Clean OID
+    $str =~ s/\@\{[\.0-9]*\}//g;
+    return $str;
+}
+
+sub substitute_centreon_var {
+    my $self = shift;
+    my $str = $_[0];
+
+    $str =~ s/\@HOSTNAME\@/$self->{current_hostname}/g;
+    $str =~ s/\@HOSTID\@/$self->{current_host_id}/g;
+    $str =~ s/\@HOSTADDRESS\@/$self->{current_ip}/g;
+    $str =~ s/\@HOSTADDRESS2\@/$self->{trap_data}->{agent_dns_name}/g;
+    $str =~ s/\@SERVICEDESC\@/$self->{current_service_desc}/g;
+    $str =~ s/\@SERVICENOTES\@/$self->{current_service_notes}/g;
+    $str =~ s/\@TRAPOUTPUT\@/$self->{traps_global_output}/g;
+    $str =~ s/\@OUTPUT\@/$self->{traps_global_output}/g;
+    $str =~ s/\@STATUS\@/$self->{traps_global_status}/g;
+    $str =~ s/\@SEVERITYNAME\@/$self->{traps_global_severity_name}/g;
+    $str =~ s/\@SEVERITYLEVEL\@/$self->{traps_global_severity_level}/g;
+    $str =~ s/\@TIME\@/$self->{trap_data}->{trap_date_time_epoch}/g;
+    $str =~ s/\@POLLERID\@/$self->{current_server_id}/g;
+    $str =~ s/\@POLLERADDRESS\@/$self->{current_server_ip_address}/g;
+    $str =~ s/\@CMDFILE\@/$self->{cmdFile}/g;
+    $str =~ s/\@CMDDIR\@/$self->{cmdDir}/g;
+    $str =~ s/\@USERARG1\@/$self->{current_user_arg1}/g;
+    $str =~ s/\@USERARG2\@/$self->{current_user_arg2}/g;
+    my $date = strftime("%Y%m%d", localtime());
+    $str =~ s/\@DAY\@/$date/g;
+    
+    $str = $self->substitute_host_macro($str);
+    return $str;
+}
+
+sub substitute_centreon_functions {
+    my $self = shift;
+    my $str = $_[0];
+
+    if ($str =~ /\@GETHOSTBYADDR\((.*?)\)\@/) {
+        my $result = gethostbyaddr(Socket::inet_aton("$1"),Socket::AF_INET());
+        $result = '' if (!defined($result));
+        $str =~ s/\@GETHOSTBYADDR\(.*?\)\@/$result/;
+    }
+    if ($str =~ /\@GETHOSTBYNAME\((.*?)\)\@/) {
+        my $result = gethostbyname("$1");
+        $result = inet_ntoa($result) if (defined($result));
+        $result = '' if (!defined($result));
+        $str =~ s/\@GETHOSTBYNAME\(.*?\)\@/$result/;
+    }
+
+    return $str;
+}
+
+#######################################
+## Check Advanced Matching Rules
+#
+sub checkMatchingRules {
+    my $self = shift;
+    my $matching_boolean = 0;
+    
+    # Check matching options 
+    foreach my $row (@{$self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_matching_properties}}) {
+        my $tmoString = $row->{tmo_string};
+        my $regexp = $row->{tmo_regexp};
+        my $tmoStatus = $row->{tmo_status};
+        my $severity_level = $row->{level};
+        my $severity_name = $row->{sc_name};
+        my $severity_id = $row->{sc_id};
+
+        $self->{logger}->writeLogDebug("[$tmoString][$regexp] => $tmoStatus");
+
+        my @temp = split(//, $regexp);
+        my $i = 0;
+        my $len = length($regexp);
+        $regexp = "";
+        foreach (@temp) {
+            if ($i eq 0 && $_ =~ "/") {
+                $regexp = $regexp . "";
+            } elsif ($i eq ($len - 1) && $_ =~ "/") { 
+                $regexp = $regexp . "";
+            } else {
+                $regexp = $regexp . $_;
+            }
+            $i++;
+        }
+
+        $tmoString = $self->substitute_string($tmoString);
+        $tmoString = $self->substitute_centreon_var($tmoString);
+
+        ##########################
+        # REPLACE special Chars
+        if ($self->{htmlentities} == 1) {
+            $tmoString = HTML::Entities::decode_entities($tmoString);
+        } else {
+            $tmoString =~ s/\&quot\;/\"/g;
+            $tmoString =~ s/\&#039\;\&#039\;/"/g;
+        }
+
+        # Integrate OID Matching            
+        if (defined($tmoString) && $tmoString =~ m/$regexp/g) {
+            $self->{traps_global_status} = $tmoStatus;
+            $self->{traps_global_severity_name} = $severity_name;
+            $self->{traps_global_severity_level} = $severity_level;
+            $self->{traps_global_severity_id} = $severity_id;
+            $self->{logger}->writeLogInfo("Regexp: String:$tmoString => REGEXP:$regexp");
+            $self->{logger}->writeLogInfo("Status: $self->{traps_global_status} ($tmoStatus)");
+            $self->{logger}->writeLogInfo("Severity id: " . (defined($self->{traps_global_severity_id}) ? $self->{traps_global_severity_id} : "null"));
+            $self->{logger}->writeLogInfo("Severity name: " . (defined($self->{traps_global_severity_name}) ? $self->{traps_global_severity_name} : "null"));
+            $self->{logger}->writeLogInfo("Severity level: " . (defined($self->{traps_global_severity_level}) ? $self->{traps_global_severity_level} : "null"));
+            $matching_boolean = 1;
+            last;
+        }    
+    }
+    
+    # Dont do submit if no matching
+    if ($matching_boolean == 0 && $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_advanced_treatment_default} == 1) {
+        return 1;
+    }
+    if ($matching_boolean == 1 && $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_advanced_treatment_default} == 2) {
+        return 1;
+    }
+    return 0;
+}
+
+################################
+## Execute a specific command
+#
+sub executeCommand {
+    my $self = shift;
+    my $datetime = time();
+    my $traps_execution_command = $self->{trap_data}->{ref_oids}->{ $self->{current_trap_id} }->{traps_execution_command};
+    
+    if ($traps_execution_command =~ /\@TRAPFORWARD\((.*?)\)\@/) {
+        centreon::trapd::lib::trap_forward(
+            trap_data => $self->{trap_data},
+            arguments => $1, 
+            logger => $self->{logger}
+        );
+        return ;
+    }
+    
+    $traps_execution_command = $self->substitute_string($traps_execution_command);
+    
+    ##########################
+    # REPLACE MACROS
+    if ($self->{htmlentities} == 1) {
+        $traps_execution_command = HTML::Entities::decode_entities($traps_execution_command);
+    } else {
+        $traps_execution_command =~ s/\&quot\;/\"/g;
+        $traps_execution_command =~ s/\&#039\;\&#039\;/"/g;
+        $traps_execution_command =~ s/\&#039\;/'/g;
+    }
+    
+    $traps_execution_command = $self->substitute_centreon_var($traps_execution_command);
+    
+    ##########################
+    # SEND COMMAND
+    if ($traps_execution_command) {
+        $self->{logger}->writeLogInfo("EXEC: Launch specific command");
+        $self->{logger}->writeLogInfo("EXEC: Launched command: $traps_execution_command");
+    
+        my ($lerror, $output, $exit_code) = centreon::common::misc::backtick(
+            command => $traps_execution_command,
+            logger => $self->{logger},
+            timeout => $self->{current_alarm_timeout},
+            wait_exit => 1
+        );
+        if ($exit_code == -1) {
+            $self->{logger}->writeLogError("EXEC: Execution error: $!");
+        } elsif (($exit_code >> 8) != 0) {
+            $self->{logger}->writeLogInfo("EXEC: Exit command: " . ($exit_code >> 8));
+        }
+        if (defined($output)) {
+            chomp $output;
+            $self->{logger}->writeLogInfo("EXEC: Output : $output");
+        }
+    }
+}
+
+#######################################
+## GET HOSTNAME AND SERVICE DESCRIPTION
+#
+sub getTrapsInfos {
+    my ($self, $ids) = @_;
+    my $fstatus;
+    
+    ### Get OIDS 
+    ($fstatus, $self->{trap_data}->{ref_oids}) = centreon::trapd::lib::get_oids($self->{cdb}, $ids);
+    return 0 if ($fstatus == -1);
+    foreach my $trap_id (keys %{$self->{trap_data}->{ref_oids}}) {
+        $self->{trap_data}->{current_trap_id} = $trap_id;
+
+        ($fstatus, $self->{trap_data}->{ref_hosts}) = centreon::trapd::lib::get_hosts(
+            logger => $self->{logger},
+            cdb => $self->{cdb},
+            trap_info => $self->{trap_data}->{ref_oids}->{$trap_id},
+            agent_dns_name => $self->{trap_data}->{agent_dns_name},
+            ip_address => $self->{trap_data}->{var}->[1],
+            centreontrapd => $self
+        );
+        return 0 if ($fstatus == -1);        
+        foreach my $host_id (keys %{$self->{trap_data}->{ref_hosts}}) {
+            if (!defined($self->{trap_data}->{ref_hosts}->{$host_id}->{nagios_server_id})) {
+                $self->{logger}->writeLogError("Cant get server associated for host '" . $self->{trap_data}->{ref_hosts}->{$host_id}->{host_name} . "'");
+                next;
+            }
+            $self->{trap_data}->{current_host_id} = $host_id;
+            
+            #### Get Services ####
+            ($fstatus, $self->{trap_data}->{ref_services}) = centreon::trapd::lib::get_services($self->{cdb}, $trap_id, $host_id);
+            return 0 if ($fstatus == -1);
+            
+            #### Check Host and Services downtimes ###
+            if (defined($self->{trap_data}->{ref_oids}->{$trap_id}->{traps_downtime}) && 
+                $self->{trap_data}->{ref_oids}->{$trap_id}->{traps_downtime} ne '' && $self->{trap_data}->{ref_oids}->{$trap_id}->{traps_downtime} > 0 &&
+                ($self->{centreontrapd_config}->{mode} == 0 || defined($self->{centreontrapd_config}->{local_broker}))) {
+                ($fstatus) = centreon::trapd::lib::check_downtimes(
+                    csdb => $self->{csdb}, 
+                    downtime => $self->{trap_data}->{ref_oids}->{$trap_id}->{traps_downtime},
+                    trap_time => $self->{trap_data}->{trap_date_time_epoch},
+                    host_id => $host_id,
+                    host_name => $self->{trap_data}->{ref_hosts}->{$host_id}->{host_name},
+                    local_broker => $self->{centreontrapd_config}->{local_broker},
+                    ref_services => $self->{trap_data}->{ref_services},
+                    logger => $self->{logger}
+                );
+                return 0 if ($fstatus == -1);
+                # Host in downtime - If no services anymore, condition will match it.
+                next if ($fstatus == 1);
+            }
+            
+            #### If none, we stop ####
+            my $size = keys %{$self->{trap_data}->{ref_services}};
+            if ($size < 1) {
+                $self->{logger}->writeLogDebug("Trap without service associated for host " . $self->{trap_data}->{ref_hosts}->{$host_id}->{host_name} . ". Skipping...");
+                next;
+            }
+            
+            #### Check if macro $_HOST*$ needed
+            $self->{trap_data}->{ref_macro_hosts} = undef;
+            if (defined($self->{trap_data}->{ref_oids}->{$trap_id}->{traps_execution_command_enable}) && $self->{trap_data}->{ref_oids}->{$trap_id}->{traps_execution_command_enable} == 1 &&
+                defined($self->{trap_data}->{ref_oids}->{$trap_id}->{traps_execution_command}) && $self->{trap_data}->{ref_oids}->{$trap_id}->{traps_execution_command} =~ /\$_HOST.*?\$/) {
+                ($fstatus, $self->{trap_data}->{ref_macro_hosts}) = centreon::trapd::lib::get_macros_host($self->{cdb}, $host_id);
+                return 0 if ($fstatus == -1);
+            }
+            
+            # Eval custom code
+            if (defined($self->{trap_data}->{ref_oids}->{$trap_id}->{traps_customcode}) && 
+                $self->{trap_data}->{ref_oids}->{$trap_id}->{traps_customcode} ne '') {
+                $self->execute_customcode();
+            }
+            
+            foreach my $service_id (keys %{$self->{trap_data}->{ref_services}}) {
+                $self->{trap_data}->{current_service_id} = $service_id;
+                $self->{logger}->writeLogDebug(
+                    "Trap found on service '" . 
+                    $self->{trap_data}->{ref_services}->{$service_id}->{service_description} . 
+                    "' for host '" . 
+                    $self->{trap_data}->{ref_hosts}->{$host_id}->{host_name} . "'."
+                );
+                # Routing filter service
+                if ($self->{trap_data}->{ref_oids}->{$trap_id}->{traps_routing_mode} == 1 &&
+                    defined($self->{trap_data}->{ref_oids}->{$trap_id}->{traps_routing_filter_services}) && 
+                    $self->{trap_data}->{ref_oids}->{$trap_id}->{traps_routing_filter_services} ne '') {
+                    my $search_str = $self->substitute_string($self->{trap_data}->{ref_oids}->{$trap_id}->{traps_routing_filter_services});
+                    if ($self->{trap_data}->{ref_services}->{$service_id}->{service_description} ne $search_str) {
+                        $self->{logger}->writeLogDebug(
+                            "Skipping trap for service '" . 
+                            $self->{trap_data}->{ref_services}->{$service_id}->{service_description} . 
+                            "' for host '" . 
+                            $self->{trap_data}->{ref_hosts}->{$host_id}->{host_name} . "' (match: $search_str)."
+                        );
+                        next;
+                    }
+                }
+                $self->manage_exec();
+            }
+        }
+    }
+    
+    return 1;
+}
+
+sub run {
+    my $self = shift;
+
+    $self->SUPER::run();
+    $self->{logger}->redirect_output();
+    
+    $self->{logger}->writeLogDebug("centreontrapd launched....");
+    $self->{logger}->writeLogDebug("PID: $$");
+
+    if ($self->{centreontrapd_config}->{mode} == 0) {
+        $self->{logger}->writeLogInfo('Mode: central server');
+        $self->{cdb} = centreon::common::db->new(
+            db => $self->{centreon_config}->{centreon_db},
+            type => $self->{centreon_config}->{db_type},
+            host => $self->{centreon_config}->{db_host},
+            port => $self->{centreon_config}->{db_port},
+            user => $self->{centreon_config}->{db_user},
+            password => $self->{centreon_config}->{db_passwd},
+            force => 0,
+            logger => $self->{logger}
+        );
+
+        $self->{cmdFile} = $self->{centreon_config}->{VarLib} . "/centcore.cmd";
+        $self->{cmdDir} = $self->{centreon_config}->{VarLib} . "/centcore";
+        $self->{csdb} = centreon::common::db->new(
+            db => $self->{centreon_config}->{centstorage_db},
+            host => $self->{centreon_config}->{db_host},
+            port => $self->{centreon_config}->{db_port},
+            user => $self->{centreon_config}->{db_user},
+            password => $self->{centreon_config}->{db_passwd},
+            force => 0,
+            logger => $self->{logger}
+        );
+    } elsif ($self->{centreontrapd_config}->{mode} == 1) {
+        $self->{logger}->writeLogInfo('Mode: poller');
+        $self->{cdb} = centreon::common::db->new(
+            db => $self->{centreontrapd_config}->{centreon_db},
+            type => $self->{centreontrapd_config}->{db_type},
+            host => $self->{centreontrapd_config}->{db_host},
+            port => $self->{centreontrapd_config}->{db_port},
+            user => $self->{centreontrapd_config}->{db_user},
+            password => $self->{centreontrapd_config}->{db_passwd},
+            force => 0,
+            logger => $self->{logger}
+        );
+        $self->{csdb} = centreon::common::db->new(
+            db => $self->{centreontrapd_config}->{centstorage_db},
+            type => $self->{centreontrapd_config}->{db_type},
+            host => $self->{centreontrapd_config}->{db_host},
+            port => $self->{centreontrapd_config}->{db_port},
+            user => $self->{centreontrapd_config}->{db_user},
+            password => $self->{centreontrapd_config}->{db_passwd},
+            force => 0,
+            logger => $self->{logger}
+        );
+        # Dirty!!! Need to know the poller (not Dirty if you use SQLite database)
+        my ($status, $sth) = $self->{cdb}->query("SELECT `command_file` FROM `cfg_nagios` WHERE `nagios_activate` = '1' LIMIT 1");
+        my @conf = $sth->fetchrow_array();
+        $self->{cmdFile} = $conf[0];
+    }
+    $self->{whoami} = getpwuid($<);
+    
+    if ($self->{centreontrapd_config}->{log_trap_db} == 1) {
+        $self->create_logdb_child();
+    }
+
+    while (1) {
+        centreon::trapd::lib::purge_duplicate_trap(
+            config => $self->{centreontrapd_config},
+            duplicate_traps => \%{$self->{duplicate_traps}}
+        );
+        while ((my $file = centreon::trapd::lib::get_trap(logger => $self->{logger}, 
+                                                          config => $self->{centreontrapd_config},
+                                                          filenames => \@{$self->{filenames}}))) {
+            $self->{logger}->writeLogDebug("Processing file: $file");
+            
+            # Test can delete before. Dont go after if we cant
+            if (! -w $self->{centreontrapd_config}->{spool_directory} . '/' . $file) {
+                $self->{logger}->writeLogError("Dont have write permission on '" . $self->{centreontrapd_config}->{spool_directory} . '/' . $file . "' file.");
+                if ($self->{centreontrapd_config}->{policy_trap} == 1) {
+                    unshift @{$self->{filenames}}, $file;
+                    # We're waiting. We are in a loop
+                    sleep $self->{centreontrapd_config}->{sleep};
+                    next;
+                }
+            }
+            
+            ### Check pool finish and check old ones
+            $self->manage_pool(1);
+            $self->check_sequential_todo();
+            
+            if (open FILE, $self->{centreontrapd_config}->{spool_directory} . '/' . $file) {
+                my $unlink_trap = 1;
+                my $trap_is_a_duplicate = 0;
+                my $readtrap_result = centreon::trapd::lib::readtrap(
+                    logger => $self->{logger},
+                    config => $self->{centreontrapd_config},
+                    handle => \*FILE,
+                    agent_dns_name => \$self->{trap_data}->{agent_dns_name},
+                    trap_date => \$self->{trap_data}->{trap_date},
+                    trap_time => \$self->{trap_data}->{trap_time},
+                    trap_date_time => \$self->{trap_data}->{trap_date_time},
+                    trap_date_time_epoch => \$self->{trap_data}->{trap_date_time_epoch},
+                    duplicate_traps => \%{$self->{duplicate_traps}},
+                    digest_trap => \$self->{digest_trap},
+                    var => \@{$self->{trap_data}->{var}},
+                    entvar => \@{$self->{trap_data}->{entvar}},
+                    entvarname => \@{$self->{trap_data}->{entvarname}}
+                );
+                
+                if ($readtrap_result == 1) {
+                    my (@return) = centreon::trapd::lib::check_known_trap(
+                        logger => $self->{logger},
+                        logger_unknown => $self->{logger_unknown},
+                        config => $self->{centreontrapd_config},
+                        trap_data => $self->{trap_data},
+                        oid2verif => $self->{trap_data}->{var}->[3],
+                        cdb => $self->{cdb},
+                        last_cache_time => \$self->{last_cache_time},
+                        oids_cache => \$self->{oids_cache}
+                    );
+                    if ($return[0] == 1) {
+                        $unlink_trap = $self->getTrapsInfos($return[1]);
+                    } elsif ($return[0] == -1) {
+                        # DB deconnection. Need to keep the file. Not deleted it.
+                        $unlink_trap = 0;
+                    }
+                } elsif ($readtrap_result == 0) {
+                    $self->{logger}->writeLogDebug("Error processing trap file $file.  Skipping...");
+                } elsif ($readtrap_result == -1) {
+                    $trap_is_a_duplicate = 1;
+                    $self->{logger}->writeLogInfo("Duplicate trap detected in trap file $file.  Skipping...");
+                }
+                
+                close FILE;
+                if ($self->{centreontrapd_config}->{policy_trap} == 0 || ($self->{centreontrapd_config}->{policy_trap} == 1 && $unlink_trap == 1)) {
+                    unless (unlink($self->{centreontrapd_config}->{spool_directory} . '/' . $file)) {
+                        $self->{logger}->writeLogError("Unable to delete trap file $file from spool dir:$!");
+                    }
+                } else {
+                    $self->{logger}->writeLogError("Dont skip trap. Need to solve the error.");
+                    # we reput in AND we delete trap_digest (avoid skipping duplicate trap)
+                    unshift @{$self->{filenames}}, $file;
+                    if ($self->{centreontrapd_config}->{duplicate_trap_window}) {
+                        delete $self->{duplicate_traps}->{$self->{digest_trap}};
+                    }
+                    sleep $self->{centreontrapd_config}->{sleep};
+                }
+            } else {
+                $self->{logger}->writeLogError("Could not open trap file " . $self->{centreontrapd_config}->{spool_directory} . '/' . "$file: ($!)");
+                if ($self->{centreontrapd_config}->{policy_trap} == 1) {
+                    $self->{logger}->writeLogError("Dont skip trap. Need to solve the error.");
+                    # we reput in
+                    unshift @{$self->{filenames}}, $file;
+                }
+            }
+            
+            if ($self->{timetoreload} == 1) {
+                $self->reload();
+            }
+        }
+
+        $self->{logger}->writeLogDebug("Sleeping for " . $self->{centreontrapd_config}->{sleep} . " seconds");
+        sleep $self->{centreontrapd_config}->{sleep};
+
+        if ($self->{timetoreload} == 1) {
+            $self->reload();
+        }
+
+        ### Check pool finish and check old ones
+        $self->manage_pool(1);
+        $self->check_sequential_todo();
+    }
+}
+
+1;
+
+__END__

--- a/perl-libs/lib/centreon/script/centreontrapdforward.pm
+++ b/perl-libs/lib/centreon/script/centreontrapdforward.pm
@@ -1,0 +1,120 @@
+################################################################################
+# Copyright 2005-2013 Centreon
+# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+# 
+# This program is free software; you can redistribute it and/or modify it under 
+# the terms of the GNU General Public License as published by the Free Software 
+# Foundation ; either version 2 of the License.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with 
+# this program; if not, see <http://www.gnu.org/licenses>.
+# 
+# Linking this program statically or dynamically with other modules is making a 
+# combined work based on this program. Thus, the terms and conditions of the GNU 
+# General Public License cover the whole combination.
+# 
+# As a special exception, the copyright holders of this program give Centreon 
+# permission to link this program with independent modules to produce an executable, 
+# regardless of the license terms of these independent modules, and to copy and 
+# distribute the resulting executable under terms of Centreon choice, provided that 
+# Centreon also meet, for each linked independent module, the terms  and conditions 
+# of the license of that module. An independent module is a module which is not 
+# derived from this program. If you modify this program, you may extend this 
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+# 
+#
+####################################################################################
+
+package centreon::script::centreontrapdforward;
+
+use strict;
+use warnings;
+use Time::HiRes qw(gettimeofday);
+use centreon::script;
+
+use base qw(centreon::script);
+use vars qw(%centreontrapd_config);
+
+sub new {
+    my $class = shift;
+    my $self = $class->SUPER::new("centreontrapdforward",
+        centreon_db_conn => 0,
+        centstorage_db_conn => 0,
+        noconfig => 1
+    );
+    bless $self, $class;
+    $self->add_options(
+        "config-extra:s" => \$self->{opt_extra},
+    );
+    %{$self->{centreontrapd_default_config}} =
+      (
+       spool_directory => "/var/spool/centreontrapd/"
+    );
+    return $self;
+}
+
+sub init {
+    my $self = shift;
+    $self->SUPER::init();
+
+    if (!defined($self->{opt_extra})) {
+        $self->{opt_extra} = "/etc/centreon/centreontrapd.pm";
+    }
+    if (-f $self->{opt_extra}) {
+        require $self->{opt_extra};
+    } else {
+        $self->{logger}->writeLogInfo("Can't find extra config file $self->{opt_extra}");
+    }
+
+    $self->{centreontrapd_config} = {%{$self->{centreontrapd_default_config}}, %centreontrapd_config};
+}
+
+sub run {
+    my $self = shift;
+
+    $self->SUPER::run();
+
+    # Create file in spool directory based on current time
+    my ($s, $usec) = gettimeofday;
+
+    # Pad the numbers with 0's to make sure they are all the same length.  Sometimes the
+    # usec is shorter than 6.
+    my $s_pad = sprintf("%09d",$s);
+    my $usec_pad = sprintf("%06d",$usec);
+
+    # Print out time
+    $self->{logger}->writeLogDebug("centreon-trapforward started: " . scalar(localtime));
+    $self->{logger}->writeLogDebug("s = $s, usec = $usec");
+    $self->{logger}->writeLogDebug("s_pad = $s_pad, usec_pad = $usec_pad");
+    $self->{logger}->writeLogDebug("Data received:");
+
+    my $spoolfile = $self->{centreontrapd_config}->{spool_directory} . '/' . '#centreon-trap-'.$s_pad.$usec_pad;
+
+    unless (open SPOOL, ">$spoolfile") {
+        $self->{logger}->writeLogError("Could not write to file: $spoolfile!  Trap will be lost!");
+        exit(1);
+    }
+
+    print SPOOL time()."\n";
+
+    while (defined(my $line = <>)) {
+        print SPOOL $line;
+	
+        if ($self->{logger}->is_debug()) {
+            # Print out item passed from snmptrapd
+            chomp $line;
+            $self->{logger}->writeLogDebug($line);
+        }
+    }
+    chmod 0664, $spoolfile;
+
+    exit(0);
+}
+
+1;

--- a/perl-libs/lib/centreon/script/dashboardBuilder.pm
+++ b/perl-libs/lib/centreon/script/dashboardBuilder.pm
@@ -1,0 +1,312 @@
+################################################################################
+# Copyright 2005-2020 Centreon
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation ; either version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see <http://www.gnu.org/licenses>.
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
+# General Public License cover the whole combination.
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+#
+#
+####################################################################################
+
+package centreon::script::dashboardBuilder;
+
+use warnings;
+use strict;
+use POSIX;
+use Time::Local;
+
+use centreon::reporting::CentreonHost;
+use centreon::reporting::CentreonService;
+use centreon::reporting::CentreonServiceStateEvents;
+use centreon::reporting::CentreonHostStateEvents;
+use centreon::reporting::CentreonDashboard;
+use centreon::script;
+
+use base qw(centreon::script);
+
+my @weekDays = ("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday");
+
+sub new {
+    my $class = shift;
+    my $self = $class->SUPER::new("dashboardBuilder",
+        centreon_db_conn => 1,
+        centstorage_db_conn => 1
+    );
+
+    bless $self, $class;
+    $self->add_options(
+        "r" => \$self->{opt_rebuild}, "rebuild" => \$self->{opt_rebuild},
+        "s=s" => \$self->{opt_startperiod}, "start-period=s" => \$self->{opt_startperiod},
+        "e=s" => \$self->{opt_endperiod}, "end-period=s" => \$self->{opt_endperiod},
+        "host-only" => \$self->{opt_hostonly},
+        "service-only" => \$self->{opt_serviceonly},
+    );
+    $self->{serviceEvents} = undef;
+    $self->{hostEvents} = undef;
+    $self->{dashboard} = undef;
+    $self->{liveService} = undef;
+    $self->{service} = undef;
+    $self->{host} = undef;
+    return $self;
+}
+
+# program exit function
+sub exit_pgr() {
+    my $self = shift;
+
+    $self->{logger}->writeLogInfo("Exiting program...");
+    exit (0);
+}
+
+# get informations about an  hidden feature
+# reporting can be calculated on a specific time range for each day of the week
+sub getLiveService {
+    my $self = shift;
+    my %result = ();
+
+    my ($status, $sth) = $self->{cdb}->query("SELECT * FROM `contact_param` WHERE `cp_contact_id` is null");
+    while (my $row = $sth->fetchrow_hashref()) {
+        $result{$row->{"cp_key"}} = $row->{"cp_value"};
+    }
+    $sth->finish;
+
+    # verifying if all variables are set
+    if (!defined($result{"report_hour_start"})) {
+        $result{"report_hour_start"} = 0;
+    }
+    if (!defined($result{"report_minute_start"})) {
+        $result{"report_minute_start"} = 0;
+    }
+    if (!defined($result{"report_hour_end"})) {
+        $result{"report_hour_end"} = 24;
+    }
+    if (!defined($result{"report_minute_end"})) {
+        $result{"report_minute_end"} = 0;
+    }
+    foreach(@weekDays) {
+        my $day = $_;
+        if (!defined($result{"report_".$day})) {
+            $result{"report_".$day} = 1;
+        }
+    }
+    return(\%result);
+}
+
+# Initialize objects for program
+sub initVars {
+    my $self = shift;
+
+    # classes to query database tables
+    $self->{host} = centreon::reporting::CentreonHost->new($self->{logger}, $self->{cdb});
+    $self->{service} = centreon::reporting::CentreonService->new($self->{logger}, $self->{cdb});
+    $self->{serviceEvents} = centreon::reporting::CentreonServiceStateEvents->new($self->{logger}, $self->{csdb});
+    $self->{hostEvents} = centreon::reporting::CentreonHostStateEvents->new($self->{logger}, $self->{csdb});
+
+    # Class that builds events
+    $self->{dashboard} = centreon::reporting::CentreonDashboard->new($self->{logger}, $self->{csdb});
+    $self->{liveService} = $self->getLiveService();
+}
+
+# For a given period returns in a table each
+sub getDaysFromPeriod {
+    my $self = shift;
+    my ($start, $end) = (shift, shift);
+
+    my @days;
+    # Check if $end is > to current time
+    my ($day,$month,$year) = (localtime(time))[3,4,5];
+    my $todayStart =  mktime(0,0,0,$day,$month,$year,0,0,-1);
+    if ($end > $todayStart) {
+        $end = $todayStart;
+    }
+
+    # get start day as mm/dd/yyyy 00:00
+    ($day,$month,$year) = (localtime($start))[3,4,5];
+    $start =  mktime(0,0,0,$day,$month,$year,0,0,-1);
+    my $previousDay = mktime(0,0,0,$day - 1,$month,$year,0,0,-1);
+
+    while ($start < $end) {
+        # getting day beginning => 00h 00min
+        # if there is few hour gap (time change : winter/summer), we also readjust it
+        if ($start == $previousDay) {
+            $start = mktime(0,0,0, ++$day, $month, $year,0,0,-1);
+        }
+        my $currentDayOfWeek = (localtime($start))[6];
+
+        # If in the configuration, this day of week is not selected, the reporting is not calculated
+        if (defined($self->{liveService}->{"report_".$weekDays[$currentDayOfWeek]}) && $self->{liveService}->{"report_".$weekDays[$currentDayOfWeek]} == 1) {
+            # setting reporting date and time ranges
+            my $dayStart = mktime(0,$self->{liveService}->{"report_minute_start"},$self->{liveService}->{"report_hour_start"},$day,$month,$year,0,0,-1);
+            my $dayEnd = mktime(0,$self->{liveService}->{"report_minute_end"},$self->{liveService}->{"report_hour_end"},$day,$month,$year,0,0,-1);
+            my %period = ("day_start" => $dayStart, "day_end" => $dayEnd);
+            $days[scalar(@days)] = \%period;
+        } else {
+            $day++;
+        }
+
+        $previousDay = $start;
+        $start = mktime(0,0,0, $day, $month, $year,0,0,-1);
+    }
+    return \@days;
+}
+
+# rebuild all events
+sub rebuildIncidents {
+    my $self = shift;
+    my ($start, $end, $purgeType, $hostOnly, $serviceOnly) = (shift, shift, shift, shift, shift);
+
+    if (!defined($start) || !defined($end)) {
+        $self->{logger}->writeLogError("Cannot determine reporting rebuild period");
+        $self->{logger}->writeLogError("Please use -s and -e option to defined the rebuild period.");
+    } else {
+        # Purge tables in order to rebuild statistics
+        my $periods = $self->getDaysFromPeriod($start, $end);
+        if (!scalar(@$periods)) {
+            $self->{logger}->writeLogInfo("Incorrect rebuild period");
+        }
+        if ($purgeType eq "truncate") {
+            $self->{dashboard}->truncateServiceStats();
+            $self->{dashboard}->truncateHostStats();
+        } else {
+            $self->{dashboard}->deleteServiceStats($start, $end);
+            $self->{dashboard}->deleteHostStats($start, $end);
+        }
+
+        if (defined($start) && defined($end) && !$serviceOnly) {
+            my $hostIds = $self->{host}->getAllHostIds(0);
+
+            # archiving logs for each days
+            foreach(@$periods) {
+                $self->{logger}->writeLogInfo("[HOST] Processing period: ".localtime($_->{"day_start"})." => ".localtime($_->{"day_end"}));
+                my $hostStateDurations = $self->{hostEvents}->getStateEventDurations($_->{"day_start"}, $_->{"day_end"});
+                $self->{dashboard}->insertHostStats($hostIds, $hostStateDurations, $_->{"day_start"}, $_->{"day_end"});
+            }
+        }
+        if (defined($start) && defined($end) && !$hostOnly) {
+            my $serviceIds = $self->{service}->getAllServiceIds(0);
+
+            # archiving logs for each days
+            foreach(@$periods) {
+                $self->{logger}->writeLogInfo("[SERVICE] Processing period: ".localtime($_->{"day_start"})." => ".localtime($_->{"day_end"}));
+                my $serviceStateDurations = $self->{serviceEvents}->getStateEventDurations($_->{"day_start"}, $_->{"day_end"});
+                $self->{dashboard}->insertServiceStats($serviceIds, $serviceStateDurations, $_->{"day_start"}, $_->{"day_end"});
+            }
+        }
+    }
+}
+
+# returns the reporting rebuild period that could be retrieved form DB or given in parameter
+# returns also reporting tables purge type truncate or delete for a specific period
+sub getRebuildOptions {
+    my $self = shift;
+    my ($paramStartDate, $paramEndDate, $hostOnly, $serviceOnly) = (shift, shift, shift, shift);
+
+    if (!defined($hostOnly)) {
+        $hostOnly = 0;
+    } else {
+        $hostOnly = 1;
+    }
+
+    if (!defined($serviceOnly)) {
+        $serviceOnly = 0;
+    } else {
+        $serviceOnly = 1;
+    }
+
+    my ($start, $end);
+    my $purgeType = "truncate";
+    if (defined($paramStartDate)){
+        if ($paramStartDate =~ /^([0-9]{4})\-([0-9]{2})\-([0-9]{2})$/) {
+            $start = mktime(0,0,0,$3,$2 - 1,$1 - 1900,0,0,-1);
+            $purgeType = "delete";
+        } else {
+            $self->{logger}->writeLogError("Bad paramater syntax for option [-s|--period-start]. Syntax example: 2011-11-09");
+        }
+    }
+    if (defined($paramEndDate)){
+        if ($paramEndDate =~ /^([0-9]{4})\-([0-9]{2})\-([0-9]{2})$/) {
+            $end = mktime(0,0,0,$3,$2 - 1,$1 - 1900,0,0,-1);
+            $purgeType = "delete";
+        }else {
+            $self->{logger}->writeLogError("Bad paramater syntax for option [-e|--period-end]. Syntax example: 2011-11-09");
+        }
+    }
+
+    my ($dbStart, $dbEnd) = $self->{hostEvents}->getFirstLastIncidentTimes();
+    if (!defined($start)) {
+        $start = $dbStart;
+    }
+    if (!defined($end)) {
+        $end = $dbEnd;
+    }
+    return ($start, $end, $purgeType, $hostOnly, $serviceOnly);
+}
+
+
+sub run {
+    my $self = shift;
+
+    $self->SUPER::run();
+    $self->{logger}->redirect_output();
+    $self->initVars();
+
+    $self->{logger}->writeLogInfo("Starting program...");
+
+    if (defined($self->{opt_rebuild})) {
+        $self->rebuildIncidents($self->getRebuildOptions($self->{opt_startperiod}, $self->{opt_endperiod}, $self->{opt_hostonly}, $self->{opt_serviceonly}));
+    } else {
+        my $currentTime = time;
+        my ($day,$month,$year, $dayOfWeek) = (localtime($currentTime))[3,4,5,6];
+
+        # getting day of week of date to process
+        if ($dayOfWeek == 0) {
+            $dayOfWeek = 6;
+        } else {
+            $dayOfWeek--;
+        }
+
+        # If in the configuration, this day of week is not selected, the reporting is not calculated
+        if (defined($self->{liveService}->{"report_".$weekDays[$dayOfWeek]}) && $self->{liveService}->{"report_".$weekDays[$dayOfWeek]} != 1) {
+            $self->{logger}->writeLogInfo("Reporting must not be calculated for this day, check your configuration");
+            $self->exit_pgr();
+        }
+
+        # setting reporting date and time ranges
+        my $end = mktime(0,$self->{liveService}->{"report_minute_end"},$self->{liveService}->{"report_hour_end"},$day - 1,$month,$year,0,0,-1);
+        my $start = mktime(0,$self->{liveService}->{"report_minute_start"},$self->{liveService}->{"report_hour_start"},$day - 1,$month,$year,0,0,-1);
+
+        my $serviceIds = $self->{service}->getAllServiceIds(0);
+        my $hostIds = $self->{host}->getAllHostIds(0);
+        $self->{logger}->writeLogInfo("Processing period: ".localtime($start)." => ".localtime($end));
+        my $hostStateDurations = $self->{hostEvents}->getStateEventDurations($start, $end);
+        $self->{dashboard}->insertHostStats($hostIds, $hostStateDurations, $start, $end);
+        my $serviceStateDurations = $self->{serviceEvents}->getStateEventDurations($start, $end);
+        $self->{dashboard}->insertServiceStats($serviceIds, $serviceStateDurations, $start, $end);
+    }
+    $self->exit_pgr();
+}
+
+1;

--- a/perl-libs/lib/centreon/script/eventReportBuilder.pm
+++ b/perl-libs/lib/centreon/script/eventReportBuilder.pm
@@ -1,0 +1,233 @@
+################################################################################
+# Copyright 2005-2020 Centreon
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation ; either version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, see <http://www.gnu.org/licenses>.
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
+# General Public License cover the whole combination.
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+#
+#
+####################################################################################
+
+package centreon::script::eventReportBuilder;
+
+use warnings;
+use strict;
+use POSIX;
+use Time::Local;
+
+use centreon::reporting::CentreonHost;
+use centreon::reporting::CentreonService;
+use centreon::reporting::CentreonLog;
+use centreon::reporting::CentreonServiceStateEvents;
+use centreon::reporting::CentreonHostStateEvents;
+use centreon::reporting::CentreonProcessStateEvents;
+use centreon::reporting::CentreonDownTime;
+use centreon::reporting::CentreonAck;
+use centreon::script;
+
+use base qw(centreon::script);
+
+sub new {
+    my $class = shift;
+    my $self = $class->SUPER::new("eventReportBuilder",
+        centreon_db_conn => 1,
+        centstorage_db_conn => 1
+    );
+
+    bless $self, $class;
+    $self->add_options(
+        "r" => \$self->{opt_rebuild}, "rebuild" => \$self->{opt_rebuild},
+        "s:s" => \$self->{opt_stime}, "start-time:s" => \$self->{opt_stime},
+        "e:s" => \$self->{opt_etime}, "end-time:s" => \$self->{opt_etime},
+        "no-validate-date" => \$self->{opt_no_validate_date},
+    );
+    $self->{centstatusdb} = undef;
+    $self->{processEvents} = undef;
+    $self->{serviceEvents} = undef;
+    $self->{hostEvents} = undef;
+    $self->{nagiosLog} = undef;
+    $self->{service} = undef;
+    $self->{host} = undef;
+    return $self;
+}
+
+# program exit function
+sub exit_pgr() {
+    my $self = shift;
+
+    $self->{logger}->writeLogInfo("Exiting program...");
+    exit (0);
+}
+
+# Initialize objects for program
+sub initVars {
+    my $self = shift;
+    my $centstatus;
+
+    # Getting centstatus database name
+    $centstatus = $self->{csdb};
+
+    # classes to query database tables
+    $self->{host} = centreon::reporting::CentreonHost->new($self->{logger}, $self->{cdb});
+    $self->{service} = centreon::reporting::CentreonService->new($self->{logger}, $self->{cdb});
+    $self->{nagiosLog} = centreon::reporting::CentreonLog->new($self->{logger}, $self->{csdb});
+    my $centreonDownTime = centreon::reporting::CentreonDownTime->new($self->{logger}, $centstatus);
+    my $centreonAck = centreon::reporting::CentreonAck->new($self->{logger}, $centstatus);
+    $self->{serviceEvents} = centreon::reporting::CentreonServiceStateEvents->new($self->{logger}, $self->{csdb}, $centreonAck, $centreonDownTime);
+    $self->{hostEvents} = centreon::reporting::CentreonHostStateEvents->new($self->{logger}, $self->{csdb}, $centreonAck, $centreonDownTime);
+
+    # Class that builds events
+    $self->{processEvents} = centreon::reporting::CentreonProcessStateEvents->new(
+        $self->{logger},
+        $self->{host},
+        $self->{service},
+        $self->{nagiosLog},
+        $self->{hostEvents},
+        $self->{serviceEvents},
+        $centreonDownTime
+    );
+}
+
+# For a given period returns in a table each
+sub getDaysFromPeriod {
+    my $self = shift;
+    my ($start, $end) = (shift, shift);
+
+    my @days;
+    # Check if $end is > to current time
+    my ($day,$month,$year) = (localtime(time))[3,4,5];
+    my $today_begin =  mktime(0,0,0,$day,$month,$year,0,0,-1);
+    if ($end > $today_begin) {
+        $end = $today_begin;
+    }
+    # get start day as mm/dd/yyyy 00:00
+    ($day,$month,$year) = (localtime($start))[3,4,5];
+    $start =  mktime(0,0,0,$day,$month,$year,0,0,-1);
+    my $previousDay = mktime(0,0,0,$day - 1,$month,$year,0,0,-1);
+
+    while ($start < $end) {
+        # getting day beginning => 00h 00min
+        # if there is few hour gap (time change : winter/summer), we also readjust it
+        if ($start == $previousDay) {
+            $start = mktime(0,0,0, ++$day, $month, $year,0,0,-1);
+        }
+        # setting day beginning/end hour and minute with the value set in centreon DB
+        my $dayEnd = mktime(0, 0, 0, ++$day, $month, $year, 0, 0, -1);
+        my %period = (day_start => $start, day_end => $dayEnd);
+        $days[scalar(@days)] = \%period;
+
+        $previousDay = $start;
+        $start = $dayEnd;
+    }
+    return \@days;
+}
+
+sub get_date {
+    my ($self, %options) = @_;
+
+    my ($date, $midnight);
+    if (defined($self->{$options{option_label}})) {
+        if ($self->{$options{option_label}} !~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/) {
+            $self->{logger}->writeLogError("Wrong $options{option} option. Syntax is: YYYY-MM-DD.");
+            $self->exit_pgr();
+        }
+        if (!defined($self->{opt_no_validate_date})) {
+            require DateTime;
+            eval {
+                my $dt = DateTime->new(
+                    year => $1,
+                    month => $2,
+                    day => $3);
+            };
+            if ($@) {
+                $self->{logger}->writeLogError("Wrong $options{option} option. Not a valid date.");
+                $self->exit_pgr();
+            }
+        }
+        $date = mktime(0,0,0,$3,$2-1,$1-1900,0,0,-1);
+        $midnight = mktime(0,0,0,$3+1,$2-1,$1-1900,0,0,-1);
+    }
+
+    return ($date, $midnight);
+}
+
+# rebuild all events
+sub rebuildIncidents {
+    my $self = shift;
+    my $time_period = shift;
+
+    my ($start, $midnight) = $self->get_date(option_label => 'opt_stime', option => '--start-time');
+    my ($start2, $end2);
+    my ($end) = $self->get_date(option_label => 'opt_etime', option => '--end-time');
+    # Getting first log and last log times
+    if (!defined($start) || !defined($end)) {
+        ($start2, $end2) = $self->{nagiosLog}->getFirstLastLogTime();
+    }
+    if (defined($start) && defined($end) && $start > $end) {
+        $self->{logger}->writeLogError("start date couldn't be more recent than end date");
+        $self->exit_pgr();
+    }
+
+    # Empty tables
+    $self->{serviceEvents}->truncateStateEvents(start => $start, midnight => $midnight);
+    $self->{hostEvents}->truncateStateEvents(start => $start, midnight => $midnight);
+    $start = $start2 if (!defined($start));
+    $end = $end2 if (!defined($end));
+
+    my $periods = $self->getDaysFromPeriod($start, $end);
+    # archiving logs for each days
+    foreach(@$periods) {
+        $self->{logger}->writeLogInfo("Processing period: ".localtime($_->{day_start})." => ".localtime($_->{day_end}));
+        $self->{processEvents}->parseHostLog($_->{day_start}, $_->{day_end});
+        $self->{processEvents}->parseServiceLog($_->{day_start}, $_->{day_end});
+    }
+}
+
+sub run {
+    my $self = shift;
+
+    $self->SUPER::run();
+    $self->{logger}->redirect_output();
+    $self->initVars();
+
+    $self->{logger}->writeLogInfo("Starting program...");
+
+    if (defined($self->{opt_rebuild})) {
+        $self->rebuildIncidents();
+    } else {
+        my $currentTime = time;
+        my ($day,$month,$year) = (localtime($currentTime))[3, 4, 5];
+        my $end = mktime(0, 0, 0, $day, $month, $year, 0, 0, -1);
+        my $start = mktime(0, 0, 0, $day - 1, $month, $year, 0, 0, -1);
+        $self->{logger}->writeLogInfo("Processing period: " . localtime($start) . " => " . localtime($end));
+        $self->{processEvents}->parseHostLog($start, $end);
+        $self->{processEvents}->parseServiceLog($start, $end);
+    }
+
+    $self->exit_pgr();
+}
+
+1;

--- a/perl-libs/lib/centreon/script/logAnalyserBroker.pm
+++ b/perl-libs/lib/centreon/script/logAnalyserBroker.pm
@@ -1,0 +1,396 @@
+################################################################################
+# Copyright 2005-2019 Centreon
+# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+# 
+# This program is free software; you can redistribute it and/or modify it under 
+# the terms of the GNU General Public License as published by the Free Software 
+# Foundation ; either version 2 of the License.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with 
+# this program; if not, see <http://www.gnu.org/licenses>.
+# 
+# Linking this program statically or dynamically with other modules is making a 
+# combined work based on this program. Thus, the terms and conditions of the GNU 
+# General Public License cover the whole combination.
+# 
+# As a special exception, the copyright holders of this program give Centreon 
+# permission to link this program with independent modules to produce an executable, 
+# regardless of the license terms of these independent modules, and to copy and 
+# distribute the resulting executable under terms of Centreon choice, provided that 
+# Centreon also meet, for each linked independent module, the terms  and conditions 
+# of the license of that module. An independent module is a module which is not 
+# derived from this program. If you modify this program, you may extend this 
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+# 
+#
+####################################################################################
+
+package centreon::script::logAnalyserBroker;
+
+use strict;
+use warnings;
+use POSIX;
+use centreon::script;
+
+use base qw(centreon::script);
+
+my %svc_status_code = (
+    "OK"       => 0,
+    "WARNING"  => 1,
+    "CRITICAL" => 2,
+    "UNKNOWN"  => 3
+);
+my %host_status_code = (
+    "UP"            => 0,
+    "DOWN"          => 1,
+    "UNREACHABLE"   => 2,
+    "PENDING"       => 4
+);
+my %type_code = (
+    "SOFT" => 0,
+    "HARD" => 1
+);
+
+sub new {
+    my $class = shift;
+    my $self = $class->SUPER::new("logAnalyserBroker",
+        centreon_db_conn => 1,
+        centstorage_db_conn => 1,
+    );
+
+    bless $self, $class;
+    $self->add_options(
+        "p=s" => \$self->{opt_p}, "poller" => \$self->{opt_p},
+        "s=s" => \$self->{opt_s}, "startdate=s" => \$self->{opt_s}
+    );
+    
+    $self->{msg_type5_disabled} = 0;
+    $self->{queries_per_transaction} = 500;
+
+    %{$self->{cache_host}} = ();
+    %{$self->{cache_host_service}} = ();
+    my ($day,$month,$year) = (localtime(time()))[3,4,5];
+    $self->{current_time} = mktime(0,0,0,$day,$month,$year,0,0,-1);
+    return $self;
+}
+
+# Get poller id from poller name
+sub getPollerId {
+    my ($self, $instance_name) = @_;
+
+    my ($status, $sth) = $self->{cdb}->query("SELECT id 
+        FROM nagios_server 
+        WHERE name = " . $self->{cdb}->quote($instance_name) . " 
+        AND ns_activate = '1' LIMIT 1");
+    if ($status == -1) {
+        $self->{logger}->writeLogError("Can't get poller id");
+        return 0;
+    }
+    while ((my $row = $sth->fetchrow_hashref())) {
+        return $row->{id};
+    }
+    return 0;
+}
+
+sub commit_to_log {
+    my ($self, $sth, $log_table_rows) = @_;
+    my @tuple_status;
+
+    $sth->execute_for_fetch(sub { shift @$log_table_rows }, \@tuple_status);
+    $self->{csdb}->commit;
+    $self->{csdb}->transaction_mode(1);
+}
+
+# Parsing .log
+sub parseFile($$) {
+    my ($self, $logFile, $instance_name) = @_;
+    my $ctime;
+    my ($nbqueries, $counter) = (0, 0, 0);
+    my @log_table_rows;
+
+    # Open Log File for parsing
+    if (!open(FILE, $logFile)) {
+        $self->{logger}->writeLogError("Cannot open file : $logFile");
+        return;
+    }
+
+    $self->{csdb}->transaction_mode(1);
+    eval {
+        my $sth = $self->{csdb}->{instance}->prepare("INSERT INTO logs (ctime, host_name, service_description, status, output, notification_cmd, notification_contact, type, retry, msg_type, instance_name, host_id, service_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+
+        while (<FILE>) {
+            my $cur_ctime;
+
+            if ($_ =~ m/^\[([0-9]*)\](?:\s\[[0-9]*\])*\sSERVICE ALERT\:\s(.*)$/) {
+                $cur_ctime = $1;
+                next if ($cur_ctime < $self->{retention_time});
+                my @tab = split(/;/, $2);
+                next if (!defined($self->{cache_host_service}{$tab[0] . ":" . $tab[1]}->{service_id}));
+                push @log_table_rows, [($cur_ctime, $tab[0], $tab[1], $svc_status_code{$tab[2]}, $tab[5], undef, undef, $type_code{$tab[3]}, $tab[4], '0', $instance_name, $self->{cache_host}{$tab[0]}, $self->{cache_host_service}{$tab[0] . ":" . $tab[1]}->{service_id})];
+            } elsif ($_ =~ m/^\[([0-9]*)\](?:\s\[[0-9]*\])*\sHOST ALERT\:\s(.*)$/) {
+                $cur_ctime = $1;
+                next if ($cur_ctime < $self->{retention_time});
+                my @tab = split(/;/, $2);
+                next if (!defined($self->{cache_host}{$tab[0]}));
+                push @log_table_rows, [($cur_ctime, $tab[0], undef, $host_status_code{$tab[1]}, $tab[4], undef, undef, $type_code{$tab[2]}, $tab[3], '1', $instance_name, $self->{cache_host}{$tab[0]}, undef)];
+            } elsif ($_ =~ m/^\[([0-9]*)\](?:\s\[[0-9]*\])*\sSERVICE NOTIFICATION\:\s(.*)$/) {
+                $cur_ctime = $1;
+                next if ($cur_ctime < $self->{retention_time});
+                my @tab = split(/;/, $2);
+                next if (!defined($self->{cache_host_service}{$tab[1] . ":" . $tab[2]}->{service_id}));
+                push @log_table_rows, [($cur_ctime, $tab[1], $tab[2], $svc_status_code{$tab[3]}, $tab[5], $tab[4], $tab[0], '', 0, '2', $instance_name, $self->{cache_host}{$tab[1]}, $self->{cache_host_service}{$tab[1] . ":" . $tab[2]}->{service_id})];
+            } elsif ($_ =~ m/^\[([0-9]*)\](?:\s\[[0-9]*\])*\sHOST NOTIFICATION\:\s(.*)$/) {
+                $cur_ctime = $1;
+                next if ($cur_ctime < $self->{retention_time});
+                my @tab = split(/;/, $2);
+                next if (!defined($self->{cache_host}{$tab[1]}));
+                push @log_table_rows, [($cur_ctime, $tab[1], undef, $host_status_code{$tab[2]}, $tab[4], $tab[3], $tab[0], '', 0, '3', $instance_name, $self->{cache_host}{$tab[1]}, undef)];
+            } elsif ($_ =~ m/^\[([0-9]*)\](?:\s\[[0-9]*\])*\sCURRENT\sHOST\sSTATE\:\s(.*)$/) {
+                $cur_ctime = $1;
+                next if ($cur_ctime < $self->{retention_time});
+                my @tab = split(/;/, $2);
+                next if (!defined($self->{cache_host}{$tab[0]}));
+                push @log_table_rows, [($cur_ctime, $tab[0], undef, $host_status_code{$tab[1]}, undef, undef, undef, $type_code{$tab[2]}, 0, '7', $instance_name, $self->{cache_host}{$tab[0]}, undef)];
+            } elsif ($_ =~ m/^\[([0-9]*)\](?:\s\[[0-9]*\])*\sCURRENT\sSERVICE\sSTATE\:\s(.*)$/) {
+                $cur_ctime = $1;
+                next if ($cur_ctime < $self->{retention_time});
+                my @tab = split(/;/, $2);
+                next if (!defined($self->{cache_host_service}{$tab[0] . ":" . $tab[1]}->{service_id}));
+                push @log_table_rows, [($cur_ctime, $tab[0], $tab[1], $svc_status_code{$tab[2]}, undef, undef, undef,  $type_code{$tab[3]}, 0, '6', $instance_name, $self->{cache_host}{$tab[0]}, $self->{cache_host_service}{$tab[0] . ":" . $tab[1]}->{service_id})];
+            } elsif ($_ =~ m/^\[([0-9]*)\](?:\s\[[0-9]*\])*\sINITIAL\sHOST\sSTATE\:\s(.*)$/) {
+                $cur_ctime = $1;
+                next if ($cur_ctime < $self->{retention_time});
+                my @tab = split(/;/, $2);
+                next if (!defined($self->{cache_host}{$tab[0]}));
+                push @log_table_rows, [($cur_ctime, $tab[0], undef, $host_status_code{$tab[1]}, undef, undef, undef, $type_code{$tab[2]}, 0, '9', $instance_name, $self->{cache_host}{$tab[0]}, undef)];
+            } elsif ($_ =~ m/^\[([0-9]*)\](?:\s\[[0-9]*\])*\sINITIAL\sSERVICE\sSTATE\:\s(.*)$/) {
+                $cur_ctime = $1;
+                next if ($cur_ctime < $self->{retention_time});
+                my @tab = split(/;/, $2);
+                next if (!defined($self->{cache_host_service}{$tab[0] . ":" . $tab[1]}->{service_id}));
+                push @log_table_rows, [($cur_ctime, $tab[0], $tab[1], $svc_status_code{$tab[2]}, undef, undef, undef, $type_code{$tab[3]}, 0, '8', $instance_name, $self->{cache_host}{$tab[0]}, $self->{cache_host_service}{$tab[0] . ":" . $tab[1]}->{service_id})];
+            } elsif ($_ =~ m/^\[([0-9]*)\](?:\s\[[0-9]*\])*\sEXTERNAL\sCOMMAND\:\sACKNOWLEDGE\_SVC\_PROBLEM\;(.*)$/) {
+                $cur_ctime = $1;
+                next if ($cur_ctime < $self->{retention_time});
+                my @tab = split(/;/, $2);
+                next if (!defined($self->{cache_host_service}{$tab[0] . ":" . $tab[1]}->{service_id}));
+                push @log_table_rows, [($cur_ctime, $tab[0], $tab[1], undef, $tab[6], undef, $tab[5], undef, 0, '10', $instance_name, $self->{cache_host}{$tab[0]}, $self->{cache_host_service}{$tab[0] . ":" . $tab[1]}->{service_id})];
+            } elsif ($_ =~ m/^\[([0-9]*)\](?:\s\[[0-9]*\])*\sEXTERNAL\sCOMMAND\:\sACKNOWLEDGE\_HOST\_PROBLEM\;(.*)$/) {
+                $cur_ctime = $1;
+                next if ($cur_ctime < $self->{retention_time});
+                my @tab = split(/;/, $2);
+                next if (!defined($self->{cache_host}{$tab[0]}));
+                push @log_table_rows, [($cur_ctime, $tab[0], undef, undef, $tab[5], undef, $tab[4], undef, 0, '11', $instance_name, $self->{cache_host}{$tab[0]}, undef)];
+            } elsif ($_ =~ m/^\[([0-9]*)\](?:\s\[[0-9]*\])*\sWarning\:\s(.*)$/) {
+                $cur_ctime = $1;
+                next if ($cur_ctime < $self->{retention_time});
+                my $tab = $2;
+                push @log_table_rows, [($cur_ctime, undef, undef, undef, $tab, undef, undef, undef, 0, '4', $instance_name, undef, undef)];
+            } elsif ($_ =~ m/^\[([0-9]*)\](?:\s\[[0-9]*\])*\s(.*)$/ && (!$self->{msg_type5_disabled})) {
+                $cur_ctime = $1;
+                next if ($cur_ctime < $self->{retention_time});
+                my $tab = $2;
+                push @log_table_rows, [($cur_ctime, undef, undef, undef, $tab, undef, undef, undef, 0, '5', $instance_name, undef, undef)];
+            }
+
+            if (scalar(@log_table_rows) > $self->{queries_per_transaction}) {
+                $self->{counter} += scalar(@log_table_rows);
+                $self->commit_to_log($sth, \@log_table_rows);
+                @log_table_rows = ();
+            }
+        }
+        $self->{counter} += scalar(@log_table_rows);
+        $self->commit_to_log($sth, \@log_table_rows);
+    };
+    close FILE;
+    if ($@) {
+        $self->{csdb}->rollback;
+        die "Database error: $@";
+    }
+    $self->{csdb}->transaction_mode(0);
+}
+
+sub parseArchive {
+    my ($self, $instance) = @_;
+    my $archives;
+
+    # Get instance name
+    my ($status, $sth) = $self->{cdb}->query("SELECT localhost, id, name FROM `nagios_server` WHERE id = " . $instance);
+    if ($status == -1) {
+        $self->{logger}->writeLogInfo("Can't get information on poller");
+        return ;
+    }
+    my $poller = $sth->fetchrow_hashref();
+
+    if ($poller->{localhost}) {
+        ($status, $sth) = $self->{cdb}->query("SELECT `log_file`
+            FROM `cfg_nagios`, `nagios_server` 
+            WHERE `nagios_server_id` = '$instance' 
+                AND `nagios_server`.`id` = `cfg_nagios`.`nagios_server_id` 
+                AND `nagios_server`.`ns_activate` = '1' 
+                AND `cfg_nagios`.`nagios_activate` = '1' LIMIT 1");
+        if ($status == -1) {
+            $self->{logger}->writeLogError("Can't get information on poller");
+            return ;
+        }
+        my $data = $sth->fetchrow_hashref();
+        $data->{log_archive_path} = $data->{log_file};
+        $data->{log_archive_path} =~  s#(.*)/.*#$1/archives/#;;
+        if (!$data->{log_archive_path}) {
+            $self->{logger}->writeLogError("Can't find local varlib directory \"$data->{log_archive_path}\"");
+            return ;
+        }
+        $archives = $data->{log_archive_path};
+    } else {
+        $archives = $self->{centreon_config}->{VarLib} . "/log/$instance/archives/";
+    }
+
+    my @files;
+    if (!opendir(DIR, $archives)) {
+        $self->{logger}->writeLogError("Can't find $archives directory");
+        return ;
+    }
+    while (my $file = readdir(DIR)) {
+        push(@files, $file) if ($file !~ m/^\.|\.gz$/msi);
+    }
+    closedir DIR;
+
+    @files = sort { ($a =~ m/.*-(.*?)$/msi)[0] <=> ($b =~ m/.*-(.*?)$/msi)[0] } @files;
+
+    while (my $file = shift @files) {
+        $self->parseFile($archives . $file, $poller->{name});
+    }
+}
+
+sub run {
+    my $self = shift;
+
+    $self->SUPER::run();
+    $self->{logger}->writeLogInfo("Starting program...");
+
+    if (defined($self->{opt_s})) {
+        if ($self->{opt_s} !~ m/\d{2}-\d{2}-\d{4}/) {
+            $self->{logger}->writeLogError("Invalid start date provided");
+            return ;
+        }
+    }
+
+    # Get conf Data
+    if (defined($self->{opt_s})) {
+        my ($day,$month,$year) = (split(/-/, $self->{opt_s}))[1,0,2];
+        $self->{retention_time} = mktime(0,0,0,$day,$month-1,$year-1900,0,0,-1);
+    } else {
+        my ($status, $sth_config) = $self->{csdb}->query("SELECT `archive_retention` FROM `config` LIMIT 1");
+        if ($status == -1) {
+            $self->{logger}->writeLogError("Can't get logs retention duration");
+            return;
+        }
+        my $data = $sth_config->fetchrow_hashref();
+
+        my ($day,$month,$year) = (localtime(time()))[3,4,5];
+        $self->{retention_time} =  mktime(0,0,0,$day-$data->{'archive_retention'},$month,$year,0,0,-1);
+    }
+
+    # Get cache
+    my $filter_instance = "";
+    my $instance_id;
+    if (defined($self->{opt_p})) {
+        $instance_id = $self->getPollerId($self->{opt_p});
+        if ($instance_id == 0) {
+            $self->{logger}->writeLogError("Unknown poller $self->{opt_p}");
+            return ;
+        }
+        $filter_instance = "ns_host_relation.nagios_server_id = '$instance_id' AND";
+    }
+
+    my ($status, $sth_cache) = $self->{cdb}->query("SELECT host.host_id, host.host_name 
+        FROM host, ns_host_relation 
+        WHERE $filter_instance ns_host_relation.host_host_id = host.host_id 
+        AND host.host_activate = '1'");
+    if ($status == -1) {
+        $self->{logger}->writeLogError("Can't get host cache");
+        return ;
+    }
+    while (my $tmp_cache = $sth_cache->fetchrow_hashref()) {
+        $self->{cache_host}{$tmp_cache->{'host_name'}} = $tmp_cache->{'host_id'};
+    }
+
+    ($status, $sth_cache) = $self->{cdb}->query("SELECT host.host_name, host.host_id, service.service_id, service.service_description 
+        FROM host, host_service_relation, service, ns_host_relation 
+        WHERE $filter_instance ns_host_relation.host_host_id = host.host_id 
+        AND host.host_id = host_service_relation.host_host_id 
+        AND host_service_relation.service_service_id = service.service_id 
+        AND service.service_activate = '1'");
+    if ($status == -1) {
+        $self->{logger}->writeLogError("Can't get service cache");
+        return;
+    }
+    while ((my $tmp_cache = $sth_cache->fetchrow_hashref())) {
+        $self->{cache_host_service}{$tmp_cache->{'host_name'} . ':' . $tmp_cache->{'service_description'}} = {'host_id' =>  $tmp_cache->{'host_id'}, 'service_id' =>  $tmp_cache->{'service_id'}};
+    }
+
+    ($status, $sth_cache) = $self->{cdb}->query("SELECT host.host_name, host.host_id, service.service_id, service.service_description 
+        FROM host, host_service_relation, hostgroup_relation, service, ns_host_relation 
+        WHERE $filter_instance ns_host_relation.host_host_id = host.host_id 
+        AND host.host_id = hostgroup_relation.host_host_id 
+        AND hostgroup_relation.hostgroup_hg_id = host_service_relation.hostgroup_hg_id 
+        AND host_service_relation.service_service_id = service.service_id 
+        AND service.service_activate = '1'");
+    if ($status == -1) {
+        $self->{logger}->writeLogError("Can't get service by hostgroup cache");
+        return;
+    }
+    while ((my $tmp_cache = $sth_cache->fetchrow_hashref())) {
+        $self->{cache_host_service}{$tmp_cache->{host_name} . ':' . $tmp_cache->{'service_description'}} = { host_id =>  $tmp_cache->{host_id}, service_id => $tmp_cache->{service_id}};
+    }
+
+    $self->{logger}->writeLogInfo("Starting logs import from " . localtime($self->{retention_time}) . " to " . localtime($self->{current_time}));
+
+    if (defined($self->{opt_p}) && $instance_id) {
+	    $self->{logger}->writeLogInfo("Processing poller $self->{opt_p}");
+
+        $self->{logger}->writeLogInfo("Purging data");
+        $self->{csdb}->query("DELETE FROM `logs` 
+            WHERE `ctime` >= $self->{retention_time} 
+            AND `ctime` < $self->{current_time} 
+            AND instance_name = " . $self->{csdb}->quote($self->{opt_p}));
+        $self->{logger}->writeLogInfo("Purge completed");
+
+        $self->{counter} = 0;
+        $self->{logger}->writeLogInfo("Importing data");
+        $self->parseArchive($instance_id);
+        $self->{logger}->writeLogInfo("Import completed ($self->{counter} entries)");
+    } else {
+        my ($status, $sth) = $self->{cdb}->query("SELECT `id`, `name`, `localhost` FROM `nagios_server` WHERE `ns_activate` = 1");
+        if ($status == -1) {
+            $self->{logger}->writeLogError("Can't get poller list");
+        } else {
+            while (my $ns_server = $sth->fetchrow_hashref()) {
+                $self->{logger}->writeLogInfo("Processing poller $ns_server->{'name'}");
+
+                $self->{logger}->writeLogInfo("Purging data");
+                $self->{csdb}->query("DELETE FROM `logs` 
+                    WHERE `ctime` >= $self->{retention_time} 
+                    AND `ctime` < $self->{current_time} 
+                    AND instance_name = " . $self->{csdb}->quote($ns_server->{'name'}));
+                $self->{logger}->writeLogInfo("Purging completed");
+                
+                $self->{counter} = 0;
+                $self->{logger}->writeLogInfo("Importing data");
+                $self->parseArchive($ns_server->{'id'});
+                $self->{logger}->writeLogInfo("Import completed ($self->{counter} entries)");
+            }
+        }
+    }
+
+    $self->{logger}->writeLogInfo("Exiting program...");
+}
+
+1;

--- a/perl-libs/lib/centreon/trapd/Log.pm
+++ b/perl-libs/lib/centreon/trapd/Log.pm
@@ -1,0 +1,220 @@
+################################################################################
+# Copyright 2005-2013 Centreon
+# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+# 
+# This program is free software; you can redistribute it and/or modify it under 
+# the terms of the GNU General Public License as published by the Free Software 
+# Foundation ; either version 2 of the License.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with 
+# this program; if not, see <http://www.gnu.org/licenses>.
+# 
+# Linking this program statically or dynamically with other modules is making a 
+# combined work based on this program. Thus, the terms and conditions of the GNU 
+# General Public License cover the whole combination.
+# 
+# As a special exception, the copyright holders of this program give Centreon 
+# permission to link this program with independent modules to produce an executable, 
+# regardless of the license terms of these independent modules, and to copy and 
+# distribute the resulting executable under terms of Centreon choice, provided that 
+# Centreon also meet, for each linked independent module, the terms  and conditions 
+# of the license of that module. An independent module is a module which is not 
+# derived from this program. If you modify this program, you may extend this 
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+# 
+#
+####################################################################################
+
+package centreon::trapd::Log;
+
+use strict;
+use warnings;
+use centreon::common::misc;
+use IO::Select;
+my %handlers = ('TERM' => {}, 'HUP' => {});
+
+sub new {
+    my $class = shift;
+    my $self  = {};
+
+    $self->{logger} = shift;
+    
+    # reload flag
+    $self->{reload} = 1;
+    $self->{config_file} = undef;
+    $self->{centreontrapd_config} = undef;
+    $self->{construct_log} = {};
+    $self->{request_log} = {};
+    $self->{last_transaction} = time;
+    
+    $self->{"save_read"} = [];
+
+    bless $self, $class;
+    $self->set_signal_handlers;
+    return $self;
+}
+
+sub set_signal_handlers {
+    my $self = shift;
+
+    $SIG{TERM} = \&class_handle_TERM;
+    $handlers{'TERM'}->{$self} = sub { $self->handle_TERM() };
+    $SIG{HUP} = \&class_handle_HUP;
+    $handlers{HUP}->{$self} = sub { $self->handle_HUP() };
+}
+
+sub handle_HUP {
+    my $self = shift;
+    $self->{reload} = 0;
+}
+
+sub handle_TERM {
+    my $self = shift;
+    $self->{'logger'}->writeLogInfo("$$ Receiving order to stop...");
+
+    $self->{'dbcentstorage'}->disconnect() if (defined($self->{'dbcentstorage'}));
+    $self->{'cdb'}->disconnect() if (defined($self->{'cdb'}));
+}
+
+sub class_handle_TERM {
+    foreach (keys %{$handlers{'TERM'}}) {
+        &{$handlers{'TERM'}->{$_}}();
+    }
+    exit(0);
+}
+
+sub class_handle_HUP {
+    foreach (keys %{$handlers{HUP}}) {
+        &{$handlers{HUP}->{$_}}();
+    }
+}
+
+sub reload {
+    my $self = shift;
+    
+    $self->{logger}->writeLogInfo("Reload in progress for logdb process...");
+    # reopen file
+    if ($self->{logger}->is_file_mode()) {
+        $self->{logger}->file_mode($self->{logger}->{file_name});
+    }
+    $self->{logger}->redirect_output();
+    
+    my ($status, $status_cdb, $status_csdb) = centreon::common::misc::reload_db_config($self->{logger}, $self->{config_file},
+                                                                                       $self->{dbcentstorage}, $self->{cdb});
+
+    if ($status_csdb == 1) {
+        $self->{dbcentstorage}->disconnect();
+        $self->{dbcentstorage}->connect();
+    }
+    if ($status_cdb == 1) {
+        $self->{cdb}->disconnect();
+        $self->{cdb}->connect();
+    }
+    if ($self->{centreontrapd_config}->{mode} == 0) {
+        centreon::common::misc::check_debug($self->{logger}, "debug_centreontrapd", $self->{cdb}, "centreontrapd logdb process");
+    }
+
+    $self->{reload} = 1;
+}
+
+sub compute_request {
+    my $self = shift;
+    
+    if (scalar(keys(%{$self->{request_log}})) > $self->{centreontrapd_config}->{log_transaction_request_max} ||
+        (time() - $self->{last_transaction}) > $self->{centreontrapd_config}->{log_transaction_timeout}) {
+        $self->{dbcentstorage}->transaction_mode(1);
+        eval {
+            foreach my $id (keys %{$self->{request_log}}) {
+                $self->{dbcentstorage}->query("INSERT INTO log_traps (`trap_time`, `timeout`, `host_name`, `ip_address`, `agent_host_name`, `agent_ip_address`, `trap_oid`, `trap_name`, `vendor`, `status`, `severity_id`, `severity_name`, `output_message`) VALUES (" . $self->{request_log}->{$id}->{value} . ")");
+                $self->{dbcentstorage}->query("SET \@last_id_trap = LAST_INSERT_ID();");
+                if (defined($self->{request_log}->{$id}->{args})) {
+                    foreach (@{$self->{request_log}->{$id}->{args}}) {
+                        $self->{dbcentstorage}->query("INSERT INTO log_traps_args (`fk_log_traps`, `arg_number`, `arg_oid`, `arg_value`, `trap_time`) VALUES (\@last_id_trap, " . $_ . ")");
+                    }
+                }
+            }
+            $self->{dbcentstorage}->commit;
+        };
+        if ($@) {
+            $self->{dbcentstorage}->rollback;
+        } else {
+             $self->{request_log} = {};
+        }
+        $self->{last_transaction} = time;
+    }
+    
+    # Check time purge
+    foreach my $id (keys %{$self->{construct_log}}) {
+        if ((time() - $self->{construct_log}->{$id}->{time}) > $self->{centreontrapd_config}->{log_purge_time}) {
+            delete $self->{construct_log}->{$id};
+        }
+    }
+}
+
+####
+# Protocol description:
+#      First: ID_UNIQUE:0:num_args:value
+#      Args:  ID_UNIQUE:1:arg_pos:value
+
+sub main {
+    my $self = shift;
+    my ($dbcentstorage, $pipe_read, $config_file, $centreontrapd_config) = @_;
+    my $status;
+
+    $self->{dbcentstorage} = $dbcentstorage;
+    $self->{config_file} = $config_file;
+    $self->{centreontrapd_config} = $centreontrapd_config;
+
+    # We have to manage if you don't need infos
+    $self->{'dbcentstorage'}->force(0);
+
+    my $read_select = new IO::Select();
+    $read_select->add($pipe_read);
+    while (1) {
+        my @rh_set = $read_select->can_read(5);
+        if (scalar(@rh_set) > 0) {
+            foreach my $rh (@rh_set) {
+                my $read_done = 0;
+                while ((my ($status_line, $readline) = centreon::common::misc::get_line_pipe($rh, \@{$self->{'save_read'}}, \$read_done))) {
+                    class_handle_TERM() if ($status_line == -1);
+                    last if ($status_line == 0);
+                    $readline =~ /^(.*?):(.*?):(.*?):(.*)/;
+                    my ($id, $type, $num, $value) = ($1, $2, $3, $4);
+                    $value =~ s/\\n/\n/g;
+
+                    if ($type == 0) {
+                        if ($num <= 0) {
+                            $self->{request_log}->{$id} = { value => $value };
+                        } else {
+                            $self->{construct_log}->{$id} = { time => time(), value => $value, current_args => 0, num_args => $num, args => [] };
+                        }
+                    } elsif ($type == 1) {
+                        if (defined($self->{construct_log}->{$id})) {
+                            if ($self->{construct_log}->{$id}->{current_args} + 1 == $self->{construct_log}->{$id}->{num_args}) {
+                                $self->{request_log}->{$id} = { value => $self->{construct_log}->{$id}->{value}, args => $self->{construct_log}->{$id}->{args} };
+                                delete $self->{construct_log}->{$id};
+                            } else {
+                                push @{$self->{construct_log}->{$id}->{args}}, $value;
+                                $self->{construct_log}->{$id}->{current_args}++;
+                            }
+                        }
+                    }
+                }
+            }
+        } 
+
+        $self->compute_request();
+
+        if ($self->{reload} == 0) {
+            $self->reload();
+        }
+    }
+}
+
+1;

--- a/perl-libs/lib/centreon/trapd/lib.pm
+++ b/perl-libs/lib/centreon/trapd/lib.pm
@@ -1,0 +1,1106 @@
+################################################################################
+# Copyright 2005-2013 Centreon
+# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# GPL Licence 2.0.
+# 
+# This program is free software; you can redistribute it and/or modify it under 
+# the terms of the GNU General Public License as published by the Free Software 
+# Foundation ; either version 2 of the License.
+# 
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License along with 
+# this program; if not, see <http://www.gnu.org/licenses>.
+# 
+# Linking this program statically or dynamically with other modules is making a 
+# combined work based on this program. Thus, the terms and conditions of the GNU 
+# General Public License cover the whole combination.
+# 
+# As a special exception, the copyright holders of this program give Centreon 
+# permission to link this program with independent modules to produce an executable, 
+# regardless of the license terms of these independent modules, and to copy and 
+# distribute the resulting executable under terms of Centreon choice, provided that 
+# Centreon also meet, for each linked independent module, the terms  and conditions 
+# of the license of that module. An independent module is a module which is not 
+# derived from this program. If you modify this program, you may extend this 
+# exception to your version of the program, but you are not obliged to do so. If you
+# do not wish to do so, delete this exception statement from your version.
+# 
+#
+####################################################################################
+
+package centreon::trapd::lib;
+
+use warnings;
+use strict;
+use POSIX qw(strftime);
+use File::stat;
+
+my $local_broker;
+
+sub init_modules {
+    # logger => obj
+    # htmlentities => (ref)
+    # config => hash
+    my %args = @_;
+
+    ####
+    # SNMP Module
+    ####
+    if ($args{config}->{net_snmp_perl_enable} == 1) {
+        eval 'require SNMP;';
+        if ($@) {
+            $args{logger}->writeLogError($@);
+            $args{logger}->writeLogError("Could not load the Perl module SNMP!  If net_snmp_perl_enable is");
+            $args{logger}->writeLogError("enabled then the SNMP module is required");
+            $args{logger}->writeLogError("for system requirements.  Note:  uses the Net-SNMP package's");
+            $args{logger}->writeLogError("SNMP module, NOT the CPAN Net::SNMP module!");
+            die("Quit");
+        }
+        if (defined ($args{config}->{mibs_environment}) && $args{config}->{mibs_environment} ne '') {
+            $ENV{'MIBS'} = $args{config}->{mibs_environment};
+        }
+        &SNMP::initMib();
+
+        $args{logger}->writeLogInfo("********** Net-SNMP version $SNMP::VERSION Perl module enabled **********");
+        if (defined ($args{config}->{mibs_environment})) {
+            $args{logger}->writeLogDebug("********** MIBS: " . $args{config}->{mibs_environment} . " **********");
+        }
+    }
+    
+    if ($args{config}->{duplicate_trap_window} > 0) {
+        eval 'require Digest::MD5;';
+        if ($@) {
+            $args{logger}->writeLogError($@);
+            $args{logger}->writeLogError("Could not load the Perl module Digest::MD5!  If centrapmanager_duplicate_trap_window");
+            $args{logger}->writeLogError("is set then the Digest::MD5 module is required");
+            $args{logger}->writeLogError("for system requirements.");
+            die("Quit");
+        }
+    }
+    
+    if (defined($args{config}->{local_broker})) {
+        eval 'require Monitoring::Livestatus;';
+        if ($@) {
+            $args{logger}->writeLogError($@);
+            $args{logger}->writeLogError("Could not load the Perl module Monitoring::Livestatus!  If local_broker");
+            $args{logger}->writeLogError("is set then the Monitoring::Livestatus module is required");
+            $args{logger}->writeLogError("for system requirements.");
+            die("Quit");
+        }
+        
+        $local_broker = Monitoring::Livestatus->new(
+            socket => $args{config}->{local_broker},
+            errors_are_fatal => 0,
+            query_timeout => 60,
+            connect_timeout => 5,
+        );
+    }
+    
+    eval "require HTML::Entities";
+    if ($@) {
+        ${$args{htmlentities}} = 0;
+    } else {
+        ${$args{htmlentities}} = 1;
+    }
+}
+
+sub manage_params_conf {
+    my ($date_format, $time_format) = @_;
+
+    if (!defined($date_format) || $date_format eq "") {
+        $date_format = "%a %b %e %Y";
+    }
+    if (!defined($time_format) || $time_format eq "") {
+        $time_format = "%H:%M:%S";
+    }
+    
+    return ($date_format, $time_format);
+}
+
+##############
+# DB Request
+##############
+
+# We get All datas for a TRAP
+sub get_oids {
+    my ($cdb, $ids) = @_;
+    my $ref_result;
+    
+    my ($dstatus, $sth) = $cdb->query(
+       "SELECT name, traps_log, traps_execution_command, traps_reschedule_svc_enable, traps_id, traps_args,
+        traps_oid, traps_name, traps_mode, traps_advanced_treatment, traps_advanced_treatment_default, traps_execution_command_enable, traps_submit_result_enable, traps_status,
+        traps_timeout, traps_customcode, traps_exec_interval, traps_exec_interval_type,
+        traps_routing_mode, traps_routing_value, traps_routing_filter_services,
+        traps_exec_method, traps_downtime, traps_output_transform,
+        service_categories.level, service_categories.sc_name, service_categories.sc_id
+        FROM traps
+        LEFT JOIN traps_vendor ON (traps_vendor.id = traps.manufacturer_id)
+        LEFT JOIN service_categories ON (service_categories.sc_id = traps.severity_id)
+        WHERE traps_id IN (" . join(',', @$ids) . ")"
+    );
+    return -1 if ($dstatus == -1);
+    $ref_result = $sth->fetchall_hashref('traps_id');
+    
+    foreach (keys %$ref_result) {
+        # Get Matching Status Rules
+        if (defined($ref_result->{$_}->{traps_advanced_treatment}) && $ref_result->{$_}->{traps_advanced_treatment} == 1) {
+            ($dstatus, $sth) = $cdb->query(
+                "SELECT * FROM traps_matching_properties
+                 LEFT JOIN service_categories ON (service_categories.sc_id = traps_matching_properties.severity_id)
+                 WHERE trap_id = " . $_ . " ORDER BY tmo_order ASC"
+            );
+            return -1 if ($dstatus == -1);
+            $ref_result->{$_}->{traps_matching_properties} = [];
+            while (my $row = $sth->fetchrow_hashref()) {
+                push @{$ref_result->{$_}->{traps_matching_properties}}, $row;
+            }
+        }
+        
+        # Get Trap PREEXEC Commands
+        ($dstatus, $sth) = $cdb->query("SELECT * FROM traps_preexec WHERE trap_id = " . $_ . " ORDER BY tpe_order ASC");
+        return -1 if ($dstatus == -1);
+        $ref_result->{$_}->{traps_preexec} = [];
+        while (my $row = $sth->fetchrow_hashref()) {
+            push @{$ref_result->{$_}->{traps_preexec}}, $row;
+        }
+        
+        # Get Trap PREEXEC Commands
+        ($dstatus, $sth) = $cdb->query("SELECT tg2.traps_id FROM traps_group_relation as tg1, traps_group_relation as tg2 WHERE tg1.traps_id = " . $_ . " AND tg1.traps_group_id = tg2.traps_group_id");
+        return -1 if ($dstatus == -1);
+        $ref_result->{$_}->{traps_group} = [];
+        while (my $row = $sth->fetchrow_hashref()) {
+            push @{$ref_result->{$_}->{traps_group}}, $row->{traps_id};
+        }
+        # We force sequential (grouping)
+        if (scalar(@{$ref_result->{$_}->{traps_group}}) > 0) {
+            $ref_result->{$_}->{traps_exec_method} = 1;
+        }
+    }
+    return (0, $ref_result);
+}
+
+sub get_hosts {
+    # logger => obj
+    # cbd => obj
+    # trap_info => ref
+    # agent_dns_name => value
+    # ip_address => value
+    my %args = @_;
+    my ($dstatus, $sth);
+    my $ref_result;
+    my $request;
+    
+    if ($args{trap_info}->{traps_routing_mode} == 1 
+        && defined($args{trap_info}->{traps_routing_value}) && $args{trap_info}->{traps_routing_value} ne '') {
+        my $search_str = $args{centreontrapd}->substitute_string($args{trap_info}->{traps_routing_value});
+        $search_str = $args{centreontrapd}->substitute_centreon_functions($search_str);
+        $request = "SELECT host_id, host_name FROM host WHERE host_address = " . $args{cdb}->quote($search_str);
+    } else {
+        # Default Mode
+        $request = "SELECT host_id, host_name FROM host WHERE host_address = " . $args{cdb}->quote($args{agent_dns_name}) .  " OR host_address=" . $args{cdb}->quote($args{ip_address});  
+    }
+    
+    ($dstatus, $sth) = $args{cdb}->query($request);
+    return -1 if ($dstatus == -1);
+    $ref_result = $sth->fetchall_hashref('host_id');
+
+    if ($args{logger}->is_debug()) {
+        if (scalar(keys %$ref_result) == 0) {
+            $args{logger}->writeLogDebug("Cant find a host. Request: " . $request);
+        }
+    }
+    
+    # Get server_id
+    foreach (keys %$ref_result) {
+        ($dstatus, $sth) = $args{cdb}->query("SELECT ns_host_relation.nagios_server_id, nagios_server.ns_ip_address FROM ns_host_relation, nagios_server WHERE 
+                                              ns_host_relation.host_host_id = " . $ref_result->{$_}->{host_id} . " AND ns_host_relation.nagios_server_id = nagios_server.id LIMIT 1");
+        return -1 if ($dstatus == -1);
+        my $data = $sth->fetchrow_hashref();
+        $ref_result->{$_}->{nagios_server_id} = $data->{nagios_server_id};
+        $ref_result->{$_}->{ns_ip_address} = $data->{ns_ip_address};
+    }
+    
+    return (0, $ref_result);
+}
+
+sub get_services {
+    my ($cdb, $trap_id, $host_id, $result) = @_;
+    my $services_do = {};
+    
+    ### Get service List for the Host
+    my ($dstatus, $sth) = $cdb->query(
+        "SELECT s.service_id, s.service_description, esi.esi_notes FROM host h, host_service_relation hsr, service s LEFT JOIN extended_service_information esi ON s.service_id = esi.service_service_id WHERE 
+            h.host_id = " . $host_id . " AND h.host_activate = '1' AND h.host_id = hsr.host_host_id AND hsr.service_service_id = s.service_id AND s.service_activate = '1'
+         UNION ALL SELECT s.service_id, s.service_description, esi.esi_notes  FROM 
+            host h, host_service_relation hsr, hostgroup_relation hgr, service s LEFT JOIN extended_service_information esi ON s.service_id = esi.service_service_id WHERE h.host_id = " . $host_id . " AND h.host_activate = '1' AND 
+            h.host_id = hgr.host_host_id AND hgr.hostgroup_hg_id = hsr.hostgroup_hg_id AND hsr.service_service_id = s.service_id AND s.service_activate = '1'"
+    );
+    return -1 if ($dstatus == -1);
+    $result = $sth->fetchall_hashref('service_id');
+    foreach my $service_id (keys %$result) {
+        # Search Template trap_id
+        my %loop_stop = ();
+        my @stack = ($service_id);
+        
+        while ((my $lservice_id = shift(@stack))) {
+            if (defined($loop_stop{$lservice_id})) {
+                # Already done
+                last;
+            }
+            $loop_stop{$lservice_id} = 1;
+            
+            ($dstatus, $sth) = $cdb->query("SELECT traps_id FROM traps_service_relation WHERE service_id = '" . $lservice_id . "' AND traps_id = '" . $trap_id . "' LIMIT 1");
+            return -1 if ($dstatus == -1);
+            my $data = $sth->fetchrow_hashref();
+            if (defined($data)) {
+                $services_do->{$service_id} = $result->{$service_id};
+                last;
+            }
+            
+            ($dstatus, $sth) = $cdb->query("SELECT service_template_model_stm_id FROM service WHERE service_id = " . $lservice_id . " LIMIT 1");
+            return -1 if ($dstatus == -1);
+            $data = $sth->fetchrow_hashref();
+            if (defined($data) && defined($data->{service_template_model_stm_id})) {
+                unshift @stack, $data->{service_template_model_stm_id};
+            }
+        }
+    }
+    
+    return (0, $services_do);
+}
+
+sub check_downtimes_local_broker {
+    my (%options) = @_;
+    
+    my $request = "GET services\nColumns: description host_scheduled_downtime_depth scheduled_downtime_depth\n";
+    my $num = 0;
+    my %description = ();
+    foreach my $service_id (keys %{$options{ref_services}}) {
+        $request .= 'Filter: description = ' . $options{ref_services}->{$service_id}->{service_description} . "\n";
+        $description{$options{ref_services}->{$service_id}->{service_description}} = $service_id;
+        $num++;
+    }
+    if ($num > 1) {
+        $request .= 'Or: ' . $num . "\n";
+    }
+    $request .= "Filter: host_name = " . $options{host_name} . "\nAnd: 2";
+ 
+    my $result = $local_broker->selectall_arrayref($request);
+    if ($Monitoring::Livestatus::ErrorCode) {
+        $options{logger}->writeLogError("Cannot request local broker for downtimes: " . $Monitoring::Livestatus::ErrorMessage);
+        return -1;
+    }
+    
+    foreach (@{$result}) {
+        if ($$_[1] == 1 || $$_[2] == 1) {
+            $options{logger}->writeLogInfo("skipping trap: host '$options{host_name}' [id: $options{host_id}] and service '$$_[0]' in downtime");
+            delete $options{ref_services}->{$description{$$_[0]}};
+        }
+    }
+ 
+    return 0;
+}
+
+sub check_downtimes {
+    my (%options) = @_;
+    my $ref_result;
+    
+    if (defined($options{local_broker})) {
+        return check_downtimes_local_broker(%options);
+    }
+    
+    # Only one request is $downtime == 2
+    if ($options{downtime} == 2) {
+        my ($dstatus, $sth) = $options{csdb}->query("SELECT DISTINCT IFNULL(service_id, 'host') as service_id FROM downtimes WHERE host_id = $options{host_id} AND start_time <= $options{trap_time} AND end_time >= $options{trap_time}");
+        return -1 if ($dstatus == -1);
+        $ref_result = $sth->fetchall_hashref('service_id');
+    }
+    
+    # Check if host is in downtime - if yes: return 1
+    if ($options{downtime} == 1) {
+        # Real-Time
+        my ($dstatus, $sth) = $options{csdb}->query("SELECT host_id FROM hosts WHERE host_id = $options{host_id} AND scheduled_downtime_depth > 0 LIMIT 1");
+        return -1 if ($dstatus == -1);
+        my $data = $sth->fetchrow_hashref();
+        if (defined($data)) {
+            # Go out. Downtime on host.
+            $options{logger}->writeLogInfo("skipping trap: host '$options{host_name}' [id: $options{host_id}] in downtime");
+            return 1;
+        }
+    } else {
+        # Check it
+        if (defined($ref_result->{host})) {
+            $options{logger}->writeLogInfo("skipping trap: host '$options{host_name}' [id: $options{host_id}] in downtime");
+            return 1;
+        }
+    }
+    
+    if (scalar(keys %{$options{ref_services}}) == 0) {
+        return 0;
+    }
+    
+    if ($options{downtime} == 1) {
+        # Check some services only
+        my ($dstatus, $sth) = $options{csdb}->query("SELECT service_id FROM services WHERE service_id IN (" . join(',', keys %{$options{ref_services}}) . ") AND scheduled_downtime_depth > 0");
+        return -1 if ($dstatus == -1);
+        $ref_result = $sth->fetchall_hashref('service_id');
+    }
+    
+    # Parse services
+    foreach my $service_id (keys %{$options{ref_services}}) {
+        if (defined($ref_result->{$service_id})) {
+            $options{logger}->writeLogInfo("Skipping trap: host '$options{host_name}' [id: $options{host_id}] and service $service_id in downtime");
+            delete $options{ref_services}->{$service_id};
+        }
+    }
+    
+    return 0;
+}
+
+sub set_macro {
+    my ($macros, $name, $value) = @_;
+    
+    if (!defined($macros->{$name})) {
+        $macros->{$name} = $value;
+    }
+}
+
+sub get_macros_host {
+    my ($cdb, $host_id) = @_;
+    my ($dstatus, $sth, $value);
+    my %macros;
+    my %loop_stop = ();
+    my @stack = ($host_id);
+    
+    while ((my $lhost_id = shift(@stack))) {
+        if (defined($loop_stop{$lhost_id})) {
+            # Already done the host
+            next;
+        }
+        $loop_stop{$lhost_id} = 1;
+    
+        ($dstatus, $sth) = $cdb->query("SELECT host_snmp_community, host_snmp_version FROM host WHERE host_id = " . $lhost_id . " LIMIT 1");
+        return -1 if ($dstatus == -1);
+        $value = $sth->fetchrow_hashref();
+        if (defined($value->{host_snmp_community}) && $value->{host_snmp_community} ne "") {
+            set_macro(\%macros, '$_HOSTSNMPCOMMUNITY$', $value->{host_snmp_community});
+        }
+        if (defined($value->{host_snmp_version}) && $value->{host_snmp_version} ne "") {
+            set_macro(\%macros, '$_HOSTSNMPVERSION$', $value->{host_snmp_version});
+        }
+    
+        ($dstatus, $sth) = $cdb->query("SELECT host_macro_name, host_macro_value FROM on_demand_macro_host WHERE host_host_id = " . $lhost_id);
+        return -1 if ($dstatus == -1);
+        while ($value = $sth->fetchrow_hashref()) {
+            set_macro(\%macros, $value->{host_macro_name}, $value->{host_macro_value});
+        }
+    
+        ($dstatus, $sth) = $cdb->query("SELECT host_tpl_id FROM host_template_relation WHERE host_host_id = " . $lhost_id . " ORDER BY `order` DESC");
+        return -1 if ($dstatus == -1);
+        while ($value = $sth->fetchrow_hashref()) {
+            unshift @stack, $value->{host_tpl_id};
+        }
+    }
+        
+    return (0, \%macros);
+}
+
+##############
+# Send trap
+##############
+
+sub trim {
+    my ($value) = $_[0];
+    
+    # Sometimes there is a null character
+    $value =~ s/\x00$//;
+    $value =~ s/^[ \t]+//;
+    $value =~ s/[ \t]+$//;
+    return $value;
+}
+
+sub trap_forward {
+    my (%options) = @_;
+    
+    my @arguments = split(',', $options{arguments});
+    if (scalar(@arguments) < 2) {
+        $options{logger}->writeLogError('At least 2 arguments for @TRAPFORWARD(oid, ip1, ...)@');
+        return ;
+    }
+    
+    my $oid = trim(shift @arguments);
+    my $agent_ip = ${$options{trap_data}->{var}}[4];
+    
+    my @bindings = ();
+    for (my $i = 0; $i <= $#{$options{trap_data}->{entvar}}; $i++) {
+        $options{trap_data}->{entvarname}->[$i] =~ /^(.*?)\.(\d+)$/;
+        push @bindings, new SNMP::Varbind([$1, $2, sprintf("%s", $options{trap_data}->{entvar}->[$i]), 'OCTETSTR']);
+    }
+    push @bindings, new SNMP::Varbind(['.1.3.6.1.6.3.18.1.3', 0, sprintf("%s", $agent_ip), 'OCTETSTR']);
+    my $vb = new SNMP::VarList(@bindings);
+    while ((my $dst_host = shift(@arguments))) {
+        my $session = new SNMP::TrapSession(DestHost => trim($dst_host), Community => 'centreon', Version => 2,
+                                            UseNumeric => 1);
+        $session->trap(oid => $oid, uptime => time(), $vb);
+        $options{logger}->writeLogInfo('trap forwarded to ' . $dst_host);
+    }
+}
+
+##############
+# Protocol with logdb
+##############
+
+sub send_logdb {
+    my %args = @_;
+    my $pipe = $args{pipe};
+    my $num_args = $#{$args{entvar}} + 1;
+    
+    # Need atomic write (Limit to 4096 with Linux)
+    $args{output_message} =~ s/\n/\\n/g;
+    my $value = $args{id} . ":0:$num_args:" . 
+                $args{trap_time} . "," .
+                $args{cdb}->quote($args{timeout}) . "," .
+                $args{cdb}->quote($args{host_name}) . "," .  
+                $args{cdb}->quote($args{ip_address}) . "," .
+                $args{cdb}->quote($args{agent_host_name}) . "," .
+                $args{cdb}->quote($args{agent_ip_address}) . "," .
+                $args{cdb}->quote($args{trap_oid}) . "," .
+                $args{cdb}->quote($args{trap_name}) . "," .
+                $args{cdb}->quote($args{vendor}) . "," .
+                $args{cdb}->quote($args{status}) . "," .
+                $args{cdb}->quote($args{severity_id}) . "," .
+                $args{cdb}->quote($args{severity_name}) . ",";
+    # We truncate if it
+    $value .= substr($args{cdb}->quote($args{output_message}), 0, 4096 - length($value) - 1);
+    print $pipe $value . "\n";
+
+    for (my $i=0; $i <= $#{$args{entvar}}; $i++) {
+        my $value = ${$args{entvar}}[$i];
+        $value =~ s/\n/\\n/g;
+        print $pipe $args{id} . ":1:$i:" . 
+                    $i . "," .
+                    $args{cdb}->quote(${$args{entvarname}}[$i]) . "," .
+                    $args{cdb}->quote($value) . "," .
+                    $args{trap_time} . "\n";
+    }
+}
+
+##############
+# CACHE MANAGEMENT
+##############
+
+sub get_cache_oids {
+    # cdb => connection db
+    # last_cache_time => ref
+    # oids_cache => ref
+    my %args = @_;
+
+    my ($status, $sth) = $args{cdb}->query('SELECT traps_oid, traps_id, traps_mode FROM traps');
+    return -1 if ($status == -1);
+    
+    ${$args{oids_cache}} = { 0 => {}, 1 => {} };
+    my $rows = [];
+    while (my $row = (
+        shift(@$rows) ||
+        shift(@{$rows = $sth->fetchall_arrayref(undef,5000)||[]})
+        )
+    ) {
+        ${$args{oids_cache}}->{$row->[2]}->{$row->[0]} = [] if (!defined(${$args{oids_cache}}->{$row->[2]}->{$row->[0]}));
+        push @{${$args{oids_cache}}->{$$row[2]}->{$$row[0]}}, $row->[1];
+    }
+
+    ${$args{last_cache_time}} = time();
+    return 0;
+}
+
+sub display_unknown_traps {
+    my %options = @_;
+    
+    $options{logger}->writeLogInfo("Unknown trap");
+    if ($options{config}->{unknown_trap_enable} == 1) {
+        $options{logger_unknown}->writeLogInfo("Trap received from $options{trap_data}->{var}->[0]: $options{trap_data}->{var}->[3]");
+        my @labels = (
+            'hostname                  ',
+            'ip address                ',
+            'uptime                    ',
+            'trapname / OID            ', 
+            'ip address from trap agent',
+            'trap community string     ',
+            'enterprise                ',
+            'securityEngineID (not use)', 
+            'securityName     (not use)',
+            'contextEngineID  (not use)',
+            'contextName      (not)    '
+        ); 
+        #print out all standard variables
+        for (my $i=0; $i <= $#{$options{trap_data}->{var}}; $i++) {
+            $options{logger_unknown}->writeLogInfo("$labels[$i]: " . $options{trap_data}->{var}->[$i]);
+        }
+
+        #print out all enterprise specific variables
+        for (my $i=0; $i <= $#{$options{trap_data}->{entvar}}; $i++) {
+            $options{logger_unknown}->writeLogInfo("Ent Value $i (\$" . ($i+1) . "): " . $options{trap_data}->{entvarname}->[$i] . "=" . $options{trap_data}->{entvar}->[$i]);
+        }
+        $options{logger_unknown}->writeLogInfo("");
+    }
+}
+
+sub check_known_trap {
+    # logger => obj
+    # config => hash
+    # oid2verif => val
+    # cdb => db connection
+    # last_cache_time => ref
+    # oids_cache => ref
+    my %args = @_;
+    my $oid2verif = $args{oid2verif};
+
+    if (!defined(${$args{last_cache_time}}) || 
+        ((time() - ${$args{last_cache_time}}) > $args{config}->{cache_unknown_traps_retention})) {
+        if (get_cache_oids(cdb => $args{cdb}, oids_cache => $args{oids_cache}, last_cache_time => $args{last_cache_time}) == -1) { 
+            $args{logger}->writeLogError("Cant load cache trap oids."); 
+            return -1;
+        }
+    }
+
+    if (defined(${$args{oids_cache}}->{0}->{$oid2verif})) {
+        return (1, ${$args{oids_cache}}->{0}->{$oid2verif});
+    }
+
+    # Regexp
+    my @traps_ids = ();
+    foreach my $oid (keys %{${$args{oids_cache}}->{1}}) {
+        if ($oid2verif =~ m/$oid/) {
+            push @traps_ids, @{${$args{oids_cache}}->{1}->{$oid}};
+        }
+    }
+    if (scalar(@traps_ids) > 0) {
+        return (1, \@traps_ids);
+    }
+
+    display_unknown_traps(
+        logger => $args{logger},
+        logger_unknown => $args{logger_unknown}, 
+        config => $args{config},
+        trap_data => $args{trap_data}
+    );
+
+    return 0;
+}
+
+###
+# Code from SNMPTT Modified
+# Copyright 2002-2009 Alex Burger
+# alex_b@users.sourceforge.net
+###
+
+sub get_trap {
+    # logger => obj
+    # config => hash
+    # filenames => ref array
+    my %args = @_;
+
+    if (!@{$args{filenames}}) { 
+        if (!(chdir($args{config}->{spool_directory}))) {
+            $args{logger}->writeLogError("Unable to enter spool dir " . $args{config}->{spool_directory} . ":$!");
+            return undef;
+        }
+        if (!(opendir(DIR, "."))) {
+            $args{logger}->writeLogError("Unable to open spool dir " . $args{config}->{spool_directory} . ":$!");
+            return undef;
+        }
+        if (!(@{$args{filenames}} = readdir(DIR))) {
+            $args{logger}->writeLogError("Unable to read spool dir " . $args{config}->{spool_directory} . ":$!");
+            return undef;
+        }
+        closedir(DIR);
+        @{$args{filenames}} = sort (@{$args{filenames}});
+    }
+    
+    while ((my $file = shift @{$args{filenames}})) {
+        next if ($file eq ".");
+        next if ($file eq "..");
+        next if (! -f $args{config}->{spool_directory} . '/' . $file);
+        return $file;
+    }
+    return undef;
+}
+
+sub purge_duplicate_trap {
+    # config => hash
+    # duplicate_traps => ref hash 
+    my %args = @_;
+
+    if ($args{config}->{duplicate_trap_window}) {
+        # Purge traps older than duplicate_trap_window in %duplicate_traps
+        my $duplicate_traps_current_time = time();
+        foreach my $key (sort keys %{$args{duplicate_traps}}) {
+            if ($args{duplicate_traps}->{$key} < $duplicate_traps_current_time - $args{config}->{duplicate_trap_window}) {
+                # Purge the record
+                delete $args{duplicate_traps}->{$key};
+            }
+        }
+    }
+}
+
+sub readtrap {
+    # logger => obj
+    # config => hash
+    # handle => str
+    # agent_dns => ref
+    # trap_date => ref
+    # trap_time => ref
+    # trap_date_time => ref
+    # trap_date_time_epoch => ref
+    # duplicate_traps => ref hash
+    # digest_trap => ref,
+    # var => ref array
+    # entvar => ref array
+    # entvarname => ref array
+    
+    my %args = @_;
+    my $input = $args{handle};
+
+    # Flush out @tempvar, @var and @entvar
+    my @tempvar = ();
+    @{$args{var}} = ();
+    @{$args{entvar}} = ();
+    @{$args{entvarname}} = ();
+    my @rawtrap = ();
+
+    $args{logger}->writeLogDebug("Reading trap.  Current time: " . scalar(localtime()));
+
+    chomp(${$args{trap_date_time_epoch}} = (<$input>));	# Pull time trap was spooled
+    push(@rawtrap, ${$args{trap_date_time_epoch}});
+    if (${$args{trap_date_time_epoch}} eq "") {
+        if ($args{logger}->is_debug()) {
+            $args{logger}->writeLogDebug("  Invalid trap file.  Expected a serial time on the first line but got nothing");
+            return 0;
+        }
+    }
+    ${$args{trap_date_time_epoch}} =~ s(`)(')g;	#` Replace any back ticks with regular single quote
+
+    my @localtime_array;
+    if ($args{config}->{use_trap_time} == 1) {
+        @localtime_array = localtime(${$args{trap_date_time_epoch}});
+
+        if ($args{config}->{date_time_format} eq "") {
+            ${$args{trap_date_time}} = localtime(${$args{trap_date_time_epoch}});
+        } else {
+            ${$args{trap_date_time}} = strftime($args{config}->{date_time_format}, @localtime_array);
+        }
+    } else {
+        @localtime_array = localtime();
+
+        if ($args{config}->{date_time_format} eq "") {
+            ${$args{trap_date_time}} = localtime();
+        } else {
+            ${$args{trap_date_time}} = strftime($args{config}->{date_time_format}, @localtime_array);
+        }
+    }
+
+    ${$args{trap_date}} = strftime($args{config}->{date_format}, @localtime_array);
+    ${$args{trap_time}} = strftime($args{config}->{time_format}, @localtime_array);
+
+    # Pull in passed SNMP info from snmptrapd via STDIN and place in the array @tempvar
+    chomp($tempvar[0]=<$input>);	# hostname
+    push(@rawtrap, $tempvar[0]);
+    $tempvar[0] =~ s(`)(')g;	#` Replace any back ticks with regular single quote 
+    if ($tempvar[0] eq "") {
+        if ($args{logger}->is_debug()) {
+            $args{logger}->writeLogDebug("  Invalid trap file.  Expected a hostname on line 2 but got nothing");
+            return 0;
+        }
+    }
+        
+    chomp($tempvar[1]=<$input>);	# ip address
+    push(@rawtrap, $tempvar[1]);
+    $tempvar[1] =~ s(`)(')g;	#` Replace any back ticks with regular single quote
+    if ($tempvar[1] eq "") {
+        if ($args{logger}->is_debug()) {
+            $args{logger}->writeLogDebug("  Invalid trap file.  Expected an IP address on line 3 but got nothing");
+            return 0;
+        }
+    }
+
+    # With DNS resolution disabled in snmptrapd, some systems pass the hostname as:
+    # UDP: [x.x.x.x]:161->[y.y.y.y]
+    # If this is detected, use x.x.x.x as the hostname.
+    if ($tempvar[0] =~ /\[(\d+\.\d+\.\d+\.\d+)\].*?->\[(\d+\.\d+\.\d+\.\d+)\]/) {
+        $tempvar[0] = $1;
+    }
+    
+    # Some systems pass the IP address as udp:ipaddress:portnumber.  This will pull
+    # out just the IP address
+    $tempvar[1] =~ /(\d+\.\d+\.\d+\.\d+)/;
+    $tempvar[1] = $1;
+
+    # Net-SNMP 5.4 has a bug which gives <UNKNOWN> for the hostname
+    if ($tempvar[0] =~ /<UNKNOWN>/) {
+        $tempvar[0] = $tempvar[1];
+    }
+
+    #Process varbinds
+    #Separate everything out, keeping both the variable name and the value
+    my $linenum = 1;
+    my $variable_fix;
+    while (defined(my $line = <$input>)) {
+        push(@rawtrap, $line);
+        $line =~ s(`)(')g;	#` Replace any back ticks with regular single quote
+
+        # Remove escape from quotes if enabled
+        if ($args{config}->{remove_backslash_from_quotes} == 1) {
+            $line =~ s/\\\"/"/g;
+        }
+
+        my $temp1;
+        my $temp2;
+
+        ($temp1, $temp2) = split (/ /, $line, 2);
+
+        chomp ($temp1);       # Variable NAME
+        chomp ($temp2);       # Variable VALUE
+        chomp ($line);
+
+        if ($linenum == 1) {
+            # Check if line 1 contains 'variable value' or just 'value' 
+            if (defined($temp2)) {
+                $variable_fix = 0;
+            } else {
+                $variable_fix = 1;
+            }
+        }
+
+        if ($variable_fix == 0) {
+            # Make sure variable names are numerical
+            $temp1 = translate_symbolic_to_oid($temp1, $args{logger}, $args{config});
+
+            # If line begins with a double quote (") but does not END in a double quote then we need to merge
+            # the following lines together into one until we find the closing double quote.  Allow for escaped quotes.
+            # Net-SNMP sometimes divides long lines into multiple lines..
+            if (($temp2 =~ /^\"/ && $temp2 !~ /\"$/) || $temp2 eq '"') {
+                $args{logger}->writeLogDebug("  Multi-line value detected - merging onto one line...");
+                $temp2 =~ s/[\r\n]//g;			# Remove the newline character
+                while (defined(my $line2 = <$input>)) {
+                    chomp $line2;
+                    push(@rawtrap, $line2);
+                    $temp2 .= " " . $line2;
+                    # Check if line ends in a non-escaped quote
+                    if (($line2 =~ /\"$/) && ($line2 !~ /\\\"$/)) {
+                        last;
+                    }
+                }
+            }
+
+            # If the value is blank, set it to (null)
+            if ($temp2 eq "") {
+                $temp2 = "(null)";
+            }
+
+            # Have quotes around it?
+            if ($temp2 =~ /^\"/ && $temp2 =~ /\"$/) {
+                $temp2 = substr($temp2,1,(length($temp2)-2)); # Remove quotes
+                push(@tempvar, $temp1);
+                push(@tempvar, $temp2);
+            } else {
+                push(@tempvar, $temp1);
+                push(@tempvar, $temp2);
+            }
+        } else {
+            # Should have been variable value, but only value found.  Workaround
+            # 
+            # Normally it is expected that a line contains a variable name
+            # followed by a space followed by the value (except for the 
+            # first line which is the hostname and the second which is the
+            # IP address).  If there is no variable name on the line (only
+            # one string), then add a variable string called 'variable' so 
+            # it is handled correctly in the next section.
+            # This happens with ucd-snmp v4.2.3 but not v4.2.1 or v4.2.5.
+            # This appears to be a bug in ucd-snmp v4.2.3.  This works around
+            # the problem by using 'variable' for the variable name, although 
+            # v4.2.3 should NOT be used with SNMPTT as it prevents SNMP V2 traps 
+            # from being handled correctly.
+
+            $args{logger}->writeLogDebug("Data passed from snmptrapd is incorrect.  UCD-SNMP v4.2.3 is known to cause this");
+
+            # If line begins with a double quote (") but does not END in a double quote then we need to merge
+            # the following lines together into one until we find the closing double quote.  Allow for escaped quotes.
+            # Net-SNMP sometimes divides long lines into multiple lines..
+            if ( ($line =~ /^\"/) && ( ! ($line =~ /[^\\]\"$/)) ) {
+                $args{logger}->writeLogDebug("  Multi-line value detected - merging onto one line...");
+                $temp2 =~ s/[\r\n]//g;			# Remove newline characters
+                while (defined(my $line2 = <$input>)) {
+                    chomp $line2;
+                    push(@rawtrap, $line2);
+                    $temp2 .= " " . $line2;
+                    if (($line2 =~ /\"$/) && ($line2 !~ /\\\"$/)) { # Ends in a non-escaped quote or it's a single line with a quote.
+                        last;
+                    }
+                }
+            }
+
+            # If the value is blank, set it to (null)
+            if ($line eq "") {
+                $line = "(null)";
+            }
+
+            # Have quotes around it?
+            if ($line =~ /^\"/ && $line =~ /\"$/) {
+                $line = substr($line,1,(length($line)-2));		# Remove quotes
+                push(@tempvar, "variable");
+                push(@tempvar, $line);
+            } else {
+                push(@tempvar, "variable");
+                push(@tempvar, $line);
+            }
+        }
+
+        $linenum++;
+    }
+
+    if ($args{logger}->is_debug()) {
+        # Print out raw trap passed from snmptrapd
+        $args{logger}->writeLogDebug("Raw trap passed from snmptrapd:");
+        for (my $i=0;$i <= $#rawtrap;$i++) {
+            chomp($rawtrap[$i]);
+            $args{logger}->writeLogDebug("$rawtrap[$i]");
+        }
+
+        # Print out all items passed from snmptrapd
+        $args{logger}->writeLogDebug("Items passed from snmptrapd:");
+        for (my $i=0;$i <= $#tempvar;$i++) {
+            $args{logger}->writeLogDebug("value $i: $tempvar[$i]");
+        }
+    }
+
+    # Copy what I need to new variables to make it easier to manipulate later
+
+    # Standard variables
+    ${$args{var}}[0] = $tempvar[0];		# hostname
+    ${$args{var}}[1] = $tempvar[1];		# ip address
+    ${$args{var}}[2] = $tempvar[3];		# uptime
+    ${$args{var}}[3] = $tempvar[5];		# trapname / OID - assume first value after uptime is
+        # the trap OID (value for .1.3.6.1.6.3.1.1.4.1.0)
+
+    ${$args{var}}[4] = "";	 # Clear ip address from trap agent
+    ${$args{var}}[5] = "";	 # Clear trap community string
+    ${$args{var}}[6] = "";	 # Clear enterprise
+    ${$args{var}}[7] = "";	 # Clear securityEngineID
+    ${$args{var}}[8] = "";	 # Clear securityName
+    ${$args{var}}[9] = "";	 # Clear contextEngineID
+    ${$args{var}}[10] = ""; # Clear contextName
+
+    # Make sure trap OID is numerical as event lookups are done using numerical OIDs only
+    ${$args{var}}[3] = translate_symbolic_to_oid(${$args{var}}[3], $args{logger}, $args{config});
+
+    # Cycle through remaining variables searching for for agent IP (.1.3.6.1.6.3.18.1.3.0),
+    # community name (.1.3.6.1.6.3.18.1.4.0) and enterpise (.1.3.6.1.6.3.1.1.4.3.0)
+    # All others found are regular passed variables
+    my $j=0;
+    for (my $i=6;$i <= $#tempvar; $i+=2) {
+        
+        if ($tempvar[$i] =~ /^.1.3.6.1.6.3.18.1.3.0$/) { # ip address from trap agent
+            ${$args{var}}[4] = $tempvar[$i+1];
+        } elsif ($tempvar[$i] =~ /^.1.3.6.1.6.3.18.1.4.0$/)	{ # trap community string
+            ${$args{var}}[5] = $tempvar[$i+1];
+        } elsif ($tempvar[$i] =~ /^.1.3.6.1.6.3.1.1.4.3.0$/) {	# enterprise
+            # ${$args{var}}[6] = $tempvar[$i+1];
+            # Make sure enterprise value is numerical
+            ${$args{var}}[6] = translate_symbolic_to_oid($tempvar[$i+1], $args{logger}, $args{config});
+        } elsif ($tempvar[$i] =~ /^.1.3.6.1.6.3.10.2.1.1.0$/) { # securityEngineID
+            ${$args{var}}[7] = $tempvar[$i+1];
+        } elsif ($tempvar[$i] =~ /^.1.3.6.1.6.3.18.1.1.1.3$/) { # securityName
+            ${$args{var}}[8] = $tempvar[$i+1];
+        } elsif ($tempvar[$i] =~ /^.1.3.6.1.6.3.18.1.1.1.4$/) {	# contextEngineID
+            ${$args{var}}[9] = $tempvar[$i+1];
+        }
+        elsif ($tempvar[$i] =~ /^.1.3.6.1.6.3.18.1.1.1.5$/)	{ # contextName
+            ${$args{var}}[10] = $tempvar[$i+1];
+        } else { # application specific variables
+            ${$args{entvarname}}[$j] = $tempvar[$i];
+            ${$args{entvar}}[$j] = $tempvar[$i+1];
+            $j++;
+        }
+    }
+
+    # Only if it's not already resolved
+    if ($args{config}->{dns_enable} == 1 && ${$args{var}}[0] =~  /^\d+\.\d+\.\d+\.\d+$/) {
+        my $temp = gethostbyaddr(Socket::inet_aton(${$args{var}}[0]),Socket::AF_INET());
+        if (defined ($temp)) {
+            $args{logger}->writeLogDebug("Host IP address (" . ${$args{var}}[0] . ") resolved to: $temp");
+            ${$args{var}}[0] = $temp;
+        } else {
+            $args{logger}->writeLogDebug("Host IP address (" . ${$args{var}}[0] . ") could not be resolved by DNS. Variable \$r / \$R etc will use the IP address");
+        }
+    }
+
+    # If the agent IP is blank, copy the IP from the host IP.
+    # var[4] would only be blank if it wasn't passed from snmptrapd, which
+    # should only happen with ucd-snmp 4.2.3, which you should be using anyway!
+    if (${$args{var}}[4] eq '') {
+        ${$args{var}}[4] = ${$args{var}}[1];
+        $args{logger}->writeLogDebug("Agent IP address was blank, so setting to the same as the host IP address of " . ${$args{var}}[1]);
+    }
+
+    # If the agent IP is the same as the host IP, then just use the host DNS name, no need
+    # to look up, as it's obviously the same..
+    if (${$args{var}}[4] eq ${$args{var}}[1]) {
+        $args{logger}->writeLogDebug("Agent IP address (" . ${$args{var}}[4] . ") is the same as the host IP, so copying the host name: " . ${$args{var}}[0]);
+        ${$args{agent_dns_name}} = ${$args{var}}[0];
+    } else {
+        ${$args{agent_dns_name}} = ${$args{var}}[4];     # Default to IP address
+        if ($args{config}->{dns_enable} == 1 && ${$args{var}}[4] ne '') {
+            my $temp = gethostbyaddr(Socket::inet_aton(${$args{var}}[4]),Socket::AF_INET());
+            if (defined ($temp)) {
+                $args{logger}->writeLogDebug("Agent IP address (" . ${$args{var}}[4] . ") resolved to: $temp");
+                ${$args{agent_dns_name}} = $temp;
+            } else {
+                $args{logger}->writeLogDebug("Agent IP address (" . ${$args{var}}[4] . ") could not be resolved by DNS.  Variable \$A etc will use the IP address");
+            }
+        }
+    }
+
+    if ($args{config}->{strip_domain}) {
+        ${$args{var}}[0] = strip_domain_name(${$args{var}}[0], $args{config}->{strip_domain}, $args{config});
+        ${$args{agent_dns_name}} = strip_domain_name(${$args{agent_dns_name}}, $args{config}->{strip_domain}, $args{config});
+    }
+
+    $args{logger}->writeLogDebug("Trap received from $tempvar[0]: $tempvar[5]");
+
+    if ($args{logger}->is_debug()) {
+        $args{logger}->writeLogDebug("0:		hostname");
+        $args{logger}->writeLogDebug("1:		ip address");
+        $args{logger}->writeLogDebug("2:		uptime");
+        $args{logger}->writeLogDebug("3:		trapname / OID");
+        $args{logger}->writeLogDebug("4:		ip address from trap agent");
+        $args{logger}->writeLogDebug("5:		trap community string");
+        $args{logger}->writeLogDebug("6:		enterprise");
+        $args{logger}->writeLogDebug("7:		securityEngineID        (not use)");
+        $args{logger}->writeLogDebug("8:		securityName            (not use)");
+        $args{logger}->writeLogDebug("9:		contextEngineID         (not use)");
+        $args{logger}->writeLogDebug("10:		contextName             (not)");
+        $args{logger}->writeLogDebug("0+:		passed variables");	
+
+        #print out all standard variables
+        for (my $i=0;$i <= $#{$args{var}};$i++) {
+            $args{logger}->writeLogDebug("Value $i: " . ${$args{var}}[$i]);
+        }
+
+        $args{logger}->writeLogDebug("Agent dns name: " . ${$args{agent_dns_name}});
+
+        #print out all enterprise specific variables
+        for (my $i=0;$i <= $#{$args{entvar}};$i++) {
+            $args{logger}->writeLogDebug("Ent Value $i (\$" . ($i+1) . "): " . ${$args{entvarname}}[$i] . "=" . ${$args{entvar}}[$i]);
+        }
+    }
+
+    # Generate hash of trap and detect duplicates
+    if ($args{config}->{duplicate_trap_window}) {
+        my $md5 = Digest::MD5->new;
+        # All variables except for uptime.
+        $md5->add(${$args{var}}[0],${$args{var}}[1].${$args{var}}[3].${$args{var}}[4].${$args{var}}[5].${$args{var}}[6].${$args{var}}[7].${$args{var}}[8].${$args{var}}[9].${$args{var}}[10]."@{$args{entvar}}");
+        
+        my $trap_digest = $md5->hexdigest;
+        ${$args{digest_trap}} = $trap_digest;
+
+        $args{logger}->writeLogDebug("Trap digest: $trap_digest");
+
+        if ($args{duplicate_traps}->{$trap_digest}) {
+            # Duplicate trap detected.  Skipping trap...
+            return -1;
+        }
+
+        $args{duplicate_traps}->{$trap_digest} = time();
+    }
+
+    return 1;
+
+    # Variables of trap received by SNMPTRAPD:
+    #
+    # $var[0]   hostname
+    # $var[1]   ip address
+    # $var[2]   uptime
+    # $var[3]   trapname / OID
+    # $var[4]   ip address from trap agent
+    # $var[5]   trap community string
+    # $var[6]   enterprise
+    # $var[7]   securityEngineID                (snmptthandler-embedded required)
+    # $var[8]   securityName                    (snmptthandler-embedded required)
+    # $var[9]   contextEngineID                 (snmptthandler-embedded required)
+    # $var[10]  contextName                     (snmptthandler-embedded required)
+    #
+    # $entvarname[0]  passed variable name 1
+    # $entvarname[1]  passed variable name 2
+    #
+    # $entvar[0]    passed variable 1
+    # $entvar[1]    passed variable 2
+    # .
+    # .
+    # etc..
+    #
+    ##############################################################################
+}
+
+# Used when reading received traps to symbolic names in variable names and
+# values to numerical
+sub translate_symbolic_to_oid
+{
+    my $temp = shift;
+    my $logger = shift;
+    my $config = shift;
+    
+    # Check to see if OID passed from snmptrapd is fully numeric.  If not, try to translate
+    if (! ($temp =~ /^(\.\d+)+$/))  {
+        # Not numeric
+        # Try to convert to numerical
+        $logger->writeLogDebug("Symbolic trap variable name detected ($temp).  Will attempt to translate to a numerical OID");
+        if ($config->{net_snmp_perl_enable} == 1) {
+            my $temp3 = SNMP::translateObj("$temp",0);
+            if (defined ($temp3) ) {
+                $logger->writeLogDebug("  Translated to $temp3");
+                $temp = $temp3;
+            } else {
+                # Could not translate default to numeric
+                $logger->writeLogDebug("  Could not translate - will leave as-is");
+            }
+        } else {
+            $logger->writeLogDebug("  Could not translate - Net-SNMP Perl module not enabled - will leave as-is");
+        }
+    }
+  return $temp;
+}
+
+# Strip domain name from hostname
+sub strip_domain_name {
+    my $name = shift;
+    my $mode = shift;
+    my $config = shift;
+
+    # If mode = 1, strip off all domain names leaving only the host
+    if ($mode == 1 && !($name =~ /^\d+\.\d+\.\d+\.\d+$/)) {
+        if ($name =~ /\./) { # Contain a . ?
+            $name =~ /^([^\.]+?)\./;
+            $name = $1;
+        }
+    } elsif ($mode == 2 && !($name =~ /^\d+\.\d+\.\d+\.\d+$/)) { # If mode = 2, strip off the domains as listed in strip_domain_list in .ini file 
+        if (@{$config->{strip_domain_list}}) {
+            foreach my $strip_domain_list_temp (@{$config->{strip_domain_list}}) {
+                if ($strip_domain_list_temp =~ /^\..*/) { # If domain from list starts with a '.' then remove it first
+                    ($strip_domain_list_temp) = $strip_domain_list_temp =~ /^\.(.*)/;
+                }
+
+                if ($name =~ /^.+\.$strip_domain_list_temp/) { # host is something . domain name?
+                    $name =~ /(.*)\.$strip_domain_list_temp/;	# strip the domain name
+                    $name = $1;
+                    last;  # Only process once 
+                }
+            }
+        }
+    }
+    return $name;
+}
+
+1;

--- a/perl-libs/lib/t/common/centreonvault.t
+++ b/perl-libs/lib/t/common/centreonvault.t
@@ -1,0 +1,289 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test2::V0;
+use Test2::Plugin::NoWarnings echo => 1;
+use Test2::Tools::Compare qw{is like match};
+use Net::Curl::Easy qw(:constants);
+use Data::Dumper qw(Dumper);
+use Storable qw(dclone);
+use FindBin;
+use lib "$FindBin::RealBin/../../";
+
+use centreon::common::centreonvault;
+use centreon::common::logger;
+use JSON::XS;
+
+
+# this sub make an hash with all generic data used in the tests, and send back a hashref.
+sub create_data_set {
+    my $set = {};
+    $set->{vault} = undef;
+    $set->{logger} = centreon::common::logger->new();
+    $set->{logger}->file_mode("/dev/null");
+
+    # this is an exemple of configuration for vault.
+    # I encrypted the string "String-to-encrypt" from the C++ implementation, and set it to secret_id and role_id
+    # the key to decrypt should be set as an environment variable.
+    # the salt can be used to encrypt again the data, so the script can be sure the decryption worked correctly, but this function is not implemented yet.
+    $set->{default_app_secret} = 'SGVsbG8gd29ybGQsIGRvZywgY2F0LCBwdXBwaWVzLgo=';
+    $set->{decryted_string} = 'String-to-encrypt';
+    $set->{vault_config_hash} = {
+        "name"      => "default",
+        "url"       => "localhost",
+        "port"      => 443,
+        "root_path" => "path",
+        "role_id"   => "4vOkzIaIJ7yxGWmysGVYY9sYHDyDM1nEv1++jSx9eAHpj83J6aIjE5SPvvpF6kBu3JeFga7o6DDS2yC7jVPAwXsWiur+KUOQncPq0JtjiFojr9YkrO8x1w1dmQFq/RqYV/S/kUare8z6r6+RnAxwsA==",
+        "secret_id" => "4vOkzIaIJ7yxGWmysGVYY9sYHDyDM1nEv1++jSx9eAHpj83J6aIjE5SPvvpF6kBu3JeFga7o6DDS2yC7jVPAwXsWiur+KUOQncPq0JtjiFojr9YkrO8x1w1dmQFq/RqYV/S/kUare8z6r6+RnAxwsA==",
+        "salt"      => "U2FsdA==" }; # for now the salt is not used, it will be used to check if the data where correctly decrypted.
+
+    $set->{wrong_vault_config_hash} = {
+        "name"      => "default",
+        "url"       => "localhost",
+        "port"      => 443,
+        "root_path" => "path",
+        "role_id"   => "WrongCryptedDataThatAESWontBeAbleToDecrypt==",
+        "secret_id" => "WrongCryptedDataThatAESWontBeAbleToDecrypt==",
+        "salt"      => "U2FsdA==" };
+
+    # We will make multiples tests about authentication.
+    # this is all the fields that should be set everytime.
+    $set->{http}->{generic_auth_fields} = {
+        CURLOPT_POST()          => { result => 1, detail => 'the http request should be POST' },
+        CURLOPT_POSTFIELDS()    => { result => 'role_id=String-to-encrypt&secret_id=String-to-encrypt', detail => 'postfields are correct' },
+        CURLOPT_POSTFIELDSIZE() => { result => 53, detail => 'post field size is set' },
+        CURLOPT_URL()           => { result => 'https://localhost:443/v1/auth/approle/login', detail => 'target url was set' }, };
+    # this is the token given by the API when the authentication work.
+    $set->{http}->{"Vault_Token"} = "RandomAuthTokenGivenByVault";
+    $set->{http}->{"vault_token_expiration"} = 13455;
+
+    $set->{http}->{working_auth} = {
+        (CURLOPT_WRITEDATA() => {
+            result => '{"auth":{"lease_duration": "' . $set->{http}->{"vault_token_expiration"} . '",
+            "client_token": "' . $set->{http}->{"Vault_Token"} . '"}}' }),
+        %{$set->{http}->{generic_auth_fields}} };
+
+    $set->{http}->{wrong_auth} = { (CURLOPT_WRITEDATA() => { result => '{' }), %{$set->{http}->{generic_auth_fields}} };
+
+    return $set;
+
+}
+
+sub test_new {
+    my $set = shift;
+    my $vault = '';
+    my @test_data = (
+        { 'logger' => undef, 'config_file' => undef, 'test' => '$error_message =~ /FATAL: No logger given to the constructor/' },
+        { 'logger' => $set->{logger}, 'config_file' => undef, 'test' => '$vault->{enabled} == 0' },
+        { 'logger' => $set->{logger}, 'config_file' => 'does_not_exist.json', 'test' => '$vault->{enabled} == 0' }
+    );
+
+    for my $i (0 .. $#test_data) {
+        my $logger = $test_data[$i]->{logger};
+        my $config_file = $test_data[$i]->{config_file};
+        my $test = $test_data[$i]->{test};
+
+        eval {
+            $vault = centreon::common::centreonvault->new(
+                (
+                    'logger'      => $logger,
+                    'config_file' => $config_file
+                )
+            );
+        };
+        my $error_message = defined($@) ? $@ : '';
+        ok(eval($test), "'$test' should be true");
+    }
+}
+
+sub test_decrypt {
+    my $set = shift;
+    my $vault = centreon::common::centreonvault->new(
+        (
+            'logger'      => $set->{logger},
+            'config_file' => $set->{vault_config_hash}
+        )
+    );
+
+    is($vault->extract_and_decrypt(('data' => $set->{vault_config_hash}->{secret_id})), 'String-to-encrypt', 'extract_and_decrypt() worked');
+
+}
+
+sub test_transform_json_to_object {
+    my $tests_cases = [
+        {
+            json   => '{"int": 12, "string": "A String with space", "array" : ["array-key", "string"]}',
+            result => { "int" => 12, "string" => "A String with space", "array" => [ "array-key", "string" ] },
+            detail => "simple json can be decoded as a perl object"
+        },
+        {
+            json   => '"int": 12, "string": "A String with space", "array" : ["array-key", "string"]}',
+            result => { "error_message" => match(qr/^Could not decode JSON from/) },
+            detail => "invalid json should generate an error"
+        },
+        {
+            json   => '',
+            result => { "error_message" => match(qr/^Could not decode JSON from.*'. Reason:/) },
+            detail => "empty json"
+        },
+        {
+            json   => 'abcdef',
+            result => { "error_message" => match(qr/^Could not decode JSON from/) },
+            detail => "simple string json"
+        },
+        {
+            json   => '{}',
+            result => {},
+            detail => "empty json brace should make an empty object"
+        },
+    ];
+
+    for my $test (@$tests_cases) {
+        is(centreon::common::centreonvault::transform_json_to_object($test->{json}), $test->{result}, $test->{detail});
+    }
+
+}
+sub test_get_app_secret {
+    `mkdir -p /usr/share/centreon/`;
+    `mv /usr/share/centreon/.env /usr/share/centreon/.env.back`;
+    my $old_app_secret = $ENV{'APP_SECRET'};
+    my $res = "SECRET";
+    $ENV{'APP_SECRET'} = $res;
+    is(centreon::common::centreonvault->get_app_secret(), $res, "get_app_secret() should return the correct value");
+    $ENV{'APP_SECRET'} = undef;
+    is(centreon::common::centreonvault->get_app_secret(), "", "get_app_secret() should return an empty string");
+    open(my $fh, '>', '/usr/share/centreon/.env');
+    print $fh "NotAPP_SECRET=toto\n";
+    print $fh "APP_SECRT=tata\n";
+    is(centreon::common::centreonvault->get_app_secret(), "", "get_app_secret() should return empty string if file don't ha.");
+
+    print $fh "APP_SECRET=$res\n";
+    close($fh);
+    is(centreon::common::centreonvault->get_app_secret(), $res, "get_app_secret() should get value from file.");
+    `rm /usr/share/centreon/.env`;
+    `mv /usr/share/centreon/.env.back /usr/share/centreon/.env`;
+    $ENV{'APP_SECRET'} = $old_app_secret;
+}
+
+sub test_authenticate {
+    my $set = shift;
+    my $vault = centreon::common::centreonvault->new(
+        (
+            'logger'      => $set->{logger},
+            'config_file' => $set->{vault_config_hash}
+        )
+    );
+
+    my $mock_http_authenticate = mock_http($set->{http}->{working_auth});
+    $vault->authenticate();
+    is($vault->{auth}->{token}, $set->{http}->{"Vault_Token"}, "the token was correctly retrieved by authenticate()");
+    is($vault->{auth}->{expiration_epoch}, time() + $set->{http}->{"vault_token_expiration"}, 'the expiration date is correct');
+}
+
+sub test_get_secret {
+    my $set = shift;
+
+    print("    When vault don't work we should send back the input token\n");
+    my $vault = centreon::common::centreonvault->new(
+        (
+            'logger'      => $set->{logger},
+            'config_file' => $set->{wrong_vault_config_hash}
+        )
+    );
+    is($vault->get_secret("token"), "token", "role_id and secret_id can't be decrypted");
+
+    $vault = centreon::common::centreonvault->new(
+        (
+            'logger'      => $set->{logger},
+            'config_file' => $set->{vault_config_hash}
+        )
+    );
+    my $clear_password = $vault->get_secret("token");
+    is($vault->get_secret("token"), "token", "no authentication done because secret don't look like an hashicorp path");
+
+    my $http_wrong_authentication = { (CURLOPT_WRITEDATA() => { result => '{' }), %{$set->{http}->{generic_auth_fields}} };
+    my $mock_http_authenticate = mock_http($http_wrong_authentication);
+    $clear_password = $vault->get_secret("secret::hashicorp_vault::SecretPathArg::secretNameFromApiResponse");
+    is($vault->get_secret("token"), "token", "authentication didn't work because api send back an invalid authentication response");
+
+    print("    When vault work we should send back the token retrieved by the API\n");
+    my $http_get_secret_work = {
+        CURLOPT_WRITEDATA()  => { result => '{"request_id": "ARandomString", "data": {"data" : {"secretNameFromApiResponse": "tokenGotFromApi"}}}' },
+        CURLOPT_POST()       => { result => '0', detail => 'the http request should not be POST.' },
+        CURLOPT_HTTPHEADER() => { result => [ "X-Vault-Token: " . $set->{http}->{"Vault_Token"} ], detail => 'the authentication header should be set.' },
+        CURLOPT_URL()        => { result => 'https://localhost:443/v1/SecretPathArg', detail => 'target url was set' }
+    };
+    $mock_http_authenticate = mock_http( $set->{http}->{working_auth}, $http_get_secret_work);
+    $clear_password = $vault->get_secret("secret::hashicorp_vault::SecretPathArg::secretNameFromApiResponse");
+    is($clear_password, "tokenGotFromApi", "authentication worked, the token was correctly retrieved by get_secret() from the API");
+
+}
+
+sub main {
+    my $set = create_data_set();
+
+    test_get_app_secret();
+    my $old_app_secret = $ENV{'APP_SECRET'};
+    $ENV{'APP_SECRET'} = $set->{default_app_secret};
+    print "    Validate function not reaching external ressources\n";
+    test_new($set);
+    test_decrypt($set);
+
+    test_transform_json_to_object($set);
+    print "    Validate authentication and secret retrieving\n";
+    test_authenticate($set);
+    test_get_secret($set);
+    $ENV{'APP_SECRET'} = $old_app_secret;
+
+    done_testing();
+}
+
+# this sub is used to mock the Net::Curl::Easy object, to simulate the http request.
+# the returned object should be stored in a local variable for the time of your test,
+# as the mock will be enabled until the variable is deleted.
+sub mock_http {
+    # without dclone, the hash is modified by the test, and the second test using it will fail.
+    my @mock_list = @{dclone(\@_)};
+    my $required_option = shift(@mock_list);
+
+    my $mock = mock 'Net::Curl::Easy'; # is from Test2::Tools::Mock, included by Test2::V0
+    $mock->override('perform' => sub($) {
+        # Normally this sub perform the actual http request and set the result to the variable given to setopt().
+        # For test purpose, we set the mocked data in the setopt(), and only use perform() to check every parameter have correctly been set.
+        # once we are sure all parameter where correctly set, we prepare the next request if there is any.
+        # this is not what is done in reality, but it's easier for mocking purpose.
+        if (keys %{$required_option}) {
+            fail "[mock-curl] Some curl parameter where not correctly set : " . join(', ', keys(%{$required_option})) . "\n";
+        }
+        $required_option = shift(@mock_list);
+    },
+        # this sub is called for each parameter set to curl, we will check if the parameter is correctly set.
+        'setopt'              => sub($$$) {
+            my $self = shift; # we don't need this one
+            my $opt_name = shift; # the option name, see Net::Curl::Easy (:constant) for the list of possible value.
+            my $opt_value = shift;
+            # the real workhorse of the lib, we must have an hashref $required_option = {} already declared.
+            # this sub check in the hash if the option is correctly set, and delete it from the hash if it's correct.
+            # when doing perform, all options should have been set. So if there is still element in the hash,
+            # it is an error, as some parameter where not correctly set.
+            # writedata is processed differently to send back the data to the caller.
+            if ($opt_name == CURLOPT_WRITEDATA) {
+                $$opt_value = $required_option->{$opt_name}->{result};
+                delete($required_option->{$opt_name});
+                return;
+            }
+            if ($required_option->{$opt_name}) {
+                is($opt_value, $required_option->{$opt_name}->{result}, "[mock-curl] " . $required_option->{$opt_name}->{detail});
+                delete($required_option->{$opt_name});
+            } else {
+                print(Dumper($required_option));
+                fail("$opt_name is not present in the required_option hash.");
+
+            }
+        }
+    );
+    # we need to return the mocked object and to keep it, or the mock will be deleted and reverted.
+    return $mock;
+
+}
+&main;

--- a/perl-libs/lib/t/common/logger.t
+++ b/perl-libs/lib/t/common/logger.t
@@ -1,0 +1,101 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use Test2::V0;
+use FindBin;
+use lib "$FindBin::Bin/../../";
+use centreon::common::logger;
+
+
+sub test_severity {
+    my $logger = centreon::common::logger->new();
+    is($logger->severity(), "WARNING", "default severity should be warning.");
+
+    for my $sev ('FATAL', 'fatal', 'ERROR', 'Error', 'WARNING', 'NOTICE', 'INFO', 'DEBUG') {
+
+        is($logger->severity($sev), uc($sev), "severity $sev was correctly set.");
+        is($logger->severity(), uc($sev), "getter was correct.");
+    }
+    $logger->severity("FATAL");
+    is($logger->severity("toto"), -1, "if severity is unknown we don't change anything.");
+}
+
+sub test_logging_levels {
+    my %options = @_;
+    my $logger = centreon::common::logger->new();
+    $logger->flush_output(enabled => 1);
+    $logger->withpid($options{pid});
+    $logger->withdate($options{with_date});
+
+    my @levels = (
+        { method => 'writeLogDebug',   severity => 'DEBUG',   message => 'Debug message' },
+        { method => 'writeLogInfo',    severity => 'INFO',    message => 'Info message' },
+        { method => 'writeLogNotice',  severity => 'NOTICE',  message => 'Notice message' },
+        { method => 'writeLogWarning', severity => 'WARNING', message => 'Warning message' },
+        { method => 'writeLogError',   severity => 'ERROR',   message => 'Error message' },
+    );
+
+    foreach my $level (@levels) {
+        my $out;
+        $logger->severity($level->{severity});
+        do {
+            local *STDOUT;
+            open STDOUT, ">", \$out;
+            my $met = $logger->can($level->{method});
+            $met->($logger, $level->{message});
+        };
+        my $log = check_log_format(log => $out, severity => $level->{severity}, pid => $options{pid}, date => $options{with_date});
+        is($log, $level->{message}, $level->{message} . " is correctly logged with pid set to " . $options{pid});
+    }
+}
+
+sub test_writeLogFatal {
+    my %options = @_;
+    my $logger = centreon::common::logger->new();
+    $logger->flush_output(enabled => 1);
+    $logger->withpid($options{pid});
+    $logger->withdate($options{with_date});
+    $logger->severity('FATAL');
+
+    my $message = 'Fatal error occurred';
+    my $out;
+    like(dies {
+        do {
+            local *STDOUT;
+            open STDOUT, ">", \$out;
+            $logger->writeLogFatal($message); };  },
+        qr/Fatal error occurred/,
+        "writeLogFatal dies as expected"
+    );
+}
+
+sub main {
+
+    test_severity();
+    test_logging_levels(pid => 1, with_date => 1);
+    test_logging_levels(pid => 0, with_date => 1);
+    test_writeLogFatal(pid => 1, with_date => 1);
+    test_writeLogFatal(pid => 0, with_date => 1);
+
+    done_testing();
+}
+
+# Helper function
+sub check_log_format {
+    # the best way to check the date would be to mock the time() function, and to run get_date().
+    # as it is a builtin function, it is possible but hard to setup and can have various hard to debug side effect.
+    my %options = @_;
+
+    my $regex = '^\[\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2}\] \[' . $options{severity} . '\] ';
+    # if there is pid we ignore it in the regex
+    $options{pid} == 1 and $regex .= '\[\d+\] ';
+    $regex .= '(.*)$';
+    like($options{log}, qr/$regex/, "log format is respected.");
+    $options{log} =~ /$regex/; # like() don't seem to return the matched string
+
+    ok(defined($1), "the log is not empty");
+    return $1;
+}
+
+main();

--- a/perl-libs/packaging/centreon-perl-libs-common.yaml
+++ b/perl-libs/packaging/centreon-perl-libs-common.yaml
@@ -1,0 +1,61 @@
+name: "centreon-perl-libs-common"
+arch: "all"
+platform: "linux"
+version_schema: "none"
+version: "${VERSION}"
+release: "${RELEASE}${DIST}"
+section: "default"
+priority: "optional"
+maintainer: "Centreon <contact@centreon.com>"
+description: |
+  This package contains Centreon Perl library for logging and vault integration.
+  Commit: @COMMIT_HASH@
+vendor: "Centreon"
+homepage: "https://www.centreon.com"
+license: "Apache-2.0"
+
+contents:
+  - src: "../lib/perl/centreon/common"
+    dst: "${PERL_VENDORLIB}/centreon/common"
+    expand: true
+    file_info:
+      mode: 0755
+
+overrides:
+  rpm:
+    depends:
+      - perl-interpreter
+      - perl(Crypt::OpenSSL::AES)
+      - perl(JSON::XS)
+      - perl(DBI)
+      - perl(FindBin)
+      - perl(IO::Handle)
+      - perl(POSIX)
+      - perl(Pod::Usage)
+      - perl(Sys::Syslog)
+    provides:
+      - perl-centreon-base
+      - perl(centreon::common::db)
+      - perl(centreon::common::lock)
+      - perl(centreon::common::lock::file)
+      - perl(centreon::common::lock::sql)
+      - perl(centreon::common::logger)
+      - perl(centreon::common::misc)
+  deb:
+    depends:
+      - libconfig-inifiles-perl
+      - libcrypt-openssl-aes-perl
+      - libjson-xs-perl
+      - libnet-curl-perl
+      - libcrypt-des-perl
+      - librrds-perl
+      - libdigest-hmac-perl
+      - libdigest-sha-perl
+      - libgd-perl
+
+rpm:
+  summary: Centreon Perl libraries Common
+  compression: zstd
+  signature:
+    key_file: ${RPM_SIGNING_KEY_FILE}
+    key_id: ${RPM_SIGNING_KEY_ID}

--- a/perl-libs/packaging/centreon-perl-libs.yaml
+++ b/perl-libs/packaging/centreon-perl-libs.yaml
@@ -1,0 +1,90 @@
+name: "centreon-perl-libs"
+arch: "all"
+platform: "linux"
+version_schema: "none"
+version: "${VERSION}"
+release: "${RELEASE}${DIST}"
+section: "default"
+priority: "optional"
+maintainer: "Centreon <contact@centreon.com>"
+description: |
+  This package contains Centreon Perl libraries for various script.
+  Commit: @COMMIT_HASH@
+vendor: "Centreon"
+homepage: "https://www.centreon.com"
+license: "Apache-2.0"
+
+contents:
+  - src: "../lib/perl/centreon/health"
+    dst: "${PERL_VENDORLIB}/centreon/health"
+    expand: true
+    file_info:
+      mode: 0755
+  - src: "../lib/perl/centreon/reporting"
+    dst: "${PERL_VENDORLIB}/centreon/reporting"
+    expand: true
+    file_info:
+      mode: 0755
+  - src: "../lib/perl/centreon/script"
+    dst: "${PERL_VENDORLIB}/centreon/script"
+    expand: true
+    file_info:
+      mode: 0755
+  - src: "../lib/perl/centreon/trapd"
+    dst: "${PERL_VENDORLIB}/centreon/trapd"
+    expand: true
+    file_info:
+      mode: 0755
+  - src: "../lib/perl/centreon/script.pm"
+    dst: "${PERL_VENDORLIB}/centreon/script.pm"
+    expand: true
+    file_info:
+      mode: 0755
+
+
+overrides:
+  rpm:
+    depends:
+      - centreon-perl-libs-common
+      - centreon-common = ${VERSION}-${RELEASE}${DIST}
+      - perl-interpreter
+      - perl(DBI)
+      - perl(FindBin)
+      - perl(Getopt::Long)
+      - perl(IO::Handle)
+      - perl(POSIX)
+      - perl(Pod::Usage)
+      - perl(Sys::Syslog)
+    provides:
+      - perl-centreon-base
+      - perl(centreon::script)
+      - perl(centreon::script::centreontrapd)
+      - perl(centreon::script::centreontrapdforward)
+      - perl(centreon::script::centFillTrapDB)
+      - perl(centreon::script::centreonSyncArchives)
+      - perl(centreon::script::centreonSyncPlugins)
+      - perl(centreon::script::centreon_trap_send)
+      - perl(centreon::script::dashboardBuilder)
+      - perl(centreon::script::eventReportBuilder)
+      - perl(centreon::script::logAnalyser)
+      - perl(centreon::script::logAnalyserBroker)
+      - perl(centreon::script::centreon_health)
+    replaces:
+      - perl-centreon-base
+  deb:
+    depends:
+      - centreon-perl-libs-common
+      - centreon-common (= ${VERSION}-${RELEASE}${DIST})
+      - libconfig-inifiles-perl
+      - libcrypt-des-perl
+      - librrds-perl
+      - libdigest-hmac-perl
+      - libdigest-sha-perl
+      - libgd-perl
+
+rpm:
+  summary: Centreon Perl libraries
+  compression: zstd
+  signature:
+    key_file: ${RPM_SIGNING_KEY_FILE}
+    key_id: ${RPM_SIGNING_KEY_ID}


### PR DESCRIPTION
## Description
This PR aim to move the centreon-perl-libs package from centreon repo to centreon-collect repo.
Some of the reason :
- avoid a cyclyc dependancy, so when creating a new major version build collect first (which don't have dependancy on web) then build web (which have dependancy on collect)
- gorgone need the new centreon-perl-libs-common package (for centreonvault)

**Fixes** # MON-106121

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] master

<h2> How this pull request can be tested ? </h2>
Build web + collect, everything should be installed correctly.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

