### PR TITLE
fix(nightly): add checkout in nightly ticket step for package-collect workflow

### DIFF
--- a/.github/workflows/centreon-collect.yml
+++ b/.github/workflows/centreon-collect.yml
@@ -98,11 +98,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Check current day of the week
-        id: day_check
-        run: echo "day_of_week=$(date +%u)" >> $GITHUB_OUTPUT
-        shell: bash
-
       - name: Run nightly on a different maintenance branch depending on the day
         run: |
           NIGHTLY_TARGETS=("dev-22.10.x" "dev-23.04.x" "dev-23.10.x" "dev-24.04.x" "dev-24.10.x")

--- a/.github/workflows/package-collect.yml
+++ b/.github/workflows/package-collect.yml
@@ -290,6 +290,9 @@ jobs:
       startsWith(github.ref_name, 'dev') &&
       github.repository == 'centreon/centreon-collect'
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Create Jira ticket on nightly build failure
         uses: ./.github/actions/create-jira-ticket
         with:


### PR DESCRIPTION
## Description
self-explanatory, prevents basically this from happening 
https://github.com/centreon/centreon-collect/actions/runs/14161715445/job/39668222145
` Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/centreon-collect/centreon-collect/.github/actions/create-jira-ticket'. Did you forget to run actions/checkout before running your local action?`

(also removed dead pipelines code in dispatch collect action)

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

