### PR TITLE
enh(ci): run push and publish jobs only on centreon/centreon-collect …

### DIFF
--- a/.github/workflows/centreon-collect.yml
+++ b/.github/workflows/centreon-collect.yml
@@ -101,7 +101,13 @@ jobs:
   deliver-sources:
     runs-on: [self-hosted, common]
     needs: [get-environment, package]
-    if: ${{ contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch' }}
+    if: |
+      github.event_name != 'workflow_dispatch' &&
+      needs.get-environment.outputs.stability == 'stable' &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
 
     steps:
       - name: Checkout sources
@@ -125,7 +131,8 @@ jobs:
       contains(fromJson('["testing"]'), needs.get-environment.outputs.stability) &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
     needs: [get-environment, package]
     runs-on: [self-hosted, common]
     strategy:
@@ -160,7 +167,8 @@ jobs:
       contains(fromJson('["testing"]'), needs.get-environment.outputs.stability) &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
     needs: [get-environment, package]
     runs-on: [self-hosted, common]
     strategy:
@@ -196,7 +204,9 @@ jobs:
       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+
     runs-on: [self-hosted, common]
     strategy:
       matrix:

--- a/.github/workflows/docker-builder.yml
+++ b/.github/workflows/docker-builder.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -103,7 +103,8 @@ jobs:
       needs.get-environment.outputs.stability == 'stable' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
 
     steps:
       - name: Checkout sources
@@ -127,7 +128,8 @@ jobs:
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
 
     strategy:
       matrix:
@@ -157,7 +159,8 @@ jobs:
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
 
     strategy:
       matrix:
@@ -186,7 +189,9 @@ jobs:
       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+
     runs-on: [self-hosted, common]
     strategy:
       matrix:

--- a/.github/workflows/libzmq.yml
+++ b/.github/workflows/libzmq.yml
@@ -215,7 +215,8 @@ jobs:
       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
     runs-on: [self-hosted, common]
     strategy:
       matrix:

--- a/.github/workflows/lua-curl.yml
+++ b/.github/workflows/lua-curl.yml
@@ -234,7 +234,8 @@ jobs:
       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
     runs-on: [self-hosted, common]
     strategy:
       matrix:

--- a/.github/workflows/rebase-master.yml
+++ b/.github/workflows/rebase-master.yml
@@ -13,7 +13,7 @@ jobs:
   main:
     name: Sync Stable Branches
     runs-on: ubuntu-24.04
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.repository == 'centreon/centreon-collect'
     steps:
       - name: git checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/rebase-version.yml
+++ b/.github/workflows/rebase-version.yml
@@ -13,7 +13,7 @@ jobs:
   main:
     name: Sync Stable Branches
     runs-on: ubuntu-24.04
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && github.repository == 'centreon/centreon-collect'
     steps:
       - name: git checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   release:
-    if: ${{ github.event.pull_request.merged == true }}
+    if: ${{ github.event.pull_request.merged == true && github.repository == 'centreon/centreon-collect' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Check base_ref


### PR DESCRIPTION
…(#1920)

* enh(ci): run push and publish jobs only on centreon/centreon

* Update .github/workflows/centreon-collect.yml

* Update .github/workflows/centreon-collect.yml

---------

## Description

* make sure to run push and publish jobs only on centreon/centreon

Fixes #MON-155163

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

