### PR TITLE
enh(ci): adapt codeowners for powershell and robot scripts (#1973)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,5 +11,10 @@ gorgone/docs/                  @centreon/owners-doc
 **/selinux/**                  @centreon/owners-pipelines
 
 tests/**                       @centreon/owners-robot-e2e
+.github/scripts/*robot*        @centreon/owners-robot-e2e
 
 gorgone/tests/robot/config/    @centreon/owners-perl
+gorgone/docs/                  @centreon/owners-doc
+gorgone/tests/robot/tests      @centreon/owners-robot-e2e
+
+*.ps1                          @centreon/owners-cpp


### PR DESCRIPTION
## Description

enh(ci): adapt codeowners for powershell and robot scripts (#1973)

**Fixes** MON-156358