### PR TITLE
fix(packaging): use nfpm 2.41.1 to avoid rpm signature regression

### DIFF
--- a/.github/docker/Dockerfile.centreon-collect-alma8
+++ b/.github/docker/Dockerfile.centreon-collect-alma8
@@ -49,7 +49,7 @@ dnf install -y cmake \
     yum-utils \
     perl-interpreter \
     zstd \
-    nfpm \
+    nfpm-2.41.1 \
     openssl-devel \
     libssh2-devel \
     libcurl-devel \

--- a/.github/docker/Dockerfile.centreon-collect-alma9
+++ b/.github/docker/Dockerfile.centreon-collect-alma9
@@ -45,7 +45,7 @@ dnf --best install -y cmake \
     perl-interpreter \
     procps-ng \
     zstd \
-    nfpm \
+    nfpm-2.41.1 \
     openssl-devel \
     libssh2-devel \
     libcurl-devel \

--- a/.github/docker/Dockerfile.centreon-collect-debian-bookworm
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bookworm
@@ -51,7 +51,7 @@ apt-get -y install git \
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 
 apt-get update
-apt-get install -y nfpm
+apt-get install -y nfpm=2.41.1
 
 apt-get clean
 

--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye
@@ -48,7 +48,7 @@ echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sourc
 echo 'deb http://deb.debian.org/debian bullseye-backports main contrib' | tee -a /etc/apt/sources.list
 
 apt-get update
-apt-get install -y nfpm
+apt-get install -y nfpm=2.41.1
 apt-get install -y -t bullseye-backports cmake
 
 apt-get clean

--- a/.github/docker/Dockerfile.centreon-collect-mysql-alma9
+++ b/.github/docker/Dockerfile.centreon-collect-mysql-alma9
@@ -44,7 +44,7 @@ dnf --best install -y cmake \
     perl-interpreter \
     procps-ng \
     zstd \
-    nfpm \
+    nfpm-2.41.1 \
     openssl-devel \
     libssh2-devel \
     libcurl-devel \

--- a/.github/docker/Dockerfile.centreon-collect-ubuntu-jammy
+++ b/.github/docker/Dockerfile.centreon-collect-ubuntu-jammy
@@ -50,7 +50,7 @@ apt-get -y install cmake \
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 apt-get update
-apt-get install -y nfpm
+apt-get install -y nfpm=2.41.1
 
 apt-get clean
 


### PR DESCRIPTION
## Description

fix(packaging): use nfpm 2.41.1 to avoid rpm signature regression  (#2004)