### PR TITLE
fix(packaging): Ensure the gorgone logrotate file has the right permissions

### DIFF
--- a/gorgone/packaging/centreon-gorgone.yaml
+++ b/gorgone/packaging/centreon-gorgone.yaml
@@ -113,6 +113,8 @@ contents:
   - src: "../config/logrotate/gorgoned"
     dst: "/etc/logrotate.d/gorgoned"
     type: config|noreplace
+    file_info:
+      mode: 0644
 
   - src: "../gorgoned"
     dst: "/usr/bin/gorgoned"


### PR DESCRIPTION
## Description

**Fixes** #[MON-147493](https://centreon.atlassian.net/browse/MON-147493)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

[MON-147493]: https://centreon.atlassian.net/browse/MON-147493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ