### PR TITLE
Mon 172275 delivery add sync delete for testing repositories when delivering testing packages

### DIFF
--- a/.github/actions/deb-delivery/action.yml
+++ b/.github/actions/deb-delivery/action.yml
@@ -76,6 +76,10 @@ runs:
 
           echo "[DEBUG] - Version: $VERSION"
 
-          jf rt upload "$FILE" "$ROOT_REPO_PATH/pool/${{ inputs.module_name }}/" --deb "${{ inputs.distrib }}/main/$ARCH" --flat
+          if [[ "${{ inputs.stability }}" == "stable" ]]; then
+            echo "[DEBUG] - Stability is ${{ inputs.stability }}, not delivering."
+          else
+            jf rt upload "$FILE" "$ROOT_REPO_PATH/pool/${{ inputs.module_name }}/" --deb "${{ inputs.distrib }}/main/$ARCH" --sync-deletes="$ROOT_REPO_PATH/pool/${{ inputs.module_name }}/" --flat
+          fi
         done
       shell: bash

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -269,7 +269,7 @@ jobs:
           script: |
             const getStability = (branchName) => {
               switch (true) {
-                case /(^develop$)|(^dev-\d{2}\.\d{2}\.x$)|(^prepare-release-cloud.*)/.test(branchName):
+                case /(^develop$)|(^dev-\d{2}\.\d{2}\.x$)|(^prepare-release-cloud.*)|(^MON-172275-delivery-add-sync-delete-for-testing-repositories-when-delivering-testing-packages)/.test(branchName):
                   return 'unstable';
                 case /(^release.+)|(^hotfix.+)/.test(branchName):
                   return 'testing';

--- a/gorgone/gorgone/class/clientzmq.pm
+++ b/gorgone/gorgone/class/clientzmq.pm
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright 2019 Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets


### PR DESCRIPTION
## Description

* added sync-deletes option to debian delivery
* this should prevent any package from being kept overtime in testing even when they are not needed anymore

**Fixes** #MON-172275

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.10.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

