### PR TITLE
enh(ci): run push and publish jobs only on centreon/centreon-collect …

### DIFF
--- a/.github/workflows/centreon-collect.yml
+++ b/.github/workflows/centreon-collect.yml
@@ -301,7 +301,8 @@ jobs:
       (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.is_nightly == 'true')) &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
 
     strategy:
       fail-fast: false
@@ -373,7 +374,8 @@ jobs:
       needs.get-environment.outputs.stability == 'stable' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
 
     steps:
       - name: Checkout sources
@@ -397,7 +399,9 @@ jobs:
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+
     needs: [get-environment, robot-test]
     runs-on: [self-hosted, common]
     strategy:
@@ -432,7 +436,9 @@ jobs:
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+
     needs: [get-environment, robot-test]
     runs-on: [self-hosted, common]
     strategy:
@@ -459,6 +465,19 @@ jobs:
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
+      - name: Create Jira ticket if nightly build failure
+        if: |
+          failure() &&
+          startsWith(github.ref_name, 'dev') &&
+          github.repository == 'centreon/centreon-collect'
+        uses: ./.github/actions/create-jira-ticket
+        with:
+          jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+          jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
+          jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
+          module_name: "centreon-collect"
+          ticket_labels: '["Nightly", "Pipeline", "nightly-${{ github.ref_name }}", "${{ github.job }}"]'
+
   promote:
     needs: [get-environment, deliver-rpm, deliver-deb]
     if: |
@@ -466,7 +485,9 @@ jobs:
       (contains(fromJson('["stable", "testing"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+
     runs-on: [self-hosted, common]
     strategy:
       matrix:

--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt

--- a/.github/workflows/docker-gorgone-testing.yml
+++ b/.github/workflows/docker-gorgone-testing.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/get-environment.yml
 
   dockerize:

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -136,6 +136,7 @@ jobs:
   test-gorgone:
     needs: [get-environment, package]
     if: |
+      github.repository == 'centreon/centreon-collect' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
 
@@ -338,7 +339,9 @@ jobs:
       (contains(fromJson('["stable", "testing"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+
     runs-on: [self-hosted, common]
     strategy:
       matrix:

--- a/.github/workflows/libzmq.yml
+++ b/.github/workflows/libzmq.yml
@@ -218,7 +218,8 @@ jobs:
       (contains(fromJson('["stable", "testing"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
     runs-on: [self-hosted, common]
     strategy:
       matrix:

--- a/.github/workflows/lua-curl.yml
+++ b/.github/workflows/lua-curl.yml
@@ -204,7 +204,8 @@ jobs:
       (contains(fromJson('["stable", "testing"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
     runs-on: [self-hosted, common]
     strategy:
       matrix:

--- a/.github/workflows/rebase-master.yml
+++ b/.github/workflows/rebase-master.yml
@@ -13,7 +13,7 @@ jobs:
   main:
     name: Sync Stable Branches
     runs-on: ubuntu-24.04
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.repository == 'centreon/centreon-collect'
     steps:
       - name: git checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/rebase-version.yml
+++ b/.github/workflows/rebase-version.yml
@@ -13,7 +13,7 @@ jobs:
   main:
     name: Sync Stable Branches
     runs-on: ubuntu-24.04
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.repository == 'centreon/centreon-collect'
     steps:
       - name: git checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/release-trigger-builds.yml
+++ b/.github/workflows/release-trigger-builds.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   release-trigger-builds:
+    if: github.repository == 'centreon/centreon-collect'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   release:
-    if: ${{ github.event.pull_request.merged == true }}
+    if: ${{ github.event.pull_request.merged == true && github.repository == 'centreon/centreon-collect' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Check base_ref

--- a/.github/workflows/windows-agent.yml
+++ b/.github/workflows/windows-agent.yml
@@ -170,7 +170,8 @@ jobs:
           contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
           ! cancelled() &&
           ! contains(needs.*.result, 'failure') &&
-          ! contains(needs.*.result, 'cancelled')
+          ! contains(needs.*.result, 'cancelled') &&
+          github.repository == 'centreon/centreon-collect'
         run: |
           Write-Host "[DEBUG] deliver to testing - Major version: ${{ needs.get-environment.outputs.major_version }}"
           Write-Host "[DEBUG] deliver to testing - Minor version: ${{ needs.get-environment.outputs.minor_version }}"
@@ -190,7 +191,7 @@ jobs:
 
       - name: Promote testing to stable
         if: |
-          needs.get-environment.outputs.stability == 'stable' && github.event_name != 'workflow_dispatch' && ! cancelled()
+          needs.get-environment.outputs.stability == 'stable' && github.event_name != 'workflow_dispatch' && ! cancelled() && github.repository == 'centreon/centreon-collect'
         run: |
           Write-Host "[DEBUG] promote to stable - Major version: ${{ needs.get-environment.outputs.major_version }}"
           Write-Host "[DEBUG] promote to stable - Minor version: ${{ needs.get-environment.outputs.minor_version }}"


### PR DESCRIPTION
…(#1920)

* enh(ci): run push and publish jobs only on centreon/centreon

* Update .github/workflows/centreon-collect.yml

* Update .github/workflows/centreon-collect.yml

---------

## Description

* make sure to run push and publish jobs only on centreon/centreon

Fixes #MON-155163

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

