### PR TITLE
fix(packaging): require initscripts dependency on centreon-gorgone

### DIFF
--- a/gorgone/packaging/centreon-gorgone.yaml
+++ b/gorgone/packaging/centreon-gorgone.yaml
@@ -159,6 +159,7 @@ overrides:
       - centreon-common
       - centreon-perl-libs-common
       - bzip2
+      - initscripts
       - perl-Libssh-Session >= 0.8
       - perl-CryptX
       - perl-Mojolicious


### PR DESCRIPTION
## Description

fix(packaging): require initscripts dependency on centreon-gorgone
it is required to run `service` command by centreon-gorgone on a poller

**Fixes** MON-158749

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)