### PR TITLE
fix(gorgone): use Centreon version to create 1 docker images per version with the right repo

### DIFF
--- a/.github/docker/Dockerfile.gorgone-testing-alma8
+++ b/.github/docker/Dockerfile.gorgone-testing-alma8
@@ -1,16 +1,15 @@
 ARG REGISTRY_URL=docker.io
-ARG CENTREON_VERSION
 
 FROM ${REGISTRY_URL}/almalinux:8
 
-ENV REPO_VERSION=${CENTREON_VERSION}
+ARG CENTREON_VERSION
 
 RUN bash -e <<EOF
 
 dnf install -y dnf-plugins-core zstd curl mariadb iproute procps lsof
 dnf install -y https://rpms.remirepo.net/enterprise/remi-release-8.rpm
 dnf config-manager --set-enabled 'powertools'
-dnf -y config-manager --add-repo https://packages.centreon.com/rpm-standard/${REPO_VERSION}/el8/centreon-${REPO_VERSION}.repo
+dnf -y config-manager --add-repo https://packages.centreon.com/rpm-standard/${CENTREON_VERSION}/el8/centreon-${CENTREON_VERSION}.repo
 dnf -y clean all --enablerepo=*
 dnf install -y python3.11 python3.11-pip
 pip3.11 install robotframework robotframework-examples robotframework-databaselibrary pymysql robotframework-requests robotframework-jsonlibrary

--- a/.github/docker/Dockerfile.gorgone-testing-alma8
+++ b/.github/docker/Dockerfile.gorgone-testing-alma8
@@ -1,11 +1,16 @@
-FROM almalinux:8
+ARG REGISTRY_URL=docker.io
+ARG CENTREON_VERSION
+
+FROM ${REGISTRY_URL}/almalinux:8
+
+ENV REPO_VERSION=${CENTREON_VERSION}
 
 RUN bash -e <<EOF
 
 dnf install -y dnf-plugins-core zstd curl mariadb iproute procps lsof
 dnf install -y https://rpms.remirepo.net/enterprise/remi-release-8.rpm
 dnf config-manager --set-enabled 'powertools'
-dnf -y config-manager --add-repo https://packages.centreon.com/rpm-standard/23.10/el8/centreon-23.10.repo
+dnf -y config-manager --add-repo https://packages.centreon.com/rpm-standard/${REPO_VERSION}/el8/centreon-${REPO_VERSION}.repo
 dnf -y clean all --enablerepo=*
 dnf install -y python3.11 python3.11-pip
 pip3.11 install robotframework robotframework-examples robotframework-databaselibrary pymysql robotframework-requests robotframework-jsonlibrary

--- a/.github/docker/Dockerfile.gorgone-testing-alma8
+++ b/.github/docker/Dockerfile.gorgone-testing-alma8
@@ -9,7 +9,12 @@ RUN bash -e <<EOF
 dnf install -y dnf-plugins-core zstd curl mariadb iproute procps lsof
 dnf install -y https://rpms.remirepo.net/enterprise/remi-release-8.rpm
 dnf config-manager --set-enabled 'powertools'
-dnf -y config-manager --add-repo https://packages.centreon.com/rpm-standard/${CENTREON_VERSION}/el8/centreon-${CENTREON_VERSION}.repo
+if curl --head --silent --fail "https://packages.centreon.com/rpm-standard/${CENTREON_VERSION}/el8/centreon-${CENTREON_VERSION}.repo" > /dev/null; then
+    internal_repo=""
+else
+    internal_repo="-internal"
+fi
+dnf -y config-manager --add-repo https://packages.centreon.com/rpm-standard$internal_repo/${CENTREON_VERSION}/el8/centreon-${CENTREON_VERSION}.repo
 dnf -y clean all --enablerepo=*
 dnf install -y python3.11 python3.11-pip
 pip3.11 install robotframework robotframework-examples robotframework-databaselibrary pymysql robotframework-requests robotframework-jsonlibrary

--- a/.github/docker/Dockerfile.gorgone-testing-alma8
+++ b/.github/docker/Dockerfile.gorgone-testing-alma8
@@ -1,21 +1,27 @@
 ARG REGISTRY_URL=docker.io
+ARG VERSION
 
 FROM ${REGISTRY_URL}/almalinux:8
 
-ARG CENTREON_VERSION
+ARG VERSION
+ARG IS_CLOUD
 
-RUN bash -e <<EOF
+RUN --mount=type=secret,id=ARTIFACTORY_INTERNAL_REPO_USERNAME \
+    --mount=type=secret,id=ARTIFACTORY_INTERNAL_REPO_PASSWORD \
+    bash -e <<EOF
 
 dnf install -y dnf-plugins-core zstd curl mariadb iproute procps lsof
 dnf install -y https://rpms.remirepo.net/enterprise/remi-release-8.rpm
 dnf config-manager --set-enabled 'powertools'
-if curl --head --silent --fail "https://packages.centreon.com/rpm-standard/${CENTREON_VERSION}/el8/centreon-${CENTREON_VERSION}.repo" > /dev/null; then
-    internal_repo=""
+
+if [[ "${IS_CLOUD}" == "true" ]]; then
+  dnf config-manager --add-repo https://$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_USERNAME):$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_PASSWORD)@packages.centreon.com/rpm-standard-internal/${VERSION}/el8/centreon-${VERSION}-internal.repo
+  sed -i "s#packages.centreon.com/rpm-standard-internal#$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_USERNAME):$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_PASSWORD)@packages.centreon.com/rpm-standard-internal#" /etc/yum.repos.d/centreon-${VERSION}-internal.repo
 else
-    internal_repo="-internal"
+  dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/${VERSION}/el8/centreon-${VERSION}.repo
 fi
-dnf -y config-manager --add-repo https://packages.centreon.com/rpm-standard$internal_repo/${CENTREON_VERSION}/el8/centreon-${CENTREON_VERSION}.repo
-dnf -y clean all --enablerepo=*
+dnf config-manager --set-enabled 'centreon*'
+
 dnf install -y python3.11 python3.11-pip
 pip3.11 install robotframework robotframework-examples robotframework-databaselibrary pymysql robotframework-requests robotframework-jsonlibrary
 

--- a/.github/docker/Dockerfile.gorgone-testing-alma9
+++ b/.github/docker/Dockerfile.gorgone-testing-alma9
@@ -4,11 +4,16 @@ FROM ${REGISTRY_URL}/almalinux:9
 
 ARG CENTREON_VERSION
 
-RUN bash -c <<EOF
+RUN bash -e <<EOF
 
 dnf install -y dnf-plugins-core zstd mariadb iproute epel-release procps lsof
 dnf config-manager --set-enabled crb
-dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/${CENTREON_VERSION}/el9/centreon-${CENTREON_VERSION}.repo
+if curl --head --silent --fail "https://packages.centreon.com/rpm-standard/${CENTREON_VERSION}/el8/centreon-${CENTREON_VERSION}.repo" > /dev/null; then
+    internal_repo=""
+else
+    internal_repo="-internal"
+fi
+dnf config-manager --add-repo https://packages.centreon.com/rpm-standard$internal_repo/${CENTREON_VERSION}/el9/centreon-${CENTREON_VERSION}.repo
 dnf install -y python3.11 python3.11-pip
 pip3.11 install robotframework robotframework-examples robotframework-databaselibrary pymysql robotframework-requests robotframework-jsonlibrary
 

--- a/.github/docker/Dockerfile.gorgone-testing-alma9
+++ b/.github/docker/Dockerfile.gorgone-testing-alma9
@@ -1,15 +1,14 @@
 ARG REGISTRY_URL=docker.io
-ARG CENTREON_VERSION
 
 FROM ${REGISTRY_URL}/almalinux:9
 
-ENV REPO_VERSION=${CENTREON_VERSION}
+ARG CENTREON_VERSION
 
-RUN bash -e <<EOF
+RUN bash -c <<EOF
 
 dnf install -y dnf-plugins-core zstd mariadb iproute epel-release procps lsof
 dnf config-manager --set-enabled crb
-dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/${REPO_VERSION}/el9/centreon-${REPO_VERSION}.repo
+dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/${CENTREON_VERSION}/el9/centreon-${CENTREON_VERSION}.repo
 dnf install -y python3.11 python3.11-pip
 pip3.11 install robotframework robotframework-examples robotframework-databaselibrary pymysql robotframework-requests robotframework-jsonlibrary
 

--- a/.github/docker/Dockerfile.gorgone-testing-alma9
+++ b/.github/docker/Dockerfile.gorgone-testing-alma9
@@ -1,22 +1,28 @@
 ARG REGISTRY_URL=docker.io
+ARG VERSION
 
 FROM ${REGISTRY_URL}/almalinux:9
 
-ARG CENTREON_VERSION
+ARG VERSION
+ARG IS_CLOUD
 
-RUN bash -e <<EOF
+RUN --mount=type=secret,id=ARTIFACTORY_INTERNAL_REPO_USERNAME \
+    --mount=type=secret,id=ARTIFACTORY_INTERNAL_REPO_PASSWORD \
+    bash -e <<EOF
 
 dnf install -y dnf-plugins-core zstd mariadb iproute epel-release procps lsof
 dnf config-manager --set-enabled crb
-if curl --head --silent --fail "https://packages.centreon.com/rpm-standard/${CENTREON_VERSION}/el8/centreon-${CENTREON_VERSION}.repo" > /dev/null; then
-    internal_repo=""
+
+if [[ "${IS_CLOUD}" == "true" ]]; then
+  dnf config-manager --add-repo https://$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_USERNAME):$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_PASSWORD)@packages.centreon.com/rpm-standard-internal/${VERSION}/el9/centreon-${VERSION}-internal.repo
+  sed -i "s#packages.centreon.com/rpm-standard-internal#$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_USERNAME):$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_PASSWORD)@packages.centreon.com/rpm-standard-internal#" /etc/yum.repos.d/centreon-${VERSION}-internal.repo
 else
-    internal_repo="-internal"
+  dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/${VERSION}/el9/centreon-${VERSION}.repo
 fi
-dnf config-manager --add-repo https://packages.centreon.com/rpm-standard$internal_repo/${CENTREON_VERSION}/el9/centreon-${CENTREON_VERSION}.repo
+dnf config-manager --set-enabled 'centreon*'
+
 dnf install -y python3.11 python3.11-pip
 pip3.11 install robotframework robotframework-examples robotframework-databaselibrary pymysql robotframework-requests robotframework-jsonlibrary
-
 
 dnf clean all
 

--- a/.github/docker/Dockerfile.gorgone-testing-alma9
+++ b/.github/docker/Dockerfile.gorgone-testing-alma9
@@ -1,10 +1,15 @@
-FROM almalinux:9
+ARG REGISTRY_URL=docker.io
+ARG CENTREON_VERSION
+
+FROM ${REGISTRY_URL}/almalinux:9
+
+ENV REPO_VERSION=${CENTREON_VERSION}
 
 RUN bash -e <<EOF
 
 dnf install -y dnf-plugins-core zstd mariadb iproute epel-release procps lsof
 dnf config-manager --set-enabled crb
-dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/23.10/el9/centreon-23.10.repo
+dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/${REPO_VERSION}/el9/centreon-${REPO_VERSION}.repo
 dnf install -y python3.11 python3.11-pip
 pip3.11 install robotframework robotframework-examples robotframework-databaselibrary pymysql robotframework-requests robotframework-jsonlibrary
 

--- a/.github/docker/Dockerfile.gorgone-testing-bookworm
+++ b/.github/docker/Dockerfile.gorgone-testing-bookworm
@@ -1,4 +1,9 @@
-FROM debian:bookworm
+ARG REGISTRY_URL=docker.io
+ARG CENTREON_VERSION
+
+FROM ${REGISTRY_URL}/debian:bookworm
+
+ENV REPO_VERSION=${CENTREON_VERSION}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -19,7 +24,7 @@ robotframework robotframework-examples robotframework-databaselibrary \
 pymysql robotframework-requests robotframework-jsonlibrary
 
 # can't use \$() method it would be executed before the main script, and lsb_release would not be installed.
-lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-24.11-unstable/ % main' | tee /etc/apt/sources.list.d/centreon.list
+lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-${REPO_VERSION}-unstable/ % main' | tee /etc/apt/sources.list.d/centreon.list
 lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-plugins-stable/ % main' | tee /etc/apt/sources.list.d/centreon-plugins.list
 
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1

--- a/.github/docker/Dockerfile.gorgone-testing-bookworm
+++ b/.github/docker/Dockerfile.gorgone-testing-bookworm
@@ -1,8 +1,9 @@
 ARG REGISTRY_URL=docker.io
+ARG VERSION
 
 FROM ${REGISTRY_URL}/debian:bookworm
 
-ARG CENTREON_VERSION
+ARG VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -23,7 +24,7 @@ robotframework robotframework-examples robotframework-databaselibrary \
 pymysql robotframework-requests robotframework-jsonlibrary
 
 # can't use \$() method it would be executed before the main script, and lsb_release would not be installed.
-lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-${CENTREON_VERSION}-unstable/ % main' | tee /etc/apt/sources.list.d/centreon.list
+lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-${VERSION}-unstable/ % main' | tee /etc/apt/sources.list.d/centreon.list
 lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-plugins-stable/ % main' | tee /etc/apt/sources.list.d/centreon-plugins.list
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 apt-update

--- a/.github/docker/Dockerfile.gorgone-testing-bookworm
+++ b/.github/docker/Dockerfile.gorgone-testing-bookworm
@@ -36,7 +36,7 @@ echo "deb https://packages.centreon.com/apt-plugins-testing/ \$VERSION_CODENAME 
 echo "deb https://packages.centreon.com/apt-plugins-unstable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-unstable.list
 wget -O- https://packages.centreon.com/api/security/keypair/APT-GPG-KEY/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 
-apt-update
+apt-get update
 
 apt-get clean
 rm -rf /var/lib/apt/lists/*

--- a/.github/docker/Dockerfile.gorgone-testing-bookworm
+++ b/.github/docker/Dockerfile.gorgone-testing-bookworm
@@ -28,10 +28,14 @@ VERSION_CODENAME=\$(
   echo \$VERSION_CODENAME
 )
 
-# can't use \$() method it would be executed before the main script, and lsb_release would not be installed.
-lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-${VERSION}-unstable/ \$VERSION_CODENAME main' | tee /etc/apt/sources.list.d/centreon.list
-lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-plugins-stable/ \$VERSION_CODENAME main' | tee /etc/apt/sources.list.d/centreon-plugins.list
-wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
+echo "deb https://packages.centreon.com/apt-standard-${VERSION}-stable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
+echo "deb https://packages.centreon.com/apt-standard-${VERSION}-testing/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
+echo "deb https://packages.centreon.com/apt-standard-${VERSION}-unstable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
+echo "deb https://packages.centreon.com/apt-plugins-testing/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list
+echo "deb https://packages.centreon.com/apt-plugins-unstable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-unstable.list
+wget -O- https://packages.centreon.com/api/security/keypair/APT-GPG-KEY/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
+
 apt-update
 
 apt-get clean

--- a/.github/docker/Dockerfile.gorgone-testing-bookworm
+++ b/.github/docker/Dockerfile.gorgone-testing-bookworm
@@ -23,9 +23,14 @@ pip3 install --break-system-packages --no-cache-dir \
 robotframework robotframework-examples robotframework-databaselibrary \
 pymysql robotframework-requests robotframework-jsonlibrary
 
+VERSION_CODENAME=\$(
+  . /etc/os-release
+  echo \$VERSION_CODENAME
+)
+
 # can't use \$() method it would be executed before the main script, and lsb_release would not be installed.
-lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-${VERSION}-unstable/ % main' | tee /etc/apt/sources.list.d/centreon.list
-lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-plugins-stable/ % main' | tee /etc/apt/sources.list.d/centreon-plugins.list
+lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-${VERSION}-unstable/ \$VERSION_CODENAME main' | tee /etc/apt/sources.list.d/centreon.list
+lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-plugins-stable/ \$VERSION_CODENAME main' | tee /etc/apt/sources.list.d/centreon-plugins.list
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 apt-update
 

--- a/.github/docker/Dockerfile.gorgone-testing-bookworm
+++ b/.github/docker/Dockerfile.gorgone-testing-bookworm
@@ -1,9 +1,8 @@
 ARG REGISTRY_URL=docker.io
-ARG CENTREON_VERSION
 
 FROM ${REGISTRY_URL}/debian:bookworm
 
-ENV REPO_VERSION=${CENTREON_VERSION}
+ARG CENTREON_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -24,10 +23,11 @@ robotframework robotframework-examples robotframework-databaselibrary \
 pymysql robotframework-requests robotframework-jsonlibrary
 
 # can't use \$() method it would be executed before the main script, and lsb_release would not be installed.
-lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-${REPO_VERSION}-unstable/ % main' | tee /etc/apt/sources.list.d/centreon.list
+lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-${CENTREON_VERSION}-unstable/ % main' | tee /etc/apt/sources.list.d/centreon.list
 lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-plugins-stable/ % main' | tee /etc/apt/sources.list.d/centreon-plugins.list
-
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
+apt-update
+
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 

--- a/.github/docker/Dockerfile.gorgone-testing-bullseye
+++ b/.github/docker/Dockerfile.gorgone-testing-bullseye
@@ -1,4 +1,9 @@
-FROM debian:bullseye
+ARG REGISTRY_URL=docker.io
+ARG CENTREON_VERSION
+
+FROM ${REGISTRY_URL}/debian:bullseye
+
+ENV REPO_VERSION=${CENTREON_VERSION}
 
 ENV DEBIAN_FRONTEND noninteractive
 # fix locale
@@ -18,7 +23,7 @@ localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 pip3 install robotframework robotframework-examples robotframework-databaselibrary \
 pymysql robotframework-requests robotframework-jsonlibrary
 
-lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-24.11-unstable/ % main' | tee /etc/apt/sources.list.d/centreon.list
+lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-${REPO_VERSION}-unstable/ % main' | tee /etc/apt/sources.list.d/centreon.list
 lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-plugins-stable/ % main' | tee /etc/apt/sources.list.d/centreon-plugins.list
 
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1

--- a/.github/docker/Dockerfile.gorgone-testing-bullseye
+++ b/.github/docker/Dockerfile.gorgone-testing-bullseye
@@ -1,8 +1,9 @@
 ARG REGISTRY_URL=docker.io
+ARG VERSION
 
 FROM ${REGISTRY_URL}/debian:bullseye
 
-ARG CENTREON_VERSION
+ARG VERSION
 
 ENV DEBIAN_FRONTEND noninteractive
 # fix locale
@@ -22,7 +23,7 @@ localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 pip3 install robotframework robotframework-examples robotframework-databaselibrary \
 pymysql robotframework-requests robotframework-jsonlibrary
 
-lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-${CENTREON_VERSION}-unstable/ % main' | tee /etc/apt/sources.list.d/centreon.list
+lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-${VERSION}-unstable/ % main' | tee /etc/apt/sources.list.d/centreon.list
 lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-plugins-stable/ % main' | tee /etc/apt/sources.list.d/centreon-plugins.list
 
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1

--- a/.github/docker/Dockerfile.gorgone-testing-bullseye
+++ b/.github/docker/Dockerfile.gorgone-testing-bullseye
@@ -1,9 +1,8 @@
 ARG REGISTRY_URL=docker.io
-ARG CENTREON_VERSION
 
 FROM ${REGISTRY_URL}/debian:bullseye
 
-ENV REPO_VERSION=${CENTREON_VERSION}
+ARG CENTREON_VERSION
 
 ENV DEBIAN_FRONTEND noninteractive
 # fix locale
@@ -23,7 +22,7 @@ localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 pip3 install robotframework robotframework-examples robotframework-databaselibrary \
 pymysql robotframework-requests robotframework-jsonlibrary
 
-lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-${REPO_VERSION}-unstable/ % main' | tee /etc/apt/sources.list.d/centreon.list
+lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-standard-${CENTREON_VERSION}-unstable/ % main' | tee /etc/apt/sources.list.d/centreon.list
 lsb_release -sc | xargs -I % sh  -c 'echo deb https://packages.centreon.com/apt-plugins-stable/ % main' | tee /etc/apt/sources.list.d/centreon-plugins.list
 
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1

--- a/.github/docker/Dockerfile.gorgone-testing-jammy
+++ b/.github/docker/Dockerfile.gorgone-testing-jammy
@@ -1,4 +1,9 @@
-FROM ubuntu:jammy
+ARG REGISTRY_URL=docker.io
+ARG CENTREON_VERSION
+
+FROM ${REGISTRY_URL}/ubuntu:jammy
+
+ENV REPO_VERSION=${CENTREON_VERSION}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -11,7 +16,7 @@ RUN apt-get update && \
 ENV LANG=en_US.UTF-8
 
 # Add Centreon repositories and their public key
-RUN echo "deb https://packages.centreon.com/ubuntu-standard-24.11-unstable/ jammy main" | tee -a /etc/apt/sources.list.d/centreon-testing.list && \
+RUN echo "deb https://packages.centreon.com/ubuntu-standard-${REPO_VERSION}-unstable/ jammy main" | tee -a /etc/apt/sources.list.d/centreon-testing.list && \
     echo "deb https://packages.centreon.com/ubuntu-plugins-testing/ jammy main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list && \
     wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1 && \
     apt-get update

--- a/.github/docker/Dockerfile.gorgone-testing-jammy
+++ b/.github/docker/Dockerfile.gorgone-testing-jammy
@@ -1,9 +1,8 @@
 ARG REGISTRY_URL=docker.io
-ARG CENTREON_VERSION
 
 FROM ${REGISTRY_URL}/ubuntu:jammy
 
-ENV REPO_VERSION=${CENTREON_VERSION}
+ARG CENTREON_VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -16,7 +15,7 @@ RUN apt-get update && \
 ENV LANG=en_US.UTF-8
 
 # Add Centreon repositories and their public key
-RUN echo "deb https://packages.centreon.com/ubuntu-standard-${REPO_VERSION}-unstable/ jammy main" | tee -a /etc/apt/sources.list.d/centreon-testing.list && \
+RUN echo "deb https://packages.centreon.com/ubuntu-standard-${CENTREON_VERSION}-unstable/ jammy main" | tee -a /etc/apt/sources.list.d/centreon-testing.list && \
     echo "deb https://packages.centreon.com/ubuntu-plugins-testing/ jammy main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list && \
     wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1 && \
     apt-get update

--- a/.github/docker/Dockerfile.gorgone-testing-jammy
+++ b/.github/docker/Dockerfile.gorgone-testing-jammy
@@ -1,8 +1,9 @@
 ARG REGISTRY_URL=docker.io
+ARG VERSION
 
 FROM ${REGISTRY_URL}/ubuntu:jammy
 
-ARG CENTREON_VERSION
+ARG VERSION
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -15,7 +16,7 @@ RUN apt-get update && \
 ENV LANG=en_US.UTF-8
 
 # Add Centreon repositories and their public key
-RUN echo "deb https://packages.centreon.com/ubuntu-standard-${CENTREON_VERSION}-unstable/ jammy main" | tee -a /etc/apt/sources.list.d/centreon-testing.list && \
+RUN echo "deb https://packages.centreon.com/ubuntu-standard-${VERSION}-unstable/ jammy main" | tee -a /etc/apt/sources.list.d/centreon-testing.list && \
     echo "deb https://packages.centreon.com/ubuntu-plugins-testing/ jammy main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list && \
     wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1 && \
     apt-get update

--- a/.github/workflows/docker-gorgone-testing.yml
+++ b/.github/workflows/docker-gorgone-testing.yml
@@ -55,7 +55,11 @@ jobs:
           context: .
           build-args: |
             "REGISTRY_URL=${{ vars.DOCKER_PROXY_REGISTRY_URL }}"
-            "CENTREON_VERSION=${{ needs.get-environment.outputs.major_version }}"
+            "VERSION=${{ needs.get-environment.outputs.major_version }}"
+            "IS_CLOUD=${{ needs.get-environment.outputs.is_cloud }}"
           pull: true
           push: true
           tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ matrix.distrib }}:${{ needs.get-environment.outputs.major_version }}
+          secrets: |
+            "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
+            "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"

--- a/.github/workflows/docker-gorgone-testing.yml
+++ b/.github/workflows/docker-gorgone-testing.yml
@@ -40,12 +40,22 @@ jobs:
           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
 
+      - name: Login to proxy registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ vars.DOCKER_PROXY_REGISTRY_URL }}
+          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+
       - uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 
       - uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           file: .github/docker/Dockerfile.gorgone-testing-${{ matrix.distrib }}
           context: .
+          build-args: |
+            "REGISTRY_URL=${{ vars.DOCKER_PROXY_REGISTRY_URL }}"
+            "CENTREON_VERSION=${{ needs.get-environment.outputs.major_version }}"
           pull: true
           push: true
-          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ matrix.distrib }}:${{ needs.get-environment.outputs.gorgone_docker_version }}
+          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ matrix.distrib }}:${{ needs.get-environment.outputs.major_version }}

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -39,9 +39,6 @@ on:
       test_img_version:
         description: "test docker image version (checksum of database sql, script and dockerfiles)"
         value: ${{ jobs.get-environment.outputs.test_img_version }}
-      gorgone_docker_version:
-        description: "md5 of gorgone dockerfile"
-        value: ${{ jobs.get-environment.outputs.gorgone_docker_version }}
 
 jobs:
   get-environment:
@@ -58,7 +55,6 @@ jobs:
       is_targeting_feature_branch: ${{ steps.get_stability.outputs.is_targeting_feature_branch }}
       img_version: ${{ steps.get_docker_images_version.outputs.img_version }}
       test_img_version: ${{ steps.get_docker_images_version.outputs.test_img_version }}
-      gorgone_docker_version: ${{ steps.get_docker_images_version.outputs.gorgone_docker_version }}
 
     steps:
       - name: Checkout sources (current branch)
@@ -239,9 +235,6 @@ jobs:
           TEST_IMG_VERSION=$(cat .github/docker/Dockerfile.centreon-collect-*-test .github/scripts/collect-prepare-test-robot.sh resources/*.sql | md5sum | cut -c1-8)
           echo "test_img_version=$TEST_IMG_VERSION" >> $GITHUB_OUTPUT
 
-          GORGONE_DOCKER_VERSION=$(cat .github/docker/Dockerfile.gorgone-testing-* | md5sum | cut -c1-8)
-          echo "gorgone_docker_version=$GORGONE_DOCKER_VERSION" >> $GITHUB_OUTPUT
-
       - name: Display info in job summary
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
@@ -260,7 +253,6 @@ jobs:
               ['is_targeting_feature_branch', '${{ steps.get_stability.outputs.is_targeting_feature_branch }}'],
               ['img_version', '${{ steps.get_docker_images_version.outputs.img_version }}'],
               ['test_img_version', '${{ steps.get_docker_images_version.outputs.test_img_version }}'],
-              ['gorgone_docker_version', '${{ steps.get_docker_images_version.outputs.gorgone_docker_version }}'],
             ];
 
             outputTable.push(['target_stability', '${{ steps.get_stability.outputs.target_stability || '<em>not defined because current run is not triggered by pull request event</em>' }}']);

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -133,7 +133,6 @@ jobs:
           stability: ${{ needs.get-environment.outputs.stability }}
 
   test-gorgone:
-    if: false
     needs: [get-environment, package]
 
     strategy:

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -155,7 +155,7 @@ jobs:
 
     runs-on: ubuntu-24.04
     container:
-      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:${{ needs.get-environment.outputs.gorgone_docker_version }}
+      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:${{ needs.get-environment.outputs.major_version }}
       credentials:
         username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
         password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -74,9 +74,6 @@ jobs:
           - package_extension: deb
             image: packaging-nfpm-bookworm
             distrib: bookworm
-          - package_extension: deb
-            image: packaging-nfpm-jammy
-            distrib: jammy
 
     runs-on: ubuntu-24.04
 
@@ -146,9 +143,6 @@ jobs:
           - package_extension: rpm
             image: gorgone-testing-alma9
             distrib: el9
-          - package_extension: deb
-            image: gorgone-testing-jammy
-            distrib: jammy
           - package_extension: deb
             image: gorgone-testing-bookworm
             distrib: bookworm

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -13,6 +13,7 @@ on:
       - reopened
       - ready_for_review
     paths:
+      - ".github/workflows/gorgone.yml"
       - "gorgone/**"
       - "!gorgone/tests/**"
       - "!gorgone/veracode.json"


### PR DESCRIPTION
## Description

The repo used by gorgone tests is not always the right one (wrong version), which can cause errors when installing dependencies during tests.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 24.11.x
- [ ] master

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

