### PR TITLE
enh(broker): AdaptiveHostStatus and AdaptiveServiceStatus added

### DIFF
--- a/agent/native_linux/src/check_cpu.cc
+++ b/agent/native_linux/src/check_cpu.cc
@@ -1,0 +1,1 @@
+class dummy{};

--- a/bbdo/bam.proto
+++ b/bbdo/bam.proto
@@ -53,7 +53,7 @@ message BaStatus {
 message BaEvent {
   uint32 ba_id = 1;
   double first_level = 2;
-  int64 end_time = 3;
+  uint64 end_time = 3;
   bool in_downtime = 4;
   uint64 start_time = 5;
   State status = 6;

--- a/bbdo/bam/ba_status.hh
+++ b/bbdo/bam/ba_status.hh
@@ -19,9 +19,7 @@
 #ifndef CCB_BAM_BA_STATUS_HH
 #define CCB_BAM_BA_STATUS_HH
 
-#include "bbdo/events.hh"
 #include "com/centreon/broker/io/data.hh"
-#include "com/centreon/broker/io/event_info.hh"
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/mapping/entry.hh"
 #include "com/centreon/broker/timestamp.hh"

--- a/bbdo/bam/dimension_ba_bv_relation_event.hh
+++ b/bbdo/bam/dimension_ba_bv_relation_event.hh
@@ -19,9 +19,7 @@
 #ifndef CCB_BAM_DIMENSION_BA_BV_RELATION_EVENT_HH
 #define CCB_BAM_DIMENSION_BA_BV_RELATION_EVENT_HH
 
-#include "bbdo/events.hh"
 #include "com/centreon/broker/io/data.hh"
-#include "com/centreon/broker/io/event_info.hh"
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/mapping/entry.hh"
 #include "com/centreon/broker/timestamp.hh"

--- a/bbdo/bam/dimension_ba_event.hh
+++ b/bbdo/bam/dimension_ba_event.hh
@@ -19,9 +19,7 @@
 #ifndef CCB_BAM_DIMENSION_BA_EVENT_HH
 #define CCB_BAM_DIMENSION_BA_EVENT_HH
 
-#include "bbdo/events.hh"
 #include "com/centreon/broker/io/data.hh"
-#include "com/centreon/broker/io/event_info.hh"
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/mapping/entry.hh"
 #include "com/centreon/broker/timestamp.hh"

--- a/bbdo/bam/dimension_bv_event.hh
+++ b/bbdo/bam/dimension_bv_event.hh
@@ -19,9 +19,7 @@
 #ifndef CCB_BAM_DIMENSION_BV_EVENT_HH
 #define CCB_BAM_DIMENSION_BV_EVENT_HH
 
-#include "bbdo/events.hh"
 #include "com/centreon/broker/io/data.hh"
-#include "com/centreon/broker/io/event_info.hh"
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/mapping/entry.hh"
 #include "com/centreon/broker/timestamp.hh"

--- a/bbdo/bam/dimension_truncate_table_signal.hh
+++ b/bbdo/bam/dimension_truncate_table_signal.hh
@@ -19,9 +19,7 @@
 #ifndef CCB_BAM_DIMENSION_TRUNCATE_TABLE_SIGNAL_HH
 #define CCB_BAM_DIMENSION_TRUNCATE_TABLE_SIGNAL_HH
 
-#include "bbdo/events.hh"
 #include "com/centreon/broker/io/data.hh"
-#include "com/centreon/broker/io/event_info.hh"
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/mapping/entry.hh"
 #include "com/centreon/broker/timestamp.hh"

--- a/bbdo/bam/kpi_status.hh
+++ b/bbdo/bam/kpi_status.hh
@@ -19,9 +19,7 @@
 #ifndef CCB_BAM_KPI_STATUS_HH
 #define CCB_BAM_KPI_STATUS_HH
 
-#include "bbdo/events.hh"
 #include "com/centreon/broker/io/data.hh"
-#include "com/centreon/broker/io/event_info.hh"
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/mapping/entry.hh"
 #include "com/centreon/broker/timestamp.hh"

--- a/bbdo/bam/rebuild.hh
+++ b/bbdo/bam/rebuild.hh
@@ -19,9 +19,7 @@
 #ifndef CCB_BAM_REBUILD_HH
 #define CCB_BAM_REBUILD_HH
 
-#include "bbdo/events.hh"
 #include "com/centreon/broker/io/data.hh"
-#include "com/centreon/broker/io/event_info.hh"
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/mapping/entry.hh"
 

--- a/bbdo/events.hh
+++ b/bbdo/events.hh
@@ -152,7 +152,9 @@ enum data_element {
   de_pb_service_group = 51,
   de_pb_service_group_member = 52,
   de_pb_host_parent = 53,
-  de_pb_instance_configuration = 54
+  de_pb_instance_configuration = 54,
+  de_pb_adaptive_service_status = 55,
+  de_pb_adaptive_host_status = 56,
 };
 }  // namespace neb
 namespace storage {

--- a/bbdo/neb.proto
+++ b/bbdo/neb.proto
@@ -156,6 +156,21 @@ message Service {
 }
 
 /**
+ * @brief Message sent in BBDO 3.0.0 to update a service status partially
+ * changed. For example, it is convenient for downtime changed.
+ */
+/* io::neb, neb::de_pb_adaptive_service_status, 53 */
+message AdaptiveServiceStatus {
+  uint64 host_id = 1;
+  uint64 service_id = 2;
+  ServiceType type = 3;
+  uint64 internal_id = 4;
+  optional int32 scheduled_downtime_depth = 5;
+  optional AckType acknowledgement_type = 6;
+  optional int32 notification_number = 7;
+}
+
+/**
  * @brief Message sent in BBDO 3.0.0 instead of neb::service_status
  */
 /* io::neb, neb::de_pb_service_status, 6 */
@@ -405,6 +420,17 @@ message HostStatus {
   int32 scheduled_downtime_depth = 28;
 }
 
+/**
+ * @brief Message sent in BBDO 3.0.0 to update a host status partially
+ * changed. For example, it is convenient for downtime changed.
+ */
+/* io::neb, neb::de_pb_adaptive_host_status, 55 */
+message AdaptiveHostStatus {
+  uint64 host_id = 1;
+  optional int32 scheduled_downtime_depth = 2;
+  optional AckType acknowledgement_type = 3;
+  optional int32 notification_number = 4;
+}
 /**
  * @brief Message used to send adaptive host configuration. When only one
  * or two configuration items change, this event is used.

--- a/broker/bam/inc/com/centreon/broker/bam/bool_service.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/bool_service.hh
@@ -21,8 +21,6 @@
 
 #include "com/centreon/broker/bam/bool_value.hh"
 #include "com/centreon/broker/bam/service_listener.hh"
-#include "com/centreon/broker/io/stream.hh"
-#include "com/centreon/broker/neb/internal.hh"
 
 namespace com::centreon::broker::bam {
 /**
@@ -56,6 +54,9 @@ class bool_service : public bool_value, public service_listener {
                       io::stream* visitor = nullptr) override;
   void service_update(const std::shared_ptr<neb::pb_service_status>& status,
                       io::stream* visitor = nullptr) override;
+  void service_update(
+      const std::shared_ptr<neb::pb_adaptive_service_status>& status,
+      io::stream* visitor = nullptr) override;
   void service_update(const std::shared_ptr<neb::service_status>& status,
                       io::stream* visitor = nullptr) override;
   double value_hard() const override;

--- a/broker/bam/inc/com/centreon/broker/bam/service_book.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/service_book.hh
@@ -78,6 +78,8 @@ class service_book {
               io::stream* visitor = nullptr);
   void update(const std::shared_ptr<neb::pb_service_status>& t,
               io::stream* visitor = nullptr);
+  void update(const std::shared_ptr<neb::pb_adaptive_service_status>& t,
+              io::stream* visitor = nullptr);
   void save_to_cache(persistent_cache& cache) const;
   void apply_services_state(const ServicesBookState& state);
 };

--- a/broker/bam/inc/com/centreon/broker/bam/service_listener.hh
+++ b/broker/bam/inc/com/centreon/broker/bam/service_listener.hh
@@ -19,7 +19,6 @@
 #ifndef CCB_BAM_SERVICE_LISTENER_HH
 #define CCB_BAM_SERVICE_LISTENER_HH
 
-#include "com/centreon/broker/io/stream.hh"
 #include "com/centreon/broker/neb/internal.hh"
 
 namespace com::centreon::broker {
@@ -51,6 +50,9 @@ class service_listener {
   virtual void service_update(const service_state& s);
   virtual void service_update(std::shared_ptr<neb::pb_service> const& status,
                               io::stream* visitor = nullptr);
+  virtual void service_update(
+      std::shared_ptr<neb::pb_adaptive_service_status> const& status,
+      io::stream* visitor = nullptr);
   virtual void service_update(
       std::shared_ptr<neb::pb_service_status> const& status,
       io::stream* visitor = nullptr);

--- a/broker/bam/src/connector.cc
+++ b/broker/bam/src/connector.cc
@@ -35,20 +35,28 @@
 #include "com/centreon/broker/neb/acknowledgement.hh"
 #include "com/centreon/broker/neb/downtime.hh"
 #include "com/centreon/broker/neb/service.hh"
-#include "com/centreon/broker/neb/service_status.hh"
 
 using namespace com::centreon::broker;
 using namespace com::centreon::broker::bam;
 
 static constexpr multiplexing::muxer_filter _monitoring_stream_filter = {
-    neb::service_status::static_type(),  neb::pb_service_status::static_type(),
-    neb::service::static_type(),         neb::pb_service::static_type(),
-    neb::acknowledgement::static_type(), neb::pb_acknowledgement::static_type(),
-    neb::downtime::static_type(),        neb::pb_downtime::static_type(),
-    bam::ba_status::static_type(),       bam::pb_ba_status::static_type(),
-    bam::kpi_status::static_type(),      bam::pb_kpi_status::static_type(),
-    inherited_downtime::static_type(),   pb_inherited_downtime::static_type(),
-    extcmd::pb_ba_info::static_type(),   pb_services_book_state::static_type()};
+    neb::service_status::static_type(),
+    neb::pb_service_status::static_type(),
+    neb::service::static_type(),
+    neb::pb_service::static_type(),
+    neb::acknowledgement::static_type(),
+    neb::pb_acknowledgement::static_type(),
+    neb::downtime::static_type(),
+    neb::pb_downtime::static_type(),
+    neb::pb_adaptive_service_status::static_type(),
+    bam::ba_status::static_type(),
+    bam::pb_ba_status::static_type(),
+    bam::kpi_status::static_type(),
+    bam::pb_kpi_status::static_type(),
+    inherited_downtime::static_type(),
+    pb_inherited_downtime::static_type(),
+    extcmd::pb_ba_info::static_type(),
+    pb_services_book_state::static_type()};
 
 static constexpr multiplexing::muxer_filter _monitoring_forbidden_filter =
     multiplexing::muxer_filter(_monitoring_stream_filter).reverse();

--- a/broker/bam/src/reporting_stream.cc
+++ b/broker/bam/src/reporting_stream.cc
@@ -1113,7 +1113,7 @@ void reporting_stream::_process_pb_ba_event(
   id_start ba_key = std::make_pair(be.ba_id(), be.start_time());
   // event exists?
   if (_ba_event_cache.find(ba_key) != _ba_event_cache.end()) {
-    if (be.end_time() <= 0)
+    if (static_cast<int64_t>(be.end_time()) <= 0)
       _ba_event_update.bind_null_u64(0);
     else
       _ba_event_update.bind_value_as_u64(0, be.end_time());
@@ -1135,7 +1135,7 @@ void reporting_stream::_process_pb_ba_event(
       _ba_full_event_insert.bind_value_as_i32(1, be.first_level());
       _ba_full_event_insert.bind_value_as_u64(2, be.start_time());
 
-      if (be.end_time() <= 0)
+      if (static_cast<int64_t>(be.end_time()) <= 0)
         _ba_full_event_insert.bind_null_i64(3);
       else
         _ba_full_event_insert.bind_value_as_i64(3, be.end_time());

--- a/broker/bam/src/service_book.cc
+++ b/broker/bam/src/service_book.cc
@@ -161,6 +161,25 @@ void service_book::update(const std::shared_ptr<neb::service_status>& t,
 }
 
 /**
+ * @brief Propagate events of type neb::service_status to the concerned services
+ * and then to the corresponding kpi.
+ *
+ * @param t The event to handle.
+ * @param visitor The stream to write into.
+ */
+void service_book::update(
+    const std::shared_ptr<neb::pb_adaptive_service_status>& t,
+    io::stream* visitor) {
+  auto obj = t->obj();
+  auto found = _book.find(std::make_pair(obj.host_id(), obj.service_id()));
+  if (found == _book.end())
+    return;
+
+  for (auto l : found->second.listeners)
+    l->service_update(t, visitor);
+}
+
+/**
  * @brief Propagate events of type pb_service to the
  * concerned services and then to the corresponding kpi.
  *

--- a/broker/bam/src/service_listener.cc
+++ b/broker/bam/src/service_listener.cc
@@ -60,6 +60,16 @@ void service_listener::service_update(
     io::stream* visitor [[maybe_unused]]) {}
 
 /**
+ * @brief Notify of a service status update (usually used for downtimes).
+ *
+ * @param [[maybe_unused]]
+ * @param [[maybe_unused]]
+ */
+void service_listener::service_update(
+    const std::shared_ptr<neb::pb_adaptive_service_status>& status
+    [[maybe_unused]],
+    io::stream* visitor [[maybe_unused]]) {}
+/**
  *  Notify of a protobuf acknowledgement.
  *
  *  @param[in]  ack      Acknowledgement.

--- a/broker/core/inc/com/centreon/broker/config/parser.hh
+++ b/broker/core/inc/com/centreon/broker/config/parser.hh
@@ -21,7 +21,6 @@
 
 #include <absl/types/optional.h>
 
-#include <nlohmann/json.hpp>
 
 #include "com/centreon/broker/config/state.hh"
 #include "com/centreon/exceptions/msg_fmt.hh"

--- a/broker/core/inc/com/centreon/broker/config/state.hh
+++ b/broker/core/inc/com/centreon/broker/config/state.hh
@@ -19,7 +19,6 @@
 #ifndef CCB_CONFIG_STATE_HH
 #define CCB_CONFIG_STATE_HH
 
-#include <fmt/format.h>
 
 #include "bbdo/bbdo/bbdo_version.hh"
 #include "com/centreon/broker/config/endpoint.hh"

--- a/broker/core/sql/inc/com/centreon/broker/sql/mysql_connection.hh
+++ b/broker/core/sql/inc/com/centreon/broker/sql/mysql_connection.hh
@@ -19,7 +19,6 @@
 #ifndef CCB_MYSQL_CONNECTION_HH
 #define CCB_MYSQL_CONNECTION_HH
 
-#include "com/centreon/broker/config/applier/state.hh"
 #include "com/centreon/broker/sql/database_config.hh"
 #include "com/centreon/broker/sql/mysql_bulk_stmt.hh"
 #include "com/centreon/broker/sql/mysql_error.hh"

--- a/broker/lua/inc/com/centreon/broker/lua/macro_cache.hh
+++ b/broker/lua/inc/com/centreon/broker/lua/macro_cache.hh
@@ -27,7 +27,6 @@
 #include "com/centreon/broker/neb/host_group.hh"
 #include "com/centreon/broker/neb/host_group_member.hh"
 #include "com/centreon/broker/neb/instance.hh"
-#include "com/centreon/broker/neb/internal.hh"
 #include "com/centreon/broker/neb/service.hh"
 #include "com/centreon/broker/neb/service_group.hh"
 #include "com/centreon/broker/neb/service_group_member.hh"
@@ -42,7 +41,7 @@ namespace com::centreon::broker::lua {
 class macro_cache {
   std::shared_ptr<persistent_cache> _cache;
   absl::flat_hash_map<uint64_t, std::shared_ptr<io::data>> _instances;
-  absl::flat_hash_map<uint64_t, std::shared_ptr<io::data>> _hosts;
+  absl::flat_hash_map<uint64_t, std::shared_ptr<neb::pb_host>> _hosts;
   /* The host groups cache stores also a set with the pollers telling they need
    * the cache. So if no more poller needs a host group, we can remove it from
    * the cache. */
@@ -54,7 +53,8 @@ class macro_cache {
       _host_group_members;
   absl::flat_hash_map<std::pair<uint64_t, uint64_t>, std::shared_ptr<io::data>>
       _custom_vars;
-  absl::flat_hash_map<std::pair<uint64_t, uint64_t>, std::shared_ptr<io::data>>
+  absl::flat_hash_map<std::pair<uint64_t, uint64_t>,
+                      std::shared_ptr<neb::pb_service>>
       _services;
   /* The service groups cache stores also a set with the pollers telling they
    * need the cache. So if no more poller needs a service group, we can remove
@@ -89,8 +89,8 @@ class macro_cache {
   const storage::pb_index_mapping& get_index_mapping(uint64_t index_id) const;
   const std::shared_ptr<storage::pb_metric_mapping>& get_metric_mapping(
       uint64_t metric_id) const;
-  const std::shared_ptr<io::data>& get_host(uint64_t host_id) const;
-  const std::shared_ptr<io::data>& get_service(uint64_t host_id,
+  const std::shared_ptr<neb::pb_host>& get_host(uint64_t host_id) const;
+  const std::shared_ptr<neb::pb_service>& get_service(uint64_t host_id,
                                                uint64_t service_id) const;
   const std::string& get_host_name(uint64_t host_id) const;
   const std::string& get_notes_url(uint64_t host_id, uint64_t service_id) const;
@@ -129,6 +129,7 @@ class macro_cache {
   void _process_host(std::shared_ptr<io::data> const& data);
   void _process_pb_host(std::shared_ptr<io::data> const& data);
   void _process_pb_host_status(std::shared_ptr<io::data> const& data);
+  void _process_pb_adaptive_host_status(const std::shared_ptr<io::data>& data);
   void _process_pb_adaptive_host(std::shared_ptr<io::data> const& data);
   void _process_host_group(std::shared_ptr<io::data> const& data);
   void _process_pb_host_group(std::shared_ptr<io::data> const& data);
@@ -138,7 +139,9 @@ class macro_cache {
   void _process_pb_custom_variable(std::shared_ptr<io::data> const& data);
   void _process_service(std::shared_ptr<io::data> const& data);
   void _process_pb_service(std::shared_ptr<io::data> const& data);
-  void _process_pb_service_status(std::shared_ptr<io::data> const& data);
+  void _process_pb_service_status(const std::shared_ptr<io::data>& data);
+  void _process_pb_adaptive_service_status(
+      const std::shared_ptr<io::data>& data);
   void _process_pb_adaptive_service(std::shared_ptr<io::data> const& data);
   void _process_service_group(std::shared_ptr<io::data> const& data);
   void _process_pb_service_group(std::shared_ptr<io::data> const& data);

--- a/broker/lua/src/macro_cache.cc
+++ b/broker/lua/src/macro_cache.cc
@@ -18,14 +18,12 @@
 
 #include "com/centreon/broker/lua/macro_cache.hh"
 #include <absl/container/flat_hash_set.h>
-#include <memory>
+#include <absl/strings/str_split.h>
 #include "bbdo/bam/dimension_ba_bv_relation_event.hh"
 #include "bbdo/bam/dimension_ba_event.hh"
 #include "bbdo/bam/dimension_bv_event.hh"
 #include "bbdo/storage/index_mapping.hh"
 #include "bbdo/storage/metric_mapping.hh"
-#include "com/centreon/broker/neb/internal.hh"
-#include "com/centreon/exceptions/msg_fmt.hh"
 #include "common/log_v2/log_v2.hh"
 
 using namespace com::centreon::exceptions;
@@ -101,7 +99,7 @@ macro_cache::get_metric_mapping(uint64_t metric_id) const {
  *
  *  @return             A shared pointer on the service.
  */
-const std::shared_ptr<io::data>& macro_cache::get_service(
+const std::shared_ptr<neb::pb_service>& macro_cache::get_service(
     uint64_t host_id,
     uint64_t service_id) const {
   auto found = _services.find({host_id, service_id});
@@ -119,7 +117,8 @@ const std::shared_ptr<io::data>& macro_cache::get_service(
  *
  *  @return             A shared pointer on the host.
  */
-const std::shared_ptr<io::data>& macro_cache::get_host(uint64_t host_id) const {
+const std::shared_ptr<neb::pb_host>& macro_cache::get_host(
+    uint64_t host_id) const {
   auto found = _hosts.find(host_id);
 
   if (found == _hosts.end())
@@ -141,13 +140,7 @@ std::string const& macro_cache::get_host_name(uint64_t host_id) const {
   if (found == _hosts.end())
     throw msg_fmt("lua: could not find information on host {}", host_id);
 
-  if (found->second->type() == neb::host::static_type()) {
-    auto const& s = std::static_pointer_cast<neb::host>(found->second);
-    return s->host_name;
-  } else {
-    auto const& s = std::static_pointer_cast<neb::pb_host>(found->second);
-    return s->obj().name();
-  }
+  return found->second->obj().name();
 }
 
 /**
@@ -210,13 +203,8 @@ std::string_view macro_cache::get_check_command(uint64_t host_id,
           "lua: could not find the check command of the service (host_id: {}, "
           "service_id: {})",
           host_id, service_id);
-    if (found->second->type() == neb::service::static_type()) {
-      neb::service& s = static_cast<neb::service&>(*found->second);
-      retval = s.check_command;
-    } else {
-      neb::pb_service& s = static_cast<neb::pb_service&>(*found->second);
-      retval = s.obj().check_command();
-    }
+    neb::pb_service& s = static_cast<neb::pb_service&>(*found->second);
+    retval = s.obj().check_command();
   }
   /* Case of hosts */
   else {
@@ -225,13 +213,8 @@ std::string_view macro_cache::get_check_command(uint64_t host_id,
       throw msg_fmt(
           "lua: could not find the check command of the host (host_id: {})",
           host_id);
-    if (found->second->type() == neb::host::static_type()) {
-      neb::host& s = static_cast<neb::host&>(*found->second);
-      retval = s.check_command;
-    } else {
-      neb::pb_host& s = static_cast<neb::pb_host&>(*found->second);
-      retval = s.obj().check_command();
-    }
+    neb::pb_host& s = static_cast<neb::pb_host&>(*found->second);
+    retval = s.obj().check_command();
   }
   return retval;
 }
@@ -252,26 +235,14 @@ std::string const& macro_cache::get_notes_url(uint64_t host_id,
     if (found == _services.end())
       throw msg_fmt("lua: could not find information on service ({}, {})",
                     host_id, service_id);
-    if (found->second->type() == neb::service::static_type()) {
-      auto const& s = std::static_pointer_cast<neb::service>(found->second);
-      return s->notes_url;
-    } else {
-      auto const& s = std::static_pointer_cast<neb::pb_service>(found->second);
-      return s->obj().notes_url();
-    }
+    return found->second->obj().notes_url();
   } else {
     auto found = _hosts.find(host_id);
 
     if (found == _hosts.end())
       throw msg_fmt("lua: could not find information on host {}", host_id);
 
-    if (found->second->type() == neb::host::static_type()) {
-      auto const& s = std::static_pointer_cast<neb::host>(found->second);
-      return s->notes_url;
-    } else {
-      auto const& s = std::static_pointer_cast<neb::pb_host>(found->second);
-      return s->obj().notes_url();
-    }
+    return found->second->obj().notes_url();
   }
 }
 
@@ -291,26 +262,14 @@ std::string const& macro_cache::get_action_url(uint64_t host_id,
     if (found == _services.end())
       throw msg_fmt("lua: could not find information on service ({}, {})",
                     host_id, service_id);
-    if (found->second->type() == neb::service::static_type()) {
-      auto const& s = std::static_pointer_cast<neb::service>(found->second);
-      return s->action_url;
-    } else {
-      auto const& s = std::static_pointer_cast<neb::pb_service>(found->second);
-      return s->obj().action_url();
-    }
+    return found->second->obj().action_url();
   } else {
     auto found = _hosts.find(host_id);
 
     if (found == _hosts.end())
       throw msg_fmt("lua: could not find information on host {}", host_id);
 
-    if (found->second->type() == neb::host::static_type()) {
-      auto const& s = std::static_pointer_cast<neb::host>(found->second);
-      return s->action_url;
-    } else {
-      auto const& s = std::static_pointer_cast<neb::pb_host>(found->second);
-      return s->obj().action_url();
-    }
+    return found->second->obj().action_url();
   }
 }
 
@@ -330,26 +289,13 @@ std::string const& macro_cache::get_notes(uint64_t host_id,
     if (found == _services.end())
       throw msg_fmt("lua: cound not find information on service ({}, {})",
                     host_id, service_id);
-    if (found->second->type() == neb::service::static_type()) {
-      auto const& s = std::static_pointer_cast<neb::service>(found->second);
-      return s->notes;
-    } else {
-      auto const& s = std::static_pointer_cast<neb::pb_service>(found->second);
-      return s->obj().notes();
-    }
+    return found->second->obj().notes();
   } else {
     auto found = _hosts.find(host_id);
 
     if (found == _hosts.end())
       throw msg_fmt("lua: could not find information on host {}", host_id);
-
-    if (found->second->type() == neb::host::static_type()) {
-      auto const& s = std::static_pointer_cast<neb::host>(found->second);
-      return s->notes;
-    } else {
-      auto const& s = std::static_pointer_cast<neb::pb_host>(found->second);
-      return s->obj().notes();
-    }
+    return found->second->obj().notes();
   }
 }
 
@@ -396,13 +342,7 @@ std::string const& macro_cache::get_service_description(
   if (found == _services.end())
     throw msg_fmt("lua: could not find information on service ({}, {})",
                   host_id, service_id);
-  if (found->second->type() == neb::service::static_type()) {
-    auto const& s = std::static_pointer_cast<neb::service>(found->second);
-    return s->service_description;
-  } else {
-    auto const& s = std::static_pointer_cast<neb::pb_service>(found->second);
-    return s->obj().description();
-  }
+  return found->second->obj().description();
 }
 
 /**
@@ -529,6 +469,9 @@ void macro_cache::write(std::shared_ptr<io::data> const& data) {
     case neb::pb_adaptive_host::static_type():
       _process_pb_adaptive_host(data);
       break;
+    case neb::pb_adaptive_host_status::static_type():
+      _process_pb_adaptive_host_status(data);
+      break;
     case neb::host_group::static_type():
       _process_host_group(data);
       break;
@@ -549,6 +492,9 @@ void macro_cache::write(std::shared_ptr<io::data> const& data) {
       break;
     case neb::pb_service_status::static_type():
       _process_pb_service_status(data);
+      break;
+    case neb::pb_adaptive_service_status::static_type():
+      _process_pb_adaptive_service_status(data);
       break;
     case neb::pb_adaptive_service::static_type():
       _process_pb_adaptive_service(data);
@@ -632,14 +578,105 @@ void macro_cache::_process_pb_instance(std::shared_ptr<io::data> const& data) {
  *
  *  @param h  The event.
  */
-void macro_cache::_process_host(std::shared_ptr<io::data> const& data) {
-  std::shared_ptr<neb::host> const& h =
+void macro_cache::_process_host(const std::shared_ptr<io::data>& data) {
+  const std::shared_ptr<neb::host>& h =
       std::static_pointer_cast<neb::host>(data);
   SPDLOG_LOGGER_DEBUG(_cache->logger(), "lua: processing host '{}' of id {}",
                       h->host_name, h->host_id);
-  if (h->enabled)
-    _hosts[h->host_id] = data;
-  else
+  if (h->enabled) {
+    auto found = _hosts.find(h->host_id);
+    if (found == _hosts.end()) {
+      auto new_host = std::make_shared<neb::pb_host>();
+      _hosts[h->host_id] = new_host;
+      found = _hosts.find(h->host_id);
+    }
+    Host& current_host =
+        std::static_pointer_cast<neb::pb_host>(found->second)->mut_obj();
+    current_host.set_host_id(h->host_id);
+    current_host.set_acknowledged(h->acknowledged);
+    current_host.set_acknowledgement_type(
+        static_cast<AckType>(h->acknowledgement_type));
+    current_host.set_active_checks(h->active_checks_enabled);
+    current_host.set_enabled(h->enabled);
+    current_host.set_scheduled_downtime_depth(h->downtime_depth);
+    current_host.set_check_command(h->check_command);
+    current_host.set_check_interval(h->check_interval);
+    current_host.set_check_period(h->check_period);
+    current_host.set_check_type(static_cast<Host_CheckType>(h->check_type));
+    current_host.set_check_attempt(h->current_check_attempt);
+    current_host.set_state(static_cast<Host_State>(h->current_state));
+    current_host.set_event_handler_enabled(h->event_handler_enabled);
+    current_host.set_event_handler(h->event_handler);
+    current_host.set_execution_time(h->execution_time);
+    current_host.set_flap_detection(h->default_flap_detection_enabled);
+    current_host.set_checked(h->has_been_checked);
+    current_host.set_flapping(h->is_flapping);
+    current_host.set_last_check(h->last_check);
+    current_host.set_last_hard_state(
+        static_cast<Host_State>(h->last_hard_state));
+    current_host.set_last_hard_state_change(h->last_hard_state_change);
+    current_host.set_last_notification(h->last_notification);
+    current_host.set_notification_number(h->notification_number);
+    current_host.set_last_state_change(h->last_state_change);
+    current_host.set_last_time_down(h->last_time_down);
+    current_host.set_last_time_unreachable(h->last_time_unreachable);
+    current_host.set_last_time_up(h->last_time_up);
+    current_host.set_last_update(h->last_update);
+    current_host.set_latency(h->latency);
+    current_host.set_max_check_attempts(h->max_check_attempts);
+    current_host.set_next_check(h->next_check);
+    current_host.set_next_host_notification(h->next_notification);
+    current_host.set_no_more_notifications(h->no_more_notifications);
+    current_host.set_notify(h->notifications_enabled);
+    current_host.set_output(h->output);
+    current_host.set_passive_checks(h->passive_checks_enabled);
+    current_host.set_percent_state_change(h->percent_state_change);
+    current_host.set_perfdata(h->perf_data);
+    current_host.set_retry_interval(h->retry_interval);
+    current_host.set_should_be_scheduled(h->should_be_scheduled);
+    current_host.set_obsess_over_host(h->obsess_over);
+    current_host.set_state_type(static_cast<Host_StateType>(h->state_type));
+    current_host.set_action_url(h->action_url);
+    current_host.set_address(h->address);
+    current_host.set_alias(h->alias);
+    current_host.set_check_freshness(h->check_freshness);
+    current_host.set_default_active_checks(h->default_active_checks_enabled);
+    current_host.set_default_event_handler_enabled(
+        h->default_event_handler_enabled);
+    current_host.set_default_flap_detection(h->default_flap_detection_enabled);
+    current_host.set_default_notify(h->default_notifications_enabled);
+    current_host.set_default_passive_checks(h->default_passive_checks_enabled);
+    current_host.set_display_name(h->display_name);
+    current_host.set_first_notification_delay(h->first_notification_delay);
+    current_host.set_flap_detection_on_down(h->flap_detection_on_down);
+    current_host.set_flap_detection_on_unreachable(
+        h->flap_detection_on_unreachable);
+    current_host.set_flap_detection_on_up(h->flap_detection_on_up);
+    current_host.set_freshness_threshold(h->freshness_threshold);
+    current_host.set_high_flap_threshold(h->high_flap_threshold);
+    current_host.set_low_flap_threshold(h->low_flap_threshold);
+    current_host.set_name(h->host_name);
+    current_host.set_icon_image(h->icon_image);
+    current_host.set_icon_image_alt(h->icon_image_alt);
+    current_host.set_instance_id(h->poller_id);
+    current_host.set_notes(h->notes);
+    current_host.set_notes_url(h->notes_url);
+    current_host.set_notification_interval(h->notification_interval);
+    current_host.set_notification_period(h->notification_period);
+    current_host.set_notify_on_down(h->notify_on_down);
+    current_host.set_notify_on_downtime(h->notify_on_downtime);
+    current_host.set_notify_on_flapping(h->notify_on_flapping);
+    current_host.set_notify_on_recovery(h->notify_on_recovery);
+    current_host.set_notify_on_unreachable(h->notify_on_unreachable);
+    current_host.set_stalk_on_down(h->stalk_on_down);
+    current_host.set_stalk_on_unreachable(h->stalk_on_unreachable);
+    current_host.set_stalk_on_up(h->stalk_on_up);
+    current_host.set_statusmap_image(h->statusmap_image);
+    current_host.set_retain_nonstatus_information(
+        h->retain_nonstatus_information);
+    current_host.set_retain_status_information(h->retain_status_information);
+    current_host.set_timezone(h->timezone);
+  } else
     _hosts.erase(h->host_id);
 }
 
@@ -649,12 +686,11 @@ void macro_cache::_process_host(std::shared_ptr<io::data> const& data) {
  *  @param h  The event.
  */
 void macro_cache::_process_pb_host(std::shared_ptr<io::data> const& data) {
-  std::shared_ptr<neb::pb_host> const& h =
-      std::static_pointer_cast<neb::pb_host>(data);
+  const auto& h = std::static_pointer_cast<neb::pb_host>(data);
   SPDLOG_LOGGER_DEBUG(_cache->logger(), "lua: processing host '{}' of id {}",
                       h->obj().name(), h->obj().host_id());
   if (h->obj().enabled())
-    _hosts[h->obj().host_id()] = data;
+    _hosts[h->obj().host_id()] = h;
   else
     _hosts.erase(h->obj().host_id());
 }
@@ -676,67 +712,67 @@ void macro_cache::_process_pb_host_status(
     return;
   }
 
-  if (it->second->type() == make_type(io::neb, neb::de_host)) {
-    auto& hst = *std::static_pointer_cast<neb::host>(it->second);
-    hst.has_been_checked = obj.checked();
-    hst.check_type = obj.check_type();
-    hst.current_state = obj.state();
-    hst.state_type = obj.state_type();
-    hst.last_state_change = obj.last_state_change();
-    hst.last_hard_state = obj.last_hard_state();
-    hst.last_hard_state_change = obj.last_hard_state_change();
-    hst.last_time_up = obj.last_time_up();
-    hst.last_time_down = obj.last_time_down();
-    hst.last_time_unreachable = obj.last_time_unreachable();
-    hst.output = obj.output();
-    hst.perf_data = obj.perfdata();
-    hst.is_flapping = obj.flapping();
-    hst.percent_state_change = obj.percent_state_change();
-    hst.latency = obj.latency();
-    hst.execution_time = obj.execution_time();
-    hst.last_check = obj.last_check();
-    hst.next_check = obj.next_check();
-    hst.should_be_scheduled = obj.should_be_scheduled();
-    hst.current_check_attempt = obj.check_attempt();
-    hst.notification_number = obj.notification_number();
-    hst.no_more_notifications = obj.no_more_notifications();
-    hst.last_notification = obj.last_notification();
-    hst.next_notification = obj.next_host_notification();
-    hst.acknowledgement_type = obj.acknowledgement_type();
-    hst.downtime_depth = obj.scheduled_downtime_depth();
-  } else if (it->second->type() == make_type(io::neb, neb::de_pb_host)) {
-    auto& hst = std::static_pointer_cast<neb::pb_host>(it->second)->mut_obj();
-    hst.set_checked(obj.checked());
-    hst.set_check_type(static_cast<Host_CheckType>(obj.check_type()));
-    hst.set_state(static_cast<Host_State>(obj.state()));
-    hst.set_state_type(static_cast<Host_StateType>(obj.state_type()));
-    hst.set_last_state_change(obj.last_state_change());
-    hst.set_last_hard_state(static_cast<Host_State>(obj.last_hard_state()));
-    hst.set_last_hard_state_change(obj.last_hard_state_change());
-    hst.set_last_time_up(obj.last_time_up());
-    hst.set_last_time_down(obj.last_time_down());
-    hst.set_last_time_unreachable(obj.last_time_unreachable());
-    hst.set_output(obj.output());
-    hst.set_perfdata(obj.perfdata());
-    hst.set_flapping(obj.flapping());
-    hst.set_percent_state_change(obj.percent_state_change());
-    hst.set_latency(obj.latency());
-    hst.set_execution_time(obj.execution_time());
-    hst.set_last_check(obj.last_check());
-    hst.set_next_check(obj.next_check());
-    hst.set_should_be_scheduled(obj.should_be_scheduled());
-    hst.set_check_attempt(obj.check_attempt());
-    hst.set_notification_number(obj.notification_number());
-    hst.set_no_more_notifications(obj.no_more_notifications());
-    hst.set_last_notification(obj.last_notification());
-    hst.set_next_host_notification(obj.next_host_notification());
-    hst.set_acknowledgement_type(obj.acknowledgement_type());
-    hst.set_scheduled_downtime_depth(obj.scheduled_downtime_depth());
-  } else {
-    _cache->logger()->error("lua: The host ({}) stored in cache is corrupted",
-                            obj.host_id());
-  }
+  auto& hst = std::static_pointer_cast<neb::pb_host>(it->second)->mut_obj();
+  hst.set_checked(obj.checked());
+  hst.set_check_type(static_cast<Host_CheckType>(obj.check_type()));
+  hst.set_state(static_cast<Host_State>(obj.state()));
+  hst.set_state_type(static_cast<Host_StateType>(obj.state_type()));
+  hst.set_last_state_change(obj.last_state_change());
+  hst.set_last_hard_state(static_cast<Host_State>(obj.last_hard_state()));
+  hst.set_last_hard_state_change(obj.last_hard_state_change());
+  hst.set_last_time_up(obj.last_time_up());
+  hst.set_last_time_down(obj.last_time_down());
+  hst.set_last_time_unreachable(obj.last_time_unreachable());
+  hst.set_output(obj.output());
+  hst.set_perfdata(obj.perfdata());
+  hst.set_flapping(obj.flapping());
+  hst.set_percent_state_change(obj.percent_state_change());
+  hst.set_latency(obj.latency());
+  hst.set_execution_time(obj.execution_time());
+  hst.set_last_check(obj.last_check());
+  hst.set_next_check(obj.next_check());
+  hst.set_should_be_scheduled(obj.should_be_scheduled());
+  hst.set_check_attempt(obj.check_attempt());
+  hst.set_notification_number(obj.notification_number());
+  hst.set_no_more_notifications(obj.no_more_notifications());
+  hst.set_last_notification(obj.last_notification());
+  hst.set_next_host_notification(obj.next_host_notification());
+  hst.set_acknowledgement_type(obj.acknowledgement_type());
+  hst.set_scheduled_downtime_depth(obj.scheduled_downtime_depth());
 }
+
+/**
+ * @brief Process a pb adaptive host event.
+ *
+ * @param data An AdaptiveHostStatus event.
+ */
+void macro_cache::_process_pb_adaptive_host_status(
+    const std::shared_ptr<io::data>& data) {
+  const auto& s = std::static_pointer_cast<neb::pb_adaptive_host_status>(data);
+  const auto& obj = s->obj();
+
+  SPDLOG_LOGGER_DEBUG(_cache->logger(),
+                      "lua: processing adaptive host status ({})",
+                      obj.host_id());
+
+  auto it = _hosts.find(obj.host_id());
+  if (it == _hosts.end()) {
+    _cache->logger()->warn(
+        "lua: Attempt to update host ({}) in lua cache, but it does not "
+        "exist. Maybe Engine should be restarted to update the cache.",
+        obj.host_id());
+    return;
+  }
+
+  auto& hst = std::static_pointer_cast<neb::pb_host>(it->second)->mut_obj();
+  if (obj.has_scheduled_downtime_depth())
+    hst.set_scheduled_downtime_depth(obj.scheduled_downtime_depth());
+  if (obj.has_acknowledgement_type())
+    hst.set_acknowledgement_type(obj.acknowledgement_type());
+  if (obj.has_notification_number())
+    hst.set_notification_number(obj.notification_number());
+}
+
 /**
  *  Process a pb adaptive host event.
  *
@@ -750,71 +786,37 @@ void macro_cache::_process_pb_adaptive_host(
   auto& ah = h->obj();
   auto it = _hosts.find(ah.host_id());
   if (it != _hosts.end()) {
-    if (it->second->type() == make_type(io::neb, neb::de_host)) {
-      auto& h = *std::static_pointer_cast<neb::host>(it->second);
-      if (ah.has_notify())
-        h.notifications_enabled = ah.notify();
-      if (ah.has_active_checks())
-        h.active_checks_enabled = ah.active_checks();
-      if (ah.has_should_be_scheduled())
-        h.should_be_scheduled = ah.should_be_scheduled();
-      if (ah.has_passive_checks())
-        h.passive_checks_enabled = ah.passive_checks();
-      if (ah.has_event_handler_enabled())
-        h.event_handler_enabled = ah.event_handler_enabled();
-      if (ah.has_flap_detection())
-        h.flap_detection_enabled = ah.flap_detection();
-      if (ah.has_obsess_over_host())
-        h.obsess_over = ah.obsess_over_host();
-      if (ah.has_event_handler())
-        h.event_handler = ah.event_handler();
-      if (ah.has_check_command())
-        h.check_command = ah.check_command();
-      if (ah.has_check_interval())
-        h.check_interval = ah.check_interval();
-      if (ah.has_retry_interval())
-        h.retry_interval = ah.retry_interval();
-      if (ah.has_max_check_attempts())
-        h.max_check_attempts = ah.max_check_attempts();
-      if (ah.has_check_freshness())
-        h.check_freshness = ah.check_freshness();
-      if (ah.has_check_period())
-        h.check_period = ah.check_period();
-      if (ah.has_notification_period())
-        h.notification_period = ah.notification_period();
-    } else {
-      auto& h = std::static_pointer_cast<neb::pb_host>(it->second)->mut_obj();
-      if (ah.has_notify())
-        h.set_notify(ah.notify());
-      if (ah.has_active_checks())
-        h.set_active_checks(ah.active_checks());
-      if (ah.has_should_be_scheduled())
-        h.set_should_be_scheduled(ah.should_be_scheduled());
-      if (ah.has_passive_checks())
-        h.set_passive_checks(ah.passive_checks());
-      if (ah.has_event_handler_enabled())
-        h.set_event_handler_enabled(ah.event_handler_enabled());
-      if (ah.has_flap_detection())
-        h.set_flap_detection(ah.flap_detection());
-      if (ah.has_obsess_over_host())
-        h.set_obsess_over_host(ah.obsess_over_host());
-      if (ah.has_event_handler())
-        h.set_event_handler(ah.event_handler());
-      if (ah.has_check_command())
-        h.set_check_command(ah.check_command());
-      if (ah.has_check_interval())
-        h.set_check_interval(ah.check_interval());
-      if (ah.has_retry_interval())
-        h.set_retry_interval(ah.retry_interval());
-      if (ah.has_max_check_attempts())
-        h.set_max_check_attempts(ah.max_check_attempts());
-      if (ah.has_check_freshness())
-        h.set_check_freshness(ah.check_freshness());
-      if (ah.has_check_period())
-        h.set_check_period(ah.check_period());
-      if (ah.has_notification_period())
-        h.set_notification_period(ah.notification_period());
-    }
+    auto& h = it->second->mut_obj();
+    if (ah.has_notify())
+      h.set_notify(ah.notify());
+    if (ah.has_active_checks())
+      h.set_active_checks(ah.active_checks());
+    if (ah.has_should_be_scheduled())
+      h.set_should_be_scheduled(ah.should_be_scheduled());
+    if (ah.has_passive_checks())
+      h.set_passive_checks(ah.passive_checks());
+    if (ah.has_event_handler_enabled())
+      h.set_event_handler_enabled(ah.event_handler_enabled());
+    if (ah.has_flap_detection())
+      h.set_flap_detection(ah.flap_detection());
+    if (ah.has_obsess_over_host())
+      h.set_obsess_over_host(ah.obsess_over_host());
+    if (ah.has_event_handler())
+      h.set_event_handler(ah.event_handler());
+    if (ah.has_check_command())
+      h.set_check_command(ah.check_command());
+    if (ah.has_check_interval())
+      h.set_check_interval(ah.check_interval());
+    if (ah.has_retry_interval())
+      h.set_retry_interval(ah.retry_interval());
+    if (ah.has_max_check_attempts())
+      h.set_max_check_attempts(ah.max_check_attempts());
+    if (ah.has_check_freshness())
+      h.set_check_freshness(ah.check_freshness());
+    if (ah.has_check_period())
+      h.set_check_period(ah.check_period());
+    if (ah.has_notification_period())
+      h.set_notification_period(ah.notification_period());
   } else
     SPDLOG_LOGGER_WARN(
         _cache->logger(),
@@ -958,9 +960,137 @@ void macro_cache::_process_service(std::shared_ptr<io::data> const& data) {
   SPDLOG_LOGGER_DEBUG(_cache->logger(),
                       "lua: processing service ({}, {}) (description:{})",
                       s->host_id, s->service_id, s->service_description);
-  if (s->enabled)
-    _services[{s->host_id, s->service_id}] = data;
-  else
+  if (s->enabled) {
+    auto found = _services.find({s->host_id, s->service_id});
+    if (found == _services.end()) {
+      auto new_service = std::make_shared<neb::pb_service>();
+      _services[{s->host_id, s->service_id}] = new_service;
+      found = _services.find({s->host_id, s->service_id});
+    }
+    Service& current_service =
+        std::static_pointer_cast<neb::pb_service>(found->second)->mut_obj();
+    current_service.set_host_id(s->host_id);
+    current_service.set_service_id(s->service_id);
+    current_service.set_acknowledged(s->acknowledged);
+    current_service.set_acknowledgement_type(
+        static_cast<AckType>(s->acknowledgement_type));
+    current_service.set_active_checks(s->active_checks_enabled);
+    current_service.set_enabled(s->enabled);
+    current_service.set_scheduled_downtime_depth(s->downtime_depth);
+    current_service.set_check_command(s->check_command);
+    current_service.set_check_interval(s->check_interval);
+    current_service.set_check_period(s->check_period);
+    current_service.set_check_type(
+        static_cast<Service_CheckType>(s->check_type));
+    current_service.set_check_attempt(s->current_check_attempt);
+    current_service.set_state(static_cast<Service_State>(s->current_state));
+    current_service.set_event_handler_enabled(s->event_handler_enabled);
+    current_service.set_event_handler(s->event_handler);
+    current_service.set_execution_time(s->execution_time);
+    current_service.set_flap_detection(s->default_flap_detection_enabled);
+    current_service.set_checked(s->has_been_checked);
+    current_service.set_flapping(s->is_flapping);
+    current_service.set_last_check(s->last_check);
+    current_service.set_last_hard_state(
+        static_cast<Service_State>(s->last_hard_state));
+    current_service.set_last_hard_state_change(s->last_hard_state_change);
+    current_service.set_last_notification(s->last_notification);
+    current_service.set_notification_number(s->notification_number);
+    current_service.set_last_state_change(s->last_state_change);
+    current_service.set_last_time_ok(s->last_time_ok);
+    current_service.set_last_time_warning(s->last_time_warning);
+    current_service.set_last_time_critical(s->last_time_critical);
+    current_service.set_last_time_unknown(s->last_time_unknown);
+    current_service.set_last_update(s->last_update);
+    current_service.set_latency(s->latency);
+    current_service.set_max_check_attempts(s->max_check_attempts);
+    current_service.set_next_check(s->next_check);
+    current_service.set_next_notification(s->next_notification);
+    current_service.set_no_more_notifications(s->no_more_notifications);
+    current_service.set_notify(s->notifications_enabled);
+    std::string_view long_output = s->output;
+    std::vector<std::string_view> output =
+        absl::StrSplit(long_output, absl::MaxSplits('\n', 2));
+    switch (output.size()) {
+      case 2:
+        current_service.set_long_output(std::string(output[1]));
+      case 1:
+        current_service.set_output(std::string(output[0]));
+        break;
+    }
+    current_service.set_passive_checks(s->passive_checks_enabled);
+    current_service.set_percent_state_change(s->percent_state_change);
+    current_service.set_perfdata(s->perf_data);
+    current_service.set_retry_interval(s->retry_interval);
+    current_service.set_host_name(s->host_name);
+    current_service.set_description(s->service_description);
+    current_service.set_should_be_scheduled(s->should_be_scheduled);
+    current_service.set_obsess_over_service(s->obsess_over);
+    current_service.set_state_type(
+        static_cast<Service_StateType>(s->state_type));
+    current_service.set_action_url(s->action_url);
+    current_service.set_check_freshness(s->check_freshness);
+    current_service.set_default_active_checks(s->default_active_checks_enabled);
+    current_service.set_default_event_handler_enabled(
+        s->default_event_handler_enabled);
+    current_service.set_default_flap_detection(
+        s->default_flap_detection_enabled);
+    current_service.set_default_notify(s->default_notifications_enabled);
+    current_service.set_default_passive_checks(
+        s->default_passive_checks_enabled);
+    current_service.set_display_name(s->display_name);
+    current_service.set_first_notification_delay(s->first_notification_delay);
+    current_service.set_flap_detection_on_critical(
+        s->flap_detection_on_critical);
+    current_service.set_flap_detection_on_ok(s->flap_detection_on_ok);
+    current_service.set_flap_detection_on_unknown(s->flap_detection_on_unknown);
+    current_service.set_flap_detection_on_warning(s->flap_detection_on_warning);
+    current_service.set_freshness_threshold(s->freshness_threshold);
+    current_service.set_high_flap_threshold(s->high_flap_threshold);
+    current_service.set_low_flap_threshold(s->low_flap_threshold);
+    current_service.set_icon_image(s->icon_image);
+    current_service.set_icon_image_alt(s->icon_image_alt);
+    current_service.set_is_volatile(s->is_volatile);
+    current_service.set_notes(s->notes);
+    current_service.set_notes_url(s->notes_url);
+    current_service.set_notification_interval(s->notification_interval);
+    current_service.set_notification_period(s->notification_period);
+    current_service.set_notify_on_critical(s->notify_on_critical);
+    current_service.set_notify_on_downtime(s->notify_on_downtime);
+    current_service.set_notify_on_flapping(s->notify_on_flapping);
+    current_service.set_notify_on_recovery(s->notify_on_recovery);
+    current_service.set_notify_on_unknown(s->notify_on_unknown);
+    current_service.set_notify_on_warning(s->notify_on_warning);
+    current_service.set_stalk_on_critical(s->stalk_on_critical);
+    current_service.set_stalk_on_ok(s->stalk_on_ok);
+    current_service.set_stalk_on_unknown(s->stalk_on_unknown);
+    current_service.set_stalk_on_warning(s->stalk_on_warning);
+    current_service.set_retain_nonstatus_information(
+        s->retain_nonstatus_information);
+    current_service.set_retain_status_information(s->retain_status_information);
+    if (std::string_view(current_service.host_name().data(), 12) ==
+        "_Module_Meta") {
+      if (std::string_view(current_service.description().data(), 5) ==
+          "meta_") {
+        current_service.set_type(METASERVICE);
+        uint64_t iid;
+        std::string_view id =
+            std::string_view(current_service.description()).substr(5);
+        if (absl::SimpleAtoi(id, &iid))
+          current_service.set_internal_id(iid);
+      }
+    } else if (std::string_view(current_service.host_name().data(), 11) ==
+               "_Module_BAM") {
+      if (std::string_view(current_service.description().data(), 3) == "ba_") {
+        current_service.set_type(BA);
+        uint64_t iid;
+        std::string_view id =
+            std::string_view(current_service.description()).substr(3);
+        if (absl::SimpleAtoi(id, &iid))
+          current_service.set_internal_id(iid);
+      }
+    }
+  } else
     _services.erase({s->host_id, s->service_id});
 }
 
@@ -975,9 +1105,42 @@ void macro_cache::_process_pb_service(std::shared_ptr<io::data> const& data) {
       _cache->logger(), "lua: processing service ({}, {}) (description:{})",
       s->obj().host_id(), s->obj().service_id(), s->obj().description());
   if (s->obj().enabled())
-    _services[{s->obj().host_id(), s->obj().service_id()}] = data;
+    _services[{s->obj().host_id(), s->obj().service_id()}] = s;
   else
     _services.erase({s->obj().host_id(), s->obj().service_id()});
+}
+
+/**
+ * @brief Process a pb adaptive service event.
+ *
+ * @param data An AdaptiveServiceStatus event.
+ */
+void macro_cache::_process_pb_adaptive_service_status(
+    const std::shared_ptr<io::data>& data) {
+  const auto& s =
+      std::static_pointer_cast<neb::pb_adaptive_service_status>(data);
+  const auto& obj = s->obj();
+
+  SPDLOG_LOGGER_DEBUG(_cache->logger(),
+                      "lua: processing adaptive service status ({}, {})",
+                      obj.host_id(), obj.service_id());
+
+  auto it = _services.find({obj.host_id(), obj.service_id()});
+  if (it == _services.end()) {
+    _cache->logger()->warn(
+        "lua: Attempt to update service ({}, {}) in lua cache, but it does not "
+        "exist. Maybe Engine should be restarted to update the cache.",
+        obj.host_id(), obj.service_id());
+    return;
+  }
+
+  auto& svc = std::static_pointer_cast<neb::pb_service>(it->second)->mut_obj();
+  if (obj.has_acknowledgement_type())
+    svc.set_acknowledgement_type(obj.acknowledgement_type());
+  if (obj.has_scheduled_downtime_depth())
+    svc.set_scheduled_downtime_depth(obj.scheduled_downtime_depth());
+  if (obj.has_notification_number())
+    svc.set_notification_number(obj.notification_number());
 }
 
 void macro_cache::_process_pb_service_status(
@@ -998,70 +1161,34 @@ void macro_cache::_process_pb_service_status(
     return;
   }
 
-  if (it->second->type() == make_type(io::neb, neb::de_service)) {
-    auto& svc = *std::static_pointer_cast<neb::service>(it->second);
-    svc.has_been_checked = obj.checked();
-    svc.check_type = obj.check_type();
-    svc.current_state = obj.state();
-    svc.state_type = obj.state_type();
-    svc.last_state_change = obj.last_state_change();
-    svc.last_hard_state = obj.last_hard_state();
-    svc.last_hard_state_change = obj.last_hard_state_change();
-    svc.last_time_ok = obj.last_time_ok();
-    svc.last_time_warning = obj.last_time_warning();
-    svc.last_time_critical = obj.last_time_critical();
-    svc.last_time_unknown = obj.last_time_unknown();
-    svc.output = obj.output();
-    svc.perf_data = obj.perfdata();
-    svc.is_flapping = obj.flapping();
-    svc.percent_state_change = obj.percent_state_change();
-    svc.latency = obj.latency();
-    svc.execution_time = obj.execution_time();
-    svc.last_check = obj.last_check();
-    svc.next_check = obj.next_check();
-    svc.should_be_scheduled = obj.should_be_scheduled();
-    svc.current_check_attempt = obj.check_attempt();
-    svc.notification_number = obj.notification_number();
-    svc.no_more_notifications = obj.no_more_notifications();
-    svc.last_notification = obj.last_notification();
-    svc.next_notification = obj.next_notification();
-    svc.acknowledgement_type = obj.acknowledgement_type();
-    svc.downtime_depth = obj.scheduled_downtime_depth();
-  } else if (it->second->type() == make_type(io::neb, neb::de_pb_service)) {
-    auto& svc =
-        std::static_pointer_cast<neb::pb_service>(it->second)->mut_obj();
-    svc.set_checked(obj.checked());
-    svc.set_check_type(static_cast<Service_CheckType>(obj.check_type()));
-    svc.set_state(static_cast<Service_State>(obj.state()));
-    svc.set_state_type(static_cast<Service_StateType>(obj.state_type()));
-    svc.set_last_state_change(obj.last_state_change());
-    svc.set_last_hard_state(static_cast<Service_State>(obj.last_hard_state()));
-    svc.set_last_hard_state_change(obj.last_hard_state_change());
-    svc.set_last_time_ok(obj.last_time_ok());
-    svc.set_last_time_warning(obj.last_time_warning());
-    svc.set_last_time_critical(obj.last_time_critical());
-    svc.set_last_time_unknown(obj.last_time_unknown());
-    svc.set_output(obj.output());
-    svc.set_perfdata(obj.perfdata());
-    svc.set_flapping(obj.flapping());
-    svc.set_percent_state_change(obj.percent_state_change());
-    svc.set_latency(obj.latency());
-    svc.set_execution_time(obj.execution_time());
-    svc.set_last_check(obj.last_check());
-    svc.set_next_check(obj.next_check());
-    svc.set_should_be_scheduled(obj.should_be_scheduled());
-    svc.set_check_attempt(obj.check_attempt());
-    svc.set_notification_number(obj.notification_number());
-    svc.set_no_more_notifications(obj.no_more_notifications());
-    svc.set_last_notification(obj.last_notification());
-    svc.set_next_notification(obj.next_notification());
-    svc.set_acknowledgement_type(obj.acknowledgement_type());
-    svc.set_scheduled_downtime_depth(obj.scheduled_downtime_depth());
-  } else {
-    _cache->logger()->error(
-        "lua: The service ({}, {}) stored in cache is corrupted", obj.host_id(),
-        obj.service_id());
-  }
+  auto& svc = it->second->mut_obj();
+  svc.set_checked(obj.checked());
+  svc.set_check_type(static_cast<Service_CheckType>(obj.check_type()));
+  svc.set_state(static_cast<Service_State>(obj.state()));
+  svc.set_state_type(static_cast<Service_StateType>(obj.state_type()));
+  svc.set_last_state_change(obj.last_state_change());
+  svc.set_last_hard_state(static_cast<Service_State>(obj.last_hard_state()));
+  svc.set_last_hard_state_change(obj.last_hard_state_change());
+  svc.set_last_time_ok(obj.last_time_ok());
+  svc.set_last_time_warning(obj.last_time_warning());
+  svc.set_last_time_critical(obj.last_time_critical());
+  svc.set_last_time_unknown(obj.last_time_unknown());
+  svc.set_output(obj.output());
+  svc.set_perfdata(obj.perfdata());
+  svc.set_flapping(obj.flapping());
+  svc.set_percent_state_change(obj.percent_state_change());
+  svc.set_latency(obj.latency());
+  svc.set_execution_time(obj.execution_time());
+  svc.set_last_check(obj.last_check());
+  svc.set_next_check(obj.next_check());
+  svc.set_should_be_scheduled(obj.should_be_scheduled());
+  svc.set_check_attempt(obj.check_attempt());
+  svc.set_notification_number(obj.notification_number());
+  svc.set_no_more_notifications(obj.no_more_notifications());
+  svc.set_last_notification(obj.last_notification());
+  svc.set_next_notification(obj.next_notification());
+  svc.set_acknowledgement_type(obj.acknowledgement_type());
+  svc.set_scheduled_downtime_depth(obj.scheduled_downtime_depth());
 }
 
 /**
@@ -1078,72 +1205,37 @@ void macro_cache::_process_pb_adaptive_service(
   auto& as = s->obj();
   auto it = _services.find({as.host_id(), as.service_id()});
   if (it != _services.end()) {
-    if (it->second->type() == make_type(io::neb, neb::de_service)) {
-      auto& s = *std::static_pointer_cast<neb::service>(it->second);
-      if (as.has_notify())
-        s.notifications_enabled = as.notify();
-      if (as.has_active_checks())
-        s.active_checks_enabled = as.active_checks();
-      if (as.has_should_be_scheduled())
-        s.should_be_scheduled = as.should_be_scheduled();
-      if (as.has_passive_checks())
-        s.passive_checks_enabled = as.passive_checks();
-      if (as.has_event_handler_enabled())
-        s.event_handler_enabled = as.event_handler_enabled();
-      if (as.has_flap_detection_enabled())
-        s.flap_detection_enabled = as.flap_detection_enabled();
-      if (as.has_obsess_over_service())
-        s.obsess_over = as.obsess_over_service();
-      if (as.has_event_handler())
-        s.event_handler = as.event_handler();
-      if (as.has_check_command())
-        s.check_command = as.check_command();
-      if (as.has_check_interval())
-        s.check_interval = as.check_interval();
-      if (as.has_retry_interval())
-        s.retry_interval = as.retry_interval();
-      if (as.has_max_check_attempts())
-        s.max_check_attempts = as.max_check_attempts();
-      if (as.has_check_freshness())
-        s.check_freshness = as.check_freshness();
-      if (as.has_check_period())
-        s.check_period = as.check_period();
-      if (as.has_notification_period())
-        s.notification_period = as.notification_period();
-    } else {
-      auto& s =
-          std::static_pointer_cast<neb::pb_service>(it->second)->mut_obj();
-      if (as.has_notify())
-        s.set_notify(as.notify());
-      if (as.has_active_checks())
-        s.set_active_checks(as.active_checks());
-      if (as.has_should_be_scheduled())
-        s.set_should_be_scheduled(as.should_be_scheduled());
-      if (as.has_passive_checks())
-        s.set_passive_checks(as.passive_checks());
-      if (as.has_event_handler_enabled())
-        s.set_event_handler_enabled(as.event_handler_enabled());
-      if (as.has_flap_detection_enabled())
-        s.set_flap_detection(as.flap_detection_enabled());
-      if (as.has_obsess_over_service())
-        s.set_obsess_over_service(as.obsess_over_service());
-      if (as.has_event_handler())
-        s.set_event_handler(as.event_handler());
-      if (as.has_check_command())
-        s.set_check_command(as.check_command());
-      if (as.has_check_interval())
-        s.set_check_interval(as.check_interval());
-      if (as.has_retry_interval())
-        s.set_retry_interval(as.retry_interval());
-      if (as.has_max_check_attempts())
-        s.set_max_check_attempts(as.max_check_attempts());
-      if (as.has_check_freshness())
-        s.set_check_freshness(as.check_freshness());
-      if (as.has_check_period())
-        s.set_check_period(as.check_period());
-      if (as.has_notification_period())
-        s.set_notification_period(as.notification_period());
-    }
+    auto& s = it->second->mut_obj();
+    if (as.has_notify())
+      s.set_notify(as.notify());
+    if (as.has_active_checks())
+      s.set_active_checks(as.active_checks());
+    if (as.has_should_be_scheduled())
+      s.set_should_be_scheduled(as.should_be_scheduled());
+    if (as.has_passive_checks())
+      s.set_passive_checks(as.passive_checks());
+    if (as.has_event_handler_enabled())
+      s.set_event_handler_enabled(as.event_handler_enabled());
+    if (as.has_flap_detection_enabled())
+      s.set_flap_detection(as.flap_detection_enabled());
+    if (as.has_obsess_over_service())
+      s.set_obsess_over_service(as.obsess_over_service());
+    if (as.has_event_handler())
+      s.set_event_handler(as.event_handler());
+    if (as.has_check_command())
+      s.set_check_command(as.check_command());
+    if (as.has_check_interval())
+      s.set_check_interval(as.check_interval());
+    if (as.has_retry_interval())
+      s.set_retry_interval(as.retry_interval());
+    if (as.has_max_check_attempts())
+      s.set_max_check_attempts(as.max_check_attempts());
+    if (as.has_check_freshness())
+      s.set_check_freshness(as.check_freshness());
+    if (as.has_check_period())
+      s.set_check_period(as.check_period());
+    if (as.has_notification_period())
+      s.set_notification_period(as.notification_period());
   } else {
     SPDLOG_LOGGER_WARN(
         _cache->logger(),

--- a/broker/lua/test/lua.cc
+++ b/broker/lua/test/lua.cc
@@ -17,7 +17,6 @@
  */
 
 #include <absl/strings/str_split.h>
-#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include <absl/strings/str_split.h>
@@ -30,10 +29,7 @@
 #include "com/centreon/broker/config/applier/init.hh"
 #include "com/centreon/broker/config/applier/modules.hh"
 #include "com/centreon/broker/lua/luabinding.hh"
-#include "com/centreon/broker/lua/macro_cache.hh"
-#include "com/centreon/broker/misc/variant.hh"
 #include "com/centreon/broker/neb/events.hh"
-#include "com/centreon/broker/neb/instance.hh"
 #include "com/centreon/exceptions/msg_fmt.hh"
 #include "common/log_v2/log_v2.hh"
 
@@ -4835,4 +4831,228 @@ TEST_F(LuaTest, WithBadFilter2) {
   auto bb{std::make_unique<luabinding>(filename, conf, *_cache)};
   ASSERT_FALSE(bb->has_filter());
   RemoveFile(filename);
+}
+
+// When a host is stored in the cache and an AdaptiveHostStatus is written
+// Then the host in cache is updated.
+TEST_F(LuaTest, AdaptiveHostCacheTest) {
+  config::applier::modules modules(log_v2::instance().get(log_v2::LUA));
+  modules.load_file("./broker/neb/10-neb.so");
+  std::map<std::string, misc::variant> conf;
+  std::string filename("/tmp/cache_test.lua");
+  auto hst{std::make_shared<neb::host>()};
+  hst->host_id = 1;
+  hst->host_name = "centreon";
+  hst->check_command = "echo 'John Doe'";
+  hst->alias = "alias-centreon";
+  hst->address = "4.3.2.1";
+  _cache->write(hst);
+
+  auto ahoststatus = std::make_shared<neb::pb_adaptive_host_status>();
+  auto& obj = ahoststatus->mut_obj();
+  obj.set_host_id(1);
+  obj.set_scheduled_downtime_depth(2);
+  _cache->write(ahoststatus);
+
+  CreateScript(filename,
+               "function init(conf)\n"
+               "  broker_log:set_parameters(3, '/tmp/log')\n"
+               "  local hst = broker_cache:get_host(1)\n"
+               "  broker_log:info(1, 'alias ' .. hst.alias .. ' address ' .. "
+               "hst.address .. ' name ' .. hst.name .. ' "
+               "scheduled_downtime_depth ' .. hst.scheduled_downtime_depth)\n"
+               "end\n\n"
+               "function write(d)\n"
+               "  return true\n"
+               "end\n");
+  auto binding{std::make_unique<luabinding>(filename, conf, *_cache)};
+  std::string lst(ReadFile("/tmp/log"));
+
+  ASSERT_NE(lst.find("alias alias-centreon address 4.3.2.1 name centreon "
+                     "scheduled_downtime_depth 2"),
+            std::string::npos);
+  RemoveFile(filename);
+  RemoveFile("/tmp/log");
+}
+
+// When an AdaptiveHostStatus is written
+// Then only the written fields are available.
+TEST_F(LuaTest, AdaptiveHostCacheFieldTest) {
+  config::applier::modules modules(log_v2::instance().get(log_v2::LUA));
+  modules.load_file("./broker/neb/10-neb.so");
+  std::map<std::string, misc::variant> conf;
+  std::string filename("/tmp/cache_test.lua");
+  auto hst{std::make_shared<neb::host>()};
+  hst->host_id = 1;
+  hst->host_name = "centreon";
+  hst->check_command = "echo 'John Doe'";
+  hst->alias = "alias-centreon";
+  hst->address = "4.3.2.1";
+  _cache->write(hst);
+
+  CreateScript(filename,
+               "broker_api_version = 2\n"
+               "function init(conf)\n"
+               "  broker_log:set_parameters(3, '/tmp/log')\n"
+               "end\n\n"
+               "function write(d)\n"
+               "  broker_log:info(1, broker.json_encode(d))\n"
+               "  return true\n"
+               "end\n");
+
+  auto binding{std::make_unique<luabinding>(filename, conf, *_cache)};
+
+  auto ahoststatus1 = std::make_shared<neb::pb_adaptive_host_status>();
+  {
+    auto& obj = ahoststatus1->mut_obj();
+    obj.set_host_id(1);
+    obj.set_notification_number(9);
+    binding->write(ahoststatus1);
+  }
+
+  auto ahoststatus2 = std::make_shared<neb::pb_adaptive_host_status>();
+  {
+    auto& obj = ahoststatus2->mut_obj();
+    obj.set_host_id(2);
+    obj.set_acknowledgement_type(STICKY);
+    binding->write(ahoststatus2);
+  }
+
+  auto ahoststatus3 = std::make_shared<neb::pb_adaptive_host_status>();
+  {
+    auto& obj = ahoststatus3->mut_obj();
+    obj.set_host_id(3);
+    obj.set_scheduled_downtime_depth(5);
+    binding->write(ahoststatus3);
+  }
+  std::string lst(ReadFile("/tmp/log"));
+  ASSERT_NE(lst.find("{\"_type\":65592, \"category\":1, \"element\":56, "
+                     "\"host_id\":1, \"notification_number\":9}"),
+            std::string::npos);
+  ASSERT_NE(lst.find("{\"_type\":65592, \"category\":1, \"element\":56, "
+                     "\"host_id\":2, \"acknowledgement_type\":2}"),
+            std::string::npos);
+  ASSERT_NE(lst.find("{\"_type\":65592, \"category\":1, \"element\":56, "
+                     "\"host_id\":3, \"scheduled_downtime_depth\":5}"),
+            std::string::npos);
+  RemoveFile(filename);
+  RemoveFile("/tmp/log");
+}
+
+// When a service is stored in the cache and an AdaptiveServiceStatus is written
+// Then the service in cache is updated.
+TEST_F(LuaTest, AdaptiveServiceCacheTest) {
+  config::applier::modules modules(log_v2::instance().get(log_v2::LUA));
+  modules.load_file("./broker/neb/10-neb.so");
+  std::map<std::string, misc::variant> conf;
+  std::string filename("/tmp/cache_test.lua");
+  auto svc{std::make_shared<neb::service>()};
+  svc->host_id = 1;
+  svc->service_id = 2;
+  svc->host_name = "centreon-host";
+  svc->service_description = "centreon-description";
+  svc->check_command = "echo 'John Doe'";
+  svc->display_name = "alias-centreon";
+  _cache->write(svc);
+
+  auto aservicestatus = std::make_shared<neb::pb_adaptive_service_status>();
+  auto& obj = aservicestatus->mut_obj();
+  obj.set_host_id(1);
+  obj.set_service_id(2);
+  obj.set_scheduled_downtime_depth(3);
+  _cache->write(aservicestatus);
+
+  CreateScript(filename,
+               "function init(conf)\n"
+               "  broker_log:set_parameters(3, '/tmp/log')\n"
+               "  local svc = broker_cache:get_service(1, 2)\n"
+               "  broker_log:info(1, 'display_name ' .. svc.display_name .. ' "
+               "description ' .. "
+               "svc.description .. ' check command ' .. svc.check_command .. ' "
+               "scheduled_downtime_depth ' .. svc.scheduled_downtime_depth)\n"
+               "end\n\n"
+               "function write(d)\n"
+               "  return true\n"
+               "end\n");
+  auto binding{std::make_unique<luabinding>(filename, conf, *_cache)};
+  std::string lst(ReadFile("/tmp/log"));
+
+  ASSERT_NE(
+      lst.find("display_name alias-centreon description centreon-description "
+               "check command echo 'John Doe' scheduled_downtime_depth 3"),
+      std::string::npos);
+  RemoveFile(filename);
+  //  RemoveFile("/tmp/log");
+}
+
+// When an AdaptiveHostStatus is written
+// Then only the written fields are available.
+TEST_F(LuaTest, AdaptiveServiceCacheFieldTest) {
+  config::applier::modules modules(log_v2::instance().get(log_v2::LUA));
+  modules.load_file("./broker/neb/10-neb.so");
+  std::map<std::string, misc::variant> conf;
+  std::string filename("/tmp/cache_test.lua");
+  auto svc{std::make_shared<neb::service>()};
+  svc->host_id = 1;
+  svc->service_id = 2;
+  svc->host_name = "centreon-host";
+  svc->service_description = "centreon-description";
+  svc->check_command = "echo 'John Doe'";
+  svc->display_name = "alias-centreon";
+  _cache->write(svc);
+
+  CreateScript(filename,
+               "broker_api_version = 2\n"
+               "function init(conf)\n"
+               "  broker_log:set_parameters(3, '/tmp/log')\n"
+               "end\n\n"
+               "function write(d)\n"
+               "  broker_log:info(1, broker.json_encode(d))\n"
+               "  return true\n"
+               "end\n");
+
+  auto binding{std::make_unique<luabinding>(filename, conf, *_cache)};
+
+  auto aservicestatus1 = std::make_shared<neb::pb_adaptive_service_status>();
+  {
+    auto& obj = aservicestatus1->mut_obj();
+    obj.set_host_id(1);
+    obj.set_service_id(2);
+    obj.set_notification_number(9);
+    binding->write(aservicestatus1);
+  }
+
+  auto aservicestatus2 = std::make_shared<neb::pb_adaptive_service_status>();
+  {
+    auto& obj = aservicestatus2->mut_obj();
+    obj.set_host_id(1);
+    obj.set_service_id(2);
+    obj.set_acknowledgement_type(STICKY);
+    binding->write(aservicestatus2);
+  }
+
+  auto aservicestatus3 = std::make_shared<neb::pb_adaptive_service_status>();
+  {
+    auto& obj = aservicestatus3->mut_obj();
+    obj.set_host_id(1);
+    obj.set_service_id(3);
+    obj.set_scheduled_downtime_depth(5);
+    binding->write(aservicestatus3);
+  }
+  std::string lst(ReadFile("/tmp/log"));
+  std::cout << lst << std::endl;
+  ASSERT_NE(lst.find("{\"_type\":65591, \"category\":1, \"element\":55, "
+                     "\"host_id\":1, \"service_id\":2, \"type\":0, "
+                     "\"internal_id\":0, \"notification_number\":9}"),
+            std::string::npos);
+  ASSERT_NE(lst.find("{\"_type\":65591, \"category\":1, \"element\":55, "
+                     "\"host_id\":1, \"service_id\":2, \"type\":0, "
+                     "\"internal_id\":0, \"acknowledgement_type\":2}"),
+            std::string::npos);
+  ASSERT_NE(lst.find("{\"_type\":65591, \"category\":1, \"element\":55, "
+                     "\"host_id\":1, \"service_id\":3, \"type\":0, "
+                     "\"internal_id\":0, \"scheduled_downtime_depth\":5}"),
+            std::string::npos);
+  RemoveFile(filename);
+  //  RemoveFile("/tmp/log");
 }

--- a/broker/neb/inc/com/centreon/broker/neb/comment.hh
+++ b/broker/neb/inc/com/centreon/broker/neb/comment.hh
@@ -19,12 +19,9 @@
 #ifndef CCB_NEB_COMMENT_HH
 #define CCB_NEB_COMMENT_HH
 
-#include "com/centreon/broker/io/data.hh"
-#include "com/centreon/broker/io/event_info.hh"
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/mapping/entry.hh"
 #include "com/centreon/broker/neb/internal.hh"
-#include "com/centreon/broker/timestamp.hh"
 
 namespace com::centreon::broker {
 
@@ -68,6 +65,6 @@ class comment : public io::data {
 };
 }  // namespace neb
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_NEB_COMMENT_HH

--- a/broker/neb/inc/com/centreon/broker/neb/custom_variable_status.hh
+++ b/broker/neb/inc/com/centreon/broker/neb/custom_variable_status.hh
@@ -19,12 +19,9 @@
 #ifndef CCB_NEB_CUSTOM_VARIABLE_STATUS_HH
 #define CCB_NEB_CUSTOM_VARIABLE_STATUS_HH
 
-#include "com/centreon/broker/io/data.hh"
-#include "com/centreon/broker/io/event_info.hh"
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/mapping/entry.hh"
 #include "com/centreon/broker/neb/internal.hh"
-#include "com/centreon/broker/timestamp.hh"
 
 namespace com::centreon::broker {
 
@@ -62,6 +59,6 @@ class custom_variable_status : public io::data {
 };
 }  // namespace neb
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_NEB_CUSTOM_VARIABLE_STATUS_HH

--- a/broker/neb/inc/com/centreon/broker/neb/downtime.hh
+++ b/broker/neb/inc/com/centreon/broker/neb/downtime.hh
@@ -19,12 +19,9 @@
 #ifndef CCB_NEB_DOWNTIME_HH
 #define CCB_NEB_DOWNTIME_HH
 
-#include "com/centreon/broker/io/data.hh"
-#include "com/centreon/broker/io/event_info.hh"
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/mapping/entry.hh"
 #include "com/centreon/broker/neb/internal.hh"
-#include "com/centreon/broker/timestamp.hh"
 
 namespace com::centreon::broker {
 
@@ -85,6 +82,6 @@ class downtime : public io::data {
 };
 }  // namespace neb
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_NEB_DOWNTIME_HH

--- a/broker/neb/inc/com/centreon/broker/neb/host.hh
+++ b/broker/neb/inc/com/centreon/broker/neb/host.hh
@@ -1,20 +1,20 @@
-/*
-** Copyright 2009-2013,2015 Centreon
-**
-** Licensed under the Apache License, Version 2.0 (the "License");
-** you may not use this file except in compliance with the License.
-** You may obtain a copy of the License at
-**
-**     http://www.apache.org/licenses/LICENSE-2.0
-**
-** Unless required by applicable law or agreed to in writing, software
-** distributed under the License is distributed on an "AS IS" BASIS,
-** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-** See the License for the specific language governing permissions and
-** limitations under the License.
-**
-** For more information : contact@centreon.com
-*/
+/**
+ * Copyright 2009-2013,2015 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
 
 #ifndef CCB_NEB_HOST_HH
 #define CCB_NEB_HOST_HH
@@ -72,6 +72,6 @@ class host : public host_service, public host_status {
 };
 }  // namespace neb
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_NEB_HOST_HH

--- a/broker/neb/inc/com/centreon/broker/neb/host_check.hh
+++ b/broker/neb/inc/com/centreon/broker/neb/host_check.hh
@@ -19,11 +19,8 @@
 #ifndef CCB_NEB_HOST_CHECK_HH
 #define CCB_NEB_HOST_CHECK_HH
 
-#include "com/centreon/broker/io/event_info.hh"
-#include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/mapping/entry.hh"
 #include "com/centreon/broker/neb/check.hh"
-#include "com/centreon/broker/neb/internal.hh"
 
 namespace com::centreon::broker {
 

--- a/broker/neb/inc/com/centreon/broker/neb/instance_configuration.hh
+++ b/broker/neb/inc/com/centreon/broker/neb/instance_configuration.hh
@@ -19,12 +19,9 @@
 #ifndef CCB_NEB_INSTANCE_CONFIGURATION_HH
 #define CCB_NEB_INSTANCE_CONFIGURATION_HH
 
-#include "com/centreon/broker/io/data.hh"
-#include "com/centreon/broker/io/event_info.hh"
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/mapping/entry.hh"
 #include "com/centreon/broker/neb/internal.hh"
-#include "com/centreon/broker/timestamp.hh"
 
 namespace com::centreon::broker {
 
@@ -59,6 +56,6 @@ class instance_configuration : public io::data {
 };
 }  // namespace neb
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_NEB_INSTANCE_CONFIGURATION_HH

--- a/broker/neb/inc/com/centreon/broker/neb/instance_status.hh
+++ b/broker/neb/inc/com/centreon/broker/neb/instance_status.hh
@@ -24,7 +24,6 @@
 #include "com/centreon/broker/mapping/entry.hh"
 #include "com/centreon/broker/neb/internal.hh"
 #include "com/centreon/broker/neb/status.hh"
-#include "com/centreon/broker/timestamp.hh"
 
 namespace com::centreon::broker {
 
@@ -70,6 +69,6 @@ class instance_status : public status {
 };
 }  // namespace neb
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_EVENTS_INSTANCE_STATUS_HH

--- a/broker/neb/inc/com/centreon/broker/neb/internal.hh
+++ b/broker/neb/inc/com/centreon/broker/neb/internal.hh
@@ -47,6 +47,9 @@ using pb_downtime =
 
 using pb_host_status =
     io::protobuf<HostStatus, make_type(io::neb, neb::de_pb_host_status)>;
+using pb_adaptive_host_status =
+    io::protobuf<AdaptiveHostStatus,
+                 make_type(io::neb, neb::de_pb_adaptive_host_status)>;
 using pb_host = io::protobuf<Host, make_type(io::neb, neb::de_pb_host)>;
 using pb_adaptive_host =
     io::protobuf<AdaptiveHost, make_type(io::neb, neb::de_pb_adaptive_host)>;
@@ -59,6 +62,10 @@ using pb_adaptive_service =
 
 using pb_service_status =
     io::protobuf<ServiceStatus, make_type(io::neb, neb::de_pb_service_status)>;
+
+using pb_adaptive_service_status =
+    io::protobuf<AdaptiveServiceStatus,
+                 make_type(io::neb, neb::de_pb_adaptive_service_status)>;
 
 using pb_severity =
     io::protobuf<Severity, make_type(io::neb, neb::de_pb_severity)>;

--- a/broker/neb/inc/com/centreon/broker/neb/service_check.hh
+++ b/broker/neb/inc/com/centreon/broker/neb/service_check.hh
@@ -19,11 +19,8 @@
 #ifndef CCB_NEB_SERVICE_CHECK_HH
 #define CCB_NEB_SERVICE_CHECK_HH
 
-#include "com/centreon/broker/io/event_info.hh"
-#include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/mapping/entry.hh"
 #include "com/centreon/broker/neb/check.hh"
-#include "com/centreon/broker/neb/internal.hh"
 
 namespace com::centreon::broker {
 

--- a/broker/neb/inc/com/centreon/broker/neb/service_status.hh
+++ b/broker/neb/inc/com/centreon/broker/neb/service_status.hh
@@ -24,7 +24,6 @@
 #include "com/centreon/broker/mapping/entry.hh"
 #include "com/centreon/broker/neb/host_service_status.hh"
 #include "com/centreon/broker/neb/internal.hh"
-#include "com/centreon/broker/timestamp.hh"
 
 namespace com::centreon::broker {
 
@@ -62,6 +61,6 @@ class service_status : public host_service_status {
 };
 }  // namespace neb
 
-}
+}  // namespace com::centreon::broker
 
 #endif  // !CCB_NEB_SERVICE_STATUS_HH

--- a/broker/neb/inc/com/centreon/broker/neb/set_log_data.hh
+++ b/broker/neb/inc/com/centreon/broker/neb/set_log_data.hh
@@ -21,7 +21,6 @@
 
 #include "com/centreon/broker/neb/log_entry.hh"
 #include "com/centreon/engine/host.hh"
-#include "com/centreon/engine/service.hh"
 
 namespace com {
 namespace centreon {

--- a/broker/neb/precomp_inc/precomp.hpp
+++ b/broker/neb/precomp_inc/precomp.hpp
@@ -29,6 +29,7 @@
 #include <map>
 #include <stack>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 

--- a/broker/neb/src/broker.cc
+++ b/broker/neb/src/broker.cc
@@ -152,6 +152,10 @@ void broker_module_init(void const* arg) {
       e.register_event(make_type(io::neb, neb::de_pb_service_status),
                        "ServiceStatus", &neb::pb_service_status::operations,
                        "services");
+      e.register_event(make_type(io::neb, neb::de_pb_adaptive_service_status),
+                       "AdaptiveServiceStatus",
+                       &neb::pb_adaptive_service_status::operations,
+                       "services");
 
       e.register_event(make_type(io::neb, neb::de_pb_host), "Host",
                        &neb::pb_host::operations, "hosts");
@@ -161,6 +165,10 @@ void broker_module_init(void const* arg) {
 
       e.register_event(make_type(io::neb, neb::de_pb_host_status), "HostStatus",
                        &neb::pb_host_status::operations, "hosts");
+      e.register_event(make_type(io::neb, neb::de_pb_adaptive_host_status),
+                       "AdaptiveHostStatus",
+                       &neb::pb_adaptive_host_status::operations,
+                       "hosts");
 
       e.register_event(make_type(io::neb, neb::de_pb_severity), "Severity",
                        &neb::pb_severity::operations, "severities");

--- a/broker/neb/src/callbacks.cc
+++ b/broker/neb/src/callbacks.cc
@@ -18,36 +18,24 @@
 
 #include "com/centreon/broker/neb/callbacks.hh"
 
+#include <absl/strings/numbers.h>
 #include <absl/strings/str_split.h>
 #include <unistd.h>
-
-#include "bbdo/neb.pb.h"
-#include "opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h"
 
 #include "com/centreon/broker/bbdo/internal.hh"
 #include "com/centreon/broker/config/applier/state.hh"
 #include "com/centreon/broker/config/parser.hh"
-#include "com/centreon/broker/config/state.hh"
-#include "com/centreon/broker/neb/callback.hh"
 #include "com/centreon/broker/neb/events.hh"
 #include "com/centreon/broker/neb/initial.hh"
-#include "com/centreon/broker/neb/internal.hh"
 #include "com/centreon/broker/neb/set_log_data.hh"
 #include "com/centreon/common/time.hh"
 #include "com/centreon/common/utf8.hh"
 #include "com/centreon/engine/anomalydetection.hh"
 #include "com/centreon/engine/broker.hh"
-#include "com/centreon/engine/comment.hh"
 #include "com/centreon/engine/events/loop.hh"
 #include "com/centreon/engine/globals.hh"
-#include "com/centreon/engine/hostgroup.hh"
-#include "com/centreon/engine/nebcallbacks.hh"
 #include "com/centreon/engine/nebstructs.hh"
-#include "com/centreon/engine/servicegroup.hh"
 #include "com/centreon/engine/severity.hh"
-#include "com/centreon/engine/tag.hh"
-#include "com/centreon/exceptions/msg_fmt.hh"
-#include "common/log_v2/log_v2.hh"
 
 using namespace com::centreon::broker;
 using namespace com::centreon::exceptions;
@@ -1992,10 +1980,9 @@ int neb::callback_pb_host_check(int callback_type, void* data) {
  *
  *  @return 0 on success.
  */
-int neb::callback_host_status(int callback_type, void* data) {
+int neb::callback_host_status(int callback_type [[maybe_unused]], void* data) {
   // Log message.
   SPDLOG_LOGGER_DEBUG(neb_logger, "callbacks: generating host status event");
-  (void)callback_type;
 
   try {
     // In/Out variables.
@@ -2121,90 +2108,115 @@ int neb::callback_host_status(int callback_type, void* data) {
  *
  *  @return 0 on success.
  */
-int neb::callback_pb_host_status(int callback_type, void* data) noexcept {
+int neb::callback_pb_host_status(int callback_type [[maybe_unused]],
+                                 void* data) noexcept {
   // Log message.
   SPDLOG_LOGGER_DEBUG(
       neb_logger,
       "callbacks: generating pb host status check result event protobuf");
-  (void)callback_type;
 
-  const engine::host* eh{static_cast<engine::host*>(
-      static_cast<nebstruct_host_status_data*>(data)->object_ptr)};
+  nebstruct_host_status_data* hsd =
+      static_cast<nebstruct_host_status_data*>(data);
+  const engine::host* eh = static_cast<engine::host*>(hsd->object_ptr);
 
-  auto h{std::make_shared<neb::pb_host_status>()};
-  HostStatus& hscr = h.get()->mut_obj();
-
-  hscr.set_host_id(eh->host_id());
-  if (hscr.host_id() == 0)
-    SPDLOG_LOGGER_ERROR(neb_logger, "could not find ID of host '{}'",
-                        eh->name());
-
-  if (eh->problem_has_been_acknowledged())
-    hscr.set_acknowledgement_type(eh->get_acknowledgement());
-  else
-    hscr.set_acknowledgement_type(AckType::NONE);
-
-  hscr.set_check_type(static_cast<HostStatus_CheckType>(eh->get_check_type()));
-  hscr.set_check_attempt(eh->get_current_attempt());
-  hscr.set_state(static_cast<HostStatus_State>(
-      eh->has_been_checked() ? eh->get_current_state() : 4));  // Pending state.
-  hscr.set_execution_time(eh->get_execution_time());
-  hscr.set_checked(eh->has_been_checked());
-  hscr.set_flapping(eh->get_is_flapping());
-  hscr.set_last_check(eh->get_last_check());
-  hscr.set_last_hard_state(
-      static_cast<HostStatus_State>(eh->get_last_hard_state()));
-  hscr.set_last_hard_state_change(eh->get_last_hard_state_change());
-  hscr.set_last_notification(eh->get_last_notification());
-  hscr.set_notification_number(eh->get_notification_number());
-  hscr.set_last_state_change(eh->get_last_state_change());
-  hscr.set_last_time_down(eh->get_last_time_down());
-  hscr.set_last_time_unreachable(eh->get_last_time_unreachable());
-  hscr.set_last_time_up(eh->get_last_time_up());
-  hscr.set_latency(eh->get_latency());
-  hscr.set_next_check(eh->get_next_check());
-  hscr.set_next_host_notification(eh->get_next_notification());
-  hscr.set_no_more_notifications(eh->get_no_more_notifications());
-  if (!eh->get_plugin_output().empty())
-    hscr.set_output(common::check_string_utf8(eh->get_plugin_output()));
-  if (!eh->get_long_plugin_output().empty())
-    hscr.set_output(common::check_string_utf8(eh->get_long_plugin_output()));
-
-  hscr.set_percent_state_change(eh->get_percent_state_change());
-  if (!eh->get_perf_data().empty())
-    hscr.set_perfdata(common::check_string_utf8(eh->get_perf_data()));
-  hscr.set_should_be_scheduled(eh->get_should_be_scheduled());
-  hscr.set_state_type(static_cast<HostStatus_StateType>(
-      eh->has_been_checked() ? eh->get_state_type() : engine::notifier::hard));
-  hscr.set_scheduled_downtime_depth(eh->get_scheduled_downtime_depth());
-
-  // Send event(s).
-  gl_publisher.write(h);
-
-  // Acknowledgement event.
-  auto it = gl_acknowledgements.find(std::make_pair(hscr.host_id(), 0u));
-  if (it != gl_acknowledgements.end() &&
-      hscr.acknowledgement_type() == AckType::NONE) {
-    if (it->second->type() == make_type(io::neb, de_pb_acknowledgement)) {
-      neb_logger->debug("acknowledgement found on host {}", hscr.host_id());
-      neb::pb_acknowledgement* a =
-          static_cast<neb::pb_acknowledgement*>(it->second.get());
-      if (!(!hscr.state()  // !(OK or (normal ack and NOK))
-            || (!a->obj().sticky() &&
-                hscr.state() != static_cast<short>(a->obj().state())))) {
-        a->mut_obj().set_deletion_time(time(nullptr));
-        gl_publisher.write(std::move(it->second));
+  auto handle_acknowledgement = [](uint16_t state, auto& hscr) {
+    auto it = gl_acknowledgements.find(std::make_pair(hscr.host_id(), 0u));
+    if (it != gl_acknowledgements.end() &&
+        hscr.acknowledgement_type() == AckType::NONE) {
+      if (it->second->type() == make_type(io::neb, de_pb_acknowledgement)) {
+        neb_logger->debug("acknowledgement found on host {}", hscr.host_id());
+        neb::pb_acknowledgement* a =
+            static_cast<neb::pb_acknowledgement*>(it->second.get());
+        if (!(!state  // !(OK or (normal ack and NOK))
+              || (!a->obj().sticky() && state != a->obj().state()))) {
+          a->mut_obj().set_deletion_time(time(nullptr));
+          gl_publisher.write(std::move(it->second));
+        }
+      } else {
+        neb::acknowledgement* a =
+            static_cast<neb::acknowledgement*>(it->second.get());
+        if (!(!state  // !(OK or (normal ack and NOK))
+              || (!a->is_sticky && state != a->state))) {
+          a->deletion_time = time(nullptr);
+          gl_publisher.write(std::move(it->second));
+        }
       }
-    } else {
-      neb::acknowledgement* a =
-          static_cast<neb::acknowledgement*>(it->second.get());
-      if (!(!hscr.state()  // !(OK or (normal ack and NOK))
-            || (!a->is_sticky && hscr.state() != a->state))) {
-        a->deletion_time = time(nullptr);
-        gl_publisher.write(std::move(it->second));
-      }
+      gl_acknowledgements.erase(it);
     }
-    gl_acknowledgements.erase(it);
+  };
+
+  uint16_t state =
+      eh->has_been_checked() ? eh->get_current_state() : 4;  // Pending state.
+
+  if (hsd->attributes != engine::host::STATUS_ALL) {
+    auto h{std::make_shared<neb::pb_adaptive_host_status>()};
+    AdaptiveHostStatus& hst = h.get()->mut_obj();
+    if (hsd->attributes & engine::host::STATUS_DOWNTIME_DEPTH) {
+      hst.set_host_id(eh->host_id());
+      hst.set_scheduled_downtime_depth(eh->get_scheduled_downtime_depth());
+    }
+    if (hsd->attributes & engine::host::STATUS_NOTIFICATION_NUMBER) {
+      hst.set_host_id(eh->host_id());
+      hst.set_notification_number(eh->get_notification_number());
+    }
+    if (hsd->attributes & engine::host::STATUS_ACKNOWLEDGEMENT) {
+      hst.set_host_id(eh->host_id());
+      hst.set_acknowledgement_type(eh->get_acknowledgement());
+    }
+    gl_publisher.write(h);
+
+    // Acknowledgement event.
+    handle_acknowledgement(state, hst);
+  } else {
+    auto h{std::make_shared<neb::pb_host_status>()};
+    HostStatus& hscr = h.get()->mut_obj();
+
+    hscr.set_host_id(eh->host_id());
+    if (hscr.host_id() == 0)
+      SPDLOG_LOGGER_ERROR(neb_logger, "could not find ID of host '{}'",
+                          eh->name());
+
+    hscr.set_acknowledgement_type(eh->get_acknowledgement());
+    hscr.set_check_type(
+        static_cast<HostStatus_CheckType>(eh->get_check_type()));
+    hscr.set_check_attempt(eh->get_current_attempt());
+    hscr.set_state(static_cast<HostStatus_State>(state));
+    hscr.set_execution_time(eh->get_execution_time());
+    hscr.set_checked(eh->has_been_checked());
+    hscr.set_flapping(eh->get_is_flapping());
+    hscr.set_last_check(eh->get_last_check());
+    hscr.set_last_hard_state(
+        static_cast<HostStatus_State>(eh->get_last_hard_state()));
+    hscr.set_last_hard_state_change(eh->get_last_hard_state_change());
+    hscr.set_last_notification(eh->get_last_notification());
+    hscr.set_notification_number(eh->get_notification_number());
+    hscr.set_last_state_change(eh->get_last_state_change());
+    hscr.set_last_time_down(eh->get_last_time_down());
+    hscr.set_last_time_unreachable(eh->get_last_time_unreachable());
+    hscr.set_last_time_up(eh->get_last_time_up());
+    hscr.set_latency(eh->get_latency());
+    hscr.set_next_check(eh->get_next_check());
+    hscr.set_next_host_notification(eh->get_next_notification());
+    hscr.set_no_more_notifications(eh->get_no_more_notifications());
+    if (!eh->get_plugin_output().empty())
+      hscr.set_output(common::check_string_utf8(eh->get_plugin_output()));
+    if (!eh->get_long_plugin_output().empty())
+      hscr.set_output(common::check_string_utf8(eh->get_long_plugin_output()));
+
+    hscr.set_percent_state_change(eh->get_percent_state_change());
+    if (!eh->get_perf_data().empty())
+      hscr.set_perfdata(common::check_string_utf8(eh->get_perf_data()));
+    hscr.set_should_be_scheduled(eh->get_should_be_scheduled());
+    hscr.set_state_type(static_cast<HostStatus_StateType>(
+        eh->has_been_checked() ? eh->get_state_type()
+                               : engine::notifier::hard));
+    hscr.set_scheduled_downtime_depth(eh->get_scheduled_downtime_depth());
+
+    // Send event(s).
+    gl_publisher.write(h);
+
+    // Acknowledgement event.
+    handle_acknowledgement(state, hscr);
   }
   neb_logger->debug("Still {} running acknowledgements",
                     gl_acknowledgements.size());
@@ -2857,6 +2869,50 @@ int neb::callback_service(int callback_type, void* data) {
   return 0;
 }
 
+template <typename SrvStatus>
+static void fill_service_type(SrvStatus& ss,
+                              const com::centreon::engine::service* es) {
+  switch (es->get_service_type()) {
+    case com::centreon::engine::service_type::METASERVICE: {
+      ss.set_type(METASERVICE);
+      uint64_t iid;
+      if (absl::SimpleAtoi(es->description().c_str() + 5, &iid))
+        ss.set_internal_id(iid);
+      else {
+        SPDLOG_LOGGER_ERROR(
+            neb_logger,
+            "callbacks: service ('{}', '{}') looks like a meta-service but "
+            "its name is malformed",
+            es->get_hostname(), es->description());
+      }
+    } break;
+    case com::centreon::engine::service_type::BA: {
+      ss.set_type(BA);
+      uint64_t iid;
+      if (absl::SimpleAtoi(es->description().c_str() + 3, &iid))
+        ss.set_internal_id(iid);
+      else {
+        SPDLOG_LOGGER_ERROR(
+            neb_logger,
+            "callbacks: service ('{}', '{}') looks like a business-activity "
+            "but its name is malformed",
+            es->get_hostname(), es->description());
+      }
+    } break;
+    case com::centreon::engine::service_type::ANOMALY_DETECTION:
+      ss.set_type(ANOMALY_DETECTION);
+      {
+        auto ad =
+            static_cast<const com::centreon::engine::anomalydetection*>(es);
+        ss.set_internal_id(ad->get_internal_id());
+      }
+      break;
+    default:
+      ss.set_type(SERVICE);
+      break;
+  }
+}
+
 /**
  *  @brief Function that process protobuf service data.
  *
@@ -2884,40 +2940,69 @@ int neb::callback_pb_service(int callback_type [[maybe_unused]], void* data) {
   if (ds->type == NEBTYPE_ADAPTIVESERVICE_UPDATE &&
       ds->modified_attribute != MODATTR_ALL) {
     auto s{std::make_shared<neb::pb_adaptive_service>()};
+    bool done = false;
     AdaptiveService& srv = s.get()->mut_obj();
-    if (ds->modified_attribute & MODATTR_NOTIFICATIONS_ENABLED)
+    if (ds->modified_attribute & MODATTR_NOTIFICATIONS_ENABLED) {
       srv.set_notify(es->get_notifications_enabled());
-    else if (ds->modified_attribute & MODATTR_ACTIVE_CHECKS_ENABLED) {
+      done = true;
+    }
+    if (ds->modified_attribute & MODATTR_ACTIVE_CHECKS_ENABLED) {
       srv.set_active_checks(es->active_checks_enabled());
       srv.set_should_be_scheduled(es->get_should_be_scheduled());
-    } else if (ds->modified_attribute & MODATTR_PASSIVE_CHECKS_ENABLED)
+      done = true;
+    }
+    if (ds->modified_attribute & MODATTR_PASSIVE_CHECKS_ENABLED) {
       srv.set_passive_checks(es->passive_checks_enabled());
-    else if (ds->modified_attribute & MODATTR_EVENT_HANDLER_ENABLED)
+      done = true;
+    }
+    if (ds->modified_attribute & MODATTR_EVENT_HANDLER_ENABLED) {
       srv.set_event_handler_enabled(es->event_handler_enabled());
-    else if (ds->modified_attribute & MODATTR_FLAP_DETECTION_ENABLED)
+      done = true;
+    }
+    if (ds->modified_attribute & MODATTR_FLAP_DETECTION_ENABLED) {
       srv.set_flap_detection_enabled(es->flap_detection_enabled());
-    else if (ds->modified_attribute & MODATTR_OBSESSIVE_HANDLER_ENABLED)
+      done = true;
+    }
+    if (ds->modified_attribute & MODATTR_OBSESSIVE_HANDLER_ENABLED) {
       srv.set_obsess_over_service(es->obsess_over());
-    else if (ds->modified_attribute & MODATTR_EVENT_HANDLER_COMMAND)
+      done = true;
+    }
+    if (ds->modified_attribute & MODATTR_EVENT_HANDLER_COMMAND) {
       srv.set_event_handler(common::check_string_utf8(es->event_handler()));
-    else if (ds->modified_attribute & MODATTR_CHECK_COMMAND)
+      done = true;
+    }
+    if (ds->modified_attribute & MODATTR_CHECK_COMMAND) {
       srv.set_check_command(common::check_string_utf8(es->check_command()));
-    else if (ds->modified_attribute & MODATTR_NORMAL_CHECK_INTERVAL)
+      done = true;
+    }
+    if (ds->modified_attribute & MODATTR_NORMAL_CHECK_INTERVAL) {
       srv.set_check_interval(es->check_interval());
-    else if (ds->modified_attribute & MODATTR_RETRY_CHECK_INTERVAL)
+      done = true;
+    }
+    if (ds->modified_attribute & MODATTR_RETRY_CHECK_INTERVAL) {
       srv.set_retry_interval(es->retry_interval());
-    else if (ds->modified_attribute & MODATTR_MAX_CHECK_ATTEMPTS)
+      done = true;
+    }
+    if (ds->modified_attribute & MODATTR_MAX_CHECK_ATTEMPTS) {
       srv.set_max_check_attempts(es->max_check_attempts());
-    else if (ds->modified_attribute & MODATTR_FRESHNESS_CHECKS_ENABLED)
+      done = true;
+    }
+    if (ds->modified_attribute & MODATTR_FRESHNESS_CHECKS_ENABLED) {
       srv.set_check_freshness(es->check_freshness_enabled());
-    else if (ds->modified_attribute & MODATTR_CHECK_TIMEPERIOD)
+      done = true;
+    }
+    if (ds->modified_attribute & MODATTR_CHECK_TIMEPERIOD) {
       srv.set_check_period(es->check_period());
-    else if (ds->modified_attribute & MODATTR_NOTIFICATION_TIMEPERIOD)
+      done = true;
+    }
+    if (ds->modified_attribute & MODATTR_NOTIFICATION_TIMEPERIOD) {
       srv.set_notification_period(es->notification_period());
-    else {
-      SPDLOG_LOGGER_ERROR(neb_logger,
-                          "callbacks: adaptive service not implemented.");
-      assert(1 == 0);
+      done = true;
+    }
+    if (!done) {
+      SPDLOG_LOGGER_ERROR(
+          neb_logger, "callbacks: adaptive service field {} not implemented.",
+          ds->modified_attribute);
     }
     std::pair<uint64_t, uint64_t> p{
         engine::get_host_and_service_id(es->get_hostname(), es->description())};
@@ -2990,58 +3075,12 @@ int neb::callback_pb_service(int callback_type [[maybe_unused]], void* data) {
     srv.set_high_flap_threshold(es->get_high_flap_threshold());
     if (!es->description().empty())
       srv.set_description(common::check_string_utf8(es->description()));
-
     if (!es->get_hostname().empty()) {
       std::string name{common::check_string_utf8(es->get_hostname())};
-      switch (es->get_service_type()) {
-        case com::centreon::engine::service_type::METASERVICE: {
-          srv.set_type(METASERVICE);
-          uint64_t iid = 0;
-          for (auto c = srv.description().begin() + 5;
-               c != srv.description().end(); ++c) {
-            if (!isdigit(*c)) {
-              SPDLOG_LOGGER_ERROR(
-                  neb_logger,
-                  "callbacks: service ('{}', '{}') looks like a meta-service "
-                  "but its name is malformed",
-                  name, srv.description());
-              break;
-            }
-            iid = 10 * iid + (*c - '0');
-          }
-          srv.set_internal_id(iid);
-        } break;
-        case com::centreon::engine::service_type::BA: {
-          srv.set_type(BA);
-          uint64_t iid = 0;
-          for (auto c = srv.description().begin() + 3;
-               c != srv.description().end(); ++c) {
-            if (!isdigit(*c)) {
-              SPDLOG_LOGGER_ERROR(
-                  neb_logger,
-                  "callbacks: service ('{}', '{}') looks like a "
-                  "business-activity but its name is malformed",
-                  name, srv.description());
-              break;
-            }
-            iid = 10 * iid + (*c - '0');
-          }
-          srv.set_internal_id(iid);
-        } break;
-        case com::centreon::engine::service_type::ANOMALY_DETECTION:
-          srv.set_type(ANOMALY_DETECTION);
-          {
-            auto ad =
-                static_cast<const com::centreon::engine::anomalydetection*>(es);
-            srv.set_internal_id(ad->get_internal_id());
-          }
-          break;
-        default:
-          srv.set_type(SERVICE);
-          break;
-      }
       *srv.mutable_host_name() = std::move(name);
     }
+    fill_service_type(srv, es);
+
     if (!es->get_icon_image().empty())
       *srv.mutable_icon_image() =
           common::check_string_utf8(es->get_icon_image());
@@ -3386,140 +3425,132 @@ int32_t neb::callback_pb_service_status(int callback_type [[maybe_unused]],
   SPDLOG_LOGGER_DEBUG(
       neb_logger, "callbacks: generating pb service status check result event");
 
-  const engine::service* es{static_cast<engine::service*>(
-      static_cast<nebstruct_service_status_data*>(data)->object_ptr)};
-  neb_logger->debug("callbacks: pb_service_status ({},{}) status {}, type {}",
-                    es->host_id(), es->service_id(),
-                    static_cast<uint32_t>(es->get_current_state()),
-                    static_cast<uint32_t>(es->get_check_type()));
+  nebstruct_service_status_data* ds =
+      static_cast<nebstruct_service_status_data*>(data);
+  const engine::service* es = static_cast<engine::service*>(ds->object_ptr);
+  neb_logger->debug(
+      "callbacks: pb_service_status ({},{}) status {}, attributes {}, type {}",
+      es->host_id(), es->service_id(),
+      static_cast<uint32_t>(es->get_current_state()), ds->attributes,
+      static_cast<uint32_t>(es->get_check_type()));
 
-  auto s{std::make_shared<neb::pb_service_status>()};
-  ServiceStatus& sscr = s.get()->mut_obj();
+  auto handle_acknowledgement = [](uint16_t state, auto& r) {
+    neb_logger->debug("Looking for acknowledgement on service ({}:{})",
+                      r.host_id(), r.service_id());
+    auto it =
+        gl_acknowledgements.find(std::make_pair(r.host_id(), r.service_id()));
+    if (it != gl_acknowledgements.end() &&
+        r.acknowledgement_type() == AckType::NONE) {
+      neb_logger->debug("acknowledgement found on service ({}:{})", r.host_id(),
+                        r.service_id());
+      if (it->second->type() == make_type(io::neb, de_pb_acknowledgement)) {
+        neb::pb_acknowledgement* a =
+            static_cast<neb::pb_acknowledgement*>(it->second.get());
+        if (!(!state  // !(OK or (normal ack and NOK))
+              || (!a->obj().sticky() && state != a->obj().state()))) {
+          a->mut_obj().set_deletion_time(time(nullptr));
+          gl_publisher.write(std::move(it->second));
+        }
+      } else {
+        neb::acknowledgement* a =
+            static_cast<neb::acknowledgement*>(it->second.get());
+        if (!(!state  // !(OK or (normal ack and NOK))
+              || (!a->is_sticky && state != a->state))) {
+          a->deletion_time = time(nullptr);
+          gl_publisher.write(std::move(it->second));
+        }
+      }
+      gl_acknowledgements.erase(it);
+    }
+  };
+  uint16_t state =
+      es->has_been_checked() ? es->get_current_state() : 4;  // Pending state.
+  if (ds->attributes != engine::service::STATUS_ALL) {
+    auto as = std::make_shared<neb::pb_adaptive_service_status>();
+    AdaptiveServiceStatus& asscr = as.get()->mut_obj();
+    fill_service_type(asscr, es);
+    if (ds->attributes & engine::service::STATUS_DOWNTIME_DEPTH) {
+      asscr.set_host_id(es->host_id());
+      asscr.set_service_id(es->service_id());
+      asscr.set_scheduled_downtime_depth(es->get_scheduled_downtime_depth());
+    }
+    if (ds->attributes & engine::service::STATUS_NOTIFICATION_NUMBER) {
+      asscr.set_host_id(es->host_id());
+      asscr.set_service_id(es->service_id());
+      asscr.set_notification_number(es->get_notification_number());
+    }
+    if (ds->attributes & engine::service::STATUS_ACKNOWLEDGEMENT) {
+      asscr.set_host_id(es->host_id());
+      asscr.set_service_id(es->service_id());
+      asscr.set_acknowledgement_type(es->get_acknowledgement());
+    }
+    gl_publisher.write(as);
 
-  sscr.set_host_id(es->host_id());
-  sscr.set_service_id(es->service_id());
-  if (es->host_id() == 0 || es->service_id() == 0)
-    SPDLOG_LOGGER_ERROR(neb_logger, "could not find ID of service ('{}', '{}')",
-                        es->get_hostname(), es->description());
-
-  if (es->problem_has_been_acknowledged())
-    sscr.set_acknowledgement_type(es->get_acknowledgement());
-  else
-    sscr.set_acknowledgement_type(AckType::NONE);
-
-  sscr.set_check_type(
-      static_cast<ServiceStatus_CheckType>(es->get_check_type()));
-  sscr.set_check_attempt(es->get_current_attempt());
-  sscr.set_state(static_cast<ServiceStatus_State>(
-      es->has_been_checked() ? es->get_current_state() : 4));  // Pending state.
-  sscr.set_execution_time(es->get_execution_time());
-  sscr.set_checked(es->has_been_checked());
-  sscr.set_flapping(es->get_is_flapping());
-  sscr.set_last_check(es->get_last_check());
-  sscr.set_last_hard_state(
-      static_cast<ServiceStatus_State>(es->get_last_hard_state()));
-  sscr.set_last_hard_state_change(es->get_last_hard_state_change());
-  sscr.set_last_notification(es->get_last_notification());
-  sscr.set_notification_number(es->get_notification_number());
-  sscr.set_last_state_change(es->get_last_state_change());
-  sscr.set_last_time_critical(es->get_last_time_critical());
-  sscr.set_last_time_ok(es->get_last_time_ok());
-  sscr.set_last_time_unknown(es->get_last_time_unknown());
-  sscr.set_last_time_warning(es->get_last_time_warning());
-  sscr.set_latency(es->get_latency());
-  sscr.set_next_check(es->get_next_check());
-  sscr.set_next_notification(es->get_next_notification());
-  sscr.set_no_more_notifications(es->get_no_more_notifications());
-  if (!es->get_plugin_output().empty())
-    sscr.set_output(common::check_string_utf8(es->get_plugin_output()));
-  if (!es->get_long_plugin_output().empty())
-    sscr.set_long_output(
-        common::check_string_utf8(es->get_long_plugin_output()));
-  sscr.set_percent_state_change(es->get_percent_state_change());
-  if (!es->get_perf_data().empty()) {
-    sscr.set_perfdata(common::check_string_utf8(es->get_perf_data()));
-    SPDLOG_LOGGER_TRACE(neb_logger,
-                        "callbacks: service ({}, {}) has perfdata <<{}>>",
-                        es->host_id(), es->service_id(), es->get_perf_data());
+    // Acknowledgement event.
+    handle_acknowledgement(state, asscr);
   } else {
-    SPDLOG_LOGGER_TRACE(neb_logger,
-                        "callbacks: service ({}, {}) has no perfdata",
-                        es->host_id(), es->service_id());
-  }
-  sscr.set_should_be_scheduled(es->get_should_be_scheduled());
-  sscr.set_state_type(static_cast<ServiceStatus_StateType>(
-      es->has_been_checked() ? es->get_state_type() : engine::notifier::hard));
-  sscr.set_scheduled_downtime_depth(es->get_scheduled_downtime_depth());
+    auto s{std::make_shared<neb::pb_service_status>()};
+    ServiceStatus& sscr = s.get()->mut_obj();
 
-  if (!es->get_hostname().empty()) {
-    if (strncmp(es->get_hostname().c_str(), "_Module_Meta", 13) == 0) {
-      if (strncmp(es->description().c_str(), "meta_", 5) == 0) {
-        sscr.set_type(METASERVICE);
-        uint64_t iid = 0;
-        for (auto c = es->description().begin() + 5;
-             c != es->description().end(); ++c) {
-          if (!isdigit(*c)) {
-            SPDLOG_LOGGER_ERROR(
-                neb_logger,
-                "callbacks: service ('{}', '{}') looks like a meta-service "
-                "but its name is malformed",
-                es->get_hostname(), es->description());
-            break;
-          }
-          iid = 10 * iid + (*c - '0');
-        }
-        sscr.set_internal_id(iid);
-      }
-    } else if (strncmp(es->get_hostname().c_str(), "_Module_BAM", 11) == 0) {
-      if (strncmp(es->description().c_str(), "ba_", 3) == 0) {
-        sscr.set_type(BA);
-        uint64_t iid = 0;
-        for (auto c = es->description().begin() + 3;
-             c != es->description().end(); ++c) {
-          if (!isdigit(*c)) {
-            SPDLOG_LOGGER_ERROR(neb_logger,
-                                "callbacks: service ('{}', '{}') looks like a "
-                                "business-activity but its name is malformed",
-                                es->get_hostname(), es->description());
-            break;
-          }
-          iid = 10 * iid + (*c - '0');
-        }
-        sscr.set_internal_id(iid);
-      }
-    }
-  }
-  // Send event(s).
-  gl_publisher.write(s);
+    fill_service_type(sscr, es);
+    sscr.set_host_id(es->host_id());
+    sscr.set_service_id(es->service_id());
+    if (es->host_id() == 0 || es->service_id() == 0)
+      SPDLOG_LOGGER_ERROR(neb_logger,
+                          "could not find ID of service ('{}', '{}')",
+                          es->get_hostname(), es->description());
 
-  neb_logger->debug("Looking for acknowledgement on service ({}:{})",
-                    sscr.host_id(), sscr.service_id());
-  // Acknowledgement event.
-  auto it = gl_acknowledgements.find(
-      std::make_pair(sscr.host_id(), sscr.service_id()));
-  if (it != gl_acknowledgements.end() &&
-      sscr.acknowledgement_type() == AckType::NONE) {
-    neb_logger->debug("acknowledgement found on service ({}:{})",
-                      sscr.host_id(), sscr.service_id());
-    if (it->second->type() == make_type(io::neb, de_pb_acknowledgement)) {
-      neb::pb_acknowledgement* a =
-          static_cast<neb::pb_acknowledgement*>(it->second.get());
-      if (!(!sscr.state()  // !(OK or (normal ack and NOK))
-            || (!a->obj().sticky() &&
-                static_cast<uint32_t>(sscr.state()) != a->obj().state()))) {
-        a->mut_obj().set_deletion_time(time(nullptr));
-        gl_publisher.write(std::move(it->second));
-      }
+    sscr.set_acknowledgement_type(es->get_acknowledgement());
+
+    sscr.set_check_type(
+        static_cast<ServiceStatus_CheckType>(es->get_check_type()));
+    sscr.set_check_attempt(es->get_current_attempt());
+    sscr.set_state(static_cast<ServiceStatus_State>(state));
+    sscr.set_execution_time(es->get_execution_time());
+    sscr.set_checked(es->has_been_checked());
+    sscr.set_flapping(es->get_is_flapping());
+    sscr.set_last_check(es->get_last_check());
+    sscr.set_last_hard_state(
+        static_cast<ServiceStatus_State>(es->get_last_hard_state()));
+    sscr.set_last_hard_state_change(es->get_last_hard_state_change());
+    sscr.set_last_notification(es->get_last_notification());
+    sscr.set_notification_number(es->get_notification_number());
+    sscr.set_last_state_change(es->get_last_state_change());
+    sscr.set_last_time_critical(es->get_last_time_critical());
+    sscr.set_last_time_ok(es->get_last_time_ok());
+    sscr.set_last_time_unknown(es->get_last_time_unknown());
+    sscr.set_last_time_warning(es->get_last_time_warning());
+    sscr.set_latency(es->get_latency());
+    sscr.set_next_check(es->get_next_check());
+    sscr.set_next_notification(es->get_next_notification());
+    sscr.set_no_more_notifications(es->get_no_more_notifications());
+    if (!es->get_plugin_output().empty())
+      sscr.set_output(common::check_string_utf8(es->get_plugin_output()));
+    if (!es->get_long_plugin_output().empty())
+      sscr.set_long_output(
+          common::check_string_utf8(es->get_long_plugin_output()));
+    sscr.set_percent_state_change(es->get_percent_state_change());
+    if (!es->get_perf_data().empty()) {
+      sscr.set_perfdata(common::check_string_utf8(es->get_perf_data()));
+      SPDLOG_LOGGER_TRACE(neb_logger,
+                          "callbacks: service ({}, {}) has perfdata <<{}>>",
+                          es->host_id(), es->service_id(), es->get_perf_data());
     } else {
-      neb::acknowledgement* a =
-          static_cast<neb::acknowledgement*>(it->second.get());
-      if (!(!sscr.state()  // !(OK or (normal ack and NOK))
-            || (!a->is_sticky && sscr.state() != a->state))) {
-        a->deletion_time = time(nullptr);
-        gl_publisher.write(std::move(it->second));
-      }
+      SPDLOG_LOGGER_TRACE(neb_logger,
+                          "callbacks: service ({}, {}) has no perfdata",
+                          es->host_id(), es->service_id());
     }
-    gl_acknowledgements.erase(it);
+    sscr.set_should_be_scheduled(es->get_should_be_scheduled());
+    sscr.set_state_type(static_cast<ServiceStatus_StateType>(
+        es->has_been_checked() ? es->get_state_type()
+                               : engine::notifier::hard));
+    sscr.set_scheduled_downtime_depth(es->get_scheduled_downtime_depth());
+
+    // Send event(s).
+    gl_publisher.write(s);
+
+    // Acknowledgement event.
+    handle_acknowledgement(state, sscr);
   }
   neb_logger->debug("Still {} running acknowledgements",
                     gl_acknowledgements.size());

--- a/broker/tls/inc/com/centreon/broker/tls/stream.hh
+++ b/broker/tls/inc/com/centreon/broker/tls/stream.hh
@@ -19,7 +19,6 @@
 #ifndef CCB_TLS_STREAM_HH
 #define CCB_TLS_STREAM_HH
 
-#include <gnutls/gnutls.h>
 
 #include "com/centreon/broker/io/stream.hh"
 #include "com/centreon/broker/tls/params.hh"

--- a/broker/tls/test/acceptor.cc
+++ b/broker/tls/test/acceptor.cc
@@ -19,10 +19,8 @@
 
 #include "com/centreon/broker/tcp/acceptor.hh"
 
-#include <fmt/format.h>
 #include <gtest/gtest.h>
 
-#include <nlohmann/json.hpp>
 
 #include "com/centreon/broker/io/raw.hh"
 #include "com/centreon/broker/misc/buffer.hh"
@@ -34,7 +32,6 @@
 #include "com/centreon/broker/tls/connector.hh"
 #include "com/centreon/broker/tls/internal.hh"
 #include "com/centreon/broker/tls/stream.hh"
-#include "com/centreon/common/pool.hh"
 #include "com/centreon/exceptions/msg_fmt.hh"
 
 using namespace com::centreon::broker;
@@ -178,7 +175,7 @@ TEST_F(TlsTest, AnonTlsStreamContinuous) {
     tls::stream* tls_centengine =
         static_cast<tls::stream*>(io_tls_centengine.get());
 
-    char str[20];
+    char str[24];
     int i = 0;
 
     /* This is not representative of a real stream. Here we have to call write

--- a/broker/unified_sql/inc/com/centreon/broker/unified_sql/stream.hh
+++ b/broker/unified_sql/inc/com/centreon/broker/unified_sql/stream.hh
@@ -18,8 +18,6 @@
 
 #ifndef CCB_UNIFIED_SQL_STREAM_HH
 #define CCB_UNIFIED_SQL_STREAM_HH
-#include <absl/container/flat_hash_map.h>
-#include <absl/container/flat_hash_set.h>
 #include <array>
 #include <atomic>
 #include <condition_variable>
@@ -437,11 +435,13 @@ class stream : public io::stream {
   void _process_pb_host(const std::shared_ptr<io::data>& d);
   uint64_t _process_pb_host_in_resources(const Host& h, int32_t conn);
   void _process_pb_host_status(const std::shared_ptr<io::data>& d);
+  void _process_pb_adaptive_host_status(const std::shared_ptr<io::data>& d);
   void _process_pb_adaptive_host(const std::shared_ptr<io::data>& d);
   void _process_pb_service(const std::shared_ptr<io::data>& d);
   uint64_t _process_pb_service_in_resources(const Service& s, int32_t conn);
   void _process_pb_adaptive_service(const std::shared_ptr<io::data>& d);
   void _process_pb_service_status(const std::shared_ptr<io::data>& d);
+  void _process_pb_adaptive_service_status(const std::shared_ptr<io::data>& d);
   void _process_severity(const std::shared_ptr<io::data>& d);
   void _process_tag(const std::shared_ptr<io::data>& d);
   void _process_pb_log(const std::shared_ptr<io::data>& d);

--- a/broker/unified_sql/src/stream.cc
+++ b/broker/unified_sql/src/stream.cc
@@ -118,7 +118,9 @@ constexpr void (stream::*const stream::neb_processing_table[])(
     &stream::_process_pb_service_group,
     &stream::_process_pb_service_group_member,
     &stream::_process_pb_host_parent,
-    nullptr  // pb_instance_configuration
+    nullptr,  // pb_instance_configuration
+    &stream::_process_pb_adaptive_service_status,
+    &stream::_process_pb_adaptive_host_status,
 };
 
 constexpr size_t neb_processing_table_size =

--- a/clib/inc/com/centreon/logging/temp_logger.hh
+++ b/clib/inc/com/centreon/logging/temp_logger.hh
@@ -19,7 +19,6 @@
 #ifndef CC_LOGGING_TEMP_LOGGER_HH
 #define CC_LOGGING_TEMP_LOGGER_HH
 
-#include <string>
 #include "com/centreon/logging/engine.hh"
 #include "com/centreon/misc/stringifier.hh"
 

--- a/cmake-vcpkg.sh
+++ b/cmake-vcpkg.sh
@@ -104,6 +104,9 @@ if [ -r /etc/centos-release -o -r /etc/almalinux-release ] ; then
     elif [[ "$maj" == "centos7" ]] ; then
       yum -y install epel-release cmake3
       cmake='cmake3'
+    elif [[ "$maj" == "centos9" ]] ; then
+      dnf config-manager --set-enabled crb
+      dnf -y install epel-release
     else
       dnf -y install cmake
       cmake='cmake'
@@ -145,6 +148,7 @@ if [ -r /etc/centos-release -o -r /etc/almalinux-release ] ; then
     openssl-devel
     libssh2-devel
     libcurl-devel
+    tar
     zlib-devel
   )
   if [[ "$maj" == 'centos8' ]] ; then

--- a/common/engine_conf/state_helper.hh
+++ b/common/engine_conf/state_helper.hh
@@ -23,7 +23,6 @@
 #include <rapidjson/document.h>
 
 #include "common/engine_conf/message_helper.hh"
-#include "common/engine_conf/state.pb.h"
 
 namespace com::centreon::engine::configuration {
 

--- a/engine/enginerpc/engine_impl.cc
+++ b/engine/enginerpc/engine_impl.cc
@@ -22,51 +22,31 @@
 
 #include <boost/asio.hpp>
 
-namespace asio = boost::asio;
-
 #include <absl/strings/str_join.h>
 
 #include <spdlog/common.h>
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/sinks/basic_file_sink.h>
-#include <spdlog/spdlog.h>
 
-#include <rapidjson/document.h>
 
 #include "com/centreon/common/process_stat.hh"
 #include "com/centreon/common/time.hh"
-#include "com/centreon/engine/host.hh"
 
-#include "com/centreon/engine/anomalydetection.hh"
 #include "com/centreon/engine/broker.hh"
 #include "com/centreon/engine/command_manager.hh"
 #include "com/centreon/engine/commands/commands.hh"
 #include "com/centreon/engine/commands/processing.hh"
-#include "com/centreon/engine/comment.hh"
-#include "com/centreon/engine/common.hh"
-#include "com/centreon/engine/contact.hh"
-#include "com/centreon/engine/contactgroup.hh"
-#include "com/centreon/engine/downtimes/downtime.hh"
 #include "com/centreon/engine/downtimes/downtime_finder.hh"
 #include "com/centreon/engine/downtimes/downtime_manager.hh"
 #include "com/centreon/engine/downtimes/service_downtime.hh"
-#include "com/centreon/engine/engine_impl.hh"
 #include "com/centreon/engine/events/loop.hh"
 #include "com/centreon/engine/globals.hh"
-#include "com/centreon/engine/hostdependency.hh"
-#include "com/centreon/engine/hostgroup.hh"
-#include "com/centreon/engine/logging/logger.hh"
-#include "com/centreon/engine/service.hh"
-#include "com/centreon/engine/servicedependency.hh"
-#include "com/centreon/engine/servicegroup.hh"
-#include "com/centreon/engine/statistics.hh"
+#include "com/centreon/engine/severity.hh"
 #include "com/centreon/engine/statusdata.hh"
 #include "com/centreon/engine/string.hh"
 #include "com/centreon/engine/version.hh"
-#include "common/log_v2/log_v2.hh"
 
 using namespace com::centreon::engine;
-using namespace com::centreon::engine::logging;
 using namespace com::centreon::engine::downtimes;
 using namespace com::centreon::engine::string;
 
@@ -944,7 +924,7 @@ grpc::Status engine_impl::RemoveHostAcknowledgement(
     /* set the acknowledgement flag */
     temp_host->set_acknowledgement(AckType::NONE);
     /* update the status log with the host info */
-    temp_host->update_status();
+    temp_host->update_status(host::STATUS_ACKNOWLEDGEMENT);
     /* remove any non-persistant comments associated with the ack */
     comment::delete_host_acknowledgement_comments(temp_host.get());
     return 0;
@@ -984,7 +964,7 @@ grpc::Status engine_impl::RemoveServiceAcknowledgement(
     /* set the acknowledgement flag */
     temp_service->set_acknowledgement(AckType::NONE);
     /* update the status log with the service info */
-    temp_service->update_status();
+    temp_service->update_status(service::STATUS_ACKNOWLEDGEMENT);
     /* remove any non-persistant comments associated with the ack */
     comment::delete_service_acknowledgement_comments(temp_service.get());
     return 0;
@@ -1040,7 +1020,7 @@ grpc::Status engine_impl::AcknowledgementHostProblem(
                         request->ack_data(),
                         notifier::notification_option_none);
     /* update the status log with the host info */
-    temp_host->update_status();
+    temp_host->update_status(host::STATUS_ACKNOWLEDGEMENT);
     /* add a comment for the acknowledgement */
     auto com = std::make_shared<comment>(
         comment::host, comment::acknowledgment, temp_host->host_id(), 0,
@@ -1103,7 +1083,7 @@ grpc::Status engine_impl::AcknowledgementServiceProblem(
                            request->ack_author(), request->ack_data(),
                            notifier::notification_option_none);
     /* update the status log with the service info */
-    temp_service->update_status();
+    temp_service->update_status(service::STATUS_ACKNOWLEDGEMENT);
 
     /* add a comment for the acknowledgement */
     auto com = std::make_shared<comment>(
@@ -1917,7 +1897,7 @@ grpc::Status engine_impl::DeleteServiceDowntimeFull(
     const DowntimeCriterias* request,
     CommandSuccess* response [[maybe_unused]]) {
   std::string err;
-  auto fn = std::packaged_task<int32_t(void)>([&err, request]() -> int32_t {
+  auto fn = std::packaged_task<int32_t(void)>([request]() -> int32_t {
     std::list<service_downtime*> dtlist;
     /* iterate through all current downtime(s) */
     for (auto it = downtimes::downtime_manager::instance()
@@ -2502,8 +2482,7 @@ grpc::Status engine_impl::ChangeHostObjectIntVar(grpc::ServerContext* context
         /* modify the check interval */
         temp_host->set_check_interval(request->dval());
         attr = MODATTR_NORMAL_CHECK_INTERVAL;
-        temp_host->set_modified_attributes(
-            temp_host->get_modified_attributes() | attr);
+        temp_host->add_modified_attributes(attr);
 
         /* schedule a host check if previous interval was 0 (checks were not
          * regularly scheduled) */

--- a/engine/inc/com/centreon/engine/broker.hh
+++ b/engine/inc/com/centreon/engine/broker.hh
@@ -25,7 +25,6 @@
 #include "com/centreon/engine/commands/command.hh"
 #include "com/centreon/engine/comment.hh"
 #include "com/centreon/engine/events/timed_event.hh"
-#include "com/centreon/engine/timeperiod.hh"
 
 /* Event broker options. */
 #define BROKER_NOTHING 0
@@ -454,7 +453,9 @@ int broker_host_check(int type,
                       int check_type,
                       const char* cmdline,
                       char* output);
-void broker_host_status(int type, com::centreon::engine::host* hst);
+void broker_host_status(int type,
+                        com::centreon::engine::host* hst,
+                        uint32_t attributes);
 void broker_log_data(char* data, time_t entry_time);
 int broker_notification_data(int type,
                              int flags,
@@ -484,7 +485,9 @@ int broker_service_check(int type,
                          com::centreon::engine::service* svc,
                          int check_type,
                          const char* cmdline);
-void broker_service_status(int type, com::centreon::engine::service* svc);
+void broker_service_status(int type,
+                           com::centreon::engine::service* svc,
+                           uint32_t attributes);
 void broker_statechange_data(int type,
                              int flags,
                              int attr,

--- a/engine/inc/com/centreon/engine/commands/command.hh
+++ b/engine/inc/com/centreon/engine/commands/command.hh
@@ -20,7 +20,6 @@
 #define CCE_COMMANDS_COMMAND_HH
 
 #include "com/centreon/engine/commands/command_listener.hh"
-#include "com/centreon/engine/commands/result.hh"
 #include "com/centreon/engine/macros/defines.hh"
 
 namespace com::centreon::engine {

--- a/engine/inc/com/centreon/engine/commands/processing.hh
+++ b/engine/inc/com/centreon/engine/commands/processing.hh
@@ -23,10 +23,7 @@
 #include "com/centreon/engine/anomalydetection.hh"
 #include "com/centreon/engine/configuration/applier/state.hh"
 #include "com/centreon/engine/contact.hh"
-#include "com/centreon/engine/contactgroup.hh"
-#include "com/centreon/engine/host.hh"
 #include "com/centreon/engine/hostgroup.hh"
-#include "com/centreon/engine/service.hh"
 #include "com/centreon/engine/servicegroup.hh"
 
 namespace com::centreon::engine {

--- a/engine/inc/com/centreon/engine/common.hh
+++ b/engine/inc/com/centreon/engine/common.hh
@@ -1,24 +1,23 @@
-/*
-** Copyright 1999-2009      Ethan Galstad
-** Copyright 2009-2011      Nagios Core Development Team and Community
-*Contributors
-** Copyright 2011-2013,2016 Centreon
-**
-** This file is part of Centreon Engine.
-**
-** Centreon Engine is free software: you can redistribute it and/or
-** modify it under the terms of the GNU General Public License version 2
-** as published by the Free Software Foundation.
-**
-** Centreon Engine is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-** General Public License for more details.
-**
-** You should have received a copy of the GNU General Public License
-** along with Centreon Engine. If not, see
-** <http://www.gnu.org/licenses/>.
-*/
+/**
+ * Copyright 1999-2009      Ethan Galstad
+ * Copyright 2009-2011      Nagios Core Development Team and Community
+ * Contributors Copyright 2011-2013,2016, 2024 Centreon
+ *
+ * This file is part of Centreon Engine.
+ *
+ * Centreon Engine is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * Centreon Engine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Centreon Engine. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef CCE_COMMON_HH
 #define CCE_COMMON_HH
@@ -291,26 +290,31 @@ enum ret_val {
   8192 /* Max length of an external command. */
 #define MAX_DATETIME_LENGTH 48
 
-/* Modified attributes. */
-#define MODATTR_NONE 0
-#define MODATTR_NOTIFICATIONS_ENABLED (1 << 0)
-#define MODATTR_ACTIVE_CHECKS_ENABLED (1 << 1)
-#define MODATTR_PASSIVE_CHECKS_ENABLED (1 << 2)
-#define MODATTR_EVENT_HANDLER_ENABLED (1 << 3)
-#define MODATTR_FLAP_DETECTION_ENABLED (1 << 4)
-#define MODATTR_FAILURE_PREDICTION_ENABLED (1 << 5)
-#define MODATTR_PERFORMANCE_DATA_ENABLED (1 << 6)
-#define MODATTR_OBSESSIVE_HANDLER_ENABLED (1 << 7)
-#define MODATTR_EVENT_HANDLER_COMMAND (1 << 8)
-#define MODATTR_CHECK_COMMAND (1 << 9)
-#define MODATTR_NORMAL_CHECK_INTERVAL (1 << 10)
-#define MODATTR_RETRY_CHECK_INTERVAL (1 << 11)
-#define MODATTR_MAX_CHECK_ATTEMPTS (1 << 12)
-#define MODATTR_FRESHNESS_CHECKS_ENABLED (1 << 13)
-#define MODATTR_CHECK_TIMEPERIOD (1 << 14)
-#define MODATTR_CUSTOM_VARIABLE (1 << 15)
-#define MODATTR_NOTIFICATION_TIMEPERIOD (1 << 16)
-#define MODATTR_ALL (~0u)
+/* Modified attributes. These attributes are configuration attributes not real
+ * time ones. For example, we have a "modified attributes" field in services
+ * that stores them to know what has been changed in the current configuration,
+ * usually changed through an external command. */
+enum modattr {
+  MODATTR_NONE = 0,
+  MODATTR_NOTIFICATIONS_ENABLED = 1 << 0,
+  MODATTR_ACTIVE_CHECKS_ENABLED = 1 << 1,
+  MODATTR_PASSIVE_CHECKS_ENABLED = 1 << 2,
+  MODATTR_EVENT_HANDLER_ENABLED = 1 << 3,
+  MODATTR_FLAP_DETECTION_ENABLED = 1 << 4,
+  MODATTR_FAILURE_PREDICTION_ENABLED = 1 << 5,
+  MODATTR_PERFORMANCE_DATA_ENABLED = 1 << 6,
+  MODATTR_OBSESSIVE_HANDLER_ENABLED = 1 << 7,
+  MODATTR_EVENT_HANDLER_COMMAND = 1 << 8,
+  MODATTR_CHECK_COMMAND = 1 << 9,
+  MODATTR_NORMAL_CHECK_INTERVAL = 1 << 10,
+  MODATTR_RETRY_CHECK_INTERVAL = 1 << 11,
+  MODATTR_MAX_CHECK_ATTEMPTS = 1 << 12,
+  MODATTR_FRESHNESS_CHECKS_ENABLED = 1 << 13,
+  MODATTR_CHECK_TIMEPERIOD = 1 << 14,
+  MODATTR_CUSTOM_VARIABLE = 1 << 15,
+  MODATTR_NOTIFICATION_TIMEPERIOD = 1 << 16,
+  MODATTR_ALL = ~0u,
+};
 
 /* Default values. */
 #define DEFAULT_ORPHAN_CHECK_INTERVAL \

--- a/engine/inc/com/centreon/engine/downtimes/downtime.hh
+++ b/engine/inc/com/centreon/engine/downtimes/downtime.hh
@@ -22,7 +22,6 @@
 #define CCE_DOWNTIMES_DOWTIME_HH
 
 #include "com/centreon/engine/host.hh"
-#include "com/centreon/engine/service.hh"
 
 namespace com::centreon::engine {
 

--- a/engine/inc/com/centreon/engine/escalation.hh
+++ b/engine/inc/com/centreon/engine/escalation.hh
@@ -18,7 +18,6 @@
 #ifndef CCE_ESCALATION_HH
 #define CCE_ESCALATION_HH
 
-#include "com/centreon/engine/contactgroup.hh"
 #include "com/centreon/engine/notifier.hh"
 #include "com/centreon/engine/shared.hh"
 

--- a/engine/inc/com/centreon/engine/flapping.hh
+++ b/engine/inc/com/centreon/engine/flapping.hh
@@ -22,7 +22,6 @@
 #define CCE_FLAPPING_HH
 
 #include "com/centreon/engine/host.hh"
-#include "com/centreon/engine/service.hh"
 
 // Flapping Types
 #define HOST_FLAPPING 0

--- a/engine/inc/com/centreon/engine/globals.hh
+++ b/engine/inc/com/centreon/engine/globals.hh
@@ -32,7 +32,6 @@
 #ifdef LEGACY_CONF
 #include "common/engine_legacy_conf/state.hh"
 #else
-#include "common/engine_conf/state.pb.h"
 #endif
 #include "common/log_v2/log_v2.hh"
 

--- a/engine/inc/com/centreon/engine/host.hh
+++ b/engine/inc/com/centreon/engine/host.hh
@@ -129,7 +129,7 @@ class host : public notifier {
   void clear_flap(double percent_change,
                   double high_threshold,
                   double low_threshold);
-  void update_status() override;
+  void update_status(uint32_t attributes = STATUS_ALL) override;
   void update_adaptive_data();
   void check_for_expired_acknowledgement();
   //  bool               check_notification_viability(reason_type type,

--- a/engine/inc/com/centreon/engine/macros.hh
+++ b/engine/inc/com/centreon/engine/macros.hh
@@ -24,7 +24,6 @@
 #include "com/centreon/engine/macros/clear_hostgroup.hh"
 #include "com/centreon/engine/macros/clear_service.hh"
 #include "com/centreon/engine/macros/clear_servicegroup.hh"
-#include "com/centreon/engine/macros/defines.hh"
 #include "com/centreon/engine/macros/grab_host.hh"
 #include "com/centreon/engine/macros/grab_service.hh"
 #include "com/centreon/engine/macros/grab_value.hh"

--- a/engine/inc/com/centreon/engine/macros/grab_host.hh
+++ b/engine/inc/com/centreon/engine/macros/grab_host.hh
@@ -21,7 +21,6 @@
 #ifndef CCE_MACROS_GRAB_HOST_HH
 #define CCE_MACROS_GRAB_HOST_HH
 
-#include "com/centreon/engine/host.hh"
 #include "com/centreon/engine/macros/defines.hh"
 
 #ifdef __cplusplus

--- a/engine/inc/com/centreon/engine/macros/grab_service.hh
+++ b/engine/inc/com/centreon/engine/macros/grab_service.hh
@@ -22,7 +22,6 @@
 #define CCE_MACROS_GRAB_SERVICE_HH
 
 #include "com/centreon/engine/macros/defines.hh"
-#include "com/centreon/engine/service.hh"
 
 #ifdef __cplusplus
 extern "C" {

--- a/engine/inc/com/centreon/engine/nebstructs.hh
+++ b/engine/inc/com/centreon/engine/nebstructs.hh
@@ -22,8 +22,6 @@
 #define CCE_NEBSTRUCTS_HH
 
 #include "com/centreon/engine/comment.hh"
-#include "com/centreon/engine/host.hh"
-#include "com/centreon/engine/service.hh"
 
 /* Acknowledgement structure. */
 typedef struct nebstruct_acknowledgement_struct {
@@ -187,6 +185,7 @@ typedef struct nebstruct_host_check_struct {
 typedef struct nebstruct_host_status_struct {
   int type;
   void* object_ptr;
+  uint32_t attributes;
 } nebstruct_host_status_data;
 
 /* Log data structure. */
@@ -248,6 +247,7 @@ typedef struct nebstruct_service_check_struct {
 typedef struct nebstruct_service_status_struct {
   int type;
   void* object_ptr;
+  uint32_t attributes;
 } nebstruct_service_status_data;
 
 typedef struct nebstruct_bench_struct {

--- a/engine/inc/com/centreon/engine/notifier.hh
+++ b/engine/inc/com/centreon/engine/notifier.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Centreon (https://www.centreon.com/)
+ * Copyright 2019-2024 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,15 @@ using AckType = com::centreon::broker::AckType;
 
 class notifier : public checkable {
  public:
+  /* Status attributes. Used as argument in the notifier::update_status(). */
+  enum status_attribute {
+    STATUS_NONE = 0,
+    STATUS_DOWNTIME_DEPTH = 1 << 0,
+    STATUS_NOTIFICATION_NUMBER = 1 << 1,
+    STATUS_ACKNOWLEDGEMENT = 1 << 2,
+    STATUS_ALL = ~0u,
+  };
+
   enum notification_category {
     cat_normal,
     cat_recovery,
@@ -173,7 +182,14 @@ class notifier : public checkable {
   virtual bool schedule_check(time_t check_time,
                               uint32_t options,
                               bool no_update_status_now) = 0;
-  virtual void update_status() = 0;
+
+  /**
+   * @brief Update the status of the notifier partially. attributes is a bits
+   * field based on enum status_attribute specifying what has to be updated.
+   *
+   * @param attributes A bits field based on enum status_attribute.
+   */
+  virtual void update_status(uint32_t attributes) = 0;
   int notify(reason_type type,
              std::string const& not_author,
              std::string const& not_data,

--- a/engine/inc/com/centreon/engine/objects.hh
+++ b/engine/inc/com/centreon/engine/objects.hh
@@ -22,13 +22,11 @@
 #define CCE_OBJECTS_HH
 #include "com/centreon/engine/anomalydetection.hh"
 #include "com/centreon/engine/comment.hh"
-#include "com/centreon/engine/daterange.hh"
 #include "com/centreon/engine/downtimes/downtime.hh"
 #include "com/centreon/engine/hostdependency.hh"
 #include "com/centreon/engine/hostescalation.hh"
 #include "com/centreon/engine/hostgroup.hh"
 #include "com/centreon/engine/servicedependency.hh"
 #include "com/centreon/engine/serviceescalation.hh"
-#include "com/centreon/engine/timerange.hh"
 
 #endif /* !CCE_OBJECTS_HH */

--- a/engine/inc/com/centreon/engine/sehandlers.hh
+++ b/engine/inc/com/centreon/engine/sehandlers.hh
@@ -21,9 +21,7 @@
 #ifndef CCE_SEHANDLERS_HH
 #define CCE_SEHANDLERS_HH
 
-#include "com/centreon/engine/host.hh"
 #include "com/centreon/engine/macros/defines.hh"
-#include "com/centreon/engine/service.hh"
 
 // Event Handler Types
 #define HOST_EVENTHANDLER 0

--- a/engine/inc/com/centreon/engine/service.hh
+++ b/engine/inc/com/centreon/engine/service.hh
@@ -20,7 +20,6 @@
 #define CCE_SERVICE_HH
 
 #include "com/centreon/engine/check_result.hh"
-#include "com/centreon/engine/common.hh"
 #include "com/centreon/engine/hash.hh"
 #include "com/centreon/engine/logging.hh"
 #include "com/centreon/engine/notifier.hh"
@@ -218,7 +217,7 @@ class service : public notifier {
                   double low_threshold);
   void enable_flap_detection();
   void disable_flap_detection();
-  void update_status() override;
+  void update_status(uint32_t status_attributes = STATUS_ALL) override;
   void update_adaptive_data();
   bool verify_check_viability(int check_options,
                               bool* time_is_valid,

--- a/engine/inc/com/centreon/engine/statusdata.hh
+++ b/engine/inc/com/centreon/engine/statusdata.hh
@@ -22,7 +22,6 @@
 #define CCE_STATUSDATA_HH
 
 #include "com/centreon/engine/host.hh"
-#include "com/centreon/engine/service.hh"
 
 #ifdef __cplusplus
 extern "C" {

--- a/engine/inc/com/centreon/engine/utils.hh
+++ b/engine/inc/com/centreon/engine/utils.hh
@@ -21,8 +21,6 @@
 #ifndef CCE_UTILS_HH
 #define CCE_UTILS_HH
 
-#include "com/centreon/engine/check_result.hh"
-#include "com/centreon/engine/daterange.hh"
 #include "com/centreon/engine/macros/defines.hh"
 
 #ifdef __cplusplus

--- a/engine/src/broker.cc
+++ b/engine/src/broker.cc
@@ -742,8 +742,9 @@ int broker_host_check(int type,
  *
  *  @param[in] type      Type.
  *  @param[in] hst       Host.
+ *  @param[in] attributes Attributes from status_attribute enumeration.
  */
-void broker_host_status(int type, host* hst) {
+void broker_host_status(int type, host* hst, uint32_t attributes) {
   // Config check.
 #ifdef LEGACY_CONF
   if (!(config->event_broker_options() & BROKER_STATUS_DATA))
@@ -757,6 +758,7 @@ void broker_host_status(int type, host* hst) {
   nebstruct_host_status_data ds;
   ds.type = type;
   ds.object_ptr = hst;
+  ds.attributes = attributes;
 
   // Make callbacks.
   neb_make_callbacks(NEBCALLBACK_HOST_STATUS_DATA, &ds);
@@ -998,8 +1000,11 @@ int broker_service_check(int type,
  *
  *  @param[in] type      Type.
  *  @param[in] svc       Target service.
+ *  @param[in] attributes Attributes from status_attribute enumeration.
  */
-void broker_service_status(int type, com::centreon::engine::service* svc) {
+void broker_service_status(int type,
+                           com::centreon::engine::service* svc,
+                           uint32_t attributes) {
   // Config check.
 #ifdef LEGACY_CONF
   if (!(config->event_broker_options() & BROKER_STATUS_DATA))
@@ -1013,6 +1018,7 @@ void broker_service_status(int type, com::centreon::engine::service* svc) {
   nebstruct_service_status_data ds;
   ds.type = type;
   ds.object_ptr = svc;
+  ds.attributes = attributes;
 
   // Make callbacks.
   neb_make_callbacks(NEBCALLBACK_SERVICE_STATUS_DATA, &ds);

--- a/engine/src/commands/commands.cc
+++ b/engine/src/commands/commands.cc
@@ -1,6 +1,6 @@
 /**
  * Copyright 1999-2008           Ethan Galstad
- * Copyright 2011-2013,2015-2022 Centreon
+ * Copyright 2011-2013,2015-2024 Centreon
  *
  * This file is part of Centreon Engine.
  *
@@ -26,9 +26,7 @@
 #include "com/centreon/engine/broker.hh"
 #include "com/centreon/engine/checks/checker.hh"
 #include "com/centreon/engine/commands/processing.hh"
-#include "com/centreon/engine/comment.hh"
-#include "com/centreon/engine/configuration/applier/state.hh"
-#include "com/centreon/engine/downtimes/downtime.hh"
+#include "com/centreon/engine/common.hh"
 #include "com/centreon/engine/downtimes/downtime_finder.hh"
 #include "com/centreon/engine/downtimes/downtime_manager.hh"
 #include "com/centreon/engine/events/loop.hh"
@@ -553,8 +551,7 @@ int cmd_process_service_check_result(int cmd [[maybe_unused]],
     runtime_logger->warn(
         "Warning:  Passive check result was received for service '{}' on host "
         "'{}', but the host could not be found!",
-        fmt::string_view(svc_description.data(), svc_description.size()),
-        fmt::string_view(host_name.data(), host_name.size()));
+        svc_description, host_name);
     return ERROR;
   }
 
@@ -2678,7 +2675,7 @@ void acknowledge_host_problem(host* hst,
                 notifier::notification_option_none);
 
   /* update the status log with the host info */
-  hst->update_status();
+  hst->update_status(host::STATUS_ACKNOWLEDGEMENT);
 
   /* add a comment for the acknowledgement */
   auto com{std::make_shared<comment>(
@@ -2719,7 +2716,7 @@ void acknowledge_service_problem(service* svc,
                 notifier::notification_option_none);
 
   /* update the status log with the service info */
-  svc->update_status();
+  svc->update_status(service::STATUS_ACKNOWLEDGEMENT);
 
   /* add a comment for the acknowledgement */
   auto com{std::make_shared<comment>(
@@ -2735,7 +2732,7 @@ void remove_host_acknowledgement(host* hst) {
   hst->set_acknowledgement(AckType::NONE);
 
   /* update the status log with the host info */
-  hst->update_status();
+  hst->update_status(host::STATUS_ACKNOWLEDGEMENT);
 
   /* remove any non-persistant comments associated with the ack */
   comment::delete_host_acknowledgement_comments(hst);
@@ -2747,7 +2744,7 @@ void remove_service_acknowledgement(service* svc) {
   svc->set_acknowledgement(AckType::NONE);
 
   /* update the status log with the service info */
-  svc->update_status();
+  svc->update_status(host::STATUS_ACKNOWLEDGEMENT);
 
   /* remove any non-persistant comments associated with the ack */
   comment::delete_service_acknowledgement_comments(svc);
@@ -2863,7 +2860,8 @@ void stop_accepting_passive_service_checks(void) {
 #ifdef LEGACY_CONF
   bool accept_passive_service_checks = config->accept_passive_service_checks();
 #else
-  bool accept_passive_service_checks = pb_config.accept_passive_service_checks();
+  bool accept_passive_service_checks =
+      pb_config.accept_passive_service_checks();
 #endif
 
   /* bail out if we're already not accepting passive services */

--- a/engine/src/downtimes/host_downtime.cc
+++ b/engine/src/downtimes/host_downtime.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Centreon (https://www.centreon.com/)
+ * Copyright 2019-2024 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 #include "com/centreon/engine/downtimes/host_downtime.hh"
 #include "com/centreon/engine/broker.hh"
-#include "com/centreon/engine/comment.hh"
+#include "com/centreon/engine/common.hh"
 #include "com/centreon/engine/configuration/applier/state.hh"
 #include "com/centreon/engine/downtimes/downtime_manager.hh"
 #include "com/centreon/engine/events/loop.hh"
@@ -468,7 +468,7 @@ int host_downtime::handle() {
 
     /* update the status data */
     /* Because of the notification the status is sent with CHECK_RESULT level */
-    it_hst->second->update_status();
+    it_hst->second->update_status(host::STATUS_DOWNTIME_DEPTH);
 
     /* schedule an event */
     if (!is_fixed())

--- a/engine/src/downtimes/service_downtime.cc
+++ b/engine/src/downtimes/service_downtime.cc
@@ -20,7 +20,7 @@
 #include "com/centreon/engine/downtimes/service_downtime.hh"
 
 #include "com/centreon/engine/broker.hh"
-#include "com/centreon/engine/comment.hh"
+#include "com/centreon/engine/common.hh"
 #include "com/centreon/engine/configuration/applier/state.hh"
 #include "com/centreon/engine/downtimes/downtime_manager.hh"
 #include "com/centreon/engine/events/loop.hh"
@@ -186,7 +186,7 @@ int service_downtime::unschedule() {
         get_triggered_by(), get_duration(), get_downtime_id(), nullptr);
 
     found->second->dec_scheduled_downtime_depth();
-    found->second->update_status();
+    found->second->update_status(service::STATUS_DOWNTIME_DEPTH);
 
     /* log a notice - this is parsed by the history CGI */
     if (found->second->get_scheduled_downtime_depth() == 0) {
@@ -485,8 +485,7 @@ int service_downtime::handle() {
       SPDLOG_LOGGER_INFO(
           events_logger,
           "SERVICE DOWNTIME ALERT: {};{};STARTED; Service has entered a period "
-          "of scheduled "
-          "downtime",
+          "of scheduled downtime",
           found->second->get_hostname(), found->second->description());
 
       /* send a notification */
@@ -502,7 +501,7 @@ int service_downtime::handle() {
 
     /* update the status data */
     /* Because of the notification the status is sent with CHECK_RESULT level */
-    found->second->update_status();
+    found->second->update_status(service::STATUS_DOWNTIME_DEPTH);
 
     /* schedule an event */
     if (!is_fixed())

--- a/engine/src/events/loop.cc
+++ b/engine/src/events/loop.cc
@@ -2,7 +2,7 @@
  * Copyright 1999-2009 Ethan Galstad
  * Copyright 2009-2010 Nagios Core Development Team and Community Contributors
  * Copyright 2011-2013 Merethis
- * Copyright 2013-2022 Centreon
+ * Copyright 2013-2024 Centreon
  *
  * This file is part of Centreon Engine.
  *
@@ -21,9 +21,7 @@
  */
 
 #include "com/centreon/engine/events/loop.hh"
-#include <chrono>
 #include <future>
-#include <thread>
 #include "com/centreon/engine/broker.hh"
 #include "com/centreon/engine/command_manager.hh"
 #include "com/centreon/engine/configuration/applier/state.hh"
@@ -31,7 +29,6 @@
 #include "com/centreon/engine/globals.hh"
 #include "com/centreon/engine/logging/logger.hh"
 #include "com/centreon/engine/statusdata.hh"
-#include "com/centreon/logging/engine.hh"
 #ifdef LEGACY_CONF
 #include "common/engine_legacy_conf/parser.hh"
 #else
@@ -373,7 +370,7 @@ void loop::_dispatching() {
             else
               temp_service->set_next_check(
                   (time_t)(temp_service->get_next_check() +
-                           (temp_service->check_interval() * interval_length)));
+                           temp_service->check_interval() * interval_length));
           }
           temp_event->run_time = temp_service->get_next_check();
           reschedule_event(std::move(temp_event), events::loop::low);

--- a/engine/src/host.cc
+++ b/engine/src/host.cc
@@ -16,14 +16,13 @@
  * For more information : contact@centreon.com
  */
 
-#include "com/centreon/engine/host.hh"
 #include <cassert>
 
 #include <fmt/chrono.h>
 
 #include "com/centreon/engine/broker.hh"
-#include "com/centreon/engine/checkable.hh"
 #include "com/centreon/engine/checks/checker.hh"
+#include "com/centreon/engine/common.hh"
 #include "com/centreon/engine/configuration/applier/state.hh"
 #include "com/centreon/engine/configuration/whitelist.hh"
 #include "com/centreon/engine/downtimes/downtime_manager.hh"
@@ -31,15 +30,12 @@
 #include "com/centreon/engine/exceptions/error.hh"
 #include "com/centreon/engine/flapping.hh"
 #include "com/centreon/engine/globals.hh"
-#include "com/centreon/engine/logging.hh"
 #include "com/centreon/engine/logging/logger.hh"
 #include "com/centreon/engine/macros.hh"
-#include "com/centreon/engine/macros/grab_host.hh"
 #include "com/centreon/engine/neberrors.hh"
 #include "com/centreon/engine/notification.hh"
 #include "com/centreon/engine/objects.hh"
 #include "com/centreon/engine/sehandlers.hh"
-#include "com/centreon/engine/shared.hh"
 #include "com/centreon/engine/statusdata.hh"
 #include "com/centreon/engine/string.hh"
 #include "com/centreon/engine/timezone_locker.hh"
@@ -2319,9 +2315,12 @@ void host::clear_flap(double percent_change,
 
 /**
  * @brief Updates host status info. Data are sent to event broker.
+ *
+ * @param attributes A bits field based on status_attribute enum (default value:
+ * STATUS_ALL).
  */
-void host::update_status() {
-  broker_host_status(NEBTYPE_HOSTSTATUS_UPDATE, this);
+void host::update_status(uint32_t attributes) {
+  broker_host_status(NEBTYPE_HOSTSTATUS_UPDATE, this, attributes);
 }
 
 /**
@@ -2338,7 +2337,7 @@ void host::check_for_expired_acknowledgement() {
         SPDLOG_LOGGER_INFO(events_logger,
                            "Acknowledgement of host '{}' just expired", name());
         set_acknowledgement(AckType::NONE);
-        update_status();
+        update_status(STATUS_ACKNOWLEDGEMENT);
       }
     }
   }
@@ -2855,7 +2854,8 @@ void host::enable_flap_detection() {
   check_for_flapping(false, false, true);
 
   /* update host status */
-  update_status();
+  /* FIXME DBO: seems not necessary */
+  // update_status();
 }
 
 /*

--- a/engine/src/notifier.cc
+++ b/engine/src/notifier.cc
@@ -16,7 +16,6 @@
  * For more information : contact@centreon.com
  *
  */
-#include "com/centreon/engine/notifier.hh"
 
 #include "com/centreon/engine/broker.hh"
 #include "com/centreon/engine/checks/checker.hh"
@@ -30,7 +29,6 @@
 #include "com/centreon/engine/neberrors.hh"
 #include "com/centreon/engine/notification.hh"
 #include "com/centreon/engine/timezone_locker.hh"
-#include "com/centreon/engine/utils.hh"
 
 using namespace com::centreon::engine;
 using namespace com::centreon::engine::logging;
@@ -206,7 +204,7 @@ void notifier::set_last_problem_id(unsigned long last_problem_id) noexcept {
 }
 
 /**
- * @brief Set the current notification number and update the notifier status.
+ * @brief Set the current notification number and send this update to Broker.
  *
  * @param num The notification number.
  */
@@ -218,7 +216,7 @@ void notifier::set_notification_number(int num) {
   _notification_number = num;
 
   /* update the status log with the notifier info */
-  update_status();
+  update_status(STATUS_NOTIFICATION_NUMBER);
 }
 
 bool notifier::_is_notification_viable_normal(reason_type type

--- a/engine/src/service.cc
+++ b/engine/src/service.cc
@@ -17,12 +17,10 @@
  *
  */
 
-#include "com/centreon/engine/service.hh"
 
 #include <absl/strings/match.h>
 
 #include "com/centreon/engine/broker.hh"
-#include "com/centreon/engine/checkable.hh"
 #include "com/centreon/engine/checks/checker.hh"
 #include "com/centreon/engine/configuration/whitelist.hh"
 #include "com/centreon/engine/deleter/listmember.hh"
@@ -31,11 +29,8 @@
 #include "com/centreon/engine/exceptions/error.hh"
 #include "com/centreon/engine/flapping.hh"
 #include "com/centreon/engine/globals.hh"
-#include "com/centreon/engine/hostdependency.hh"
-#include "com/centreon/engine/logging.hh"
 #include "com/centreon/engine/logging/logger.hh"
 #include "com/centreon/engine/macros.hh"
-#include "com/centreon/engine/macros/grab_host.hh"
 #include "com/centreon/engine/neberrors.hh"
 #include "com/centreon/engine/notification.hh"
 #include "com/centreon/engine/objects.hh"
@@ -848,7 +843,7 @@ void service::check_for_expired_acknowledgement() {
         // FIXME DBO: could be improved with something smaller.
         // We will see later, I don't know if there are many events concerning
         // acks.
-        update_status();
+        update_status(STATUS_ACKNOWLEDGEMENT);
       }
     }
   }
@@ -3169,10 +3164,13 @@ void service::disable_flap_detection() {
 }
 
 /**
- * @brief Updates service status info. Send data to event broker.
+ * @brief Updates the status of the service partially.
+ *
+ * @param status_attributes A bits field based on status_attribute enum (default
+ * value: STATUS_ALL).
  */
-void service::update_status() {
-  broker_service_status(NEBTYPE_SERVICESTATUS_UPDATE, this);
+void service::update_status(uint32_t status_attributes) {
+  broker_service_status(NEBTYPE_SERVICESTATUS_UPDATE, this, status_attributes);
 }
 
 /**

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,26 +13,37 @@ These tests are executed from the `centreon-tests/robot` folder and uses the [Ro
 
 From a Centreon host, you need to install Robot Framework
 
-On CentOS 7, the following commands should work to initialize your robot tests:
+On AlmaLinux, the following commands should work to initialize your robot tests:
 
-```
-pip3 install -U robotframework robotframework-databaselibrary robotframework-examples pymysql robotframework-requests
+```bash
+dnf install "Development Tools" python3-devel -y
 
-yum install "Development Tools" python3-devel -y
+pip3 install -U robotframework         robotframework-databaselibrary         robotframework-examples pymysql         robotframework-requests psutil         robotframework-httpctrl boto3         GitPython unqlite py-cpuinfo
 
-pip3 install grpcio==1.33.2 grpcio_tools==1.33.2
+
+pip3 install grpcio grpcio_tools
 
 #you need also to provide opentelemetry proto files at the project root with this command
 git clone https://github.com/open-telemetry/opentelemetry-proto.git opentelemetry-proto
-          
+
 #Then you must have something like that:
 #root directory/bbdo
 #              /broker
 #              /engine
 #              /opentelemetry-proto
 #              /tests
+```
 
+We need some perl modules to run the tests, you can install them with the following command:
 
+```bash
+dnf install perl-HTTP-Daemon-SSL
+dnf install perl-JSON
+```
+
+Then you can initialize the tests with the following commands:
+
+```bash
 ./init-proto.sh
 ./init-sql.sh
 ```
@@ -250,268 +261,276 @@ Here is the list of the currently implemented tests:
 39. [x] **BEDTHOSTFIXED**: A downtime is set on a host, the total number of downtimes is really 21 (1 for the host and 20 for its 20 services) then we delete this downtime and the number is 0.
 40. [x] **BEDTMASS1**: New services with several pollers are created. Then downtimes are set on all configured hosts. This action results on 1050 downtimes if we also count impacted services. Then all these downtimes are removed. This test is done with BBDO 3.0.0
 41. [x] **BEDTMASS2**: New services with several pollers are created. Then downtimes are set on all configured hosts. This action results on 1050 downtimes if we also count impacted services. Then all these downtimes are removed. This test is done with BBDO 2.0
-42. [x] **BEDTSVCFIXED**: A downtime is set on a service, the total number of downtimes is really 1 then we delete this downtime and the number of downtime is 0.
-43. [x] **BEDTSVCREN1**: A downtime is set on a service then the service is renamed. The downtime is still active on the renamed service. The downtime is removed from the renamed service and it is well removed.
-44. [x] **BEEXTCMD1**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo3.0
-45. [x] **BEEXTCMD10**: external command CHANGE_MAX_SVC_CHECK_ATTEMPTS on bbdo2.0
-46. [x] **BEEXTCMD11**: external command CHANGE_MAX_HOST_CHECK_ATTEMPTS on bbdo3.0
-47. [x] **BEEXTCMD12**: external command CHANGE_MAX_HOST_CHECK_ATTEMPTS on bbdo2.0
-48. [x] **BEEXTCMD13**: external command CHANGE_HOST_CHECK_TIMEPERIOD on bbdo3.0
-49. [x] **BEEXTCMD14**: external command CHANGE_HOST_CHECK_TIMEPERIOD on bbdo2.0
-50. [x] **BEEXTCMD15**: external command CHANGE_HOST_NOTIFICATION_TIMEPERIOD on bbdo3.0
-51. [x] **BEEXTCMD16**: external command CHANGE_HOST_NOTIFICATION_TIMEPERIOD on bbdo2.0
-52. [x] **BEEXTCMD17**: external command CHANGE_SVC_CHECK_TIMEPERIOD on bbdo3.0
-53. [x] **BEEXTCMD18**: external command CHANGE_SVC_CHECK_TIMEPERIOD on bbdo2.0
-54. [x] **BEEXTCMD19**: external command CHANGE_SVC_NOTIFICATION_TIMEPERIOD on bbdo3.0
-55. [x] **BEEXTCMD2**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo2.0
-56. [x] **BEEXTCMD20**: external command CHANGE_SVC_NOTIFICATION_TIMEPERIOD on bbdo2.0
-57. [x] **BEEXTCMD21**: external command DISABLE_HOST_AND_CHILD_NOTIFICATIONS and ENABLE_HOST_AND_CHILD_NOTIFICATIONS on bbdo3.0
-58. [x] **BEEXTCMD22**: external command DISABLE_HOST_AND_CHILD_NOTIFICATIONS and ENABLE_HOST_AND_CHILD_NOTIFICATIONS on bbdo2.0
-59. [x] **BEEXTCMD23**: external command DISABLE_HOST_CHECK and ENABLE_HOST_CHECK on bbdo3.0
-60. [x] **BEEXTCMD24**: external command DISABLE_HOST_CHECK and ENABLE_HOST_CHECK on bbdo2.0
-61. [x] **BEEXTCMD25**: external command DISABLE_HOST_EVENT_HANDLER and ENABLE_HOST_EVENT_HANDLER on bbdo3.0
-62. [x] **BEEXTCMD26**: external command DISABLE_HOST_EVENT_HANDLER and ENABLE_HOST_EVENT_HANDLER on bbdo2.0
-63. [x] **BEEXTCMD27**: external command DISABLE_HOST_FLAP_DETECTION and ENABLE_HOST_FLAP_DETECTION on bbdo3.0
-64. [x] **BEEXTCMD28**: external command DISABLE_HOST_FLAP_DETECTION and ENABLE_HOST_FLAP_DETECTION on bbdo2.0
-65. [x] **BEEXTCMD29**: external command DISABLE_HOST_NOTIFICATIONS and ENABLE_HOST_NOTIFICATIONS on bbdo3.0
-66. [x] **BEEXTCMD3**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo3.0
-67. [x] **BEEXTCMD30**: external command DISABLE_HOST_NOTIFICATIONS and ENABLE_HOST_NOTIFICATIONS on bbdo2.0
-68. [x] **BEEXTCMD31**: external command DISABLE_HOST_SVC_CHECKS and ENABLE_HOST_SVC_CHECKS on bbdo3.0
-69. [x] **BEEXTCMD32**: external command DISABLE_HOST_SVC_CHECKS and ENABLE_HOST_SVC_CHECKS on bbdo2.0
-70. [x] **BEEXTCMD33**: external command DISABLE_HOST_SVC_NOTIFICATIONS and ENABLE_HOST_SVC_NOTIFICATIONS on bbdo3.0
-71. [x] **BEEXTCMD34**: external command DISABLE_HOST_SVC_NOTIFICATIONS and ENABLE_HOST_SVC_NOTIFICATIONS on bbdo2.0
-72. [x] **BEEXTCMD35**: external command DISABLE_PASSIVE_HOST_CHECKS and ENABLE_PASSIVE_HOST_CHECKS on bbdo3.0
-73. [x] **BEEXTCMD36**: external command DISABLE_PASSIVE_HOST_CHECKS and ENABLE_PASSIVE_HOST_CHECKS on bbdo2.0
-74. [x] **BEEXTCMD37**: external command DISABLE_PASSIVE_SVC_CHECKS and ENABLE_PASSIVE_SVC_CHECKS on bbdo3.0
-75. [x] **BEEXTCMD38**: external command DISABLE_PASSIVE_SVC_CHECKS and ENABLE_PASSIVE_SVC_CHECKS on bbdo2.0
-76. [x] **BEEXTCMD39**: external command START_OBSESSING_OVER_HOST and STOP_OBSESSING_OVER_HOST on bbdo3.0
-77. [x] **BEEXTCMD4**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo2.0
-78. [x] **BEEXTCMD40**: external command START_OBSESSING_OVER_HOST and STOP_OBSESSING_OVER_HOST on bbdo2.0
-79. [x] **BEEXTCMD41**: external command START_OBSESSING_OVER_SVC and STOP_OBSESSING_OVER_SVC on bbdo3.0
-80. [x] **BEEXTCMD42**: external command START_OBSESSING_OVER_SVC and STOP_OBSESSING_OVER_SVC on bbdo2.0
-81. [x] **BEEXTCMD5**: external command CHANGE_RETRY_SVC_CHECK_INTERVAL on bbdo3.0
-82. [x] **BEEXTCMD6**: external command CHANGE_RETRY_SVC_CHECK_INTERVAL on bbdo2.0
-83. [x] **BEEXTCMD7**: external command CHANGE_RETRY_HOST_CHECK_INTERVAL on bbdo3.0
-84. [x] **BEEXTCMD8**: external command CHANGE_RETRY_HOST_CHECK_INTERVAL on bbdo2.0
-85. [x] **BEEXTCMD9**: external command CHANGE_MAX_SVC_CHECK_ATTEMPTS on bbdo3.0
-86. [x] **BEEXTCMD_COMPRESS_GRPC1**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo3.0 and compressed grpc
-87. [x] **BEEXTCMD_GRPC1**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo3.0 and grpc
-88. [x] **BEEXTCMD_GRPC2**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo2.0 and grpc
-89. [x] **BEEXTCMD_GRPC3**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo3.0 and grpc
-90. [x] **BEEXTCMD_GRPC4**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo2.0 and grpc
-91. [x] **BEEXTCMD_REVERSE_GRPC1**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo3.0 and reversed gRPC
-92. [x] **BEEXTCMD_REVERSE_GRPC2**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo2.0 and grpc reversed
-93. [x] **BEEXTCMD_REVERSE_GRPC3**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo3.0 and grpc reversed
-94. [x] **BEEXTCMD_REVERSE_GRPC4**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo2.0 and grpc reversed
-95. [x] **BEHOSTCHECK**: external command CHECK_HOST_RESULT
-96. [x] **BEHS1**: store_in_resources is enabled and store_in_hosts_services is not. Only writes into resources should be done (except hosts/services events that continue to be written in hosts/services tables)
-97. [x] **BEINSTANCE**: Instance to bdd
-98. [x] **BEINSTANCESTATUS**: Instance status to bdd
-99. [x] **BENCH_${nb_checks}STATUS**: external command CHECK_SERVICE_RESULT 1000 times
-100. [x] **BENCH_${nb_checks}STATUS_TRACES**: external command CHECK_SERVICE_RESULT ${nb_checks} times
-101. [x] **BENCH_${nb_checks}_REVERSE_SERVICE_STATUS_TRACES_WITHOUT_SQL**: Broker is configured without SQL output. The connection between Engine and Broker is reversed. External command CHECK_SERVICE_RESULT is sent ${nb_checks} times. Logs are in trace level.
-102. [x] **BENCH_${nb_checks}_REVERSE_SERVICE_STATUS_WITHOUT_SQL**: Broker is configured without SQL output. The connection between Engine and Broker is reversed. External command CHECK_SERVICE_RESULT is sent ${nb_checks} times.
-103. [x] **BENCH_${nb_checks}_SERVICE_STATUS_TRACES_WITHOUT_SQL**: Broker is configured without SQL output. External command CHECK_SERVICE_RESULT is sent ${nb_checks} times. Logs are in trace level.
-104. [x] **BENCH_${nb_checks}_SERVICE_STATUS_WITHOUT_SQL**: Broker is configured without SQL output. External command CHECK_SERVICE_RESULT is sent ${nb_checks} times.
-105. [x] **BENCH_1000STATUS_100${suffixe}**: external command CHECK_SERVICE_RESULT 100 times    with 100 pollers with 20 services
-106. [x] **BEOTEL_CENTREON_AGENT_CHECK_HOST**: agent check host and we expect to get it in check result
-107. [x] **BEOTEL_CENTREON_AGENT_CHECK_HOST_CRYPTED**: agent check host with encrypted connection and we expect to get it in check result
-108. [x] **BEOTEL_CENTREON_AGENT_CHECK_SERVICE**: agent check service and we expect to get it in check result
-109. [x] **BEOTEL_REVERSE_CENTREON_AGENT_CHECK_HOST**: agent check host with reversed connection and we expect to get it in check result
-110. [x] **BEOTEL_REVERSE_CENTREON_AGENT_CHECK_HOST_CRYPTED**: agent check host with encrypted reversed connection and we expect to get it in check result
-111. [x] **BEOTEL_REVERSE_CENTREON_AGENT_CHECK_SERVICE**: agent check service with reversed connection and we expect to get it in check result
-112. [x] **BEOTEL_SERVE_TELEGRAF_CONFIGURATION_CRYPTED**: we configure engine with a telegraf conf server and we check telegraf conf file
-113. [x] **BEOTEL_SERVE_TELEGRAF_CONFIGURATION_NO_CRYPTED**: we configure engine with a telegraf conf server and we check telegraf conf file
-114. [x] **BEOTEL_TELEGRAF_CHECK_HOST**: we send nagios telegraf formatted datas and we expect to get it in check result
-115. [x] **BEOTEL_TELEGRAF_CHECK_SERVICE**: we send nagios telegraf formatted datas and we expect to get it in check result
-116. [x] **BEPBBEE1**: central-module configured with bbdo_version 3.0 but not others. Unable to establish connection.
-117. [x] **BEPBBEE2**: bbdo_version 3 not compatible with sql/storage
-118. [x] **BEPBBEE3**: bbdo_version 3 generates new bbdo protobuf service status messages.
-119. [x] **BEPBBEE4**: bbdo_version 3 generates new bbdo protobuf host status messages.
-120. [x] **BEPBBEE5**: bbdo_version 3 generates new bbdo protobuf service messages.
-121. [x] **BEPBCVS**: bbdo_version 3 communication of custom variables.
-122. [x] **BEPBHostParent**: bbdo_version 3 communication of host parent relations
-123. [x] **BEPBINST_CONF**: bbdo_version 3 communication of instance configuration.
-124. [x] **BEPBRI1**: bbdo_version 3 use pb_resource new bbdo protobuf ResponsiveInstance message.
-125. [x] **BERD1**: Starting/stopping Broker does not create duplicated events.
-126. [x] **BERD2**: Starting/stopping Engine does not create duplicated events.
-127. [x] **BERDUC1**: Starting/stopping Broker does not create duplicated events in usual cases
-128. [x] **BERDUC2**: Starting/stopping Engine does not create duplicated events in usual cases
-129. [x] **BERDUC3U1**: Starting/stopping Broker does not create duplicated events in usual cases with unified_sql and BBDO 3.0
-130. [x] **BERDUC3U2**: Starting/stopping Engine does not create duplicated events in usual cases with unified_sql and BBDO 3.0
-131. [x] **BERDUCA300**: Starting/stopping Engine is stopped ; it should emit a stop event and receive an ack event with events to clean from broker.
-132. [x] **BERDUCA301**: Starting/stopping Engine is stopped ; it should emit a stop event and receive an ack event with events to clean from broker with bbdo 3.0.1.
-133. [x] **BERDUCU1**: Starting/stopping Broker does not create duplicated events in usual cases with unified_sql
-134. [x] **BERDUCU2**: Starting/stopping Engine does not create duplicated events in usual cases with unified_sql
-135. [x] **BERES1**: store_in_resources is enabled and store_in_hosts_services is not. Only writes into resources should be done (except hosts/services events that continue to be written in hosts/services tables)
-136. [x] **BESERVCHECK**: external command CHECK_SERVICE_RESULT
-137. [x] **BESS1**: Start-Stop Broker/Engine - Broker started first - Broker stopped first
-138. [x] **BESS2**: Start-Stop Broker/Engine - Broker started first - Engine stopped first
-139. [x] **BESS2U**: Start-Stop Broker/Engine - Broker started first - Engine stopped first. Unified_sql is used.
-140. [x] **BESS3**: Start-Stop Broker/Engine - Engine started first - Engine stopped first
-141. [x] **BESS4**: Start-Stop Broker/Engine - Engine started first - Broker stopped first
-142. [x] **BESS5**: Start-Stop Broker/engine - Engine debug level is set to all, it should not hang
-143. [x] **BESSBQ1**: A very bad queue file is written for broker. Broker and Engine are then started, Broker must read the file raising an error because of that file and then get data sent by Engine.
-144. [x] **BESS_CRYPTED_GRPC1**: Start-Stop grpc version Broker/Engine - well configured
-145. [x] **BESS_CRYPTED_GRPC2**: Start-Stop grpc version Broker/Engine only server crypted
-146. [x] **BESS_CRYPTED_GRPC3**: Start-Stop grpc version Broker/Engine only engine crypted
-147. [x] **BESS_CRYPTED_REVERSED_GRPC1**: Start-Stop grpc version Broker/Engine - well configured
-148. [x] **BESS_CRYPTED_REVERSED_GRPC2**: Start-Stop grpc version Broker/Engine only engine server crypted
-149. [x] **BESS_CRYPTED_REVERSED_GRPC3**: Start-Stop grpc version Broker/Engine only engine crypted
-150. [x] **BESS_ENGINE_DELETE_HOST**: once engine and cbd started, stop and restart cbd, delete an host and reload engine, cbd mustn't core
-151. [x] **BESS_GRPC1**: Start-Stop grpc version Broker/Engine - Broker started first - Broker stopped first
-152. [x] **BESS_GRPC2**: Start-Stop grpc version Broker/Engine - Broker started first - Engine stopped first
-153. [x] **BESS_GRPC3**: Start-Stop grpc version Broker/Engine - Engine started first - Engine stopped first
-154. [x] **BESS_GRPC4**: Start-Stop grpc version Broker/Engine - Engine started first - Broker stopped first
-155. [x] **BESS_GRPC5**: Start-Stop grpc version Broker/engine - Engine debug level is set to all, it should not hang
-156. [x] **BESS_GRPC_COMPRESS1**: Start-Stop grpc version Broker/Engine - Broker started first - Broker stopped last compression activated
-157. [x] **BETAG1**: Engine is configured with some tags. When broker receives them, it stores them in the centreon_storage.tags table. Broker is started before.
-158. [x] **BETAG2**: Engine is configured with some tags. When broker receives them, it stores them in the centreon_storage.tags table. Engine is started before.
-159. [x] **BEUTAG1**: Engine is configured with some tags. When broker receives them through unified_sql stream, it stores them in the centreon_storage.tags table. Broker is started before.
-160. [x] **BEUTAG10**: some services are configured with tags on two pollers. Then tags are removed from some of them and in centreon_storage, we can observe resources_tags table updated.
-161. [x] **BEUTAG11**: some services are configured with tags on two pollers. Then several tags are removed, and we can observe resources_tags table updated.
-162. [x] **BEUTAG12**: Engine is configured with some tags. Group tags tag2, tag6 are set to hosts 1 and 2. Category tags tag4 and tag8 are added to hosts 2, 3, 4. The resources and resources_tags tables are well filled. The tag6 and tag8 are removed and resources_tags is also well updated.
-163. [x] **BEUTAG2**: Engine is configured with some tags. A new service is added with a tag. Broker should make the relations.
-164. [x] **BEUTAG3**: Engine is configured with some tags. When broker receives them, it stores them in the centreon_storage.tags table. Engine is started before.
-165. [x] **BEUTAG4**: Engine is configured with some tags. Group tags tag9, tag13 are set to services 1 and 3. Category tags tag3 and tag11 are added to services 1, 3, 5 and 6. The centreon_storage.resources and resources_tags tables are well filled.
-166. [x] **BEUTAG5**: Engine is configured with some tags. Group tags tag2, tag6 are set to hosts 1 and 2. Category tags tag4 and tag8 are added to hosts 2, 3, 4. The resources and resources_tags tables are well filled.
-167. [x] **BEUTAG6**: Engine is configured with some tags. When broker receives them, it stores them in the centreon_storage.resources_tags table. Engine is started before.
-168. [x] **BEUTAG7**: Some services are configured with tags on two pollers. Then tags configuration is modified.
-169. [x] **BEUTAG8**: Services have tags provided by templates.
-170. [x] **BEUTAG9**: hosts have tags provided by templates.
-171. [x] **BEUTAG_REMOVE_HOST_FROM_HOSTGROUP**: remove a host from hostgroup, reload, insert 2 host in the hostgroup must not make sql error
-172. [x] **BE_BACKSLASH_CHECK_RESULT**: external command PROCESS_SERVICE_CHECK_RESULT with \:
-173. [x] **BE_DEFAULT_NOTIFCATION_INTERVAL_IS_ZERO_SERVICE_RESOURCE**: default notification_interval must be set to NULL in services, hosts and resources tables.
-174. [x] **BE_NOTIF_OVERFLOW**: bbdo 2.0 notification number =40000. make an overflow => notification_number null in db
-175. [x] **BE_TIME_NULL_SERVICE_RESOURCE**: With BBDO 3, notification_interval time must be set to NULL on 0 in services, hosts and resources tables.
-176. [x] **BRCS1**: Broker reverse connection stopped
-177. [x] **BRCTS1**: Broker reverse connection too slow
-178. [x] **BRCTSMN**: Broker connected to map with neb filter
-179. [x] **BRCTSMNS**: Broker connected to map with neb and storage filters
-180. [x] **BRGC1**: Broker good reverse connection
-181. [x] **BRRDCDDID1**: RRD metrics deletion from index ids with rrdcached.
-182. [x] **BRRDCDDIDDB1**: RRD metrics deletion from index ids with a query in centreon_storage with rrdcached.
-183. [x] **BRRDCDDIDU1**: RRD metrics deletion from index ids with unified sql output with rrdcached.
-184. [x] **BRRDCDDM1**: RRD metrics deletion from metric ids with rrdcached.
-185. [x] **BRRDCDDMDB1**: RRD metrics deletion from metric ids with a query in centreon_storage and rrdcached.
-186. [x] **BRRDCDDMID1**: RRD deletion of non existing metrics and indexes with rrdcached
-187. [x] **BRRDCDDMIDU1**: RRD deletion of non existing metrics and indexes with rrdcached
-188. [x] **BRRDCDDMU1**: RRD metric deletion on table metric with unified sql output with rrdcached
-189. [x] **BRRDCDRB1**: RRD metric rebuild with gRPC API. 3 indexes are selected then a message to rebuild them is sent. This is done with storage/sql sql output and rrdcached.
-190. [x] **BRRDCDRBDB1**: RRD metric rebuild with a query in centreon_storage and unified sql with rrdcached
-191. [x] **BRRDCDRBU1**: RRD metric rebuild with gRPC API. 3 indexes are selected then a message to rebuild them is sent. This is done with unified_sql output and rrdcached.
-192. [x] **BRRDCDRBUDB1**: RRD metric rebuild with a query in centreon_storage and unified sql with rrdcached
-193. [x] **BRRDDID1**: RRD metrics deletion from index ids.
-194. [x] **BRRDDIDDB1**: RRD metrics deletion from index ids with a query in centreon_storage.
-195. [x] **BRRDDIDU1**: RRD metrics deletion from index ids with unified sql output.
-196. [x] **BRRDDM1**: RRD metrics deletion from metric ids.
-197. [x] **BRRDDMDB1**: RRD metrics deletion from metric ids with a query in centreon_storage.
-198. [x] **BRRDDMID1**: RRD deletion of non existing metrics and indexes
-199. [x] **BRRDDMIDU1**: RRD deletion of non existing metrics and indexes
-200. [x] **BRRDDMU1**: RRD metric deletion on table metric with unified sql output
-201. [x] **BRRDRBDB1**: RRD metric rebuild with a query in centreon_storage and unified sql
-202. [x] **BRRDRBUDB1**: RRD metric rebuild with a query in centreon_storage and unified sql
-203. [x] **BRRDRM1**: RRD metric rebuild with gRPC API. 3 indexes are selected then a message to rebuild them is sent. This is done with storage/sql sql output.
-204. [x] **BRRDRMU1**: RRD metric rebuild with gRPC API. 3 indexes are selected then a message to rebuild them is sent. This is done with unified_sql output.
-205. [x] **BRRDSTATUS**: We are working with BBDO3. This test checks status are correctly handled independently from their value.
-206. [x] **BRRDSTATUSRETENTION**: We are working with BBDO3. This test checks status are not sent twice after Engine reload.
-207. [x] **BRRDUPLICATE**: RRD metric rebuild with a query in centreon_storage and unified sql with duplicate rows in database
-208. [x] **BRRDWM1**: We are working with BBDO3. This test checks protobuf metrics and status are sent to cbd RRD.
-209. [x] **CBD_RELOAD_AND_FILTERS**: We start engine/broker with a classical configuration. All is up and running. Some filters are added to the rrd output and cbd is reloaded. All is still up and running but some events are rejected. Then all is newly set as filter and all events are sent to rrd broker.
-210. [x] **CBD_RELOAD_AND_FILTERS_WITH_OPR**: We start engine/broker with an almost classical configuration, just the connection between cbd central and cbd rrd is reversed with one peer retention. All is up and running. Some filters are added to the rrd output and cbd is reloaded. All is still up and running but some events are rejected. Then all is newly set as filter and all events are sent to rrd broker.
-211. [x] **DTIM**: New services with several pollers are created. Then downtimes are set on all configured hosts. This action results on 5250 downtimes if we also count impacted services. Then all these downtimes are removed. This test is done with BBDO 3.0.1
-212. [x] **EBBM1**: A service status contains metrics that do not fit in a float number.
-213. [x] **EBBPS1**: 1000 service check results are sent to the poller. The test is done with the unified_sql stream, no service status is lost, we find the 1000 results in the database: table resources.
-214. [x] **EBBPS2**: 1000 service check results are sent to the poller. The test is done with the unified_sql stream, no service status is lost, we find the 1000 results in the database: table services.
-215. [x] **EBDP1**: Four new pollers are started and then we remove Poller3.
-216. [x] **EBDP2**: Three new pollers are started, then they are killed. After a simple restart of broker, it is still possible to remove Poller2 if removed from the configuration.
-217. [x] **EBDP3**: Three new pollers are started, then they are killed. It is still possible to remove Poller2 if removed from the configuration.
-218. [x] **EBDP4**: Four new pollers are started and then we remove Poller3 with its hosts and services. All service status/host status are then refused by Broker.
-219. [x] **EBDP5**: Four new pollers are started and then we remove Poller3.
-220. [x] **EBDP6**: Three new pollers are started, then they are killed. After a simple restart of broker, it is still possible to remove Poller2 if removed from the configuration.
-221. [x] **EBDP7**: Three new pollers are started, then they are killed. It is still possible to remove Poller2 if removed from the configuration.
-222. [x] **EBDP8**: Four new pollers are started and then we remove Poller3 with its hosts and services. All service status/host status are then refused by broker.
-223. [x] **EBDP_GRPC2**: Three new pollers are started, then they are killed. After a simple restart of broker, it is still possible to remove Poller2 if removed from the configuration.
-224. [x] **EBMSSM**: 1000 services are configured with 100 metrics each. The rrd output is removed from the broker configuration. GetSqlManagerStats is called to measure writes into data_bin.
-225. [x] **EBNHG1**: New host group with several pollers and connections to DB
-226. [x] **EBNHG4**: New host group with several pollers and connections to DB with broker and rename this hostgroup
-227. [x] **EBNHGU1**: New host group with several pollers and connections to DB with broker configured with unified_sql
-228. [x] **EBNHGU2**: New host group with several pollers and connections to DB with broker configured with unified_sql
-229. [x] **EBNHGU3**: New host group with several pollers and connections to DB with broker configured with unified_sql
-230. [x] **EBNHGU4_${test_label}**: New host group with several pollers and connections to DB with broker and rename this hostgroup
-231. [x] **EBNSG1**: New service group with several pollers and connections to DB
-232. [x] **EBNSGU1**: New service group with several pollers and connections to DB with broker configured with unified_sql
-233. [x] **EBNSGU2**: New service group with several pollers and connections to DB with broker configured with unified_sql
-234. [x] **EBNSGU3_${test_label}**: New service group with several pollers and connections to DB with broker and rename this servicegroup
-235. [x] **EBNSVC1**: New services with several pollers
-236. [x] **EBPS2**: 1000 services are configured with 20 metrics each. The rrd output is removed from the broker configuration to avoid to write too many rrd files. While metrics are written in bulk, the database is stopped. This must not crash broker.
-237. [x] **EBSAU2**: New services with action_url with more than 2000 characters
-238. [x] **EBSN3**: New services with notes with more than 500 characters
-239. [x] **EBSNU1**: New services with notes_url with more than 2000 characters
-240. [x] **ENRSCHE1**: Verify that next check of a rescheduled host is made at last_check + interval_check
-241. [x] **FILTER_ON_LUA_EVENT**: stream connector with a bad configured filter generate a log error message
-242. [x] **GRPC_CLOUD_FAILURE**: simulate a broker failure in cloud environment, we provide a muted grpc server and there must remain only one grpc connection. Then we start broker and connection must be ok
-243. [x] **GRPC_RECONNECT**: We restart broker and engine must reconnect to it and send data
-244. [x] **LCDNU**: the lua cache updates correctly service cache.
-245. [x] **LCDNUH**: the lua cache updates correctly host cache
-246. [x] **LOGV2DB1**: log-v2 disabled old log enabled check broker sink
-247. [x] **LOGV2DB2**: log-v2 disabled old log disabled check broker sink
-248. [x] **LOGV2DF1**: log-v2 disabled old log enabled check logfile sink
-249. [x] **LOGV2DF2**: log-v2 disabled old log disabled check logfile sink
-250. [x] **LOGV2EB1**: Checking broker sink when log-v2 is enabled and legacy logs are disabled.
-251. [x] **LOGV2EB2**: log-v2 enabled old log enabled check broker sink
-252. [x] **LOGV2EBU1**: Checking broker sink when log-v2 is enabled and legacy logs are disabled with bbdo3.
-253. [x] **LOGV2EBU2**: Check Broker sink with log-v2 enabled and legacy log enabled with BBDO3.
-254. [x] **LOGV2EF1**: log-v2 enabled    old log disabled check logfile sink
-255. [x] **LOGV2EF2**: log-v2 enabled old log enabled check logfile sink
-256. [x] **LOGV2FE2**: log-v2 enabled old log enabled check logfile sink
-257. [x] **NO_FILTER_NO_ERROR**: no filter configured => no filter error.
-258. [x] **RLCode**: Test if reloading LUA code in a stream connector applies the changes
-259. [x] **RRD1**: RRD metric rebuild asked with gRPC API. Three non existing indexes IDs are selected then an error message is sent. This is done with unified_sql output.
-260. [x] **SDER**: The check attempts and the max check attempts of (host_1,service_1) are changed to 280 thanks to the retention.dat file. Then Engine and Broker are started and Broker should write these values in the services and resources tables. We only test the services table because we need a resources table that allows bigger numbers for these two attributes. But we see that Broker doesn't crash anymore.
-261. [x] **SEVERAL_FILTERS_ON_LUA_EVENT**: Two stream connectors with different filters are configured.
-262. [x] **STORAGE_ON_LUA**: The category 'storage' is applied on the stream connector. Only events of this category should be sent to this stream.
-263. [x] **STUPID_FILTER**: Unified SQL is configured with only the bbdo category as filter. An error is raised by broker and broker should run correctly.
-264. [x] **Service_increased_huge_check_interval**: New services with high check interval at creation time.
-265. [x] **Services_and_bulks_${id}**: One service is configured with one metric with a name of 150 to 1021 characters.
-266. [x] **Start_Stop_Broker_Engine_${id}**: Start-Stop Broker/Engine - Broker started first - Engine stopped first
-267. [x] **Start_Stop_Engine_Broker_${id}**: Start-Stop Broker/Engine - Broker started first - Broker stopped first
-268. [x] **UNIFIED_SQL_FILTER**: With bbdo version 3.0.1, we watch events written or rejected in unified_sql
-269. [x] **VICT_ONE_CHECK_METRIC**: victoria metrics metric output
-270. [x] **VICT_ONE_CHECK_METRIC_AFTER_FAILURE**: victoria metrics metric output after victoria shutdown
-271. [x] **VICT_ONE_CHECK_STATUS**: victoria metrics status output
-272. [x] **Whitelist_Directory_Rights**: log if /etc/centreon-engine-whitelist has not mandatory rights or owner
-273. [x] **Whitelist_Empty_Directory**: log if /etc/centreon-engine-whitelist is empty
-274. [x] **Whitelist_Host**: test allowed and forbidden commands for hosts
-275. [x] **Whitelist_No_Whitelist_Directory**: log if /etc/centreon-engine-whitelist doesn't exist
-276. [x] **Whitelist_Perl_Connector**: test allowed and forbidden commands for services
-277. [x] **Whitelist_Service**: test allowed and forbidden commands for services
-278. [x] **Whitelist_Service_EH**: test allowed and forbidden event handler for services
-279. [x] **metric_mapping**: Check if metric name exists using a stream connector
-280. [x] **not1**: This test case configures a single service and verifies that a notification is sent when the service is in a non-OK HARD state.
-281. [x] **not10**: This test case involves scheduling downtime on a down host that already had a critical notification. When The Host return to UP state we should receive a recovery notification.
-282. [x] **not11**: This test case involves configuring one service and checking that three alerts are sent for it.
-283. [x] **not12**: Escalations
-284. [x] **not13**: notification for a dependencies host
-285. [x] **not14**: notification for a Service dependency
-286. [x] **not15**: several notification commands for the same user.
-287. [x] **not16**: notification for dependencies services group
-288. [x] **not17**: notification for a dependensies host group
-289. [x] **not18**: notification delay where first notification delay equal retry check
-290. [x] **not19**: notification delay where first notification delay greater than retry check 
-291. [x] **not1_WL_KO**: This test case configures a single service. When it is in non-OK HARD state a notification should be sent but it is not allowed by the whitelist
-292. [x] **not1_WL_OK**: This test case configures a single service. When it is in non-OK HARD state a notification is sent because it is allowed by the whitelist
-293. [x] **not2**: This test case configures a single service and verifies that a recovery notification is sent
-294. [x] **not20**: notification delay where first notification delay samller than retry check
-295. [x] **not3**: This test case configures a single service and verifies the notification system's behavior during and after downtime
-296. [x] **not4**: This test case configures a single service and verifies the notification system's behavior during and after acknowledgement
-297. [x] **not5**: This test case configures two services with two different users being notified when the services transition to a critical state.
-298. [x] **not6**: This test case validate the behavior when the notification time period is set to null.
-299. [x] **not7**: This test case simulates a host alert scenario.
-300. [x] **not8**: This test validates the critical host notification.
-301. [x] **not9**: This test case configures a single host and verifies that a recovery notification is sent after the host recovers from a non-OK state.
-302. [x] **not_in_timeperiod_with_send_recovery_notifications_anyways**: This test case configures a single service and verifies that a notification is sent when the service is in a non-OK state and OK is sent outside timeperiod when _send_recovery_notifications_anyways is set
-303. [x] **not_in_timeperiod_without_send_recovery_notifications_anyways**: This test case configures a single service and verifies that a notification is sent when the service is in a non-OK state and OK is not sent outside timeperiod when _send_recovery_notifications_anyways is not set
+42. [x] **BEDTRRD1**: A service is forced checked then a downtime is set on this service. The service is forced checked again and the downtime is removed. This test is done with BBDO 3.0.0. Then we should not get any error in cbd RRD of kind 'ignored update error in file...'.
+43. [x] **BEDTSVCFIXED**: A downtime is set on a service, the total number of downtimes is really 1 then we delete this downtime and the number of downtime is 0.
+44. [x] **BEDTSVCREN1**: A downtime is set on a service then the service is renamed. The downtime is still active on the renamed service. The downtime is removed from the renamed service and it is well removed.
+45. [x] **BEEXTCMD1**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo3.0
+46. [x] **BEEXTCMD10**: external command CHANGE_MAX_SVC_CHECK_ATTEMPTS on bbdo2.0
+47. [x] **BEEXTCMD11**: external command CHANGE_MAX_HOST_CHECK_ATTEMPTS on bbdo3.0
+48. [x] **BEEXTCMD12**: external command CHANGE_MAX_HOST_CHECK_ATTEMPTS on bbdo2.0
+49. [x] **BEEXTCMD13**: external command CHANGE_HOST_CHECK_TIMEPERIOD on bbdo3.0
+50. [x] **BEEXTCMD14**: external command CHANGE_HOST_CHECK_TIMEPERIOD on bbdo2.0
+51. [x] **BEEXTCMD15**: external command CHANGE_HOST_NOTIFICATION_TIMEPERIOD on bbdo3.0
+52. [x] **BEEXTCMD16**: external command CHANGE_HOST_NOTIFICATION_TIMEPERIOD on bbdo2.0
+53. [x] **BEEXTCMD17**: external command CHANGE_SVC_CHECK_TIMEPERIOD on bbdo3.0
+54. [x] **BEEXTCMD18**: external command CHANGE_SVC_CHECK_TIMEPERIOD on bbdo2.0
+55. [x] **BEEXTCMD19**: external command CHANGE_SVC_NOTIFICATION_TIMEPERIOD on bbdo3.0
+56. [x] **BEEXTCMD2**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo2.0
+57. [x] **BEEXTCMD20**: external command CHANGE_SVC_NOTIFICATION_TIMEPERIOD on bbdo2.0
+58. [x] **BEEXTCMD21**: external command DISABLE_HOST_AND_CHILD_NOTIFICATIONS and ENABLE_HOST_AND_CHILD_NOTIFICATIONS on bbdo3.0
+59. [x] **BEEXTCMD22**: external command DISABLE_HOST_AND_CHILD_NOTIFICATIONS and ENABLE_HOST_AND_CHILD_NOTIFICATIONS on bbdo2.0
+60. [x] **BEEXTCMD23**: external command DISABLE_HOST_CHECK and ENABLE_HOST_CHECK on bbdo3.0
+61. [x] **BEEXTCMD24**: external command DISABLE_HOST_CHECK and ENABLE_HOST_CHECK on bbdo2.0
+62. [x] **BEEXTCMD25**: external command DISABLE_HOST_EVENT_HANDLER and ENABLE_HOST_EVENT_HANDLER on bbdo3.0
+63. [x] **BEEXTCMD26**: external command DISABLE_HOST_EVENT_HANDLER and ENABLE_HOST_EVENT_HANDLER on bbdo2.0
+64. [x] **BEEXTCMD27**: external command DISABLE_HOST_FLAP_DETECTION and ENABLE_HOST_FLAP_DETECTION on bbdo3.0
+65. [x] **BEEXTCMD28**: external command DISABLE_HOST_FLAP_DETECTION and ENABLE_HOST_FLAP_DETECTION on bbdo2.0
+66. [x] **BEEXTCMD29**: external command DISABLE_HOST_NOTIFICATIONS and ENABLE_HOST_NOTIFICATIONS on bbdo3.0
+67. [x] **BEEXTCMD3**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo3.0
+68. [x] **BEEXTCMD30**: external command DISABLE_HOST_NOTIFICATIONS and ENABLE_HOST_NOTIFICATIONS on bbdo2.0
+69. [x] **BEEXTCMD31**: external command DISABLE_HOST_SVC_CHECKS and ENABLE_HOST_SVC_CHECKS on bbdo3.0
+70. [x] **BEEXTCMD32**: external command DISABLE_HOST_SVC_CHECKS and ENABLE_HOST_SVC_CHECKS on bbdo2.0
+71. [x] **BEEXTCMD33**: external command DISABLE_HOST_SVC_NOTIFICATIONS and ENABLE_HOST_SVC_NOTIFICATIONS on bbdo3.0
+72. [x] **BEEXTCMD34**: external command DISABLE_HOST_SVC_NOTIFICATIONS and ENABLE_HOST_SVC_NOTIFICATIONS on bbdo2.0
+73. [x] **BEEXTCMD35**: external command DISABLE_PASSIVE_HOST_CHECKS and ENABLE_PASSIVE_HOST_CHECKS on bbdo3.0
+74. [x] **BEEXTCMD36**: external command DISABLE_PASSIVE_HOST_CHECKS and ENABLE_PASSIVE_HOST_CHECKS on bbdo2.0
+75. [x] **BEEXTCMD37**: external command DISABLE_PASSIVE_SVC_CHECKS and ENABLE_PASSIVE_SVC_CHECKS on bbdo3.0
+76. [x] **BEEXTCMD38**: external command DISABLE_PASSIVE_SVC_CHECKS and ENABLE_PASSIVE_SVC_CHECKS on bbdo2.0
+77. [x] **BEEXTCMD39**: external command START_OBSESSING_OVER_HOST and STOP_OBSESSING_OVER_HOST on bbdo3.0
+78. [x] **BEEXTCMD4**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo2.0
+79. [x] **BEEXTCMD40**: external command START_OBSESSING_OVER_HOST and STOP_OBSESSING_OVER_HOST on bbdo2.0
+80. [x] **BEEXTCMD41**: external command START_OBSESSING_OVER_SVC and STOP_OBSESSING_OVER_SVC on bbdo3.0
+81. [x] **BEEXTCMD42**: external command START_OBSESSING_OVER_SVC and STOP_OBSESSING_OVER_SVC on bbdo2.0
+82. [x] **BEEXTCMD5**: external command CHANGE_RETRY_SVC_CHECK_INTERVAL on bbdo3.0
+83. [x] **BEEXTCMD6**: external command CHANGE_RETRY_SVC_CHECK_INTERVAL on bbdo2.0
+84. [x] **BEEXTCMD7**: external command CHANGE_RETRY_HOST_CHECK_INTERVAL on bbdo3.0
+85. [x] **BEEXTCMD8**: external command CHANGE_RETRY_HOST_CHECK_INTERVAL on bbdo2.0
+86. [x] **BEEXTCMD9**: external command CHANGE_MAX_SVC_CHECK_ATTEMPTS on bbdo3.0
+87. [x] **BEEXTCMD_COMPRESS_GRPC1**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo3.0 and compressed grpc
+88. [x] **BEEXTCMD_GRPC1**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo3.0 and grpc
+89. [x] **BEEXTCMD_GRPC2**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo2.0 and grpc
+90. [x] **BEEXTCMD_GRPC3**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo3.0 and grpc
+91. [x] **BEEXTCMD_GRPC4**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo2.0 and grpc
+92. [x] **BEEXTCMD_REVERSE_GRPC1**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo3.0 and reversed gRPC
+93. [x] **BEEXTCMD_REVERSE_GRPC2**: external command CHANGE_NORMAL_SVC_CHECK_INTERVAL on bbdo2.0 and grpc reversed
+94. [x] **BEEXTCMD_REVERSE_GRPC3**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo3.0 and grpc reversed
+95. [x] **BEEXTCMD_REVERSE_GRPC4**: external command CHANGE_NORMAL_HOST_CHECK_INTERVAL on bbdo2.0 and grpc reversed
+96. [x] **BEFL1**: The flapping is enabled on the service (1;1). When it goes flapping, the flapping information is well sent to Broker. Then the service is stabilized and the flapping information is disabled on Broker side. And during all that test, the RRD broker should not have any error.
+97. [x] **BEHOSTCHECK**: external command CHECK_HOST_RESULT
+98. [x] **BEHS1**: store_in_resources is enabled and store_in_hosts_services is not. Only writes into resources should be done (except hosts/services events that continue to be written in hosts/services tables)
+99. [x] **BEINSTANCE**: Instance to bdd
+100. [x] **BEINSTANCESTATUS**: Instance status to bdd
+101. [x] **BENCH_${nb_checks}STATUS**: external command CHECK_SERVICE_RESULT 1000 times
+102. [x] **BENCH_${nb_checks}STATUS_TRACES**: external command CHECK_SERVICE_RESULT ${nb_checks} times
+103. [x] **BENCH_${nb_checks}_REVERSE_SERVICE_STATUS_TRACES_WITHOUT_SQL**: Broker is configured without SQL output. The connection between Engine and Broker is reversed. External command CHECK_SERVICE_RESULT is sent ${nb_checks} times. Logs are in trace level.
+104. [x] **BENCH_${nb_checks}_REVERSE_SERVICE_STATUS_WITHOUT_SQL**: Broker is configured without SQL output. The connection between Engine and Broker is reversed. External command CHECK_SERVICE_RESULT is sent ${nb_checks} times.
+105. [x] **BENCH_${nb_checks}_SERVICE_STATUS_TRACES_WITHOUT_SQL**: Broker is configured without SQL output. External command CHECK_SERVICE_RESULT is sent ${nb_checks} times. Logs are in trace level.
+106. [x] **BENCH_${nb_checks}_SERVICE_STATUS_WITHOUT_SQL**: Broker is configured without SQL output. External command CHECK_SERVICE_RESULT is sent ${nb_checks} times.
+107. [x] **BENCH_1000STATUS_100${suffixe}**: external command CHECK_SERVICE_RESULT 100 times    with 100 pollers with 20 services
+108. [x] **BENCV**: Engine is configured with hosts/services. The first host has no customvariable. Then we add a customvariable to the first host and we reload engine. Then the host should have this new customvariable defined and centengine should not crash.
+109. [x] **BEOTEL_CENTREON_AGENT_CHECK_HOST**: agent check host and we expect to get it in check result
+110. [x] **BEOTEL_CENTREON_AGENT_CHECK_HOST_CRYPTED**: agent check host with encrypted connection and we expect to get it in check result
+111. [x] **BEOTEL_CENTREON_AGENT_CHECK_SERVICE**: agent check service and we expect to get it in check result
+112. [x] **BEOTEL_REVERSE_CENTREON_AGENT_CHECK_HOST**: agent check host with reversed connection and we expect to get it in check result
+113. [x] **BEOTEL_REVERSE_CENTREON_AGENT_CHECK_HOST_CRYPTED**: agent check host with encrypted reversed connection and we expect to get it in check result
+114. [x] **BEOTEL_REVERSE_CENTREON_AGENT_CHECK_SERVICE**: agent check service with reversed connection and we expect to get it in check result
+115. [x] **BEOTEL_SERVE_TELEGRAF_CONFIGURATION_CRYPTED**: we configure engine with a telegraf conf server and we check telegraf conf file
+116. [x] **BEOTEL_SERVE_TELEGRAF_CONFIGURATION_NO_CRYPTED**: we configure engine with a telegraf conf server and we check telegraf conf file
+117. [x] **BEOTEL_TELEGRAF_CHECK_HOST**: we send nagios telegraf formatted datas and we expect to get it in check result
+118. [x] **BEOTEL_TELEGRAF_CHECK_SERVICE**: we send nagios telegraf formatted datas and we expect to get it in check result
+119. [x] **BEPBBEE1**: central-module configured with bbdo_version 3.0 but not others. Unable to establish connection.
+120. [x] **BEPBBEE2**: bbdo_version 3 not compatible with sql/storage
+121. [x] **BEPBBEE3**: bbdo_version 3 generates new bbdo protobuf service status messages.
+122. [x] **BEPBBEE4**: bbdo_version 3 generates new bbdo protobuf host status messages.
+123. [x] **BEPBBEE5**: bbdo_version 3 generates new bbdo protobuf service messages.
+124. [x] **BEPBCVS**: bbdo_version 3 communication of custom variables.
+125. [x] **BEPBHostParent**: bbdo_version 3 communication of host parent relations
+126. [x] **BEPBINST_CONF**: bbdo_version 3 communication of instance configuration.
+127. [x] **BEPBRI1**: bbdo_version 3 use pb_resource new bbdo protobuf ResponsiveInstance message.
+128. [x] **BERD1**: Starting/stopping Broker does not create duplicated events.
+129. [x] **BERD2**: Starting/stopping Engine does not create duplicated events.
+130. [x] **BERDUC1**: Starting/stopping Broker does not create duplicated events in usual cases
+131. [x] **BERDUC2**: Starting/stopping Engine does not create duplicated events in usual cases
+132. [x] **BERDUC3U1**: Starting/stopping Broker does not create duplicated events in usual cases with unified_sql and BBDO 3.0
+133. [x] **BERDUC3U2**: Starting/stopping Engine does not create duplicated events in usual cases with unified_sql and BBDO 3.0
+134. [x] **BERDUCA300**: Starting/stopping Engine is stopped ; it should emit a stop event and receive an ack event with events to clean from broker.
+135. [x] **BERDUCA301**: Starting/stopping Engine is stopped ; it should emit a stop event and receive an ack event with events to clean from broker with bbdo 3.0.1.
+136. [x] **BERDUCU1**: Starting/stopping Broker does not create duplicated events in usual cases with unified_sql
+137. [x] **BERDUCU2**: Starting/stopping Engine does not create duplicated events in usual cases with unified_sql
+138. [x] **BERES1**: store_in_resources is enabled and store_in_hosts_services is not. Only writes into resources should be done (except hosts/services events that continue to be written in hosts/services tables)
+139. [x] **BESERVCHECK**: external command CHECK_SERVICE_RESULT
+140. [x] **BESS1**: Start-Stop Broker/Engine - Broker started first - Broker stopped first
+141. [x] **BESS2**: Start-Stop Broker/Engine - Broker started first - Engine stopped first
+142. [x] **BESS2U**: Start-Stop Broker/Engine - Broker started first - Engine stopped first. Unified_sql is used.
+143. [x] **BESS3**: Start-Stop Broker/Engine - Engine started first - Engine stopped first
+144. [x] **BESS4**: Start-Stop Broker/Engine - Engine started first - Broker stopped first
+145. [x] **BESS5**: Start-Stop Broker/engine - Engine debug level is set to all, it should not hang
+146. [x] **BESSBQ1**: A very bad queue file is written for broker. Broker and Engine are then started, Broker must read the file raising an error because of that file and then get data sent by Engine.
+147. [x] **BESS_CRYPTED_GRPC1**: Start-Stop grpc version Broker/Engine - well configured
+148. [x] **BESS_CRYPTED_GRPC2**: Start-Stop grpc version Broker/Engine only server crypted
+149. [x] **BESS_CRYPTED_GRPC3**: Start-Stop grpc version Broker/Engine only engine crypted
+150. [x] **BESS_CRYPTED_REVERSED_GRPC1**: Start-Stop grpc version Broker/Engine - well configured
+151. [x] **BESS_CRYPTED_REVERSED_GRPC2**: Start-Stop grpc version Broker/Engine only engine server crypted
+152. [x] **BESS_CRYPTED_REVERSED_GRPC3**: Start-Stop grpc version Broker/Engine only engine crypted
+153. [x] **BESS_ENGINE_DELETE_HOST**: once engine and cbd started, stop and restart cbd, delete an host and reload engine, cbd mustn't core
+154. [x] **BESS_GRPC1**: Start-Stop grpc version Broker/Engine - Broker started first - Broker stopped first
+155. [x] **BESS_GRPC2**: Start-Stop grpc version Broker/Engine - Broker started first - Engine stopped first
+156. [x] **BESS_GRPC3**: Start-Stop grpc version Broker/Engine - Engine started first - Engine stopped first
+157. [x] **BESS_GRPC4**: Start-Stop grpc version Broker/Engine - Engine started first - Broker stopped first
+158. [x] **BESS_GRPC5**: Start-Stop grpc version Broker/engine - Engine debug level is set to all, it should not hang
+159. [x] **BESS_GRPC_COMPRESS1**: Start-Stop grpc version Broker/Engine - Broker started first - Broker stopped last compression activated
+160. [x] **BETAG1**: Engine is configured with some tags. When broker receives them, it stores them in the centreon_storage.tags table. Broker is started before.
+161. [x] **BETAG2**: Engine is configured with some tags. When broker receives them, it stores them in the centreon_storage.tags table. Engine is started before.
+162. [x] **BEUTAG1**: Engine is configured with some tags. When broker receives them through unified_sql stream, it stores them in the centreon_storage.tags table. Broker is started before.
+163. [x] **BEUTAG10**: some services are configured with tags on two pollers. Then tags are removed from some of them and in centreon_storage, we can observe resources_tags table updated.
+164. [x] **BEUTAG11**: some services are configured with tags on two pollers. Then several tags are removed, and we can observe resources_tags table updated.
+165. [x] **BEUTAG12**: Engine is configured with some tags. Group tags tag2, tag6 are set to hosts 1 and 2. Category tags tag4 and tag8 are added to hosts 2, 3, 4. The resources and resources_tags tables are well filled. The tag6 and tag8 are removed and resources_tags is also well updated.
+166. [x] **BEUTAG2**: Engine is configured with some tags. A new service is added with a tag. Broker should make the relations.
+167. [x] **BEUTAG3**: Engine is configured with some tags. When broker receives them, it stores them in the centreon_storage.tags table. Engine is started before.
+168. [x] **BEUTAG4**: Engine is configured with some tags. Group tags tag9, tag13 are set to services 1 and 3. Category tags tag3 and tag11 are added to services 1, 3, 5 and 6. The centreon_storage.resources and resources_tags tables are well filled.
+169. [x] **BEUTAG5**: Engine is configured with some tags. Group tags tag2, tag6 are set to hosts 1 and 2. Category tags tag4 and tag8 are added to hosts 2, 3, 4. The resources and resources_tags tables are well filled.
+170. [x] **BEUTAG6**: Engine is configured with some tags. When broker receives them, it stores them in the centreon_storage.resources_tags table. Engine is started before.
+171. [x] **BEUTAG7**: Some services are configured with tags on two pollers. Then tags configuration is modified.
+172. [x] **BEUTAG8**: Services have tags provided by templates.
+173. [x] **BEUTAG9**: hosts have tags provided by templates.
+174. [x] **BEUTAG_REMOVE_HOST_FROM_HOSTGROUP**: remove a host from hostgroup, reload, insert 2 host in the hostgroup must not make sql error
+175. [x] **BE_BACKSLASH_CHECK_RESULT**: external command PROCESS_SERVICE_CHECK_RESULT with \:
+176. [x] **BE_DEFAULT_NOTIFCATION_INTERVAL_IS_ZERO_SERVICE_RESOURCE**: default notification_interval must be set to NULL in services, hosts and resources tables.
+177. [x] **BE_NOTIF_OVERFLOW**: bbdo 2.0 notification number =40000. make an overflow => notification_number null in db
+178. [x] **BE_TIME_NULL_SERVICE_RESOURCE**: With BBDO 3, notification_interval time must be set to NULL on 0 in services, hosts and resources tables.
+179. [x] **BRCS1**: Broker reverse connection stopped
+180. [x] **BRCTS1**: Broker reverse connection too slow
+181. [x] **BRCTSMN**: Broker connected to map with neb filter
+182. [x] **BRCTSMNS**: Broker connected to map with neb and storage filters
+183. [x] **BRGC1**: Broker good reverse connection
+184. [x] **BRRDCDDID1**: RRD metrics deletion from index ids with rrdcached.
+185. [x] **BRRDCDDIDDB1**: RRD metrics deletion from index ids with a query in centreon_storage with rrdcached.
+186. [x] **BRRDCDDIDU1**: RRD metrics deletion from index ids with unified sql output with rrdcached.
+187. [x] **BRRDCDDM1**: RRD metrics deletion from metric ids with rrdcached.
+188. [x] **BRRDCDDMDB1**: RRD metrics deletion from metric ids with a query in centreon_storage and rrdcached.
+189. [x] **BRRDCDDMID1**: RRD deletion of non existing metrics and indexes with rrdcached
+190. [x] **BRRDCDDMIDU1**: RRD deletion of non existing metrics and indexes with rrdcached
+191. [x] **BRRDCDDMU1**: RRD metric deletion on table metric with unified sql output with rrdcached
+192. [x] **BRRDCDRB1**: RRD metric rebuild with gRPC API. 3 indexes are selected then a message to rebuild them is sent. This is done with storage/sql sql output and rrdcached.
+193. [x] **BRRDCDRBDB1**: RRD metric rebuild with a query in centreon_storage and unified sql with rrdcached
+194. [x] **BRRDCDRBU1**: RRD metric rebuild with gRPC API. 3 indexes are selected then a message to rebuild them is sent. This is done with unified_sql output and rrdcached.
+195. [x] **BRRDCDRBUDB1**: RRD metric rebuild with a query in centreon_storage and unified sql with rrdcached
+196. [x] **BRRDDID1**: RRD metrics deletion from index ids.
+197. [x] **BRRDDIDDB1**: RRD metrics deletion from index ids with a query in centreon_storage.
+198. [x] **BRRDDIDU1**: RRD metrics deletion from index ids with unified sql output.
+199. [x] **BRRDDM1**: RRD metrics deletion from metric ids.
+200. [x] **BRRDDMDB1**: RRD metrics deletion from metric ids with a query in centreon_storage.
+201. [x] **BRRDDMID1**: RRD deletion of non existing metrics and indexes
+202. [x] **BRRDDMIDU1**: RRD deletion of non existing metrics and indexes
+203. [x] **BRRDDMU1**: RRD metric deletion on table metric with unified sql output
+204. [x] **BRRDRBDB1**: RRD metric rebuild with a query in centreon_storage and unified sql
+205. [x] **BRRDRBUDB1**: RRD metric rebuild with a query in centreon_storage and unified sql
+206. [x] **BRRDRM1**: RRD metric rebuild with gRPC API. 3 indexes are selected then a message to rebuild them is sent. This is done with storage/sql sql output.
+207. [x] **BRRDRMU1**: RRD metric rebuild with gRPC API. 3 indexes are selected then a message to rebuild them is sent. This is done with unified_sql output.
+208. [x] **BRRDSTATUS**: We are working with BBDO3. This test checks status are correctly handled independently from their value.
+209. [x] **BRRDSTATUSRETENTION**: We are working with BBDO3. This test checks status are not sent twice after Engine reload.
+210. [x] **BRRDUPLICATE**: RRD metric rebuild with a query in centreon_storage and unified sql with duplicate rows in database
+211. [x] **BRRDWM1**: We are working with BBDO3. This test checks protobuf metrics and status are sent to cbd RRD.
+212. [x] **CBD_RELOAD_AND_FILTERS**: We start engine/broker with a classical configuration. All is up and running. Some filters are added to the rrd output and cbd is reloaded. All is still up and running but some events are rejected. Then all is newly set as filter and all events are sent to rrd broker.
+213. [x] **CBD_RELOAD_AND_FILTERS_WITH_OPR**: We start engine/broker with an almost classical configuration, just the connection between cbd central and cbd rrd is reversed with one peer retention. All is up and running. Some filters are added to the rrd output and cbd is reloaded. All is still up and running but some events are rejected. Then all is newly set as filter and all events are sent to rrd broker.
+214. [x] **DTIM**: New services with several pollers are created. Then downtimes are set on all configured hosts. This action results on 5250 downtimes if we also count impacted services. Then all these downtimes are removed. This test is done with BBDO 3.0.1
+215. [x] **EBBM1**: A service status contains metrics that do not fit in a float number.
+216. [x] **EBBPS1**: 1000 service check results are sent to the poller. The test is done with the unified_sql stream, no service status is lost, we find the 1000 results in the database: table resources.
+217. [x] **EBBPS2**: 1000 service check results are sent to the poller. The test is done with the unified_sql stream, no service status is lost, we find the 1000 results in the database: table services.
+218. [x] **EBDP1**: Four new pollers are started and then we remove Poller3.
+219. [x] **EBDP2**: Three new pollers are started, then they are killed. After a simple restart of broker, it is still possible to remove Poller2 if removed from the configuration.
+220. [x] **EBDP3**: Three new pollers are started, then they are killed. It is still possible to remove Poller2 if removed from the configuration.
+221. [x] **EBDP4**: Four new pollers are started and then we remove Poller3 with its hosts and services. All service status/host status are then refused by Broker.
+222. [x] **EBDP5**: Four new pollers are started and then we remove Poller3.
+223. [x] **EBDP6**: Three new pollers are started, then they are killed. After a simple restart of broker, it is still possible to remove Poller2 if removed from the configuration.
+224. [x] **EBDP7**: Three new pollers are started, then they are killed. It is still possible to remove Poller2 if removed from the configuration.
+225. [x] **EBDP8**: Four new pollers are started and then we remove Poller3 with its hosts and services. All service status/host status are then refused by broker.
+226. [x] **EBDP_GRPC2**: Three new pollers are started, then they are killed. After a simple restart of broker, it is still possible to remove Poller2 if removed from the configuration.
+227. [x] **EBMSSM**: 1000 services are configured with 100 metrics each. The rrd output is removed from the broker configuration. GetSqlManagerStats is called to measure writes into data_bin.
+228. [x] **EBNHG1**: New host group with several pollers and connections to DB
+229. [x] **EBNHG4**: New host group with several pollers and connections to DB with broker and rename this hostgroup
+230. [x] **EBNHGU1**: New host group with several pollers and connections to DB with broker configured with unified_sql
+231. [x] **EBNHGU2**: New host group with several pollers and connections to DB with broker configured with unified_sql
+232. [x] **EBNHGU3**: New host group with several pollers and connections to DB with broker configured with unified_sql
+233. [x] **EBNHGU4_${test_label}**: New host group with several pollers and connections to DB with broker and rename this hostgroup
+234. [x] **EBNSG1**: New service group with several pollers and connections to DB
+235. [x] **EBNSGU1**: New service group with several pollers and connections to DB with broker configured with unified_sql
+236. [x] **EBNSGU2**: New service group with several pollers and connections to DB with broker configured with unified_sql
+237. [x] **EBNSGU3_${test_label}**: New service group with several pollers and connections to DB with broker and rename this servicegroup
+238. [x] **EBNSVC1**: New services with several pollers
+239. [x] **EBPS2**: 1000 services are configured with 20 metrics each. The rrd output is removed from the broker configuration to avoid to write too many rrd files. While metrics are written in bulk, the database is stopped. This must not crash broker.
+240. [x] **EBSAU2**: New services with action_url with more than 2000 characters
+241. [x] **EBSN3**: New services with notes with more than 500 characters
+242. [x] **EBSN4**: New hosts with No Alias / Alias and have A Template
+243. [x] **EBSN5**: Verify inheritance host : host(empty) inherit from template (full) , on Start Engine
+244. [x] **EBSN6**: Verify inheritance host : host(full) inherit from template (full) , on Start engine
+245. [x] **EBSN7**: Verify inheritance host : host(empty) inherit from template (full) , on Reload engine
+246. [x] **EBSN8**: Verify inheritance host : host(full) inherit from template (full) , on engine Reload
+247. [x] **EBSNU1**: New services with notes_url with more than 2000 characters
+248. [x] **ENRSCHE1**: Verify that next check of a rescheduled host is made at last_check + interval_check
+249. [x] **FILTER_ON_LUA_EVENT**: stream connector with a bad configured filter generate a log error message
+250. [x] **GRPC_CLOUD_FAILURE**: simulate a broker failure in cloud environment, we provide a muted grpc server and there must remain only one grpc connection. Then we start broker and connection must be ok
+251. [x] **GRPC_RECONNECT**: We restart broker and engine must reconnect to it and send data
+252. [x] **LCDNU**: the lua cache updates correctly service cache.
+253. [x] **LCDNUH**: the lua cache updates correctly host cache
+254. [x] **LOGV2DB1**: log-v2 disabled old log enabled check broker sink
+255. [x] **LOGV2DB2**: log-v2 disabled old log disabled check broker sink
+256. [x] **LOGV2DF1**: log-v2 disabled old log enabled check logfile sink
+257. [x] **LOGV2DF2**: log-v2 disabled old log disabled check logfile sink
+258. [x] **LOGV2EB1**: Checking broker sink when log-v2 is enabled and legacy logs are disabled.
+259. [x] **LOGV2EB2**: log-v2 enabled old log enabled check broker sink
+260. [x] **LOGV2EBU1**: Checking broker sink when log-v2 is enabled and legacy logs are disabled with bbdo3.
+261. [x] **LOGV2EBU2**: Check Broker sink with log-v2 enabled and legacy log enabled with BBDO3.
+262. [x] **LOGV2EF1**: log-v2 enabled    old log disabled check logfile sink
+263. [x] **LOGV2EF2**: log-v2 enabled old log enabled check logfile sink
+264. [x] **LOGV2FE2**: log-v2 enabled old log enabled check logfile sink
+265. [x] **NO_FILTER_NO_ERROR**: no filter configured => no filter error.
+266. [x] **RLCode**: Test if reloading LUA code in a stream connector applies the changes
+267. [x] **RRD1**: RRD metric rebuild asked with gRPC API. Three non existing indexes IDs are selected then an error message is sent. This is done with unified_sql output.
+268. [x] **SDER**: The check attempts and the max check attempts of (host_1,service_1) are changed to 280 thanks to the retention.dat file. Then Engine and Broker are started and Broker should write these values in the services and resources tables. We only test the services table because we need a resources table that allows bigger numbers for these two attributes. But we see that Broker doesn't crash anymore.
+269. [x] **SEVERAL_FILTERS_ON_LUA_EVENT**: Two stream connectors with different filters are configured.
+270. [x] **STORAGE_ON_LUA**: The category 'storage' is applied on the stream connector. Only events of this category should be sent to this stream.
+271. [x] **STUPID_FILTER**: Unified SQL is configured with only the bbdo category as filter. An error is raised by broker and broker should run correctly.
+272. [x] **Service_increased_huge_check_interval**: New services with high check interval at creation time.
+273. [x] **Services_and_bulks_${id}**: One service is configured with one metric with a name of 150 to 1021 characters.
+274. [x] **Start_Stop_Broker_Engine_${id}**: Start-Stop Broker/Engine - Broker started first - Engine stopped first
+275. [x] **Start_Stop_Engine_Broker_${id}**: Start-Stop Broker/Engine - Broker started first - Broker stopped first
+276. [x] **UNIFIED_SQL_FILTER**: With bbdo version 3.0.1, we watch events written or rejected in unified_sql
+277. [x] **VICT_ONE_CHECK_METRIC**: victoria metrics metric output
+278. [x] **VICT_ONE_CHECK_METRIC_AFTER_FAILURE**: victoria metrics metric output after victoria shutdown
+279. [x] **VICT_ONE_CHECK_STATUS**: victoria metrics status output
+280. [x] **Whitelist_Directory_Rights**: log if /etc/centreon-engine-whitelist has not mandatory rights or owner
+281. [x] **Whitelist_Empty_Directory**: log if /etc/centreon-engine-whitelist is empty
+282. [x] **Whitelist_Host**: test allowed and forbidden commands for hosts
+283. [x] **Whitelist_No_Whitelist_Directory**: log if /etc/centreon-engine-whitelist doesn't exist
+284. [x] **Whitelist_Perl_Connector**: test allowed and forbidden commands for services
+285. [x] **Whitelist_Service**: test allowed and forbidden commands for services
+286. [x] **Whitelist_Service_EH**: test allowed and forbidden event handler for services
+287. [x] **metric_mapping**: Check if metric name exists using a stream connector
+288. [x] **not1**: This test case configures a single service and verifies that a notification is sent when the service is in a non-OK HARD state.
+289. [x] **not10**: This test case involves scheduling downtime on a down host that already had a critical notification. When The Host return to UP state we should receive a recovery notification.
+290. [x] **not11**: This test case involves configuring one service and checking that three alerts are sent for it.
+291. [x] **not12**: Escalations
+292. [x] **not13**: notification for a dependencies host
+293. [x] **not14**: notification for a Service dependency
+294. [x] **not15**: several notification commands for the same user.
+295. [x] **not16**: notification for dependencies services group
+296. [x] **not17**: notification for a dependensies host group
+297. [x] **not18**: notification delay where first notification delay equal retry check
+298. [x] **not19**: notification delay where first notification delay greater than retry check 
+299. [x] **not1_WL_KO**: This test case configures a single service. When it is in non-OK HARD state a notification should be sent but it is not allowed by the whitelist
+300. [x] **not1_WL_OK**: This test case configures a single service. When it is in non-OK HARD state a notification is sent because it is allowed by the whitelist
+301. [x] **not2**: This test case configures a single service and verifies that a recovery notification is sent
+302. [x] **not20**: notification delay where first notification delay samller than retry check
+303. [x] **not3**: This test case configures a single service and verifies the notification system's behavior during and after downtime
+304. [x] **not4**: This test case configures a single service and verifies the notification system's behavior during and after acknowledgement
+305. [x] **not5**: This test case configures two services with two different users being notified when the services transition to a critical state.
+306. [x] **not6**: This test case validate the behavior when the notification time period is set to null.
+307. [x] **not7**: This test case simulates a host alert scenario.
+308. [x] **not8**: This test validates the critical host notification.
+309. [x] **not9**: This test case configures a single host and verifies that a recovery notification is sent after the host recovers from a non-OK state.
+310. [x] **not_in_timeperiod_with_send_recovery_notifications_anyways**: This test case configures a single service and verifies that a notification is sent when the service is in a non-OK state and OK is sent outside timeperiod when _send_recovery_notifications_anyways is set
+311. [x] **not_in_timeperiod_without_send_recovery_notifications_anyways**: This test case configures a single service and verifies that a notification is sent when the service is in a non-OK state and OK is not sent outside timeperiod when _send_recovery_notifications_anyways is not set
 
 ### Ccc
 1. [x] **BECCC1**: ccc without port fails with an error message
@@ -543,14 +562,16 @@ Here is the list of the currently implemented tests:
 6. [x] **EMACROS_NOTIF**: macros ADMINEMAIL and ADMINPAGER are replaced in notification commands
 7. [x] **EMACROS_SEMICOLON**: Macros with a semicolon are used even if they contain a semicolon.
 8. [x] **EPC1**: Check with perl connector
-9. [x] **ESS1**: Start-Stop (0s between start/stop) 5 times one instance of engine and no coredump
-10. [x] **ESS2**: Start-Stop (300ms between start/stop) 5 times one instance of engine and no coredump
-11. [x] **ESS3**: Start-Stop (0s between start/stop) 5 times three instances of engine and no coredump
-12. [x] **ESS4**: Start-Stop (300ms between start/stop) 5 times three instances of engine and no coredump
-13. [x] **EXT_CONF1**: Engine configuration is overided by json conf
-14. [x] **EXT_CONF2**: Engine configuration is overided by json conf after reload
-15. [x] **E_HOST_DOWN_DISABLE_SERVICE_CHECKS**: host_down_disable_service_checks is set to 1, host down switch all services to UNKNOWN
-16. [x] **E_HOST_UNREACHABLE_DISABLE_SERVICE_CHECKS**: host_down_disable_service_checks is set to 1, host unreachable switch all services to UNKNOWN
+9. [x] **ERL**: Engine is started and writes logs in centengine.log. Then we remove the log file. The file disappears but Engine is still writing into it. Engine is reloaded and the centengine.log should appear again.
+10. [x] **ESS1**: Start-Stop (0s between start/stop) 5 times one instance of engine and no coredump
+11. [x] **ESS2**: Start-Stop (300ms between start/stop) 5 times one instance of engine and no coredump
+12. [x] **ESS3**: Start-Stop (0s between start/stop) 5 times three instances of engine and no coredump
+13. [x] **ESS4**: Start-Stop (300ms between start/stop) 5 times three instances of engine and no coredump
+14. [x] **EXT_CONF1**: Engine configuration is overided by json conf
+15. [x] **EXT_CONF2**: Engine configuration is overided by json conf after reload
+16. [x] **E_HOST_DOWN_DISABLE_SERVICE_CHECKS**: host_down_disable_service_checks is set to 1, host down switch all services to UNKNOWN
+17. [x] **E_HOST_UNREACHABLE_DISABLE_SERVICE_CHECKS**: host_down_disable_service_checks is set to 1, host unreachable switch all services to UNKNOWN
+18. [x] **VERIF**: When centengine is started in verification mode, it does not log in its file.
 
 ### Migration
 1. [x] **MIGRATION**: Migration bbdo2 with sql/storage to bbdo2 with unified_sql and then to bbdo3 with unified_sql and then to bbdo2 with unified_sql and then to bbdo2 with sql/storage
@@ -566,4 +587,17 @@ Here is the list of the currently implemented tests:
 8. [x] **BEUSEV2**: Engine is configured with some severities. When broker receives them, it stores them in the centreon_storage.severities table. Engine is started before.
 9. [x] **BEUSEV3**: Four services have a severity added. Then we remove the severity from service 1. Then we change severity 11 to severity7 for service 3.
 10. [x] **BEUSEV4**: Seven services are configured with a severity on two pollers. Then we remove severities from the first and second services of the first poller but only the severity from the first service of the second poller. Then only severities no more used should be removed from the database.
+
+### Vault
+1. [x] **BAEBC**: Broker is used to AES256 decrypt a content not well encrypted
+2. [x] **BAEBS**: Broker is used to AES256 encrypt a content but the salt is wrong.
+3. [x] **BAEOK**: Broker is used to AES256 encrypt a content.
+4. [x] **BASV**: Broker accesses to the vault to get database credentials but vault is stopped.
+5. [x] **BAV**: Broker accesses to the vault to get database credentials.
+6. [x] **BWVC1**: Broker is tuned with a wrong vault configuration and the env file doesn't exist.
+7. [x] **BWVC2**: Broker is tuned with a wrong vault configuration and the env file exists with a wrong content.
+8. [x] **BWVC3**: Broker is tuned with an env file containing a strange key APP_SECRET and a wrong vault configuration.
+9. [x] **BWVC4**: Broker is tuned with an env file containing a strange key APP_SECRET and a vault configuration with a bad json.
+10. [x] **BWVC5**: Broker is tuned with strange keys APP_SECRET and salt.
+11. [x] **BWVC6**: Broker is tuned with strange keys APP_SECRET and salt that are not base64 encoded.
 

--- a/tests/bam/inherited_downtime.robot
+++ b/tests/bam/inherited_downtime.robot
@@ -11,7 +11,10 @@ Test Teardown       Ctn Save Logs If Failed
 
 *** Test Cases ***
 BEBAMIDT1
-    [Documentation]    A BA of type 'worst' with one service is configured. The BA is in critical state, because of its service. Then we set a downtime on this last one. An inherited downtime is set to the BA. The downtime is removed from the service, the inherited downtime is then deleted.
+    [Documentation]    A BA of type 'worst' with one service is configured. The BA is in critical
+    ...    state, because of its service. Then we set a downtime on this last one. An inherited
+    ...    downtime is set to the BA. The downtime is removed from the service, the inherited
+    ...    downtime is then deleted.
     [Tags]    broker    downtime    engine    bam
     Ctn Clear Commands Status
     Ctn Config Broker    module
@@ -30,15 +33,10 @@ BEBAMIDT1
     ${cmd_1}    Ctn Get Service Command Id    314
     Log To Console    service_314 has command id ${cmd_1}
     Ctn Set Command Status    ${cmd_1}    2
-    Ctn Start Broker
     ${start}    Get Current Date
-    Ctn Start engine
-    # Let's wait for Engine to be ready
-    ${content}    Create List    check_for_external_commands()
-    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
-    Should Be True
-    ...    ${result}
-    ...    A message about checking for external commands should have raised.
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
 
     # KPI set to critical
     Ctn Process Service Result Hard    host_16    service_314    2    output critical for service_314
@@ -67,8 +65,8 @@ BEBAMIDT1
     ${result}    Ctn Check Service Downtime With Timeout    _Module_BAM_1    ba_1    0    60
     Should Be True    ${result}    The BA ba_1 is in downtime as it should not
 
-    Ctn Stop engine
-    Ctn Kindly Stop Broker
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker    only_central=False    bbdo2=True
 
 BEBAMIDT2
     [Documentation]    A BA of type 'worst' with one service is configured. The BA is in critical state, because of its service. Then we set a downtime on this last one. An inherited downtime is set to the BA. Engine is restarted. Broker is restarted. The two downtimes are still there with no duplicates. The downtime is removed from the service, the inherited downtime is then deleted.
@@ -92,7 +90,7 @@ BEBAMIDT2
     Ctn Set Command Status    ${cmd_1}    2
     Ctn Start Broker
     ${start}    Get Current Date
-    Ctn Start engine
+    Ctn Start Engine
     # Let's wait for Engine to be ready
     ${content}    Create List    check_for_external_commands()
     ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
@@ -122,9 +120,9 @@ BEBAMIDT2
 
     FOR    ${i}    IN RANGE    2
         # Engine is restarted
-        Ctn Stop engine
+        Ctn Stop Engine
         ${start}    Get Current Date
-        Ctn Start engine
+        Ctn Start Engine
         # Let's wait for Engine to be ready
         ${content}    Create List    check_for_external_commands()
         ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
@@ -155,7 +153,7 @@ BEBAMIDT2
     Should Be True    ${result}    The BA ba_1 is in downtime as it should not
 
     Log To Console    Broker is stopped (end of BEBAMIDT2)
-    Ctn Stop engine
+    Ctn Stop Engine
     Ctn Kindly Stop Broker
 
 BEBAMIGNDT1
@@ -195,7 +193,7 @@ BEBAMIGNDT1
 
     Ctn Start Broker
     ${start}    Get Current Date
-    Ctn Start engine
+    Ctn Start Engine
     # Let's wait for the initial service states.
     ${content}    Create List    INITIAL SERVICE STATE: host_50;service_1000;
     ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
@@ -265,7 +263,7 @@ BEBAMIGNDT1
     Should Be True    ${result}    The critical service is no more in downtime, the BA should be critical.
     Log To Console    The BA is now critical (no more downtime)
 
-    Ctn Stop engine
+    Ctn Stop Engine
     Ctn Kindly Stop Broker
 
 BEBAMIGNDT2
@@ -294,7 +292,7 @@ BEBAMIGNDT2
     Ctn Set Command Status    ${cmd_2}    2
     Ctn Start Broker
     ${start}    Get Current Date
-    Ctn Start engine
+    Ctn Start Engine
     # Let's wait for the initial service states.
     ${content}    Create List    INITIAL SERVICE STATE: host_50;service_1000;
     ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
@@ -356,7 +354,7 @@ BEBAMIGNDT2
     Should Be True    ${result}    The critical service is no more in downtime, the BA should be critical.
     Log To Console    The BA is now critical (no more downtime)
 
-    Ctn Stop engine
+    Ctn Stop Engine
     Ctn Kindly Stop Broker
 
 

--- a/tests/bam/pb_inherited_downtime.robot
+++ b/tests/bam/pb_inherited_downtime.robot
@@ -18,6 +18,11 @@ BEBAMIDTU1
     Ctn Config Broker    central
     Ctn Config Broker    rrd
     Ctn Broker Config Log    central    bam    trace
+    Log To Console    Configuring core logger to info
+    Ctn Broker Config Log    central    core    info
+    Ctn Broker Config Log    rrd    core    info
+    Ctn Broker Config Log    module0    core    info
+    Log To Console    core logger configured
     Ctn Config BBDO3    ${1}
     Ctn Config Engine    ${1}
 
@@ -31,15 +36,10 @@ BEBAMIDTU1
     ${cmd_1}    Ctn Get Service Command Id    314
     Log To Console    service_314 has command id ${cmd_1}
     Ctn Set Command Status    ${cmd_1}    2
-    Ctn Start Broker
     ${start}    Get Current Date
-    Ctn Start engine
-    # Let's wait for the initial service states.
-    ${content}    Create List    INITIAL SERVICE STATE: host_50;service_1000;
-    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
-    Should Be True
-    ...    ${result}
-    ...    An Initial service state on service (50, 1000) should be raised before we can start external commands.
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${start}    1
 
     # KPI set to critical
     Ctn Process Service Result Hard    host_16    service_314    2    output critical for 314
@@ -67,7 +67,7 @@ BEBAMIDTU1
     ${result}    Ctn Check Service Downtime With Timeout    _Module_BAM_1    ba_1    0    60
     Should Be True    ${result}    The BA ba_1 is in downtime as it should not
 
-    Ctn Stop engine
+    Ctn Stop Engine
     Ctn Kindly Stop Broker
 
 BEBAMIDTU2
@@ -94,7 +94,7 @@ BEBAMIDTU2
     Ctn Set Command Status    ${cmd_1}    2
     Ctn Start Broker
     ${start}    Get Current Date
-    Ctn Start engine
+    Ctn Start Engine
     # Let's wait for the initial service states.
     ${content}    Create List    INITIAL SERVICE STATE: host_50;service_1000;
     ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
@@ -120,9 +120,9 @@ BEBAMIDTU2
 
     FOR    ${i}    IN RANGE    2
         # Engine is restarted
-        Ctn Stop engine
+        Ctn Stop Engine
         ${start}    Get Current Date
-        Ctn Start engine
+        Ctn Start Engine
         # Let's wait for the initial service states.
         ${content}    Create List    INITIAL SERVICE STATE: host_50;service_1000;
         ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
@@ -153,20 +153,28 @@ BEBAMIDTU2
     Should Be True    ${result}    We should have no more downtime
 
     Log To Console    Broker is stopped (end of BEBAMIDT2)
-    Ctn Stop engine
+    Ctn Stop Engine
     Ctn Kindly Stop Broker
 
 BEBAMIGNDTU1
-    [Documentation]    With bbdo version 3.0.1, a BA of type 'worst' with two services is configured. The downtime policy on this ba is "Ignore the indicator in the calculation". The BA is in critical state, because of the second critical service. Then we apply two downtimes on this last one. The BA state is ok because of the policy on indicators. A first downtime is cancelled, the BA is still OK, but when the second downtime is cancelled, the BA should be CRITICAL.
+    [Documentation]    With bbdo version 3.0.1, a BA of type 'worst' with two services is configured.
+    ...    The downtime policy on this ba is "Ignore the indicator in the calculation". The BA is in
+    ...    critical state, because of the second critical service. Then we apply two downtimes on this
+    ...    last one. The BA state is ok because of the policy on indicators. A first downtime is cancelled,
+    ...    the BA is still OK, but when the second downtime is cancelled, the BA should be CRITICAL.
     [Tags]    broker    downtime    engine    bam
     Ctn Clear Commands Status
+    Ctn Clear Retention
     Ctn Config Broker    module
     Ctn Config Broker    central
+    Ctn Config Broker    rrd
     Ctn Broker Config Log    central    bam    trace
     Ctn Broker Config Log    central    sql    trace
     Ctn Broker Config Flush Log    module0    0
     Ctn Broker Config Log    module0    neb    trace
-    Ctn Config Broker    rrd
+    Ctn Broker Config Log    central    core    info
+    Ctn Broker Config Log    rrd    core    info
+    Ctn Broker Config Log    module0    core    info
     Ctn Config Broker Sql Output    central    unified_sql
     Ctn Config BBDO3    1
     Ctn Config Engine    ${1}
@@ -192,15 +200,10 @@ BEBAMIGNDTU1
     Log To Console    service_314 has command id ${cmd_2}
     Ctn Set Command Status    ${cmd_2}    2
 
-    Ctn Start Broker
     ${start}    Get Current Date
-    Ctn Start engine
-    # Let's wait for the initial service states.
-    ${content}    Create List    INITIAL SERVICE STATE: host_50;service_1000;
-    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
-    Should Be True
-    ...    ${result}
-    ...    An Initial service state on service (50, 1000) should be raised before we can start external commands.
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${start}    1
 
     # KPI set to ok
     Ctn Process Service Result Hard    host_16    service_313    0    output critical for 313
@@ -264,7 +267,7 @@ BEBAMIGNDTU1
     Should Be True    ${result}    The critical service is no more in downtime, the BA should be critical.
     Log To Console    The BA is now critical (no more downtime)
 
-    Ctn Stop engine
+    Ctn Stop Engine
     Ctn Kindly Stop Broker
 
 BEBAMIGNDTU2
@@ -293,15 +296,10 @@ BEBAMIGNDTU2
     ${cmd_2}    Ctn Get Service Command Id    314
     Log To Console    service_314 has command id ${cmd_2}
     Ctn Set Command Status    ${cmd_2}    2
-    Ctn Start Broker
     ${start}    Get Current Date
-    Ctn Start engine
-    # Let's wait for the initial service states.
-    ${content}    Create List    INITIAL SERVICE STATE: host_50;service_1000;
-    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
-    Should Be True
-    ...    ${result}
-    ...    An Initial service state on service (50, 1000) should be raised before we can start external commands.
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${start}    1
 
     # KPI set to ok
     Ctn Process Service Result Hard    host_16    service_313    0    output critical for 313
@@ -354,7 +352,7 @@ BEBAMIGNDTU2
     Should Be True    ${result}    The critical service is no more in downtime, the BA should be critical.
     Log To Console    The BA is now critical (no more downtime)
 
-    Ctn Stop engine
+    Ctn Stop Engine
     Ctn Kindly Stop Broker
 
 

--- a/tests/broker-engine/acknowledgement.robot
+++ b/tests/broker-engine/acknowledgement.robot
@@ -164,7 +164,7 @@ BEACK4
     ...                acknowledge it. The centreon_storage.acknowledgements table is then updated with this
     ...                acknowledgement. The acknowledgement is removed and the comment in the comments table has its
     ...                deletion_time column updated.
-    [Tags]    broker    engine    services    extcmd
+    [Tags]    broker    engine    services    extcmd    MON-150015
     Ctn Config Engine    ${1}    ${50}    ${20}
     Ctn Config Broker    rrd
     Ctn Config Broker    central
@@ -262,17 +262,17 @@ BEACK5
 
 BEACK6
     [Documentation]    Configuration is made with BBDO3. Engine has a critical service. An external command is sent to
-    ...                acknowledge it ; the acknowledgement is sticky. The centreon_storage.acknowledgements table is
-    ...                then updated with this acknowledgement. The service is newly set to WARNING.
-    ...                And the acknowledgement in database is still there.
-    [Tags]    broker    engine    services    extcmd
+    ...    acknowledge it ; the acknowledgement is sticky. The centreon_storage.acknowledgements table is
+    ...    then updated with this acknowledgement. The service is newly set to WARNING.
+    ...    And the acknowledgement in database is still there.
+    [Tags]    broker    engine    services    extcmd    MON-150015
     Ctn Config Engine    ${1}    ${50}    ${20}
     Ctn Config Broker    rrd
     Ctn Config Broker    central
     Ctn Config Broker    module    ${1}
     Ctn Config BBDO3    ${1}
     Ctn Broker Config Log    module0    neb    debug
-    Ctn Broker Config Log    central    sql    debug
+    Ctn Broker Config Log    central    sql    trace
 
     ${start}    Get Current Date
     Ctn Start Broker
@@ -303,7 +303,7 @@ BEACK6
 
     # Acknowledgement is not deleted.
     ${result}    Ctn Check Acknowledgement Is Deleted With Timeout    ${ack_id}    10
-    Should Be True    not ${result}    Acknowledgement ${ack_id} should not be deleted.
+    Should Not Be True    ${result}    Acknowledgement ${ack_id} should not be deleted.
 
     Ctn Remove Service Acknowledgement    host_1    service_1
 

--- a/tests/broker-engine/downtimes.robot
+++ b/tests/broker-engine/downtimes.robot
@@ -330,6 +330,71 @@ DTIM
     Ctn Kindly Stop Broker
 
 
+BEDTRRD1
+    [Documentation]    A service is forced checked then a downtime is set on this service.
+    ...    The service is forced checked again and the downtime is removed.
+    ...    This test is done with BBDO 3.0.0.
+    ...    Then we should not get any error in cbd RRD of kind 'ignored update error in file...'.
+    [Tags]    broker    engine    services    protobuf    MON-150015
+    Ctn Config Engine    ${1}
+    Ctn Engine Config Set Value    ${0}    log_level_functions    trace
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module    ${1}
+    Ctn Broker Config Log    central    sql    debug
+    Ctn Broker Config Log    module0    neb    debug
+
+    Ctn Config BBDO3    1
+    Ctn Clear Retention
+    ${start}    Ctn Get Round Current Date
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+
+    Ctn Process Service Check Result With Metrics    host_1    service_1    2    host_1:service_1 is CRITICAL HARD    20
+    Sleep    1s
+    Ctn Process Service Check Result With Metrics    host_1    service_1    2    host_1:service_1 is CRITICAL HARD    20
+    Sleep    1s
+    Ctn Process Service Check Result With Metrics    host_1    service_1    2    host_1:service_1 is CRITICAL HARD    20
+    Sleep    1s
+    ${result}    Ctn Check Service Resource Status With Timeout    host_1    service_1    2    ${60}    HARD
+    Should Be True    ${result}    The service should be in CRITICAL state HARD.
+
+    ${result}    Grep File    ${rrdLog}    "ignored update error in file"
+    Should Be Empty
+    ...    ${result}
+    ...    There should not be any error in cbd RRD of kind 'ignored update error in file...' After step 1.
+
+    Ctn Schedule Service Downtime    host_1    service_1    ${3600}
+    ${result}    Ctn Check Service Downtime With Timeout    host_1    service_1    1    ${60}
+    Should Be True    ${result}    The service should be in downtime.
+
+    ${result}    Grep File    ${rrdLog}    "ignored update error in file"
+    Should Be Empty    ${result}    There should not be any error in cbd RRD of kind 'ignored update error in file...' After step 2.
+
+    Ctn Process Service Check Result With Metrics    host_1    service_1    1    host_1:service_1 is WARNING HARD    20
+    Sleep    1s
+    Ctn Process Service Check Result With Metrics    host_1    service_1    1    host_1:service_1 is WARNING HARD    20
+    Sleep    1s
+    Ctn Process Service Check Result With Metrics    host_1    service_1    1    host_1:service_1 is WARNING HARD    20
+    Sleep    1s
+    ${result}    Ctn Check Service Resource Status With Timeout    host_1    service_1    1    ${60}    HARD
+    Should Be True    ${result}    The service should be in CRITICAL state HARD.
+
+    ${result}    Grep File    ${rrdLog}    "ignored update error in file"
+    Should Be Empty    ${result}    There should not be any error in cbd RRD of kind 'ignored update error in file...' After step 3.
+
+    Ctn Delete Service Downtime    host_1    service_1
+    ${result}    Ctn Check Number Of Downtimes    ${0}    ${start}    ${120}
+    Should Be True    ${result}    We should have no downtime enabled.
+
+    ${result}    Grep File    ${rrdLog}    "ignored update error in file"
+    Should Be Empty    ${result}    There should not be any error in cbd RRD of kind 'ignored update error in file...' After step 4.
+
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker
+
+
 *** Keywords ***
 Ctn Clean Downtimes Before Suite
     Ctn Clean Before Suite

--- a/tests/broker-engine/notifications.robot
+++ b/tests/broker-engine/notifications.robot
@@ -1009,7 +1009,6 @@ not15
     Ctn Engine Config Set Value In Contacts    0    John_Doe    host_notification_commands    command_notif,command_notif1
     Ctn Engine Config Set Value In Contacts    0    John_Doe    service_notification_commands    command_notif,command_notif1
 
-
     ${start}    Get Current Date
     Ctn Start Broker
     Ctn Start Engine

--- a/tests/resources/Broker.py
+++ b/tests/resources/Broker.py
@@ -1327,7 +1327,7 @@ def ctn_broker_config_log(name, key, value):
     if name == 'central':
         filename = "central-broker.json"
     elif name.startswith('module'):
-        filename = "central-{}.json".format(name)
+        filename = f"central-{name}.json"
     else:
         filename = "central-rrd.json"
     with open(f"{ETC_ROOT}/centreon-broker/{filename}", "r") as f:

--- a/tests/resources/resources.resource
+++ b/tests/resources/resources.resource
@@ -89,7 +89,12 @@ Ctn Reload Broker
     IF    not ${only_central}    Send Signal To Process    SIGHUP    b2
 
 Ctn Kindly Stop Broker
-    [Arguments]    ${only_central}=False
+    [Documentation]    Stop broker and check if it's correctly stopped.
+    ...    If not, generate a coredump and kill the process.
+    ...    If only_central is set to True, only the central broker will be stopped.
+    ...    If bbdo2 is set to True, the rrd broker will not be checked for RRD logs
+    ...    since there are still bugs in this context.
+    [Arguments]    ${only_central}=False    ${bbdo2}=False
     Send Signal To Process    SIGTERM    b1
     IF    not ${only_central}    Send Signal To Process    SIGTERM    b2
     ${result}    Wait For Process    b1    timeout=60s
@@ -106,6 +111,11 @@ Ctn Kindly Stop Broker
             # Copy Coredump In Failed Dir    b1    /usr/sbin/cbd    broker_central
             Ctn Coredump Info    b1    /usr/sbin/cbd    broker_central
             Should Be Equal As Integers    ${result.rc}    0    Central Broker not correctly stopped
+        ELIF	not ${bbdo2}
+            Log To Console    "central broker stopped"
+            # We have to check if central RRD logs contain errors about data sent in the past.
+            ${result}    Grep File    ${rrdLog}    RRD: ignored update error in file
+            Should Be Empty    ${result}    Central RRD logs contain errors about metrics sent in the past.
         END
     END
 
@@ -369,13 +379,15 @@ Ctn Dump Ba On Error
 
 Ctn Process Service Result Hard
     [Arguments]    ${host}    ${svc}    ${state}    ${output}
-    Repeat Keyword
-    ...    3 times
-    ...    Ctn Process Service Check Result
-    ...    ${host}
-    ...    ${svc}
-    ...    ${state}
-    ...    ${output}
+    FOR    ${idx}    IN RANGE    3
+        Ctn Process Service Check Result
+        ...    ${host}
+        ...    ${svc}
+        ...    ${state}
+        ...    ${output}
+	Sleep    1s
+    END
+
 
 Ctn Wait For Engine To Be Ready
     [Arguments]    ${start}    ${nbEngine}=1

--- a/tests/update-doc.py
+++ b/tests/update-doc.py
@@ -90,26 +90,42 @@ These tests are executed from the `centreon-tests/robot` folder and uses the [Ro
 
 From a Centreon host, you need to install Robot Framework
 
-On CentOS 7, the following commands should work to initialize your robot tests:
+On AlmaLinux, the following commands should work to initialize your robot tests:
 
-```
-pip3 install -U robotframework robotframework-databaselibrary robotframework-examples pymysql robotframework-requests
+```bash
+dnf install "Development Tools" python3-devel -y
 
-yum install "Development Tools" python3-devel -y
+pip3 install -U robotframework \
+        robotframework-databaselibrary \
+        robotframework-examples pymysql \
+        robotframework-requests psutil \
+        robotframework-httpctrl boto3 \
+        GitPython unqlite py-cpuinfo
 
-pip3 install grpcio==1.33.2 grpcio_tools==1.33.2
+
+pip3 install grpcio grpcio_tools
 
 #you need also to provide opentelemetry proto files at the project root with this command
 git clone https://github.com/open-telemetry/opentelemetry-proto.git opentelemetry-proto
-          
+
 #Then you must have something like that:
 #root directory/bbdo
 #              /broker
 #              /engine
 #              /opentelemetry-proto
 #              /tests
+```
 
+We need some perl modules to run the tests, you can install them with the following command:
 
+```bash
+dnf install perl-HTTP-Daemon-SSL
+dnf install perl-JSON
+```
+
+Then you can initialize the tests with the following commands:
+
+```bash
 ./init-proto.sh
 ./init-sql.sh
 ```


### PR DESCRIPTION
* enh(broker/grpc): Improvement of the grpc python generator script
* enh(tests): new test on downtimes, to check duplicates in rrd
* enh(broker): AdaptiveHostStatus and AdaptiveServiceStatus added
* fix(engine): update_status() generalized with an argument
* fix(broker): neb::callbacks works better with service_type and internal_id
* enh(broker/lua): the lua stream must handle AdaptiveHostStatus and AdaptiveServiceStatus
* enh(broker/unified_sql): work on adaptive status in unified_sql
* cleanup(collect): headers removed when not needed
* enh(cmake): cmake-vcpkg improved
* fix(broker/bam): pb_adaptive_service_status are handled by bam now

REFS: MON-151250
