### PR TITLE
fix(packaging): Add perl(Tie::File) dependency in gorgone rpm package

### DIFF
--- a/gorgone/packaging/centreon-gorgone.spectemplate
+++ b/gorgone/packaging/centreon-gorgone.spectemplate
@@ -45,6 +45,7 @@ Requires:   perl(Sys::Syslog)
 Requires:   perl(DateTime)
 Requires:   perl(Try::Tiny)
 Requires:   perl(lib)
+Requires:   perl(Tie::File)
 Requires:   tar
 AutoReqProv: no
 


### PR DESCRIPTION
On Alma9, this module has been split out and needs to be explicitly installed. On Alma8, it worked fine as it is part of perl-interpreter -- but the new dependency will not be a problem as perl-interpreter provides it.

On Debian 11 and 12, the Tie::File perl module is part of the perl-modules packages; no need to do anything.

## Description

Backport of https://github.com/centreon/centreon-collect/pull/2300

**Fixes** #[MON-168759](https://centreon.atlassian.net/browse/MON-168759)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

[MON-168759]: https://centreon.atlassian.net/browse/MON-168759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ