### PR TITLE
fix(ci): only run dispatch from specific repositories

### DIFF
--- a/.github/workflows/agent-analysis.yml
+++ b/.github/workflows/agent-analysis.yml
@@ -22,6 +22,8 @@ on:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon-collect'
+
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: .version.centreon-monitoring-agent
@@ -30,8 +32,7 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true' &&
-      github.repository == 'centreon/centreon-collect'
+      github.event.pull_request.draft != 'true'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: agent

--- a/.github/workflows/agent-analysis.yml
+++ b/.github/workflows/agent-analysis.yml
@@ -30,7 +30,8 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true'
+      github.event.pull_request.draft != 'true' &&
+      github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: agent

--- a/.github/workflows/bbdo-analysis.yml
+++ b/.github/workflows/bbdo-analysis.yml
@@ -30,7 +30,8 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true'
+      github.event.pull_request.draft != 'true' &&
+      github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: bbdo

--- a/.github/workflows/bbdo-analysis.yml
+++ b/.github/workflows/bbdo-analysis.yml
@@ -22,6 +22,8 @@ on:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon-collect'
+
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt
@@ -30,8 +32,7 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true' &&
-      github.repository == 'centreon/centreon-collect'
+      github.event.pull_request.draft != 'true'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: bbdo

--- a/.github/workflows/broker-analysis.yml
+++ b/.github/workflows/broker-analysis.yml
@@ -30,7 +30,8 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true'
+      github.event.pull_request.draft != 'true' &&
+      github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: broker

--- a/.github/workflows/broker-analysis.yml
+++ b/.github/workflows/broker-analysis.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt
@@ -30,8 +31,7 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true' &&
-      github.repository == 'centreon/centreon-collect'
+      github.event.pull_request.draft != 'true'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: broker

--- a/.github/workflows/checkmarx-analysis.yml
+++ b/.github/workflows/checkmarx-analysis.yml
@@ -23,6 +23,7 @@ on:
 jobs:
   build:
     name: Binary preparation
+    if: github.repository == 'centreon/centreon-collect'
     runs-on: centreon-ubuntu-22.04
     outputs:
       enable_analysis: ${{ steps.routing.outputs.enable_analysis }}

--- a/.github/workflows/clib-analysis.yml
+++ b/.github/workflows/clib-analysis.yml
@@ -30,7 +30,8 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true'
+      github.event.pull_request.draft != 'true' &&
+      github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: clib

--- a/.github/workflows/clib-analysis.yml
+++ b/.github/workflows/clib-analysis.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt
@@ -30,8 +31,7 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true' &&
-      github.repository == 'centreon/centreon-collect'
+      github.event.pull_request.draft != 'true'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: clib

--- a/.github/workflows/connectors-analysis.yml
+++ b/.github/workflows/connectors-analysis.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt
@@ -30,8 +31,7 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true' &&
-      github.repository == 'centreon/centreon-collect'
+      github.event.pull_request.draft != 'true'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: connectors

--- a/.github/workflows/connectors-analysis.yml
+++ b/.github/workflows/connectors-analysis.yml
@@ -30,7 +30,8 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true'
+      github.event.pull_request.draft != 'true' &&
+      github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: connectors

--- a/.github/workflows/docker-collect-testing.yml
+++ b/.github/workflows/docker-collect-testing.yml
@@ -35,7 +35,8 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable'
+      needs.get-environment.outputs.stability != 'stable' &&
+      github.repository == 'centreon/centreon-collect'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/docker-gorgone-testing.yml
+++ b/.github/workflows/docker-gorgone-testing.yml
@@ -29,7 +29,8 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable'
+      needs.get-environment.outputs.stability != 'stable' &&
+      github.repository == 'centreon/centreon-collect'
     runs-on: ubuntu-24.04
 
     strategy:

--- a/.github/workflows/docker-packaging.yml
+++ b/.github/workflows/docker-packaging.yml
@@ -29,7 +29,8 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable'
+      needs.get-environment.outputs.stability != 'stable' &&
+      github.repository == 'centreon/centreon-collect'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/engine-analysis.yml
+++ b/.github/workflows/engine-analysis.yml
@@ -30,7 +30,8 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true'
+      github.event.pull_request.draft != 'true' &&
+      github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: engine

--- a/.github/workflows/engine-analysis.yml
+++ b/.github/workflows/engine-analysis.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt
@@ -30,8 +31,7 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true' &&
-      github.repository == 'centreon/centreon-collect'
+      github.event.pull_request.draft != 'true'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: engine

--- a/.github/workflows/gorgone-analysis.yml
+++ b/.github/workflows/gorgone-analysis.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: .version.centreon-gorgone
@@ -30,8 +31,7 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true' &&
-      github.repository == 'centreon/centreon-collect'
+      github.event.pull_request.draft != 'true'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: gorgone

--- a/.github/workflows/gorgone-analysis.yml
+++ b/.github/workflows/gorgone-analysis.yml
@@ -30,7 +30,8 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true'
+      github.event.pull_request.draft != 'true' &&
+      github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: gorgone

--- a/.github/workflows/perl-libs-analysis.yml
+++ b/.github/workflows/perl-libs-analysis.yml
@@ -30,7 +30,8 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true'
+      github.event.pull_request.draft != 'true' &&
+      github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: perl-libs

--- a/.github/workflows/perl-libs-analysis.yml
+++ b/.github/workflows/perl-libs-analysis.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt
@@ -30,8 +31,7 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.event.pull_request.draft != 'true' &&
-      github.repository == 'centreon/centreon-collect'
+      github.event.pull_request.draft != 'true'
     uses: ./.github/workflows/checkmarx-analysis.yml
     with:
       module_directory: perl-libs


### PR DESCRIPTION
## Description

In order to reduce the amount of GHA runtime

run dispatch jobs only on specific repositories
run analysis jobs on relevant repositories only

**Fixes** #MON-170068

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

