### PR TITLE
fix(mbi): fix group by statement for mysql 8

### DIFF
--- a/gorgone/gorgone/modules/centreon/mbi/libs/bi/BIMetric.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/bi/BIMetric.pm
@@ -83,7 +83,7 @@ sub insertMetricsIntoTable {
 	$query .= " s.`sc_id`, s.`sc_name`, s.`host_id`, s.`host_name`, `hc_id`, `hc_name`, `hg_id`, `hg_name`";
 	$query .= " FROM `mod_bi_tmp_today_services` s, `metrics` m, `index_data` i";
 	$query .= " WHERE i.id = m.index_id and i.host_id=s.host_id and i.service_id=s.service_id";
-	$query .= " group by s.hg_id, s.hc_id, s.sc_id, m.index_id, m.metric_id";
+	$query .= " group by s.hg_id, s.hc_id, s.sc_id, m.index_id, m.metric_id, m.metric_name, m.unit_name, s.service_description, s.sc_name, s.host_name, s.host_id, hc_name, s.hg_name";
 	my $sth = $db->query({ query => $query });
 	return $sth;
 }

--- a/gorgone/gorgone/modules/centreon/mbi/libs/bi/HostAvailability.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/bi/HostAvailability.pm
@@ -151,7 +151,7 @@ sub getHGMonthAvailability {
 	$query .= " STRAIGHT_JOIN mod_bi_hostgroups hg ON (h.hg_name=hg.hg_name AND h.hg_id=hg.hg_id)";
 	$query .= " STRAIGHT_JOIN mod_bi_hostcategories hc ON (h.hc_name=hc.hc_name AND h.hc_id=hc.hc_id)";
 	$query .= " WHERE t.year = YEAR('".$start."') AND t.month = MONTH('".$start."') and t.hour=0";
-	$query .= " GROUP BY h.hg_id, h.hc_id, ha.liveservice_id";
+	$query .= " GROUP BY h.hg_id, h.hc_id,hc.id,hg.id,  ha.liveservice_id";
 	my $sth = $db->query({ query => $query });
 	
 	$self->{"logger"}->writeLog("DEBUG","[HOST] Calculating MTBF/MTRS/MTBSI for Host");	

--- a/gorgone/gorgone/modules/centreon/mbi/libs/bi/ServiceAvailability.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/bi/ServiceAvailability.pm
@@ -156,7 +156,7 @@ sub getHGMonthAvailability {
 	$query .= " STRAIGHT_JOIN mod_bi_hostcategories hc ON (s.hc_name=hc.hc_name AND s.hc_id=hc.hc_id)";
 	$query .= " STRAIGHT_JOIN mod_bi_servicecategories sc ON (s.sc_id=sc.sc_id AND s.sc_name=sc.sc_name)";
 	$query .= " WHERE t.year = YEAR('".$start."') AND t.month = MONTH('".$start."') and t.hour=0";
-	$query .= " GROUP BY s.hg_id, s.hc_id, s.sc_id, sa.liveservice_id";
+	$query .= " GROUP BY s.hg_id, s.hc_id, s.sc_id, sa.liveservice_id, hc.id, hg.id, sc.id";
 	my $sth = $db->query({ query => $query });
 
 	my @data = ();
@@ -194,9 +194,9 @@ sub getHGMonthAvailability_optimised {
 	$query .= "STRAIGHT_JOIN mod_bi_hostcategories hc ON (s.hc_name=hc.hc_name AND s.hc_id=hc.hc_id) ";
 	$query .= "STRAIGHT_JOIN mod_bi_servicecategories sc ON (s.sc_id=sc.sc_id AND s.sc_name=sc.sc_name)";
 	$query .= " WHERE YEAR(from_unixtime(time_id)) = YEAR('".$start."') AND MONTH(from_unixtime(time_id))  = MONTH('".$start."') and hour(from_unixtime(time_id)) = 0 ";
-	$query .= "GROUP BY s.hg_id, s.hc_id, s.sc_id, sa.liveservice_id ) availability ";
+	$query .= "GROUP BY s.hg_id, s.hc_id, s.sc_id, sa.liveservice_id, hc.id, sc.id, hg.id ) availability ";
 	$query .= "LEFT JOIN (  SELECT s.hg_id,s.hc_id,s.sc_id,e.modbiliveservice_id, ";
-	$query .= "SUM(IF(state=1,1,0)) as warningEvents,   SUM(IF(state=2,1,0)) as criticalEvents,  ";
+	$query .= "SUM(IF(state=1,1,0)) as warningEvents,   SUM(IF(state=2,1,0)) as criticalEvents, ";
 	$query .= "SUM(IF(state=3,1,0)) as unknownEvents  FROM mod_bi_servicestateevents e ";
 	$query .= "STRAIGHT_JOIN mod_bi_services s ON (e.modbiservice_id = s.id)  ";
 	$query .= "STRAIGHT_JOIN mod_bi_hostgroups hg ON (s.hg_name=hg.hg_name AND s.hg_id=hg.hg_id)  ";
@@ -204,7 +204,7 @@ sub getHGMonthAvailability_optimised {
 	$query .= "STRAIGHT_JOIN mod_bi_servicecategories sc ON (s.sc_id=sc.sc_id AND s.sc_name=sc.sc_name) ";
 	$query .= "AND s.id = e.modbiservice_id   AND start_time < UNIX_TIMESTAMP('".$end."') ";
 	$query .= "AND end_time > UNIX_TIMESTAMP('".$start."')   AND e.state in (1,2,3) ";
-	$query .= "GROUP BY s.hg_id, s.hc_id, s.sc_id, e.modbiliveservice_id ) events  ";
+	$query .= "GROUP BY s.hg_id, s.hc_id, s.sc_id, e.modbiliveservice_id) events  ";
 	$query .= "ON availability.hg_id = events.hg_id AND availability.hc_id = events.hc_id ";
 	$query .= "AND availability.sc_id = events.sc_id ";
 	$query .= "AND availability.liveservice_id = events.modbiliveservice_id";

--- a/gorgone/gorgone/modules/centreon/mbi/libs/centstorage/Metrics.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/centstorage/Metrics.pm
@@ -210,7 +210,7 @@ sub getFirstAndLastValues {
     $query .= " FROM data_bin as d, data_bin as d2, " . $self->{name_minmaxctime_tmp} . " as db";
     $query .= " WHERE db.id_metric=d.id_metric AND db.min_val=d.ctime";
     $query .=         " AND db.id_metric=d2.id_metric AND db.max_val=d2.ctime";
-    $query .= " GROUP BY db.id_metric";
+    $query .= " GROUP BY db.id_metric, d.value, d2.value, d.id_metric";
     my $sth = $db->query({ query => $query });
     $self->addIndexTempTableMetricDayFirstLastValues();
     $self->dropTempTableCtimeMinMaxValues();


### PR DESCRIPTION
* mysql 5.7.5 and later don't allow a select statement with a group by, where a column is in the select but not in the group by.

Refs:MON-156429

## Description

**Fixes** # [MON-156429](https://centreon.atlassian.net/browse/MON-156429)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

[MON-156429]: https://centreon.atlassian.net/browse/MON-156429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ