### PR TITLE
fix(engine): Fix undefined symbol

### DIFF
--- a/broker/stats/CMakeLists.txt
+++ b/broker/stats/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(
   ${SRC_DIR}/parser.cc
   ${SRC_DIR}/worker.cc
   ${SRC_DIR}/worker_pool.cc
+  ${PROJECT_SOURCE_DIR}/core/src/stats/helper.cc
   # Headers.
   ${INC_DIR}/builder.hh
   ${INC_DIR}/parser.hh


### PR DESCRIPTION
## Description

**Fixes** #[MON-171621](https://centreon.atlassian.net/browse/MON-171621)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

[MON-171621]: https://centreon.atlassian.net/browse/MON-171621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ