### PR TITLE
Mon 106121 build centreon perl libs

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -112,7 +112,7 @@ runs:
         key: ${{ inputs.cache_key }}
 
     # Update if condition to true to get packages as artifacts
-    - if: ${{ false }}
+    - if: ${{ contains(github.event.pull_request.labels.*.name, 'upload-artifacts') }}
       name: Upload package artifacts
       uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
       with:

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -59,6 +59,49 @@ jobs:
       docker_registry_id: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
       docker_registry_passwd: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
 
+  unit-test-perl:
+    needs: [get-environment]
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [unit-tests-alma8, unit-tests-alma9, unit-tests-bullseye-arm64, unit-tests-bookworm]
+        include:
+          - runner_name: ubuntu-22.04
+          - package_extension: rpm
+            image: unit-tests-alma8
+            distrib: el8
+          - package_extension: rpm
+            image: unit-tests-alma9
+            distrib: el9
+          - package_extension: deb
+            image: unit-tests-bullseye-arm64
+            distrib: bullseye-arm64
+            runner_name: ["self-hosted", "collect-arm64"]
+          - package_extension: deb
+            image: unit-tests-bookworm
+            distrib: bookworm
+    runs-on: ${{ matrix.runner_name }}
+    container:
+      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}
+      credentials:
+        username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+        password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Run unit tests
+        run: yath -L test ./perl-libs/lib/
+
+      - name: Upload logs as artifacts if tests failed
+        if: failure()
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: plugin-installation-${{ matrix.distrib }}
+          path: ./lastlog.jsonl
+          retention-days: 1
+
+
   package:
     needs: [get-environment]
     if: ${{ needs.get-environment.outputs.stability != 'stable' }}
@@ -132,7 +175,7 @@ jobs:
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
 
-  test-gorgone:
+  robot-test-gorgone:
     needs: [get-environment, package]
 
     strategy:

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -101,7 +101,6 @@ jobs:
           path: ./lastlog.jsonl
           retention-days: 1
 
-
   package:
     needs: [get-environment]
     if: ${{ needs.get-environment.outputs.stability != 'stable' }}

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - ".github/workflows/gorgone.yml"
       - "gorgone/**"
+      - "perl-libs/**"
       - "!gorgone/tests/**"
       - "!gorgone/veracode.json"
       - "!gorgone/.veracode-exclusions"
@@ -25,7 +26,9 @@ on:
       - master
       - "[2-9][0-9].[0-9][0-9].x"
     paths:
+      - ".github/workflows/gorgone.yml"
       - "gorgone/**"
+      - "perl-libs/**"
       - "!gorgone/tests/**"
       - "!gorgone/veracode.json"
       - "!gorgone/.veracode-exclusions"
@@ -115,7 +118,7 @@ jobs:
       - name: Package
         uses: ./.github/actions/package
         with:
-          nfpm_file_pattern: "gorgone/packaging/*.yaml"
+          nfpm_file_pattern: "gorgone/packaging/*.yaml perl-libs/packaging/*.yaml"
           distrib: ${{ matrix.distrib }}
           package_extension: ${{ matrix.package_extension }}
           major_version: ${{ needs.get-environment.outputs.major_version }}
@@ -149,7 +152,7 @@ jobs:
 
     runs-on: ubuntu-24.04
     container:
-      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:${{ needs.get-environment.outputs.major_version }}
+      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:${{ needs.get-environment.outputs.gorgone_docker_version }}
       credentials:
         username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
         password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
@@ -191,7 +194,7 @@ jobs:
             centreon/www/install/createTables.sql
             centreon/www/install/createTablesCentstorage.sql
 
-      - name: get cached gorgone package
+      - name: get cached gorgone and perl-libs package
         uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: ./*.${{ matrix.package_extension }}
@@ -209,9 +212,9 @@ jobs:
         run: |
           if [[ "${{ matrix.package_extension }}" == "deb" ]]; then
             apt update
-            apt install -y ./centreon-gorgone*${{ steps.parse-distrib.outputs.package_distrib_name }}*
+            apt install -y ./centreon-gorgone*${{ steps.parse-distrib.outputs.package_distrib_name }}* ./centreon-perl-libs-common*${{ steps.parse-distrib.outputs.package_distrib_name }}*
           else
-            dnf install -y ./centreon-gorgone*${{ steps.parse-distrib.outputs.package_distrib_name }}* ./centreon-gorgone-centreon-config*${{ steps.parse-distrib.outputs.package_distrib_name }}*
+            dnf install -y ./centreon-gorgone*${{ steps.parse-distrib.outputs.package_distrib_name }}* ./centreon-perl-libs-common*${{ steps.parse-distrib.outputs.package_distrib_name }}*
             # in el8 at least, there is a package for the configuration and a package for the actual code.
             # this is not the case for debian, and for now I don't know why it was made any different between the 2 Os.
           fi

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -152,7 +152,7 @@ jobs:
 
     runs-on: ubuntu-24.04
     container:
-      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:${{ needs.get-environment.outputs.gorgone_docker_version }}
+      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:${{ needs.get-environment.outputs.major_version }}
       credentials:
         username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
         password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}

--- a/perl-libs/lib/t/common/centreonvault.t
+++ b/perl-libs/lib/t/common/centreonvault.t
@@ -145,7 +145,8 @@ sub test_transform_json_to_object {
 }
 sub test_get_app_secret {
     `mkdir -p /usr/share/centreon/`;
-    `mv /usr/share/centreon/.env /usr/share/centreon/.env.back`;
+    -e '/usr/share/centreon/.env' and `mv /usr/share/centreon/.env /usr/share/centreon/.env.back`;
+
     my $old_app_secret = $ENV{'APP_SECRET'};
     my $res = "SECRET";
     $ENV{'APP_SECRET'} = $res;
@@ -161,7 +162,7 @@ sub test_get_app_secret {
     close($fh);
     is(centreon::common::centreonvault->get_app_secret(), $res, "get_app_secret() should get value from file.");
     `rm /usr/share/centreon/.env`;
-    `mv /usr/share/centreon/.env.back /usr/share/centreon/.env`;
+    -e '/usr/share/centreon/.env.back' and `mv /usr/share/centreon/.env.back /usr/share/centreon/.env`;
     $ENV{'APP_SECRET'} = $old_app_secret;
 }
 

--- a/perl-libs/packaging/centreon-perl-libs-common.yaml
+++ b/perl-libs/packaging/centreon-perl-libs-common.yaml
@@ -15,7 +15,7 @@ homepage: "https://www.centreon.com"
 license: "Apache-2.0"
 
 contents:
-  - src: "../lib/perl/centreon/common"
+  - src: "../lib/centreon/common"
     dst: "${PERL_VENDORLIB}/centreon/common"
     expand: true
     file_info:

--- a/perl-libs/packaging/centreon-perl-libs.yaml
+++ b/perl-libs/packaging/centreon-perl-libs.yaml
@@ -15,27 +15,27 @@ homepage: "https://www.centreon.com"
 license: "Apache-2.0"
 
 contents:
-  - src: "../lib/perl/centreon/health"
+  - src: "../lib/centreon/health"
     dst: "${PERL_VENDORLIB}/centreon/health"
     expand: true
     file_info:
       mode: 0755
-  - src: "../lib/perl/centreon/reporting"
+  - src: "../lib/centreon/reporting"
     dst: "${PERL_VENDORLIB}/centreon/reporting"
     expand: true
     file_info:
       mode: 0755
-  - src: "../lib/perl/centreon/script"
+  - src: "../lib/centreon/script"
     dst: "${PERL_VENDORLIB}/centreon/script"
     expand: true
     file_info:
       mode: 0755
-  - src: "../lib/perl/centreon/trapd"
+  - src: "../lib/centreon/trapd"
     dst: "${PERL_VENDORLIB}/centreon/trapd"
     expand: true
     file_info:
       mode: 0755
-  - src: "../lib/perl/centreon/script.pm"
+  - src: "../lib/centreon/script.pm"
     dst: "${PERL_VENDORLIB}/centreon/script.pm"
     expand: true
     file_info:
@@ -46,7 +46,6 @@ overrides:
   rpm:
     depends:
       - centreon-perl-libs-common
-      - centreon-common = ${VERSION}-${RELEASE}${DIST}
       - perl-interpreter
       - perl(DBI)
       - perl(FindBin)
@@ -74,7 +73,6 @@ overrides:
   deb:
     depends:
       - centreon-perl-libs-common
-      - centreon-common (= ${VERSION}-${RELEASE}${DIST})
       - libconfig-inifiles-perl
       - libcrypt-des-perl
       - librrds-perl


### PR DESCRIPTION
## Description

use gorgone workflow to build the centreon-perl-libs* package moved from centreon/centreon.


**Fixes**

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] master

<h2> How this pull request can be tested ? </h2>

Run the multiples script depending from centreon-perl-libs, they should be installable and work as before.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).