### PR TITLE
fix(packaging): use nfpm 2.41.1 to avoid rpm signature regression

### DIFF
--- a/.github/docker/Dockerfile.centreon-collect-alma8
+++ b/.github/docker/Dockerfile.centreon-collect-alma8
@@ -49,7 +49,7 @@ dnf install -y cmake \
     perl-interpreter \
     rpm-build \
     zstd \
-    nfpm
+    nfpm-2.41.1
 
 dnf update libarchive
 

--- a/.github/docker/Dockerfile.centreon-collect-alma9
+++ b/.github/docker/Dockerfile.centreon-collect-alma9
@@ -44,7 +44,7 @@ dnf --best install -y cmake \
     rpm-build \
     procps-ng \
     zstd \
-    nfpm \
+    nfpm-2.41.1 \
     sudo
 
 # TEMPORARY PYTHON UPGRADE TO 3.18 TO HELP WITH DATA_FILTER ISSUE

--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye
@@ -37,7 +37,7 @@ apt-get -y install cmake \
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 apt-get update
-apt-get install -y nfpm
+apt-get install -y nfpm=2.41.1
 
 apt-get clean
 

--- a/.github/docker/Dockerfile.centreon-collect-mysql-alma9
+++ b/.github/docker/Dockerfile.centreon-collect-mysql-alma9
@@ -45,7 +45,7 @@ dnf --best install -y cmake \
     rpm-build \
     procps-ng \
     zstd \
-    nfpm \
+    nfpm-2.41.1 \
     sudo
 
 pip3 install conan==1.64.0 --prefix=/usr --upgrade


### PR DESCRIPTION
## Description

fix(packaging): use nfpm 2.41.1 to avoid rpm signature regression (#2004)