### PR TITLE
enh(ci): skip workflows when it is a bump branch

### DIFF
--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -173,6 +173,11 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
+            if (/^bump-.+/.test('${{ github.head_ref || github.ref_name }}')) {
+              core.notice('skipping workflow because it is a bump branch');
+              return true;
+            }
+
             if (${{ steps.has_skip_label.outputs.result }} === false) {
               return false;
             }


### PR DESCRIPTION
## Description

enh(ci): skip workflows when it is a bump branch

**Fixes** MON-156258