### PR TITLE
fix typo on hosts_hostgroups

### DIFF
--- a/broker/unified_sql/src/stream_sql.cc
+++ b/broker/unified_sql/src/stream_sql.cc
@@ -1493,7 +1493,7 @@ void stream::_process_pb_host_group_member(const std::shared_ptr<io::data>& d) {
     }
 
     std::string query = fmt::format(
-        "DELETE FROM hosts_hostgroup WHERE host_id={} and hostgroup_id = {}",
+        "DELETE FROM hosts_hostgroups WHERE host_id={} and hostgroup_id = {}",
         hgm.host_id(), hgm.hostgroup_id());
 
     _mysql.run_query(query, database::mysql_error::delete_host_group_member,


### PR DESCRIPTION
## Description

Fix a typo on a query related to the hosts_hostgroups table.

**Fixes** # MON-153092

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

