### PR TITLE
feat(ci): allow PR merge only on qa validation

### DIFF
--- a/.github/actions/get-pr-labels/action.yml
+++ b/.github/actions/get-pr-labels/action.yml
@@ -1,0 +1,33 @@
+name: "get-pr-labels"
+description: "Get pull request labels. Allow to get new labels on re-run (not possible with github context)."
+outputs:
+  labels:
+    description: "list of labels on the pull request"
+    value: ${{ steps.get-labels.outputs.result }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check if PR has skip label
+      id: get-labels
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      with:
+        script: |
+          let labels = [];
+
+          if (${{ contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) }} === true) {
+            try {
+              const fetchedLabels = await github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number
+              });
+              for (const label of fetchedLabels.data) {
+                labels.push(label.name);
+              }
+            } catch (e) {
+              core.warning(`failed to list labels: ${e}`);
+            }
+          }
+
+          return labels;

--- a/.github/workflows/check-qa-validation.yml
+++ b/.github/workflows/check-qa-validation.yml
@@ -1,0 +1,80 @@
+name: check-qa-validation
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.action }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - dev-[2-9][0-9].[0-9][0-9].x
+      - master
+      - "[2-9][0-9].[0-9][0-9].x"
+      - hotfix-*
+      - release-*
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+jobs:
+  check-qa-validation:
+    if: ${{ ! github.event.pull_request.draft }}
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Get PR labels
+        id: get-labels
+        uses: ./.github/actions/get-pr-labels
+
+      - name: Check if PR has been approved by QA
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        id: has-qa-approved-label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+          PR_LABELS: ${{ steps.get-labels.outputs.labels }}
+        with:
+          script: |
+            for (const label of JSON.parse(process.env.PR_LABELS)) {
+              if (label === 'qa-approved') {
+                console.log('This PR has been approved by the QA team');
+                return;
+              }
+            }
+
+            const teamsWithQaApproval = [
+              'owners-php',
+              'owners-react',
+              'owners-cpp',
+            ];
+
+            let needsQaApproval = false;
+            try {
+              const fetchedReviewers = await github.rest.pulls.listRequestedReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number
+              });
+              for (const team of fetchedReviewers.data.teams) {
+                if (teamsWithQaApproval.includes(team.slug)) {
+                  needsQaApproval = true;
+                }
+              }
+            } catch (e) {
+              core.warning(`failed to list required reviewers: ${e}`);
+              needsQaApproval = true;
+            }
+
+            if (needsQaApproval) {
+              throw new Error('This PR is not yet approved by the QA team. If label "qa-approved" has been added, please re-run this workflow.');
+            }
+
+            core.notice('This PR does not need approval by the QA team');

--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -39,6 +39,10 @@ jobs:
           script: |
             await exec.exec("sleep 20s");
 
+            const excludedJobs = [
+              'check-qa-validation',
+            ];
+
             for (let i = 0; i < 120; i++) {
               const failure = [];
               const cancelled = [];
@@ -49,7 +53,7 @@ jobs:
                 repo: context.repo.repo,
                 ref: "${{ github.head_ref }}"
               });
-              result.data.check_suites.forEach(({ app: { slug }, conclusion, id}) => {
+              result.data.check_suites.forEach(({ app: { slug }, conclusion, id }) => {
                 if (slug === 'github-actions') {
                   if (conclusion === 'failure' || conclusion === 'cancelled') {
                     failure.push(id);
@@ -76,7 +80,7 @@ jobs:
                   });
 
                   resultCheckRuns.data.check_runs.forEach(({ conclusion, name, html_url }) => {
-                    if (conclusion === 'failure' || conclusion === 'cancelled') {
+                    if (['failure', 'cancelled'].includes(conclusion) && ! excludedJobs.includes(name)) {
                       failedCheckRuns.push(`<a href="${html_url}">${name} (${conclusion})</a>`);
                     }
                   });
@@ -84,7 +88,7 @@ jobs:
 
                 core.summary.addRaw(`${failedCheckRuns.length} job(s) failed:`, true)
                 core.summary.addList(failedCheckRuns);
-                core.summary.write()
+                core.summary.write();
 
                 if (failedCheckRuns.length > 0) {
                   core.setFailed(`${failedCheckRuns.length} job(s) failed`);


### PR DESCRIPTION
## Description

feat(ci): allow PR merge only on qa validation
This is managed by the label `qa-approved`

**Fixes** MON-158226