### PR TITLE
fix(ci): add jammy to gorgone delivery

### DIFF
--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -301,7 +301,7 @@ jobs:
 
     strategy:
       matrix:
-        distrib: [bookworm, noble]
+        distrib: [bookworm, jammy, noble]
 
     steps:
       - name: Checkout sources
@@ -332,7 +332,7 @@ jobs:
     runs-on: centreon-common
     strategy:
       matrix:
-        distrib: [el8, el9, bookworm, noble]
+        distrib: [el8, el9, bookworm, jammy, noble]
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
## Description

add jammy to gorgone delivery on 24.10.x since the client is expected to update their platform before centreon (so they must have jammy packages available)

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

