### PR TITLE
fix(engine/broker): segfault relations child/parent host

### DIFF
--- a/broker/neb/src/callbacks.cc
+++ b/broker/neb/src/callbacks.cc
@@ -2614,12 +2614,8 @@ int neb::callback_relation(int callback_type, void* data) {
       if (relation->hst && relation->dep_hst && !relation->svc &&
           !relation->dep_svc) {
         // Find host IDs.
-        int host_id;
-        int parent_id;
-        {
-          host_id = engine::get_host_id(relation->dep_hst->name());
-          parent_id = engine::get_host_id(relation->hst->name());
-        }
+        int host_id = relation->dep_hst->host_id();
+        int parent_id = relation->hst->host_id();
         if (host_id && parent_id) {
           // Generate parent event.
           auto new_host_parent{std::make_shared<host_parent>()};
@@ -2670,10 +2666,8 @@ int neb::callback_pb_relation(int callback_type [[maybe_unused]], void* data) {
       if (relation->hst && relation->dep_hst && !relation->svc &&
           !relation->dep_svc) {
         // Find host IDs.
-        int host_id;
-        int parent_id;
-        host_id = engine::get_host_id(relation->dep_hst->name());
-        parent_id = engine::get_host_id(relation->hst->name());
+        int host_id = relation->dep_hst->host_id();
+        int parent_id = relation->hst->host_id();
         if (host_id && parent_id) {
           // Generate parent event.
           auto new_host_parent{std::make_shared<pb_host_parent>()};

--- a/broker/neb/src/initial.cc
+++ b/broker/neb/src/initial.cc
@@ -288,19 +288,15 @@ static void send_host_parents_list(neb_sender sender = neb::callback_relation) {
 
   try {
     // Loop through all hosts.
-    for (host_map::iterator it{com::centreon::engine::host::hosts.begin()},
-         end{com::centreon::engine::host::hosts.end()};
-         it != end; ++it) {
+    for (const auto& [_, sptr_host] : com::centreon::engine::host::hosts) {
       // Loop through all parents.
-      for (host_map_unsafe::iterator pit{it->second->parent_hosts.begin()},
-           pend{it->second->parent_hosts.end()};
-           pit != pend; ++pit) {
+      for (const auto& [_, sptr_host_parent] : sptr_host->parent_hosts) {
         // Fill callback struct.
         nebstruct_relation_data nsrd;
         memset(&nsrd, 0, sizeof(nsrd));
         nsrd.type = NEBTYPE_PARENT_ADD;
-        nsrd.hst = pit->second;
-        nsrd.dep_hst = it->second.get();
+        nsrd.hst = sptr_host_parent.get();
+        nsrd.dep_hst = sptr_host.get();
 
         // Callback.
         sender(NEBTYPE_PARENT_ADD, &nsrd);

--- a/engine/inc/com/centreon/engine/host.hh
+++ b/engine/inc/com/centreon/engine/host.hh
@@ -249,7 +249,7 @@ class host : public notifier {
   void set_check_command_ptr(
       const std::shared_ptr<commands::command>& cmd) override;
 
-  host_map_unsafe parent_hosts;
+  host_map parent_hosts;
   host_map_unsafe child_hosts;
   static host_map hosts;
   static host_id_map hosts_by_id;
@@ -309,6 +309,7 @@ int number_of_total_parent_hosts(com::centreon::engine::host* hst);
 std::ostream& operator<<(std::ostream& os,
                          com::centreon::engine::host const& obj);
 std::ostream& operator<<(std::ostream& os, host_map_unsafe const& obj);
+std::ostream& operator<<(std::ostream& os, host_map const& obj);
 
 namespace com::centreon::engine {
 
@@ -319,7 +320,5 @@ uint64_t get_host_id(std::string const& name);
 std::string get_host_name(const uint64_t host_id);
 
 }  // namespace com::centreon::engine
-
-std::ostream& operator<<(std::ostream& os, host_map_unsafe const& obj);
 
 #endif  // !CCE_HOST_HH

--- a/engine/src/command_manager.cc
+++ b/engine/src/command_manager.cc
@@ -411,19 +411,17 @@ void command_manager::schedule_and_propagate_downtime(
     unsigned long triggered_by,
     unsigned long duration) {
   /* check all child hosts... */
-  for (host_map_unsafe::iterator it(temp_host->child_hosts.begin()),
-       end(temp_host->child_hosts.end());
-       it != end; ++it) {
-    if (it->second == nullptr)
+  for (const auto& [_, ptr_host] : temp_host->child_hosts) {
+    if (ptr_host == nullptr)
       continue;
     /* recurse... */
-    schedule_and_propagate_downtime(it->second, entry_time, author,
-                                    comment_data, start_time, end_time, fixed,
-                                    triggered_by, duration);
+    schedule_and_propagate_downtime(ptr_host, entry_time, author, comment_data,
+                                    start_time, end_time, fixed, triggered_by,
+                                    duration);
 
     /* schedule downtime for this host */
     downtime_manager::instance().schedule_downtime(
-        downtime::host_downtime, it->second->host_id(), 0, entry_time, author,
+        downtime::host_downtime, ptr_host->host_id(), 0, entry_time, author,
         comment_data, start_time, end_time, fixed, triggered_by, duration,
         nullptr);
   }

--- a/engine/src/commands/commands.cc
+++ b/engine/src/commands/commands.cc
@@ -2449,28 +2449,24 @@ void enable_and_propagate_notifications(host* hst,
     enable_host_notifications(hst);
 
   /* check all child hosts... */
-  for (host_map_unsafe::iterator it(hst->child_hosts.begin()),
-       end(hst->child_hosts.end());
-       it != end; ++it) {
-    if (it->second == nullptr)
+  for (const auto& [_, ptr_host] : hst->child_hosts) {
+    if (ptr_host == nullptr)
       continue;
 
     /* recurse... */
-    enable_and_propagate_notifications(it->second, level + 1, affect_top_host,
+    enable_and_propagate_notifications(ptr_host, level + 1, affect_top_host,
                                        affect_hosts, affect_services);
 
     /* enable notifications for this host */
     if (affect_hosts)
-      enable_host_notifications(it->second);
+      enable_host_notifications(ptr_host);
 
     /* enable notifications for all services on this host... */
     if (affect_services) {
-      for (service_map_unsafe::iterator it2(it->second->services.begin()),
-           end2(it->second->services.end());
-           it2 != end2; ++it2) {
-        if (!it2->second)
+      for (const auto& [_, ptr_srv] : ptr_host->services) {
+        if (!ptr_srv)
           continue;
-        enable_service_notifications(it2->second);
+        enable_service_notifications(ptr_srv);
       }
     }
   }
@@ -2490,28 +2486,24 @@ void disable_and_propagate_notifications(host* hst,
     disable_host_notifications(hst);
 
   /* check all child hosts... */
-  for (host_map_unsafe::iterator it(hst->child_hosts.begin()),
-       end(hst->child_hosts.begin());
-       it != end; ++it) {
-    if (!it->second)
+  for (const auto& [_, ptr_host] : hst->child_hosts) {
+    if (!ptr_host)
       continue;
 
     /* recurse... */
-    disable_and_propagate_notifications(it->second, level + 1, affect_top_host,
+    disable_and_propagate_notifications(ptr_host, level + 1, affect_top_host,
                                         affect_hosts, affect_services);
 
     /* disable notifications for this host */
     if (affect_hosts)
-      disable_host_notifications(it->second);
+      disable_host_notifications(ptr_host);
 
     /* disable notifications for all services on this host... */
     if (affect_services) {
-      for (service_map_unsafe::iterator it2(it->second->services.begin()),
-           end2(it->second->services.end());
-           it2 != end2; ++it2) {
-        if (!it2->second)
+      for (const auto& [_, ptr_srv] : ptr_host->services) {
+        if (!ptr_srv)
           continue;
-        disable_service_notifications(it2->second);
+        disable_service_notifications(ptr_srv);
       }
     }
   }
@@ -2632,20 +2624,18 @@ void schedule_and_propagate_downtime(host* temp_host,
                                      unsigned long triggered_by,
                                      unsigned long duration) {
   /* check all child hosts... */
-  for (host_map_unsafe::iterator it(temp_host->child_hosts.begin()),
-       end(temp_host->child_hosts.end());
-       it != end; ++it) {
-    if (it->second == nullptr)
+  for (const auto& [_, ptr_host] : temp_host->child_hosts) {
+    if (ptr_host == nullptr)
       continue;
 
     /* recurse... */
-    schedule_and_propagate_downtime(it->second, entry_time, author,
-                                    comment_data, start_time, end_time, fixed,
-                                    triggered_by, duration);
+    schedule_and_propagate_downtime(ptr_host, entry_time, author, comment_data,
+                                    start_time, end_time, fixed, triggered_by,
+                                    duration);
 
     /* schedule downtime for this host */
     downtime_manager::instance().schedule_downtime(
-        downtime::host_downtime, it->second->host_id(), 0, entry_time, author,
+        downtime::host_downtime, ptr_host->host_id(), 0, entry_time, author,
         comment_data, start_time, end_time, fixed, triggered_by, duration,
         nullptr);
   }

--- a/engine/src/config.cc
+++ b/engine/src/config.cc
@@ -63,19 +63,17 @@ static int dfs_host_path(host* root) {
   dfs_set_status(root, DFS_TEMP_CHECKED);
 
   /* We are scanning the children */
-  for (host_map_unsafe::iterator it(root->child_hosts.begin()),
-       end(root->child_hosts.end());
-       it != end; it++) {
-    int child_status = dfs_get_status(it->second);
+  for (const auto& [_, ptr_host] : root->child_hosts) {
+    int child_status = dfs_get_status(ptr_host);
 
     /* If a child is not checked, check it */
     if (child_status == DFS_UNCHECKED)
-      child_status = dfs_host_path(it->second);
+      child_status = dfs_host_path(ptr_host);
 
     /* If a child already temporary checked, its a problem,
      * loop inside, and its a acked status */
     if (child_status == DFS_TEMP_CHECKED) {
-      dfs_set_status(it->second, DFS_LOOPY);
+      dfs_set_status(ptr_host, DFS_LOOPY);
       dfs_set_status(root, DFS_LOOPY);
     }
 
@@ -86,7 +84,7 @@ static int dfs_host_path(host* root) {
         dfs_set_status(root, DFS_NEAR_LOOP);
 
       /* we already saw this child, it's a problem */
-      dfs_set_status(it->second, DFS_LOOPY);
+      dfs_set_status(ptr_host, DFS_LOOPY);
     }
   }
 

--- a/engine/src/host.cc
+++ b/engine/src/host.cc
@@ -575,13 +575,25 @@ int host::get_current_state_int() const {
 }
 
 std::ostream& operator<<(std::ostream& os, host_map_unsafe const& obj) {
-  for (host_map_unsafe::const_iterator it{obj.begin()}, end{obj.end()};
-       it != end; ++it) {
-    os << it->first;
-    if (std::next(it) != end)
+  bool first = true;
+  for (const auto& [key, _] : obj) {
+    if (!first) {
       os << ", ";
-    else
-      os << "";
+    }
+    os << key;
+    first = false;
+  }
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, host_map const& obj) {
+  bool first = true;
+  for (const auto& [key, _] : obj) {
+    if (!first) {
+      os << ", ";
+    }
+    os << key;
+    first = false;
   }
   return os;
 }
@@ -1029,8 +1041,7 @@ int is_host_immediate_child_of_host(com::centreon::engine::host* parent_host,
   }
   // Mid-level/bottom hosts.
   else {
-    host_map_unsafe::const_iterator it{
-        child_host->parent_hosts.find(parent_host->name())};
+    auto it{child_host->parent_hosts.find(parent_host->name())};
     return it != child_host->parent_hosts.end();
   }
 
@@ -1064,9 +1075,8 @@ int is_host_immediate_parent_of_host(com::centreon::engine::host* child_host,
  */
 int number_of_immediate_child_hosts(com::centreon::engine::host* hst) {
   int children(0);
-  for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end; ++it)
-    if (is_host_immediate_child_of_host(hst, it->second.get()))
+  for (const auto& [_, sptr_host] : host::hosts)
+    if (is_host_immediate_child_of_host(hst, sptr_host.get()))
       ++children;
   return children;
 }
@@ -1082,9 +1092,8 @@ int number_of_immediate_child_hosts(com::centreon::engine::host* hst) {
  */
 int number_of_immediate_parent_hosts(com::centreon::engine::host* hst) {
   int parents(0);
-  for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end; ++it)
-    if (is_host_immediate_parent_of_host(hst, it->second.get()))
+  for (const auto& [_, sptr_host] : host::hosts)
+    if (is_host_immediate_parent_of_host(hst, sptr_host.get()))
       ++parents;
   return parents;
 }
@@ -1100,10 +1109,9 @@ int number_of_immediate_parent_hosts(com::centreon::engine::host* hst) {
  */
 int number_of_total_child_hosts(com::centreon::engine::host* hst) {
   int children(0);
-  for (host_map::iterator it{host::hosts.begin()}, end{host::hosts.end()};
-       it != end; ++it)
-    if (is_host_immediate_child_of_host(hst, it->second.get()))
-      children += number_of_total_child_hosts(it->second.get()) + 1;
+  for (const auto& [_, sptr_host] : host::hosts)
+    if (is_host_immediate_child_of_host(hst, sptr_host.get()))
+      children += number_of_total_child_hosts(sptr_host.get()) + 1;
   return children;
 }
 
@@ -3253,17 +3261,15 @@ int host::process_check_result_3x(enum host::host_state new_state,
       SPDLOG_LOGGER_DEBUG(checks_logger,
                           "Propagating checks to parent host(s)...");
 
-      for (host_map_unsafe::iterator it{parent_hosts.begin()},
-           end{parent_hosts.end()};
-           it != end; it++) {
-        if (!it->second)
+      for (const auto& [key, sptr_host] : parent_hosts) {
+        if (!sptr_host)
           continue;
-        if (it->second->get_current_state() != host::state_up) {
+        if (sptr_host->get_current_state() != host::state_up) {
           engine_logger(dbg_checks, more)
-              << "Check of parent host '" << it->first << "' queued.";
+              << "Check of parent host '" << key << "' queued.";
           SPDLOG_LOGGER_DEBUG(checks_logger,
-                              "Check of parent host '{}' queued.", it->first);
-          check_hostlist.push_back(it->second);
+                              "Check of parent host '{}' queued.", key);
+          check_hostlist.push_back(sptr_host.get());
         }
       }
 
@@ -3275,17 +3281,15 @@ int host::process_check_result_3x(enum host::host_state new_state,
       SPDLOG_LOGGER_DEBUG(checks_logger,
                           "Propagating checks to child host(s)...");
 
-      for (host_map_unsafe::iterator it{child_hosts.begin()},
-           end{child_hosts.end()};
-           it != end; it++) {
-        if (!it->second)
+      for (const auto& [key, ptr_host] : child_hosts) {
+        if (!ptr_host)
           continue;
-        if (it->second->get_current_state() != host::state_up) {
+        if (ptr_host->get_current_state() != host::state_up) {
           engine_logger(dbg_checks, more)
-              << "Check of child host '" << it->first << "' queued.";
+              << "Check of child host '" << key << "' queued.";
           SPDLOG_LOGGER_DEBUG(checks_logger, "Check of child host '{}' queued.",
-                              it->first);
-          check_hostlist.push_back(it->second);
+                              key);
+          check_hostlist.push_back(ptr_host);
         }
       }
     }
@@ -3375,24 +3379,21 @@ int host::process_check_result_3x(enum host::host_state new_state,
               "** WARNING: Max attempts = 1, so we have to run serial "
               "checks of all parent hosts!");
 
-          for (host_map_unsafe::iterator it{parent_hosts.begin()},
-               end{parent_hosts.end()};
-               it != end; it++) {
-            if (!it->second)
+          for (const auto& [key, sptr_host] : parent_hosts) {
+            if (!sptr_host)
               continue;
 
             has_parent = true;
 
             engine_logger(dbg_checks, more)
-                << "Running serial check parent host '" << it->first << "'...";
-            SPDLOG_LOGGER_DEBUG(checks_logger,
-                                "Running serial check parent host '{}'...",
-                                it->first);
+                << "Running serial check parent host '" << key << "'...";
+            SPDLOG_LOGGER_DEBUG(
+                checks_logger, "Running serial check parent host '{}'...", key);
 
             /* run an immediate check of the parent host */
-            it->second->run_sync_check_3x(&parent_state, check_options,
-                                          use_cached_result,
-                                          check_timestamp_horizon);
+            sptr_host->run_sync_check_3x(&parent_state, check_options,
+                                         use_cached_result,
+                                         check_timestamp_horizon);
 
             /* bail out as soon as we find one parent host that is UP */
             if (parent_state == host::state_up) {
@@ -3442,17 +3443,15 @@ int host::process_check_result_3x(enum host::host_state new_state,
             checks_logger,
             "Propagating check to immediate non-UNREACHABLE child hosts...");
 
-        for (host_map_unsafe::iterator it{child_hosts.begin()},
-             end{child_hosts.end()};
-             it != end; it++) {
-          if (!it->second)
+        for (const auto& [key, ptr_host] : child_hosts) {
+          if (!ptr_host)
             continue;
-          if (it->second->get_current_state() != host::state_unreachable) {
+          if (ptr_host->get_current_state() != host::state_unreachable) {
             engine_logger(dbg_checks, more)
-                << "Check of child host '" << it->first << "' queued.";
+                << "Check of child host '" << key << "' queued.";
             SPDLOG_LOGGER_DEBUG(checks_logger,
-                                "Check of child host '{}' queued.", it->first);
-            check_hostlist.push_back(it->second);
+                                "Check of child host '{}' queued.", key);
+            check_hostlist.push_back(ptr_host);
           }
         }
       }
@@ -3486,17 +3485,15 @@ int host::process_check_result_3x(enum host::host_state new_state,
                             "Propagating checks to immediate parent hosts that "
                             "are UP...");
 
-        for (host_map_unsafe::iterator it{parent_hosts.begin()},
-             end{parent_hosts.end()};
-             it != end; it++) {
-          if (it->second == nullptr)
+        for (const auto& [key, sptr_host] : parent_hosts) {
+          if (sptr_host == nullptr)
             continue;
-          if (it->second->get_current_state() == host::state_up) {
-            check_hostlist.push_back(it->second);
+          if (sptr_host->get_current_state() == host::state_up) {
+            check_hostlist.push_back(sptr_host.get());
             engine_logger(dbg_checks, more)
-                << "Check of host '" << it->first << "' queued.";
+                << "Check of host '" << key << "' queued.";
             SPDLOG_LOGGER_DEBUG(checks_logger, "Check of host '{}' queued.",
-                                it->first);
+                                key);
           }
         }
 
@@ -3509,17 +3506,15 @@ int host::process_check_result_3x(enum host::host_state new_state,
                             "Propagating checks to immediate non-UNREACHABLE "
                             "child hosts...");
 
-        for (host_map_unsafe::iterator it{child_hosts.begin()},
-             end{child_hosts.end()};
-             it != end; it++) {
-          if (!it->second)
+        for (const auto& [key, ptr_host] : child_hosts) {
+          if (!ptr_host)
             continue;
-          if (it->second->get_current_state() != host::state_unreachable) {
+          if (ptr_host->get_current_state() != host::state_unreachable) {
             engine_logger(dbg_checks, more)
-                << "Check of child host '" << it->first << "' queued.";
+                << "Check of child host '" << key << "' queued.";
             SPDLOG_LOGGER_DEBUG(checks_logger,
-                                "Check of child host '{}' queued.", it->first);
-            check_hostlist.push_back(it->second);
+                                "Check of child host '{}' queued.", key);
+            check_hostlist.push_back(ptr_host);
           }
         }
 
@@ -3737,22 +3732,20 @@ enum host::host_state host::determine_host_reachability(
 
   /* check all parent hosts to see if we're DOWN or UNREACHABLE */
   else {
-    for (host_map_unsafe::iterator it{parent_hosts.begin()},
-         end{parent_hosts.end()};
-         it != end; it++) {
-      if (!it->second)
+    for (const auto& [key, sptr_host] : parent_hosts) {
+      if (!sptr_host)
         continue;
 
       /* bail out as soon as we find one parent host that is UP */
-      if (it->second->get_current_state() == host::state_up) {
+      if (sptr_host->get_current_state() == host::state_up) {
         is_host_present = true;
         /* set the current state */
         state = host::state_down;
-        engine_logger(dbg_checks, most) << "At least one parent (" << it->first
-                                        << ") is up, so host is DOWN.";
+        engine_logger(dbg_checks, most)
+            << "At least one parent (" << key << ") is up, so host is DOWN.";
         SPDLOG_LOGGER_DEBUG(checks_logger,
                             "At least one parent ({}) is up, so host is DOWN.",
-                            it->first);
+                            key);
         break;
       }
     }
@@ -4100,22 +4093,20 @@ void host::resolve(uint32_t& w, uint32_t& e) {
   }
 
   /* check all parent parent host */
-  for (host_map_unsafe::iterator it(parent_hosts.begin()),
-       end(parent_hosts.end());
-       it != end; it++) {
-    host_map::const_iterator it_host{host::hosts.find(it->first)};
+  for (auto& [key, sptr_host] : parent_hosts) {
+    host_map::const_iterator it_host{host::hosts.find(key)};
     if (it_host == host::hosts.end() || !it_host->second) {
-      engine_logger(log_verification_error, basic) << "Error: '" << it->first
+      engine_logger(log_verification_error, basic) << "Error: '" << key
                                                    << "' is not a "
                                                       "valid parent for host '"
                                                    << name() << "'!";
       config_logger->error("Error: '{}' is not a valid parent for host '{}'!",
-                           it->first, name());
+                           key, name());
       errors++;
     } else {
-      it->second = it_host->second.get();
-      it_host->second->add_child_host(
-          this);  // add a reverse (child) link to make searches faster later on
+      sptr_host = it_host->second;
+      it_host->second->add_child_host(this);  // add a reverse (child) link to
+                                              // make searches faster later on
     }
   }
 

--- a/engine/src/macros/grab_host.cc
+++ b/engine/src/macros/grab_host.cc
@@ -184,12 +184,10 @@ std::string get_host_total_services(host& hst, nagios_macros* mac) {
 static std::string get_host_parents(host& hst, nagios_macros* mac) {
   (void)mac;
   std::string retval;
-  for (host_map_unsafe::const_iterator it(hst.parent_hosts.begin()),
-       end(hst.parent_hosts.end());
-       it != end; it++) {
+  for (const auto& [key, _] : hst.parent_hosts) {
     if (!retval.empty())
       retval.append(",");
-    retval.append(it->first);
+    retval.append(key);
   }
   return retval;
 }
@@ -205,12 +203,10 @@ static std::string get_host_parents(host& hst, nagios_macros* mac) {
 static std::string get_host_children(host& hst, nagios_macros* mac) {
   (void)mac;
   std::string retval;
-  for (host_map_unsafe::const_iterator it(hst.child_hosts.begin()),
-       end(hst.child_hosts.end());
-       it != end; it++) {
+  for (const auto& [key, _] : hst.child_hosts) {
     if (!retval.empty())
       retval.append(",");
-    retval.append(it->first);
+    retval.append(key);
   }
   return retval;
 }

--- a/tests/broker-engine/parent_child_relation.robot
+++ b/tests/broker-engine/parent_child_relation.robot
@@ -1,0 +1,261 @@
+*** Settings ***
+Documentation       Centreon Engine/Broker verify relation parent child host.
+
+Resource            ../resources/import.resource
+
+Suite Setup         Ctn Clean Before Suite
+Suite Teardown      Ctn Clean After Suite
+Test Setup          Ctn Stop Processes
+Test Teardown       Ctn Save Logs If Failed
+
+
+*** Test Cases ***
+
+EBPN0
+    [Documentation]    Verify if child is in queue when parent is down.
+    [Tags]    broker    engine    MON-151686
+    
+    Ctn Config Engine    ${1}    ${5}    ${1}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module
+    Ctn Config BBDO3    1
+
+    Ctn Broker Config Log    rrd    rrd    trace
+    Ctn Broker Config Log    central    sql    debug
+    Ctn Broker Config Log    rrd    core    error
+    Ctn Engine Config Set Value    0    log_level_checks    debug
+    Ctn Config Broker Sql Output    central    unified_sql    10
+    Ctn Broker Config Flush Log    central    0
+    Ctn Broker Config Flush Log    rrd    0
+
+    Ctn Clear Retention
+    Ctn Clear Db    resources
+
+    # force the check result to 2
+    Ctn Config Host Command Status    ${0}    checkh1    2
+
+    # host_1 is parent of host_2
+    Ctn Add Parent To Host    0    host_2    host_1
+
+    ${start}    Get Current Date
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+
+    # check if host_2 is child of host_1
+    Connect To Database    pymysql    ${DBName}    ${DBUser}    ${DBPass}    ${DBHost}    ${DBPort}
+
+    FOR    ${index}    IN RANGE    30
+        ${output}    Query
+        ...    SELECT child_id, parent_id FROM hosts_hosts_parents
+        Log To Console    ${output}
+        Sleep    1s
+        IF    "${output}" == "((2, 1),)"    BREAK
+    END
+    Should Be Equal As Strings    ${output}    ((2, 1),)    host parent not inserted
+    
+    # check if host_1 is pending
+    ${result}    Ctn Check Host Status    host_1    4    1    True
+    Should Be True    ${result}    host_1 should be pending
+
+    ${result}    Ctn Check Host Status    host_2    4    1    True
+    Should Be True    ${result}    host_2 should be pending
+
+    ${content}    Create List    INITIAL HOST STATE: host_1;
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True
+    ...    ${result}
+    ...    An Initial host state on host_1 should be raised before we can start our external commands.
+    
+    Ctn Process Host Check Result    host_1    0    host_1 UP
+
+    FOR    ${i}    IN RANGE    ${4}
+        Ctn Schedule Forced Host Check    host_1    ${VarRoot}/lib/centreon-engine/config0/rw/centengine.cmd
+        Sleep    1s
+    END
+
+    ${content}    Create List
+    ...    EXTERNAL COMMAND: SCHEDULE_FORCED_HOST_CHECK;host_1;
+    ...    HOST ALERT: host_1;DOWN;HARD;
+
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    Message about SCHEDULE HOST should be down in log.
+
+    ${result}    Ctn Check Host Status    host_1    1    1    True
+    Should Be True    ${result}    host_1 should be down/hard
+
+    ${content}    Create List
+     ...    Check of child host 'host_2' queued.
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    Check of child host 'host_2' should be queued.
+
+    Disconnect From Database
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker
+
+EBPN1
+    [Documentation]    verify relation parent child when delete parent.
+    [Tags]    broker    engine    MON-151686
+    
+    Ctn Config Engine    ${1}    ${5}    ${1}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module
+    Ctn Config BBDO3    1
+
+    Ctn Broker Config Log    rrd    rrd    error
+    Ctn Broker Config Log    rrd    core    error
+    Ctn Broker Config Log    module0    core    error
+
+    Ctn Broker Config Log    central    sql    debug
+    Ctn Engine Config Set Value    0    log_level_checks    error
+    Ctn Config Broker Sql Output    central    unified_sql    10
+    Ctn Broker Config Flush Log    central    0
+    Ctn Broker Config Flush Log    rrd    0
+
+    Ctn Clear Retention
+
+    # host_1 is parent of host_2
+    Ctn Add Parent To Host    0    host_2    host_1
+
+    ${start}    Get Current Date
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+
+    ${output}    Ctn Get Host Info Grpc    ${2}
+    Log To Console    parents:${output}[parentHosts]
+    Should Contain    ${output}[parentHosts]    host_1    parentHosts
+
+    ${output}    Ctn Get Host Info Grpc    ${1}
+    Log To Console    childs:${output}[childHosts]
+    Should Contain    ${output}[childHosts]    host_2    childHosts
+
+    Connect To Database    pymysql    ${DBName}    ${DBUser}    ${DBPass}    ${DBHost}    ${DBPort}
+
+    FOR    ${index}    IN RANGE    30
+        ${output}    Query
+        ...    SELECT child_id, parent_id FROM hosts_hosts_parents
+        Log To Console    ${output}
+        Sleep    1s
+        IF    "${output}" == "((2, 1),)"    BREAK
+    END
+    Should Be Equal As Strings    ${output}    ((2, 1),)    the parent link not inserted
+    
+    Ctn Engine Config Del Block In Cfg    ${0}    host    host_1    hosts.cfg
+    Ctn Engine Config Del Block In Cfg    ${0}    service    host_1    services.cfg
+    Ctn Engine Config Delete Value In Hosts    ${0}    host_2    parents
+
+    ${start}    Get Current Date
+    Ctn Reload Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+    ${content}    Create List    Reload configuration finished
+    ${result}    Ctn Find In Log With Timeout
+    ...    ${ENGINE_LOG}/config0/centengine.log
+    ...    ${start}
+    ...    ${content}
+    ...    60
+    ...    verbose=False
+    Should Be True    ${result}    Engine is Not Ready after 60s!!
+
+
+    ${output}    Ctn Get Host Info Grpc    ${2}
+    Log To Console    parents:${output}[parentHosts]
+    Should Be Empty    ${output}[parentHosts]
+
+    FOR    ${index}    IN RANGE    30
+        ${output}    Query
+        ...    SELECT child_id, parent_id FROM hosts_hosts_parents
+        Log To Console    ${output}
+        Sleep    1s
+        IF    "${output}" == "()"    BREAK
+    END
+    Should Be Equal As Strings    ${output}    ()    the parent link should be deleted
+
+    Disconnect From Database
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker
+
+EBPN2
+    [Documentation]    verify relation parent child when delete child.
+    [Tags]    broker    engine    MON-151686
+    
+    Ctn Config Engine    ${1}    ${5}    ${1}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module
+    Ctn Config BBDO3    1
+
+    Ctn Broker Config Log    rrd    rrd    error
+    Ctn Broker Config Log    rrd    core    error
+    Ctn Broker Config Log    module0    core    error
+
+    Ctn Broker Config Log    central    sql    debug
+    Ctn Engine Config Set Value    0    log_level_checks    error
+    Ctn Config Broker Sql Output    central    unified_sql    10
+    Ctn Broker Config Flush Log    central    0
+    Ctn Broker Config Flush Log    rrd    0
+
+    Ctn Clear Retention
+
+    # host_1 is parent of host_2
+    Ctn Add Parent To Host    0    host_2    host_1
+
+    ${start}    Get Current Date
+    Ctn Clear Retention
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+
+    ${output}    Ctn Get Host Info Grpc    ${2}
+    Log To Console    parents:${output}[parentHosts]
+    Should Contain    ${output}[parentHosts]    host_1    parentHosts
+
+    ${output}    Ctn Get Host Info Grpc    ${1}
+    Log To Console    childs:${output}[childHosts]
+    Should Contain    ${output}[childHosts]    host_2    childHosts
+
+    Connect To Database    pymysql    ${DBName}    ${DBUser}    ${DBPass}    ${DBHost}    ${DBPort}
+
+    FOR    ${index}    IN RANGE    30
+        ${output}    Query
+        ...    SELECT child_id, parent_id FROM hosts_hosts_parents
+        Log To Console    ${output}
+        Sleep    1s
+        IF    "${output}" == "((2, 1),)"    BREAK
+    END
+    Should Be Equal As Strings    ${output}    ((2, 1),)    the parent link not inserted
+
+    Ctn Engine Config Del Block In Cfg    ${0}    host    host_2    hosts.cfg
+    Ctn Engine Config Del Block In Cfg    ${0}    service    host_2    services.cfg
+    Ctn Engine Config Delete Value In Hosts    ${0}    host_2    parents
+
+    ${start}    Get Current Date
+    Ctn Reload Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+    ${content}    Create List    Reload configuration finished
+    ${result}    Ctn Find In Log With Timeout
+    ...    ${ENGINE_LOG}/config0/centengine.log
+    ...    ${start}
+    ...    ${content}
+    ...    60
+    ...    verbose=False
+    Should Be True    ${result}    Engine is Not Ready after 60s!!
+
+    ${output}    Ctn Get Host Info Grpc    ${1}
+    Log To Console    childs:${output}[childHosts]
+    Should Be Empty    ${output}[childHosts]
+
+    FOR    ${index}    IN RANGE    30
+        ${output}    Query
+        ...    SELECT child_id, parent_id FROM hosts_hosts_parents
+        Log To Console    ${output}
+        Sleep    1s
+        IF    "${output}" == "()"    BREAK
+    END
+    Should Be Equal As Strings    ${output}    ()    the parent link should be deleted
+
+    Disconnect From Database
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker

--- a/tests/resources/Engine.py
+++ b/tests/resources/Engine.py
@@ -4086,3 +4086,35 @@ def ctn_check_key_value_existence(data_list, key, value):
             return True
     return False
 
+def ctn_engine_config_del_block_in_cfg(idx: int, type: str, key: str, file):
+    """
+    Delete a element in the file given for the Engine configuration idx.
+
+    Args:
+        idx (int): Index of the Engine configuration (from 0)
+        type (str): The type (host/service/...).
+        key (str): The parameter that will be deleted.
+        file (str): The file to delete the key from.
+    """
+    filename = f"{ETC_ROOT}/centreon-engine/config{idx}/{file}"
+    
+    with open(filename, "r") as f:
+        content = f.read()
+
+    if type == "host":
+        pattern = rf"define host \{{\s*host_name\s+{re.escape(key)}\b.*?\}}"
+    elif type == "service":
+        pattern = rf"define service \{{\s*host_name\s+{re.escape(key)}\b.*?\}}"
+
+    # Use re.sub to remove the matched block
+    new_content = re.sub(pattern, '', content, flags=re.DOTALL)
+    new_content = re.sub(r'\n\s*\n', '\n', new_content)
+
+    if content != new_content:
+        with open(filename, "w") as f:
+            f.write(new_content)
+    else:
+        logger.console(f'\n\033[91mFailed : Cannot delete the block  with the type : {type} and the key : {key} in {file}\033[0m')
+
+    
+


### PR DESCRIPTION
There was an issue with parents/children hosts relations.
When the configuration was sent to broker, we had some dangling pointers that could lead to a segfault.

REFS: MON-151686