### PR TITLE
enh(ci): migrate runners to arc v2 (#2147)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Download actionlint
         id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.7.1/scripts/download-actionlint.bash)
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash)
         shell: bash
 
       - name: Check workflow files
@@ -35,9 +35,7 @@ jobs:
           SHELLCHECK_OPTS: "--severity=error"
         run: |
           ${{ steps.get_actionlint.outputs.executable }} \
-            -ignore 'label "ubuntu-24.04" is unknown' \
-            -ignore 'label "(common|collect|collect-arm64)" is unknown' \
-            -ignore 'label "veracode" is unknown' \
+            -ignore 'label "centreon-(ubuntu-22.04|common|collect|collect-arm64)" is unknown' \
             -ignore '"github.head_ref" is potentially untrusted' \
             -pyflakes= \
             -color

--- a/.github/workflows/centreon-collect.yml
+++ b/.github/workflows/centreon-collect.yml
@@ -143,7 +143,7 @@ jobs:
             only_cma: "OFF"
           - distrib: jammy
             only_cma: "ON"
-    runs-on: [self-hosted, collect]
+    runs-on: centreon-collect
     env:
       SCCACHE_PATH: "/usr/bin/sccache"
       SCCACHE_BUCKET: "centreon-github-sccache"
@@ -265,53 +265,53 @@ jobs:
           - image: packaging-centreon-collect-vcpkg-alma8
             distrib: el8
             package_extension: rpm
-            runner: [self-hosted, collect]
+            runner: centreon-collect
             arch: amd64
             only_robot_cma: false
           - image: packaging-centreon-collect-vcpkg-alma9
             distrib: el9
             package_extension: rpm
-            runner: [self-hosted, collect]
+            runner: centreon-collect
             arch: amd64
             only_robot_cma: false
           - image: packaging-centreon-collect-vcpkg-bullseye
             distrib: bullseye
             package_extension: deb
-            runner: [self-hosted, collect]
+            runner: centreon-collect
             arch: amd64
             only_robot_cma: true
           - image: packaging-centreon-collect-vcpkg-bullseye-arm64
             distrib: bullseye
             package_extension: deb
-            runner: [self-hosted, collect-arm64]
+            runner: centreon-collect-arm64
             arch: arm64
             only_robot_cma: true
           - image: packaging-centreon-collect-vcpkg-bookworm
             distrib: bookworm
             package_extension: deb
-            runner: [self-hosted, collect]
+            runner: centreon-collect
             arch: amd64
             only_robot_cma: false
           - image: packaging-centreon-collect-vcpkg-bookworm-arm64
             distrib: bookworm
             package_extension: deb
-            runner: [self-hosted, collect-arm64]
+            runner: centreon-collect-arm64
             arch: arm64
             only_robot_cma: false
           - image: packaging-centreon-collect-vcpkg-jammy
             distrib: jammy
             package_extension: deb
-            runner: [self-hosted, collect]
+            runner: centreon-collect
             arch: amd64
             only_robot_cma: true
           - image: packaging-centreon-collect-vcpkg-jammy-arm64
             distrib: jammy
             package_extension: deb
-            runner: [self-hosted, collect-arm64]
+            runner: centreon-collect-arm64
             arch: arm64
             only_robot_cma: true
 
-    name: package ${{ matrix.distrib }} ${{ contains(toJson(matrix.runner), 'arm') && ' arm' || '' }}
+    name: package ${{ matrix.distrib }} ${{ contains(matrix.runner, 'arm') && ' arm' || '' }}
 
     uses: ./.github/workflows/package-collect.yml
 
@@ -330,7 +330,7 @@ jobs:
       image: ${{ matrix.image }}
       distrib: ${{ matrix.distrib }}
       package_extension: ${{ matrix.package_extension }}
-      runner: ${{ toJSON(matrix.runner) }}
+      runner: ${{ matrix.runner }}
       arch: ${{ matrix.arch }}
       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
       only_robot_cma: ${{ matrix.only_robot_cma }}
@@ -532,7 +532,7 @@ jobs:
       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
 
   deliver-sources:
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     needs: [get-environment, package]
     if: |
       github.event_name != 'workflow_dispatch' &&
@@ -568,7 +568,7 @@ jobs:
       github.repository == 'centreon/centreon-collect'
 
     needs: [get-environment, robot-test]
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     strategy:
       matrix:
         include:
@@ -619,7 +619,7 @@ jobs:
       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
 
     needs: [get-environment, robot-test]
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     strategy:
       matrix:
         include:
@@ -685,7 +685,7 @@ jobs:
       ! contains(needs.*.result, 'cancelled') &&
       github.repository == 'centreon/centreon-collect'
 
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     strategy:
       matrix:
         distrib: [el8, el9, bookworm]

--- a/.github/workflows/centreon-common.yml
+++ b/.github/workflows/centreon-common.yml
@@ -93,7 +93,7 @@ jobs:
           stability: ${{ needs.get-environment.outputs.stability }}
 
   deliver-rpm:
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     needs: [get-environment, package]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
@@ -123,7 +123,7 @@ jobs:
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
   deliver-deb:
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     needs: [get-environment, package]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
@@ -163,7 +163,7 @@ jobs:
       ! contains(needs.*.result, 'cancelled') &&
       github.repository == 'centreon/centreon-collect'
 
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     strategy:
       matrix:
         distrib: [el8, el9, bookworm]

--- a/.github/workflows/docker-collect-testing.yml
+++ b/.github/workflows/docker-collect-testing.yml
@@ -41,39 +41,39 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: [self-hosted, collect]
+          - runner: centreon-collect
             distrib: alma9
             database: mariadb
-          - runner: [self-hosted, collect]
+          - runner: centreon-collect
             distrib: alma9
             database: mysql
             dockerfile: centreon-collect-mysql-alma9-test
             image: centreon-collect-mysql-alma9-test
-          - runner: [self-hosted, collect]
+          - runner: centreon-collect
             distrib: bookworm
             database: mariadb
-          - runner: [self-hosted, collect-arm64]
+          - runner: centreon-collect-arm64
             distrib: bookworm
             database: mariadb
-          - runner: [self-hosted, collect]
+          - runner: centreon-collect
             distrib: bullseye
             database: mariadb
-          - runner: [self-hosted, collect-arm64]
+          - runner: centreon-collect-arm64
             distrib: bullseye
             database: mariadb
-          - runner: [self-hosted, collect]
+          - runner: centreon-collect
             distrib: jammy
             database: mariadb
-          - runner: [self-hosted, collect-arm64]
+          - runner: centreon-collect-arm64
             distrib: jammy
             database: mariadb
 
     runs-on: ${{ matrix.runner }}
 
-    name: build image ${{ matrix.database }} ${{ matrix.distrib }} ${{ contains(toJson(matrix.runner), 'arm') && ' arm' || '' }}
+    name: build image ${{ matrix.database }} ${{ matrix.distrib }} ${{ contains(matrix.runner, 'arm') && ' arm' || '' }}
 
     env:
-      IMAGE_NAME: centreon-collect-${{ matrix.database }}-${{ matrix.distrib }}${{ contains(toJson(matrix.runner), 'arm') && '-arm64' || '' }}-test
+      IMAGE_NAME: centreon-collect-${{ matrix.database }}-${{ matrix.distrib }}${{ contains(matrix.runner, 'arm') && '-arm64' || '' }}-test
 
     steps:
       - name: Checkout sources
@@ -101,8 +101,8 @@ jobs:
           context: .
           build-args: |
             "REGISTRY_URL=${{ vars.DOCKER_PROXY_REGISTRY_URL }}"
-            "TRIPLET=${{ contains(toJson(matrix.runner), 'arm') && 'arm64-linux' || 'x64-linux' }}"
-          platforms: ${{ contains(toJson(matrix.runner), 'arm') && 'linux/arm64' || 'linux/amd64' }}
+            "TRIPLET=${{ contains(matrix.runner, 'arm') && 'arm64-linux' || 'x64-linux' }}"
+          platforms: ${{ contains(matrix.runner, 'arm') && 'linux/arm64' || 'linux/amd64' }}
           pull: true
           push: true
           tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.IMAGE_NAME }}:${{ needs.get-environment.outputs.test_img_version }}

--- a/.github/workflows/docker-packaging.yml
+++ b/.github/workflows/docker-packaging.yml
@@ -35,30 +35,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: [self-hosted, collect]
+          - runner: centreon-collect
             distrib: alma8
-          - runner: [self-hosted, collect]
+          - runner: centreon-collect
             distrib: alma9
-          - runner: [self-hosted, collect]
+          - runner: centreon-collect
             distrib: bookworm
-          - runner: [self-hosted, collect-arm64]
+          - runner: centreon-collect-arm64
             distrib: bookworm
-          - runner: [self-hosted, collect]
+          - runner: centreon-collect
             distrib: bullseye
-          - runner: [self-hosted, collect-arm64]
+          - runner: centreon-collect-arm64
             distrib: bullseye
-          - runner: [self-hosted, collect]
+          - runner: centreon-collect
             distrib: jammy
-          - runner: [self-hosted, collect-arm64]
+          - runner: centreon-collect-arm64
             distrib: jammy
 
     runs-on: ${{ matrix.runner }}
 
-    name: build docker image ${{ matrix.distrib }} ${{ contains(toJson(matrix.runner), 'arm') && ' arm' || '' }}
+    name: build docker image ${{ matrix.distrib }} ${{ contains(matrix.runner, 'arm') && ' arm' || '' }}
 
     env:
       IMAGE_BASE_NAME: packaging-centreon-collect
-      IMAGE_SUFFIX: ${{ contains(toJson(matrix.runner), 'arm') && '-arm64' || '' }}
+      IMAGE_SUFFIX: ${{ contains(matrix.runner, 'arm') && '-arm64' || '' }}
 
     steps:
       - name: Checkout sources
@@ -87,8 +87,8 @@ jobs:
           target: centreon_collect_packaging
           build-args: |
             "REGISTRY_URL=${{ vars.DOCKER_PROXY_REGISTRY_URL }}"
-            "TRIPLET=${{ contains(toJson(matrix.runner), 'arm') && 'arm64-linux' || 'x64-linux' }}"
-          platforms: ${{ contains(toJson(matrix.runner), 'arm') && 'linux/arm64' || 'linux/amd64' }}
+            "TRIPLET=${{ contains(matrix.runner, 'arm') && 'arm64-linux' || 'x64-linux' }}"
+          platforms: ${{ contains(matrix.runner, 'arm') && 'linux/arm64' || 'linux/amd64' }}
           pull: true
           push: true
           tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.IMAGE_BASE_NAME }}-${{ matrix.distrib }}${{ env.IMAGE_SUFFIX }}:${{ needs.get-environment.outputs.packaging_img_version }}
@@ -105,8 +105,8 @@ jobs:
           target: centreon_collect_packaging_vcpkg
           build-args: |
             "REGISTRY_URL=${{ vars.DOCKER_PROXY_REGISTRY_URL }}"
-            "TRIPLET=${{ contains(toJson(matrix.runner), 'arm') && 'arm64-linux' || 'x64-linux' }}"
-          platforms: ${{ contains(toJson(matrix.runner), 'arm') && 'linux/arm64' || 'linux/amd64' }}
+            "TRIPLET=${{ contains(matrix.runner, 'arm') && 'arm64-linux' || 'x64-linux' }}"
+          platforms: ${{ contains(matrix.runner, 'arm') && 'linux/arm64' || 'linux/amd64' }}
           pull: false
           push: true
           tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.IMAGE_BASE_NAME }}-vcpkg-${{ matrix.distrib }}${{ env.IMAGE_SUFFIX }}:${{ needs.get-environment.outputs.packaging_img_version }}

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -99,7 +99,7 @@ jobs:
           - package_extension: deb
             image: unit-tests-bullseye-arm64
             distrib: bullseye-arm64
-            runner_name: ["self-hosted", "collect-arm64"]
+            runner_name: centreon-collect-arm64
           - package_extension: deb
             image: unit-tests-bookworm
             distrib: bookworm
@@ -315,7 +315,7 @@ jobs:
           retention-days: 1
 
   deliver-sources:
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     needs: [get-environment, package]
     if: |
       github.event_name != 'workflow_dispatch' &&
@@ -339,7 +339,7 @@ jobs:
           token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
 
   deliver-rpm:
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     needs: [get-environment, unit-test-perl, robot-test-gorgone, changes]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
@@ -370,7 +370,7 @@ jobs:
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
   deliver-deb:
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     needs: [get-environment, unit-test-perl, robot-test-gorgone, changes]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
@@ -411,7 +411,7 @@ jobs:
       ! contains(needs.*.result, 'cancelled') &&
       github.repository == 'centreon/centreon-collect'
 
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     strategy:
       matrix:
         distrib: [el8, el9, bookworm]

--- a/.github/workflows/libzmq.yml
+++ b/.github/workflows/libzmq.yml
@@ -153,7 +153,7 @@ jobs:
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     strategy:
       matrix:
         include:
@@ -189,7 +189,7 @@ jobs:
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     strategy:
       matrix:
         include:
@@ -223,7 +223,7 @@ jobs:
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       github.repository == 'centreon/centreon-collect'
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     strategy:
       matrix:
         distrib: [el8, el9, bookworm]

--- a/.github/workflows/lua-curl.yml
+++ b/.github/workflows/lua-curl.yml
@@ -67,7 +67,7 @@ jobs:
             image: packaging-centreon-collect-bookworm-arm64
             distrib: bookworm
             lua_version: 5.3
-            runner: ["self-hosted", "collect-arm64"]
+            runner: centreon-collect-arm64
             arch: arm64
 
     runs-on: ${{ matrix.runner }}
@@ -209,7 +209,7 @@ jobs:
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       github.repository == 'centreon/centreon-collect'
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     strategy:
       matrix:
         distrib: [el8, el9, bookworm]

--- a/.github/workflows/package-collect.yml
+++ b/.github/workflows/package-collect.yml
@@ -81,7 +81,7 @@ on:
         required: true
 jobs:
   package:
-    runs-on: ${{ fromJSON(inputs.runner) }}
+    runs-on: ${{ inputs.runner }}
 
     env:
       SCCACHE_PATH: "/usr/bin/sccache"

--- a/.github/workflows/robot-test.yml
+++ b/.github/workflows/robot-test.yml
@@ -82,13 +82,13 @@ jobs:
 
       - name: image to disk
         run: |
-          docker save -o /tmp/${{inputs.image}} ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{inputs.image_test}}
+          docker save -o ./${{inputs.image}} ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{inputs.image_test}}
         shell: bash
 
       - name: image to cache
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
-          path: /tmp/${{inputs.image}}
+          path: ./${{inputs.image}}
           key: ${{inputs.image_test}}
 
   robot-test-list:
@@ -133,7 +133,7 @@ jobs:
       - name: Restore image
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
-          path: /tmp/${{inputs.image}}
+          path: ./${{inputs.image}}
           key: ${{inputs.image_test}}
           fail-on-cache-miss: true
 
@@ -146,7 +146,7 @@ jobs:
 
       - name: load image
         run: |
-          docker load --input /tmp/${{ inputs.image }}
+          docker load --input ./${{ inputs.image }}
 
       - name: Test ${{ matrix.feature }}
         env:

--- a/.github/workflows/robot-test.yml
+++ b/.github/workflows/robot-test.yml
@@ -56,7 +56,7 @@ on:
         required: true
 jobs:
   test-image-to-cache:
-    runs-on: ${{ contains(inputs.image, 'arm') && fromJson('["self-hosted", "collect-arm64"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ contains(inputs.image, 'arm') && 'centreon-collect-arm64' || 'ubuntu-24.04' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -115,7 +115,7 @@ jobs:
 
   robot-test:
     needs: [robot-test-list]
-    runs-on: ${{ contains(inputs.image, 'arm') && fromJson('["self-hosted", "collect-arm64"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ contains(inputs.image, 'arm') && 'centreon-collect-arm64' || 'ubuntu-24.04' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/veracode-analysis.yml
+++ b/.github/workflows/veracode-analysis.yml
@@ -55,7 +55,7 @@ jobs:
 
   build:
     name: Binary preparation
-    runs-on: [self-hosted, common]
+    runs-on: centreon-common
     needs: [routing]
     if: needs.routing.outputs.skip_analysis == 'false'
 

--- a/.github/workflows/windows-agent-robot-test.yml
+++ b/.github/workflows/windows-agent-robot-test.yml
@@ -33,7 +33,7 @@ jobs:
       image: packaging-centreon-collect-vcpkg-bullseye
       distrib: bullseye
       package_extension: deb
-      runner: '["self-hosted", "collect"]'
+      runner: centreon-collect
       arch: amd64
       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
       only_robot_cma: true


### PR DESCRIPTION
## Description

enh(ci): migrate runners to arc v2 (#2147)

**Fixes** MON-152896

waiting following issue is resolved :  https://github.com/centreon/centreon-collect/actions/runs/13588499873/job/37989469037
```
/bin/tar: ../../../../tmp: Cannot mkdir: Permission denied
/bin/tar: ../../../../tmp/centreon-collect-mariadb-bookworm-arm64-test: Cannot open: No such file or directory
/bin/tar: Exiting with failure status due to previous errors
Warning: Failed to restore: "/bin/tar" failed with error: The process '/bin/tar' failed with exit code 2
```
EDIT: fixed by moving the cache out of /tmp directory