### PR TITLE
MON-151544-hosts-not-displayed-in-resource-status-after-moving-them-to-a-poller-and-gorgone-web-socket-error-1009

### DIFF
--- a/gorgone/docs/modules/core/proxy.md
+++ b/gorgone/docs/modules/core/proxy.md
@@ -12,16 +12,16 @@ A SSH client library make routing to non-gorgoned nodes possible.
 
 ## Configuration
 
-| Directive            | Description                                                        | Default value  |
-|:---------------------|:-------------------------------------------------------------------|:---------------|
-| pool                 | Number of children to instantiate to process events                | `5`            |
-| synchistory_time     | Time in seconds between two log synchronisations                   | `60`           |
-| synchistory_timeout  | Time in seconds before log synchronisation is considered timed out | `30`           |
-| ping                 | Time in seconds between two node pings                             | `60`           |
-| pong_discard_timeout | Time in seconds before a ping is considered lost                   | `300`          |
+| Directive            | Description                                                                                                                        | Default value |
+|:---------------------|:-----------------------------------------------------------------------------------------------------------------------------------|:--------------|
+| pool                 | Number of children to instantiate to process events                                                                                | `5`           |
+| synchistory_time     | Time in seconds between two log synchronisations                                                                                   | `60`          |
+| synchistory_timeout  | Time in seconds before log synchronisation is considered timed out                                                                 | `30`          |
+| ping                 | Time in seconds between two node pings                                                                                             | `60`          |
+| pong_discard_timeout | Time in seconds before a ping is considered lost                                                                                   | `300`         |
+| buffer_size          | maximum size of the packet send from a node to another. This is mainly used by legacycmd to send files to poller from the central. | `150000`      |
 
 This part of the configuration is only used if some poller must connect with the pullwss module.
-
 
 | Directive     | Description                                                                                    | Default value |
 |:--------------|:-----------------------------------------------------------------------------------------------|:--------------|

--- a/gorgone/docs/modules/core/proxy.md
+++ b/gorgone/docs/modules/core/proxy.md
@@ -19,7 +19,8 @@ A SSH client library make routing to non-gorgoned nodes possible.
 | synchistory_timeout  | Time in seconds before log synchronisation is considered timed out                                                                 | `30`          |
 | ping                 | Time in seconds between two node pings                                                                                             | `60`          |
 | pong_discard_timeout | Time in seconds before a ping is considered lost                                                                                   | `300`         |
-| buffer_size          | maximum size of the packet send from a node to another. This is mainly used by legacycmd to send files to poller from the central. | `150000`      |
+| buffer_size          | Maximum size of the packet sent from a node to another. This is mainly used by legacycmd to send files from the central to the poller. | `150000`      |
+
 
 This part of the configuration is only used if some poller must connect with the pullwss module.
 

--- a/gorgone/gorgone/modules/core/proxy/hooks.pm
+++ b/gorgone/gorgone/modules/core/proxy/hooks.pm
@@ -1169,7 +1169,7 @@ sub prepare_remote_copy {
 
     sysopen(FH, $localsrc, O_RDONLY);
     binmode(FH);
-    my $buffer_size = (defined($config->{buffer_size})) ? $config->{buffer_size} : 500_000;
+    my $buffer_size = (defined($config->{buffer_size})) ? $config->{buffer_size} : 150_000;
     my $buffer;
     while (my $bytes = sysread(FH, $buffer, $buffer_size)) {
         my $action = JSON::XS->new->encode({


### PR DESCRIPTION
## Description
When gorgone try to send a file too big (1-50MB) from a node to another in pullwss, the transfer can fail with error 1009.
a mechanism already exist in gorgone to split the data transferer in multiples chunk, but the buffer_size configured by default is way to high (500 000 instead of 200 000 in my test) 
This pr change the default size to 150 000 to be safe and document it.
It also change an automated test to check for this behaviour.
**Fixes** # MON-1515144

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] master

<h2> How this pull request can be tested ? </h2>
On a central with a poller connected with id 2.
Add a 50MB file in /var/cache/centreon/config/2/engine/ and push the configuration from the webapp. The file should be present and identical on the poller in /etc/centreon-engine/

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

