### PR TITLE
fix(scope): metric names not escaped graphite 24.04

### DIFF
--- a/broker/graphite/src/query.cc
+++ b/broker/graphite/src/query.cc
@@ -299,7 +299,7 @@ void query::_get_metric_id(io::data const& d, std::ostream& is) {
  *  @param[out] is  The stream
  */
 void query::_get_metric_name(io::data const& d, std::ostream& is) {
-  is << static_cast<storage::pb_metric const&>(d).obj().name();
+  is << _escape(static_cast<const storage::pb_metric&>(d).obj().name());
 }
 
 /**

--- a/broker/graphite/test/query.cc
+++ b/broker/graphite/test/query.cc
@@ -270,14 +270,14 @@ TEST(graphiteQuery, Except) {
   }
 
   m.mut_obj().set_metric_id(3);
-  m.mut_obj().set_name("A");
+  m.mut_obj().set_name("The.full.name.A");
 
   graphite::query q4{"test . $METRICID$ $METRIC$", "a", graphite::query::metric,
                      cache};
 
   ASSERT_THROW(q.generate_status(s), msg_fmt);
   ASSERT_THROW(q2.generate_metric(m), msg_fmt);
-  ASSERT_EQ(q4.generate_metric(m), "test_._3_A 0 0\n");
+  ASSERT_EQ(q4.generate_metric(m), "test_._3_TheafullanameaA 0 0\n");
 
   graphite::query q5{"test . $INSTANCE$", "a", graphite::query::metric, cache};
   ASSERT_EQ(q5.generate_metric(m), "");


### PR DESCRIPTION
## Description

Metric names should be escaped now.

REFS: MON-152669

