### PR TITLE
enh(ci): skip windows monitoring agent job if workflow succeed (#2430)

### DIFF
--- a/.github/workflows/monitoring-agent.yml
+++ b/.github/workflows/monitoring-agent.yml
@@ -54,6 +54,9 @@ jobs:
 
   build-and-test-agent-windows:
     needs: [get-environment]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      needs.get-environment.outputs.stability != 'stable'
     runs-on: windows-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.COLLECT_S3_ACCESS_KEY }}


### PR DESCRIPTION
## Description

enh(ci): skip windows monitoring agent job if workflow succeed (#2430)

**Fixes** MON-170942