### PR TITLE
enh(ci): adapt codeowners for powershell and robot scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,9 @@ perl-libs/                     @centreon/owners-perl
 selinux/**                     @centreon/owners-pipelines
 
 tests/**                       @centreon/owners-robot-e2e
+.github/scripts/*robot*        @centreon/owners-robot-e2e
 
 gorgone/docs/                  @centreon/owners-doc
 gorgone/tests/robot/tests      @centreon/owners-robot-e2e
+
+*.ps1                          @centreon/owners-cpp


### PR DESCRIPTION
## Description

enh(ci): adapt codeowners for powershell and robot scripts

**Fixes** MON-156358