### PR TITLE
enh(ci): use github public runners for arm (#2323)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -36,6 +36,7 @@ jobs:
         run: |
           ${{ steps.get_actionlint.outputs.executable }} \
             -ignore 'label "centreon-(ubuntu-22.04|common|collect|collect-arm64)" is unknown' \
+            -ignore 'label "ubuntu-24.04-arm" is unknown' \
             -ignore '"github.head_ref" is potentially untrusted' \
             -pyflakes= \
             -color

--- a/.github/workflows/lua-curl.yml
+++ b/.github/workflows/lua-curl.yml
@@ -59,7 +59,7 @@ jobs:
             image: packaging-centreon-collect-bookworm-arm64
             distrib: bookworm
             lua_version: 5.3
-            runner: centreon-collect-arm64
+            runner: ubuntu-24.04-arm
             arch: arm64
           - package_extension: deb
             image: packaging-centreon-collect-jammy

--- a/.github/workflows/robot-test.yml
+++ b/.github/workflows/robot-test.yml
@@ -109,7 +109,7 @@ jobs:
 
   robot-test:
     needs: [robot-test-list]
-    runs-on: ${{ contains(inputs.image, 'arm') && 'centreon-collect-arm64' || 'ubuntu-24.04' }}
+    runs-on: ${{ contains(inputs.image, 'arm') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

enh(ci): use github public runners for arm (#2323)

**Fixes** MON-165634