### PR TITLE
ci(secu): replace gitleaks secret and remove PRT

### DIFF
--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -96,7 +96,7 @@ jobs:
             let hasSkipLabel = false;
             let labels = [];
 
-            if (${{ contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) }} === true) {
+            if (${{ contains(fromJSON('["pull_request"]') , github.event_name) }} === true) {
               try {
                 const fetchedLabels = await github.rest.issues.listLabelsOnIssue({
                   owner: context.repo.owner,

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: gitleaks/gitleaks-action@83373cf2f8c4db6e24b41c1a9b086bb9619e9cd3 # v2.3.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}}
+          GITLEAKS_LICENSE: "Centreon"
           GITLEAKS_ENABLE_COMMENTS: false
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
           GITLEAKS_ENABLE_SUMMARY: false

--- a/.github/workflows/rebase-master.yml
+++ b/.github/workflows/rebase-master.yml
@@ -2,7 +2,7 @@
 name: Sync next major stable and dev version branches
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
     branches:

--- a/.github/workflows/rebase-version.yml
+++ b/.github/workflows/rebase-version.yml
@@ -2,7 +2,7 @@
 name: Sync stable and dev version branches
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
     branches:

--- a/.github/workflows/set-pull-request-skip-label.yml
+++ b/.github/workflows/set-pull-request-skip-label.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   set-pull-request-skip-label:
-    if: ${{ success() && contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) }}
+    if: ${{ success() && contains(fromJSON('["pull_request"]') , github.event_name) }}
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
## Description

Remove secret in order to allow dependabot and external PR to be able to run the gitleaks mandatory workflow