### PR TITLE
fix(docker): fix collect mariadb docker not installing several python3 dependencies

### DIFF
--- a/.github/docker/Dockerfile.centreon-collect-mariadb-alma9-test
+++ b/.github/docker/Dockerfile.centreon-collect-mariadb-alma9-test
@@ -41,6 +41,7 @@ dnf install --best -y \
     zstd
 
 dnf clean all
+dnf update -y
 
 echo "install robot and dependencies"
 

--- a/.github/docker/Dockerfile.centreon-collect-mariadb-alma9-test
+++ b/.github/docker/Dockerfile.centreon-collect-mariadb-alma9-test
@@ -24,6 +24,13 @@ dnf install --best -y \
     python3 \
     python3-devel \
     python3-pip \
+    python3-audit \
+    python3-distro \
+    python3-libselinux \
+    python3-libsemanage \
+    python3-policycoreutils \
+    python3-setools \
+    python3-setuptools
     perl-interpreter \
     procps-ng \
     psmisc \

--- a/.github/docker/Dockerfile.centreon-collect-mariadb-alma9-test
+++ b/.github/docker/Dockerfile.centreon-collect-mariadb-alma9-test
@@ -40,6 +40,8 @@ dnf install --best -y \
     sudo \
     zstd
 
+dnf clean all
+
 echo "install robot and dependencies"
 
 pip3 install -U robotframework robotframework-databaselibrary==2.0.4 robotframework-httpctrl robotframework-examples pymysql python-dateutil psutil

--- a/.github/docker/Dockerfile.centreon-collect-mysql-alma9-test
+++ b/.github/docker/Dockerfile.centreon-collect-mysql-alma9-test
@@ -38,6 +38,7 @@ dnf install --best -y \
     zstd
 
 dnf clean all
+dnf update -y
 
 echo "install robot and dependencies"
 


### PR DESCRIPTION
## Description

fixing this https://github.com/centreon/centreon-collect/actions/runs/14854677099/job/41724952067?pr=2350

```#7 70.37   Preparing metadata (setup.py): finished with status 'error'
#7 70.37   ERROR: Command errored out with exit status 1:
#7 70.37    command: /usr/bin/python3 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-yluqpopb/robotframework-httpctrl_f45e52e7633147ad8cc0cba5d2d9babe/setup.py'"'"'; __file__='"'"'/tmp/pip-install-yluqpopb/robotframework-httpctrl_f45e52e7633147ad8cc0cba5d2d9babe/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-mf64z5lr
#7 70.37        cwd: /tmp/pip-install-yluqpopb/robotframework-httpctrl_f45e52e7633147ad8cc0cba5d2d9babe/
#7 70.37   Complete output (3 lines):
#7 70.37   Traceback (most recent call last):
#7 70.37     File "<string>", line 1, in <module>
#7 70.37   ModuleNotFoundError: No module named 'setuptools'
#7 70.37   ----------------------------------------
#7 70.37 WARNING: Discarding https://files.pythonhosted.org/packages/13/47/228d969fec339ca5386dbb68e872039374c6fec60e8dfb74998d2a208942/robotframework-httpctrl-0.3.1.tar.gz#sha256=12aea9007bfd906ba457d89b895476daba1be35a59b68d12271f95504a6a2679 (from https://pypi.org/simple/robotframework-httpctrl/) (requires-python:>=3.8). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
#7 70.38   Downloading robotframework-httpctrl-0.3.0.tar.gz (19 kB)
#7 70.39   Preparing metadata (setup.py): started
#7 70.41   Preparing metadata (setup.py): finished with status 'error'
#7 70.41   ERROR: Command errored out with exit status 1:
#7 70.41    command: /usr/bin/python3 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-yluqpopb/robotframework-httpctrl_26e026f8551b4c2a9baa1f239e8ca2ed/setup.py'"'"'; __file__='"'"'/tmp/pip-install-yluqpopb/robotframework-httpctrl_26e026f8551b4c2a9baa1f239e8ca2ed/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-j0ledv6v
#7 70.41        cwd: /tmp/pip-install-yluqpopb/robotframework-httpctrl_26e026f8551b4c2a9baa1f239e8ca2ed/
#7 70.41   Complete output (3 lines):
#7 70.41   Traceback (most recent call last):
#7 70.41     File "<string>", line 1, in <module>
#7 70.41   ModuleNotFoundError: No module named 'setuptools'
```


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

