### PR TITLE
enh(ci): adapt codeowners for powershell and robot scripts (#1973)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,5 @@ gorgone/docs/                  @centreon/owners-doc
 gorgone/tests/robot/config/    @centreon/owners-perl
 *.pm                           @centreon/owners-perl
 *.pl                           @centreon/owners-perl
+
+.github/scripts/*robot*        @centreon/owners-robot-e2e


### PR DESCRIPTION
## Description

enh(ci): adapt codeowners for powershell and robot scripts (#1973)

**Fixes** MON-126358