### PR TITLE
Mon 159779 dev 24 10 x  false alarms when restarting cbd

### DIFF
--- a/.github/docker/Dockerfile.centreon-collect-mariadb-alma9-test
+++ b/.github/docker/Dockerfile.centreon-collect-mariadb-alma9-test
@@ -35,7 +35,7 @@ dnf install --best -y \
 
 echo "install robot and dependencies"
 
-pip3 install -U robotframework robotframework-databaselibrary robotframework-httpctrl robotframework-examples pymysql python-dateutil psutil
+pip3 install -U robotframework robotframework-databaselibrary==2.0.4 robotframework-httpctrl robotframework-examples pymysql python-dateutil psutil
 pip3 install grpcio grpcio_tools py-cpuinfo cython unqlite gitpython boto3 robotframework-requests
 
 cd /tmp/collect

--- a/.github/docker/Dockerfile.centreon-collect-mariadb-bookworm-test
+++ b/.github/docker/Dockerfile.centreon-collect-mariadb-bookworm-test
@@ -34,7 +34,7 @@ apt-get clean
 
 localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-pip3 install --break-system-packages -U robotframework robotframework-databaselibrary robotframework-httpctrl robotframework-examples pymysql python-dateutil psutil
+pip3 install --break-system-packages -U robotframework robotframework-databaselibrary==2.0.4 robotframework-httpctrl robotframework-examples pymysql python-dateutil psutil
 pip3 install --break-system-packages grpcio grpcio_tools py-cpuinfo cython unqlite gitpython boto3 robotframework-requests
 
 cd /tmp/collect

--- a/.github/docker/Dockerfile.centreon-collect-mariadb-bullseye-test
+++ b/.github/docker/Dockerfile.centreon-collect-mariadb-bullseye-test
@@ -34,7 +34,7 @@ apt-get clean
 
 localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-pip3 install -U robotframework robotframework-databaselibrary robotframework-httpctrl robotframework-examples pymysql python-dateutil psutil
+pip3 install -U robotframework robotframework-databaselibrary==2.0.4 robotframework-httpctrl robotframework-examples pymysql python-dateutil psutil
 pip3 install grpcio grpcio_tools py-cpuinfo cython unqlite gitpython boto3 robotframework-requests
 
 cd /tmp/collect

--- a/.github/docker/Dockerfile.centreon-collect-mariadb-jammy-test
+++ b/.github/docker/Dockerfile.centreon-collect-mariadb-jammy-test
@@ -38,7 +38,7 @@ apt-get clean
 
 localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-pip3 install -U robotframework robotframework-databaselibrary robotframework-httpctrl robotframework-examples pymysql python-dateutil psutil
+pip3 install -U robotframework robotframework-databaselibrary==2.0.4 robotframework-httpctrl robotframework-examples pymysql python-dateutil psutil
 pip3 install grpcio grpcio_tools py-cpuinfo cython unqlite gitpython boto3 robotframework-requests
 
 cd /tmp/collect

--- a/.github/docker/Dockerfile.centreon-collect-mysql-alma9-test
+++ b/.github/docker/Dockerfile.centreon-collect-mysql-alma9-test
@@ -41,7 +41,7 @@ dnf clean all
 
 echo "install robot and dependencies"
 
-pip3 install -U robotframework robotframework-databaselibrary robotframework-httpctrl robotframework-examples pymysql python-dateutil psutil
+pip3 install -U robotframework robotframework-databaselibrary==2.0.4 robotframework-httpctrl robotframework-examples pymysql python-dateutil psutil
 pip3 install grpcio grpcio_tools py-cpuinfo cython unqlite gitpython boto3 robotframework-requests cryptography
 
 cd /tmp/collect

--- a/.github/workflows/robot-test.yml
+++ b/.github/workflows/robot-test.yml
@@ -262,7 +262,7 @@ jobs:
           python-version: "3.10"
 
       - run: |
-          pip3 install -U robotframework robotframework-databaselibrary pymysql python-dateutil
+          pip3 install -U robotframework robotframework-databaselibrary==2.0.4 pymysql python-dateutil
           cd reports
           rebot -o output.xml ./*-output.xml || true
         shell: bash

--- a/broker/unified_sql/src/stream_sql.cc
+++ b/broker/unified_sql/src/stream_sql.cc
@@ -281,16 +281,15 @@ void stream::_update_hosts_and_services_of_instance(uint32_t id,
     _mysql.run_query(query, database::mysql_error::restore_instances, conn);
     _add_action(conn, actions::instances);
     query = fmt::format(
-        "UPDATE hosts AS h "
-        "SET h.state=h.real_state WHERE h.instance_id={} and h.real_state IS "
-        "NOT NULL",
+        "UPDATE hosts SET state=real_state,real_state=NULL WHERE "
+        "instance_id={} AND real_state IS NOT NULL",
         id);
     _mysql.run_query(query, database::mysql_error::restore_instances, conn);
     _add_action(conn, actions::hosts);
     query = fmt::format(
         "UPDATE services AS s JOIN hosts as h ON h.host_id=s.host_id "
-        "SET s.state=s.real_state WHERE h.instance_id={} and s.real_state IS "
-        "NOT NULL",
+        "SET s.state=s.real_state, s.real_state=NULL WHERE h.instance_id={} "
+        "and s.real_state IS NOT NULL",
         id);
     _mysql.run_query(query, database::mysql_error::restore_instances, conn);
     _add_action(conn, actions::services);

--- a/tests/bam/bam_pb.robot
+++ b/tests/bam/bam_pb.robot
@@ -684,7 +684,7 @@ BA_BOOL_KPI
     ${result}    Ctn Check Service Status With Timeout    host_16    service_314    0    30    HARD
     Should Be True    ${result}    The service (host_16,service_314) is not OK as expected
 
-#    Ctn Schedule Forced Svc Check    _Module_BAM_1    ba_1
+#    Ctn Schedule Forced Service Check    _Module_BAM_1    ba_1
     ${result}    Ctn Check Ba Status With Timeout    test    2    30
     Ctn Dump Ba On Error    ${result}    ${id_ba__sid[0]}
     Should Be True    ${result}    The BA test is not CRITICAL as expected

--- a/tests/broker-engine/external-commands2.robot
+++ b/tests/broker-engine/external-commands2.robot
@@ -1382,7 +1382,7 @@ BESERVCHECK
     Should Be True    ${result}    No check for external commands executed for 1mn.
     Connect To Database    pymysql    ${DBName}    ${DBUser}    ${DBPass}    ${DBHost}    ${DBPort}
     Execute SQL String    UPDATE services set command_line='toto', next_check=0 where service_id=1 and host_id=1
-    Ctn Schedule Forced Svc Check    host_1    service_1
+    Ctn Schedule Forced Service Check    host_1    service_1
     ${command_id}    Ctn Get Service Command Id    1
     ${result}    Ctn Check Service Check With Timeout
     ...    host_1

--- a/tests/broker-engine/rrd-from-db.robot
+++ b/tests/broker-engine/rrd-from-db.robot
@@ -122,9 +122,9 @@ BRRDRBDB1
             BREAK
 	ELSE
 	    # If not available, we force checks to have them.
-            Ctn Schedule Forced Svc Check    host_1    service_1
-            Ctn Schedule Forced Svc Check    host_1    service_2
-            Ctn Schedule Forced Svc Check    host_1    service_3
+            Ctn Schedule Forced Service Check    host_1    service_1
+            Ctn Schedule Forced Service Check    host_1    service_2
+            Ctn Schedule Forced Service Check    host_1    service_3
         END
 	Sleep    1s
     END
@@ -181,9 +181,9 @@ BRRDRBUDB1
             BREAK
 	ELSE
 	    # If not available, we force checks to have them.
-            Ctn Schedule Forced Svc Check    host_1    service_1
-            Ctn Schedule Forced Svc Check    host_1    service_2
-            Ctn Schedule Forced Svc Check    host_1    service_3
+            Ctn Schedule Forced Service Check    host_1    service_1
+            Ctn Schedule Forced Service Check    host_1    service_2
+            Ctn Schedule Forced Service Check    host_1    service_3
         END
 	Sleep    1s
     END
@@ -239,9 +239,9 @@ BRRDUPLICATE
             BREAK
 	ELSE
 	    # If not available, we force checks to have them.
-            Ctn Schedule Forced Svc Check    host_1    service_1
-            Ctn Schedule Forced Svc Check    host_1    service_2
-            Ctn Schedule Forced Svc Check    host_1    service_3
+            Ctn Schedule Forced Service Check    host_1    service_1
+            Ctn Schedule Forced Service Check    host_1    service_2
+            Ctn Schedule Forced Service Check    host_1    service_3
         END
 	Sleep    1s
     END

--- a/tests/broker-engine/rrd.robot
+++ b/tests/broker-engine/rrd.robot
@@ -305,9 +305,9 @@ BRRDRM1
             BREAK
 	ELSE
 	    # If not available, we force checks to have them.
-            Ctn Schedule Forced Svc Check    host_1    service_1
-            Ctn Schedule Forced Svc Check    host_1    service_2
-            Ctn Schedule Forced Svc Check    host_1    service_3
+            Ctn Schedule Forced Service Check    host_1    service_1
+            Ctn Schedule Forced Service Check    host_1    service_2
+            Ctn Schedule Forced Service Check    host_1    service_3
         END
 	Sleep    1s
     END
@@ -375,9 +375,9 @@ BRRDRMU1
             BREAK
 	ELSE
 	    # If not available, we force checks to have them.
-            Ctn Schedule Forced Svc Check    host_1    service_1
-            Ctn Schedule Forced Svc Check    host_1    service_2
-            Ctn Schedule Forced Svc Check    host_1    service_3
+            Ctn Schedule Forced Service Check    host_1    service_1
+            Ctn Schedule Forced Service Check    host_1    service_2
+            Ctn Schedule Forced Service Check    host_1    service_3
         END
 	Sleep    1s
     END
@@ -523,7 +523,7 @@ BRRDSTATUSRETENTION
     Ctn Start Engine
     Ctn Wait For Engine To Be Ready    ${start}    ${1}
 
-    Ctn Schedule Forced Svc Check    host_1    service_1    ${VarRoot}/lib/centreon-engine/config0/rw/centengine.cmd
+    Ctn Schedule Forced Service Check    host_1    service_1    ${VarRoot}/lib/centreon-engine/config0/rw/centengine.cmd
     Log To Console    Engine works during 20s
     Sleep    20s
 

--- a/tests/broker-engine/rrdcached-from-db.robot
+++ b/tests/broker-engine/rrdcached-from-db.robot
@@ -125,9 +125,9 @@ BRRDCDRBDB1
             BREAK
 	ELSE
 	    # If not available, we force checks to have them.
-            Ctn Schedule Forced Svc Check    host_1    service_1
-            Ctn Schedule Forced Svc Check    host_1    service_2
-            Ctn Schedule Forced Svc Check    host_1    service_3
+            Ctn Schedule Forced Service Check    host_1    service_1
+            Ctn Schedule Forced Service Check    host_1    service_2
+            Ctn Schedule Forced Service Check    host_1    service_3
         END
 	Sleep    1s
     END
@@ -185,9 +185,9 @@ BRRDCDRBUDB1
             BREAK
 	ELSE
 	    # If not available, we force checks to have them.
-            Ctn Schedule Forced Svc Check    host_1    service_1
-            Ctn Schedule Forced Svc Check    host_1    service_2
-            Ctn Schedule Forced Svc Check    host_1    service_3
+            Ctn Schedule Forced Service Check    host_1    service_1
+            Ctn Schedule Forced Service Check    host_1    service_2
+            Ctn Schedule Forced Service Check    host_1    service_3
         END
 	Sleep    1s
     END

--- a/tests/broker-engine/rrdcached.robot
+++ b/tests/broker-engine/rrdcached.robot
@@ -253,9 +253,9 @@ BRRDCDRB1
             BREAK
 	ELSE
 	    # If not available, we force checks to have them.
-            Ctn Schedule Forced Svc Check    host_1    service_1
-            Ctn Schedule Forced Svc Check    host_1    service_2
-            Ctn Schedule Forced Svc Check    host_1    service_3
+            Ctn Schedule Forced Service Check    host_1    service_1
+            Ctn Schedule Forced Service Check    host_1    service_2
+            Ctn Schedule Forced Service Check    host_1    service_3
         END
 	Sleep    1s
     END
@@ -324,9 +324,9 @@ BRRDCDRBU1
             BREAK
 	ELSE
 	    # If not available, we force checks to have them.
-            Ctn Schedule Forced Svc Check    host_1    service_1
-            Ctn Schedule Forced Svc Check    host_1    service_2
-            Ctn Schedule Forced Svc Check    host_1    service_3
+            Ctn Schedule Forced Service Check    host_1    service_1
+            Ctn Schedule Forced Service Check    host_1    service_2
+            Ctn Schedule Forced Service Check    host_1    service_3
         END
 	Sleep    1s
     END

--- a/tests/broker-engine/services-increased.robot
+++ b/tests/broker-engine/services-increased.robot
@@ -90,8 +90,8 @@ Service_increased_huge_check_interval
             BREAK
 	ELSE
 	    # If not available, we force checks to have them.
-            Ctn Schedule Forced Svc Check    host_1    service_1
-            Ctn Schedule Forced Svc Check    host_1    service_2
+            Ctn Schedule Forced Service Check    host_1    service_1
+            Ctn Schedule Forced Service Check    host_1    service_2
         END
 	Sleep    1s
     END

--- a/tests/broker-engine/services.robot
+++ b/tests/broker-engine/services.robot
@@ -72,7 +72,7 @@ SRSAS
     ...    Then the "state" of "service_1" is changed to "CRITICAL"
     ...    And the "real_state" of "service_1" in the "services" table is set to NULL
 
-    [Tags]    broker    engine    host
+    [Tags]    broker    engine    service    MON-152343
     Ctn Config Engine    ${1}
     Ctn Config Broker    rrd
     Ctn Config Broker    central
@@ -121,7 +121,7 @@ HRSAS
     ...    Then the "state" of "host_1" is changed to "DOWN"
     ...    And the "real_state" of "host_1" in the "hosts" table is set to NULL
 
-    [Tags]    broker    engine    host
+    [Tags]    broker    engine    host    MON-152343
     Ctn Config Engine    ${1}
     Ctn Config Broker    rrd
     Ctn Config Broker    central

--- a/tests/broker-engine/services.robot
+++ b/tests/broker-engine/services.robot
@@ -59,3 +59,105 @@ SDER
     END
 
     Should Be Equal As Strings    ${output}    ((280,),)
+
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker
+
+SRSAS
+    [Documentation]
+    ...    Given the service "service_1" on "host_1" has its "real_state" set to
+    ...    "CRITICAL" in the "services" table
+    ...    and its "state" set to "WARNING"
+    ...    When the "cbd" service is started
+    ...    Then the "state" of "service_1" is changed to "CRITICAL"
+    ...    And the "real_state" of "service_1" in the "services" table is set to NULL
+
+    [Tags]    broker    engine    host
+    Ctn Config Engine    ${1}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module    ${1}
+    Ctn Config BBDO3    1
+
+    Ctn Start Broker
+    Ctn Start Engine
+
+    Log To Console    Let's wait for the service to be created in the "services" table
+    Connect To Database    pymysql    ${DBName}    ${DBUser}    ${DBPass}    ${DBHost}    ${DBPort}
+    FOR    ${t}    IN RANGE    ${60}
+        ${output}    Query    SELECT count(*) FROM services WHERE description='service_1' AND enabled=1
+	IF    ${output} == ((1,),)    BREAK
+	Sleep    1s
+    END
+
+    Should Be Equal As Strings    ${output}    ((1,),)    We should have one service named service_1 in the "services" table
+    Ctn Kindly Stop Broker
+
+    Log To Console    Initializing real_state to CRITICAL and state to WARNING
+    Execute SQL String
+    ...    UPDATE services SET real_state=2, state=1 WHERE description='service_1'
+
+    Ctn Start Broker
+
+    Ctn Schedule Forced Service Check    host_1    service_1
+
+    Log To Console    Let's wait for the real_state to be NULL and state to be CRITICAL
+    FOR    ${t}    IN RANGE    ${60}
+        ${output}    Query    SELECT real_state, state FROM services WHERE description='service_1' AND enabled=1
+	IF    ${output} == ((None, 2),)    BREAK
+	Sleep    1s
+    END
+    Should Be Equal As Strings    ${output}    ((None, 2),)    real_state should be NULL and state should be CRITICAL
+    Disconnect From Database
+
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker
+
+HRSAS
+    [Documentation]
+    ...    Given the host "host_1" has its "real_state" set to "DOWN" in the "hosts" table
+    ...    and its "state" set to "UP"
+    ...    When the "cbd" service is started
+    ...    Then the "state" of "host_1" is changed to "DOWN"
+    ...    And the "real_state" of "host_1" in the "hosts" table is set to NULL
+
+    [Tags]    broker    engine    host
+    Ctn Config Engine    ${1}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module    ${1}
+    Ctn Config BBDO3    1
+
+    Ctn Start Broker
+    Ctn Start Engine
+
+    Connect To Database    pymysql    ${DBName}    ${DBUser}    ${DBPass}    ${DBHost}    ${DBPort}
+    FOR    ${t}    IN RANGE    ${60}
+        ${output}    Query    SELECT count(*) FROM hosts WHERE name='host_1' AND enabled=1
+	IF    ${output} == ((1,),)    BREAK
+	log to console    ${output}
+	Sleep    1s
+    END
+
+    Should Be Equal As Strings    ${output}    ((1,),)    We should have one host named host_1 in the hosts table
+    Ctn Kindly Stop Broker
+
+    Log To Console    Initializing real_state to DOWN and state to UP
+    Execute SQL String
+    ...    UPDATE hosts SET real_state=1, state=0 WHERE name='host_1';
+
+    Ctn Start Broker
+
+    Ctn Schedule Forced Host Check    host_1
+
+    Log To Console    Let's wait for the real_state to be NULL and state to be DOWN
+    FOR    ${t}    IN RANGE    ${60}
+        ${output}    Query    SELECT real_state, state FROM hosts WHERE name='host_1' AND enabled=1
+	IF    ${output} == ((None, 1),)    BREAK
+	Sleep    1s
+    END
+    Should Be Equal As Strings    ${output}    ((None, 1),)    real_state should be NULL and state should be DOWN
+    Disconnect From Database
+
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker

--- a/tests/broker-engine/whitelist.robot
+++ b/tests/broker-engine/whitelist.robot
@@ -198,7 +198,7 @@ Whitelist_Service
 
     # no file => no restriction
     ${start}    Get Current Date
-    Ctn Schedule Forced Svc Check    host_1    service_1
+    Ctn Schedule Forced Service Check    host_1    service_1
     ${content}    Create List    raw::run: cmd='/tmp/var/lib/centreon-engine/check.pl 0 1.0.0.0'
     ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
     Should Be True    ${result}    No check result found for service_1
@@ -209,7 +209,7 @@ Whitelist_Service
     Create File    /etc/centreon-engine-whitelist/test    ${whitelist_content}
     Ctn Reload Engine
     ${start}    Get Current Date
-    Ctn Schedule Forced Svc Check    host_1    service_1
+    Ctn Schedule Forced Service Check    host_1    service_1
     ${content}    Create List
     ...    service_1: this command cannot be executed because of security restrictions on the poller. A whitelist has been defined, and it does not include this command.
     ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
@@ -219,7 +219,7 @@ Whitelist_Service
     Ctn Engine Config Change Command    0    1    /tmp/var/lib/centreon-engine/check.pl 1 $HOSTADDRESS$
     Ctn Reload Engine
     ${start}    Get Current Date
-    Ctn Schedule Forced Svc Check    host_1    service_1
+    Ctn Schedule Forced Service Check    host_1    service_1
     ${content}    Create List    raw::run: cmd='/tmp/var/lib/centreon-engine/check.pl 1 1.0.0.0'
     ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
     Should Be True    ${result}    /tmp/var/lib/centreon-engine/check.pl 1 not run
@@ -228,7 +228,7 @@ Whitelist_Service
     Ctn Engine Config Change Command    0    1    /tmp/var/lib/centreon-engine/totozea 1 $HOSTADDRESS$
     Ctn Reload Engine
     ${start}    Get Current Date
-    Ctn Schedule Forced Svc Check    host_1    service_1
+    Ctn Schedule Forced Service Check    host_1    service_1
     ${content}    Create List    raw::run: cmd='/tmp/var/lib/centreon-engine/totozea 1 1.0.0.0'
     ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
     Should Be True    ${result}    totozea not found
@@ -259,7 +259,7 @@ Whitelist_Perl_Connector
 
     # command not allowed because of 0 in first argument
     ${start}    Get Current Date
-    Ctn Schedule Forced Svc Check    host_1    service_1
+    Ctn Schedule Forced Service Check    host_1    service_1
     ${content}    Create List
     ...    service_1: this command cannot be executed because of security restrictions on the poller. A whitelist has been defined, and it does not include this command.
     ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
@@ -269,7 +269,7 @@ Whitelist_Perl_Connector
     Ctn Engine Config Change Command    0    14    /tmp/var/lib/centreon-engine/check.pl 1 $HOSTADDRESS$
     Ctn Reload Engine
     ${start}    Get Current Date
-    Ctn Schedule Forced Svc Check    host_1    service_1
+    Ctn Schedule Forced Service Check    host_1    service_1
     ${content}    Create List
     ...    connector::run: connector='Perl Connector', cmd='/tmp/var/lib/centreon-engine/check.pl 1 1.0.0.0'
     ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60

--- a/tests/engine/forced_checks.robot
+++ b/tests/engine/forced_checks.robot
@@ -223,7 +223,7 @@ EMACROS
     Should Be True
     ...    ${result}
     ...    An Initial host state on host_1 should be raised before we can start our external commands.
-    Ctn Schedule Forced Svc Check    host_1    service_1
+    Ctn Schedule Forced Service Check    host_1    service_1
     Sleep    5s
 
     ${content}    Create List
@@ -305,7 +305,7 @@ EMACROS_SEMICOLON
     Should Be True
     ...    ${result}
     ...    An Initial host state on host_1 should be raised before we can start our external commands.
-    Ctn Schedule Forced Svc Check    host_1    service_1
+    Ctn Schedule Forced Service Check    host_1    service_1
     Sleep    5s
 
     ${content}    Create List    KEY2=VAL1;val3;

--- a/tests/resources/Engine.py
+++ b/tests/resources/Engine.py
@@ -2301,7 +2301,7 @@ def ctn_delete_service_downtime_full(poller: int, hst: str, svc: str):
         f.write(cmd)
 
 
-def ctn_schedule_forced_svc_check(host: str, svc: str, pipe: str = f"{VAR_ROOT}/lib/centreon-engine/config0/rw/centengine.cmd"):
+def ctn_schedule_forced_service_check(host: str, svc: str, pipe: str = f"{VAR_ROOT}/lib/centreon-engine/config0/rw/centengine.cmd"):
     """
     Schedule a forced check on a service.
 


### PR DESCRIPTION
This issue is a backport of MON-152343: False alarms when restarting cbd:
real_state in hosts and services tables were not reset to NULL once used.
REFS: MON-159779
