### PR TITLE
fix(install): centengine scripts were parametrized in old mode

### DIFF
--- a/agent/bench/centreon_conf/centreon-engine/centengine.cfg
+++ b/agent/bench/centreon_conf/centreon-engine/centengine.cfg
@@ -22,7 +22,6 @@ cfg_file=/etc/centreon-engine/commands.cfg
 cfg_file=/etc/centreon-engine/timeperiods.cfg
 cfg_file=/etc/centreon-engine/connectors.cfg
 broker_module=/usr/lib64/centreon-engine/externalcmd.so
-broker_module=/usr/lib64/nagios/cbmod.so /etc/centreon-broker/central-module.json
 broker_module=/usr/lib64/centreon-engine/libopentelemetry.so /etc/centreon-engine/otl_server.json
 interval_length=60
 use_timezone=:Europe/Paris

--- a/engine/conf/centengine.cfg.in
+++ b/engine/conf/centengine.cfg.in
@@ -1,21 +1,21 @@
-##
-## Copyright 2009-2022 Centreon
-##
-## This file is part of Centreon Engine.
-##
-## Centreon Engine is free software: you can redistribute it and/or
-## modify it under the terms of the GNU General Public License version 2
-## as published by the Free Software Foundation.
-##
-## Centreon Engine is distributed in the hope that it will be useful,
-## but WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-## General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with Centreon Engine. If not, see
-## <http://www.gnu.org/licenses/>.
-##
+#
+# Copyright 2009-2025 Centreon
+#
+# This file is part of Centreon Engine.
+#
+# Centreon Engine is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License version 2
+# as published by the Free Software Foundation.
+#
+# Centreon Engine is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Centreon Engine. If not, see
+# <http://www.gnu.org/licenses/>.
+#
 
 # file:  centengine.cfg
 # brief: Sample main config file for Centreon Engine @VERSION@
@@ -119,7 +119,6 @@ event_broker_options=-1
 
 #broker_module=<modulepath> [moduleargs]
 broker_module=@ENGINE_MODULES_DIR@externalcmd.so
-broker_module=@CMAKE_INSTALL_PREFIX@/lib64/nagios/cbmod.so @CMAKE_INSTALL_FULL_SYSCONFDIR@/centreon-broker/central-module.json
 
 
 # var:    use_syslog

--- a/engine/scripts/centengine.service.in
+++ b/engine/scripts/centengine.service.in
@@ -24,7 +24,7 @@ ReloadPropagatedFrom=centreon.service
 After=cbd.service
 
 [Service]
-ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/centengine @PREFIX_ENGINE_CONF@/centengine.cfg
+ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/centengine -b @CMAKE_INSTALL_FULL_SYSCONFDIR@/centreon-broker/central-module.json @PREFIX_ENGINE_CONF@/centengine.cfg
 ExecReload=/bin/kill -HUP $MAINPID
 Type=simple
 User=centreon-engine

--- a/engine/tests/cfg_files/conf1/centengine.cfg
+++ b/engine/tests/cfg_files/conf1/centengine.cfg
@@ -34,7 +34,6 @@ cfg_file=/tmp/meta_services.cfg
 cfg_file=/tmp/tags.cfg
 cfg_file=/tmp/severities.cfg
 broker_module=/usr/lib64/centreon-engine/externalcmd.so
-broker_module=/usr/lib64/nagios/cbmod.so /etc/centreon-broker/central-module.json
 interval_length=60
 use_timezone=:America/New_York
 resource_file=/tmp/resource.cfg

--- a/tests/engine/start-stop.robot
+++ b/tests/engine/start-stop.robot
@@ -36,16 +36,6 @@ ESS4
     Ctn Config Broker    module    ${3}
     Repeat Keyword    5 times    Ctn Start Stop Instances    300ms
 
-ESS5
-    [Documentation]    Engine here is started with cbmod configured with evoluated parameters.
-    ...    The legacy way to start cbmod is cbmod /etc/centreon-broker/central-module.json.
-    ...    Now we can also start it with cbmod -c /etc/centreon-broker/central-module.json -e /etc/centreon-engine.
-    [Tags]    engine    start-stop    MON-15671
-    Ctn Config Engine    ${1}
-    Ctn Config Broker    module    ${1}
-    Ctn Engine Config Set Value    ${0}    broker_module    /usr/lib64/nagios/cbmod.so -c /etc/centreon-broker/central-module0.json -e /etc/centreon-engine    disambiguous=True
-    Repeat Keyword    3 times    Ctn Start Stop Instances    2s
-
 E_FD_LIMIT
     [Documentation]    Engine here is started with a low file descriptor limit.
     ...    The engine should not crash and limit should be set.


### PR DESCRIPTION
## Description

I missed the startup scripts of engine in my previous PR.

REFS: MON-156194
