### PR TITLE
fix(gorgone): use dnf instead of yum if it exists on rpm based distro

### DIFF
--- a/gorgone/contrib/gorgone_install_plugins.pl
+++ b/gorgone/contrib/gorgone_install_plugins.pl
@@ -43,15 +43,16 @@ if (scalar(@$plugins) <= 0) {
 
 my $command;
 if ($type eq 'rpm') {
-    $command = 'yum -y install';
-    foreach (@$plugins) {
-        $command .= " '" . $_ . "-*'"
+    if (-x '/usr/bin/dnf' or -x '/usr/sbin/dnf') {
+      $command = 'dnf -y install';
+    } else {
+      $command = 'yum -y install';
     }
 } elsif ($type eq 'deb') {
     $command = 'apt-get -y install';
-    foreach (@$plugins) {
-        $command .= " '" . $_ . "-*'"
-    }
+}
+foreach (@$plugins) {
+    $command .= " '" . $_ . "-*'"
 }
 $command .= ' 2>&1';
 


### PR DESCRIPTION
## Description
Backport of MON-160976, use DNF if available on the system.


## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Run gorgone on rpm based distro with and without dnf installed, it should be able to install any plugins.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

