### PR TITLE
fix(mbi): Remove -o option in centreonBIETL help message

### DIFF
--- a/gorgone/contrib/mbi/centreonBIETL
+++ b/gorgone/contrib/mbi/centreonBIETL
@@ -360,7 +360,6 @@ Execution modes
             Extra arguments for option -I:
             -C  Extract only Centreon configuration database only. Works with option -I.
             -i  Ignore perfdata extraction from monitoring server
-            -o  Extract only perfdata from monitoring server
 
         -D  Calculate dimensions
         -E  Calculate event and availability statistics


### PR DESCRIPTION
## Description

This option does not exist anymore.

**Fixes** #[MON-164612](https://centreon.atlassian.net/browse/MON-164612)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

[MON-164612]: https://centreon.atlassian.net/browse/MON-164612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ