### PR TITLE
fix(common/perfdata): Fix parsing labels with brackets in their names…

### DIFF
--- a/common/src/perfdata.cc
+++ b/common/src/perfdata.cc
@@ -265,18 +265,21 @@ std::list<perfdata> perfdata::parse_perfdata(
 
     /* The label is given by s and finishes at end */
     if (*end == ']') {
-      --end;
       if (strncmp(s, "a[", 2) == 0) {
         s += 2;
+        --end;
         p._value_type = perfdata::data_type::absolute;
       } else if (strncmp(s, "c[", 2) == 0) {
         s += 2;
+        --end;
         p._value_type = perfdata::data_type::counter;
       } else if (strncmp(s, "d[", 2) == 0) {
         s += 2;
+        --end;
         p._value_type = perfdata::data_type::derive;
       } else if (strncmp(s, "g[", 2) == 0) {
         s += 2;
+        --end;
         p._value_type = perfdata::data_type::gauge;
       }
     }

--- a/common/tests/perfdata_test.cc
+++ b/common/tests/perfdata_test.cc
@@ -623,3 +623,18 @@ TEST_F(PerfdataParser, BadMetric1) {
     ++i;
   }
 }
+
+TEST_F(PerfdataParser, ExtractPerfdataBrackets) {
+  std::string perfdata(
+      "'xx[aa a aa]'=2;3;7;1;9 '[a aa]'=12;25;50;0;118 'aa a]'=28;13;54;0;80");
+  auto lst{common::perfdata::parse_perfdata(0, 0, perfdata.c_str(), _logger)};
+  auto it = lst.begin();
+  ASSERT_NE(it, lst.end());
+  ASSERT_EQ(it->name(), "xx[aa a aa]");
+  ++it;
+  ASSERT_NE(it, lst.end());
+  ASSERT_EQ(it->name(), "[a aa]");
+  ++it;
+  ASSERT_NE(it, lst.end());
+  ASSERT_EQ(it->name(), "aa a]");
+}

--- a/engine/tests/string/string.cc
+++ b/engine/tests/string/string.cc
@@ -62,6 +62,17 @@ TEST(string_utils, extractPerfdataGaugeDiff) {
             "d[aa a]=28;13;54;0;80");
 }
 
+TEST(string_utils, extractPerfdataBrackets) {
+  std::string perfdata(
+      "'xx[aa a aa]'=2;3;7;1;9 '[a aa]'=12;25;50;0;118 'aa a]'=28;13;54;0;80");
+  ASSERT_EQ(string::extract_perfdata(perfdata, "xx[aa a aa]"),
+            "'xx[aa a aa]'=2;3;7;1;9");
+  ASSERT_EQ(string::extract_perfdata(perfdata, "[a aa]"),
+            "'[a aa]'=12;25;50;0;118");
+  ASSERT_EQ(string::extract_perfdata(perfdata, "aa a]"),
+            "'aa a]'=28;13;54;0;80");
+}
+
 TEST(string_utils, removeThresholdsWithoutThresholds) {
   std::string perfdata("a=2V");
   ASSERT_EQ(string::remove_thresholds(perfdata), "a=2V");


### PR DESCRIPTION
… (but not data source types)

REFS: MON-153096

## Description

I tried to add a test case, let's see if it works ;-)

**Fixes** #[MON-153096](https://centreon.atlassian.net/browse/MON-153096)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

[MON-153096]: https://centreon.atlassian.net/browse/MON-153096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ