### PR TITLE
fix(gorgone): Sensitive Credentials Exposed in Logs

### DIFF
--- a/gorgone/gorgone/modules/core/action/class.pm
+++ b/gorgone/gorgone/modules/core/action/class.pm
@@ -35,6 +35,7 @@ use POSIX ":sys_wait_h";
 use MIME::Base64;
 use Digest::MD5::File qw(file_md5_hex);
 use Archive::Tar;
+use Text::ParseWords;
 use Fcntl;
 use Try::Tiny;
 use EV;
@@ -387,14 +388,21 @@ sub action_command {
         }
 
         if ($self->is_command_authorized(command => $command->{command})) {
-            $self->{logger}->writeLogError("[action] command not allowed (whitelist): " . $command->{command});
+            my $commandtolog = $command->{command};
+            unless ($self->{logger}->is_debug()) {
+                my @commands = shellwords($command->{command});
+                $commandtolog = $commands[0];
+                $commandtolog .= ' ...' if @commands > 1;
+            }
+
+            $self->{logger}->writeLogError("[action] command not allowed (whitelist): " . $commandtolog);
             $self->send_log(
                 socket => $options{socket_log},
                 code => GORGONE_ACTION_FINISH_KO,
                 token => $options{token},
                 logging => $options{data}->{logging},
                 data => {
-                    message => "command not allowed (whitelist) at array index '$index' : $command->{command}"
+                    message => "command not allowed (whitelist) at array index '$index' : $commandtolog"
                 }
             );
             return -1;
@@ -701,14 +709,21 @@ sub action_actionengine {
     }
 
     if ($self->is_command_authorized(command => $options{data}->{content}->{command})) {
-        $self->{logger}->writeLogError("[action] command not allowed (whitelist): " . $options{data}->{content}->{command});
+        my $commandtolog = $options{data}->{content}->{command};
+        unless ($self->{logger}->is_debug()) {
+            my @commands = shellwords($options{data}->{content}->{command});
+            $commandtolog = $commands[0];
+            $commandtolog .= ' ...' if @commands > 1;
+        }
+
+        $self->{logger}->writeLogError("[action] command not allowed (whitelist): " . $commandtolog);
         $self->send_log(
             socket => $options{socket_log},
             code => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
             logging => $options{data}->{logging},
             data => {
-                message => 'command not allowed (whitelist)' . $options{data}->{content}->{command}
+                message => 'command not allowed (whitelist)' . $commandtolog
             }
         );
         return -1;

--- a/gorgone/tests/unit/modules/core/action/class.t
+++ b/gorgone/tests/unit/modules/core/action/class.t
@@ -6,7 +6,7 @@ use Test2::V0;
 use Test2::Plugin::NoWarnings echo => 1;
 use Test2::Tools::Compare qw{is like match};
 use FindBin;
-use lib "$FindBin::Bin/../../../../../../";
+use lib "$FindBin::Bin/../../../../../";
 use gorgone::modules::core::action::class;
 use tests::unit::lib::mockLogger;
 

--- a/gorgone/tests/unit/modules/core/action/class.t
+++ b/gorgone/tests/unit/modules/core/action/class.t
@@ -1,0 +1,83 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test2::V0;
+use Test2::Plugin::NoWarnings echo => 1;
+use Test2::Tools::Compare qw{is like match};
+use FindBin;
+use lib "$FindBin::Bin/../../../../../../";
+use gorgone::modules::core::action::class;
+use tests::unit::lib::mockLogger;
+
+sub main {
+    my $mock_logger = mock 'centreon::common::logger'; # this is from Test2::Tools::Mock, included by Test2::V0
+
+    
+    # The writeLogError function is redefined to capture log messages into $output
+    my $is_debug = 0;
+    my $output = '';
+    $mock_logger->override('writeLogError' => sub {
+        $output .= "@_\n";
+    });
+    # is_debug function is redefined to control the debug mode using the $is_debug variable
+    $mock_logger->set('is_debug' => sub {
+        return $is_debug;
+    });
+
+    my %options = (
+        logger  => $mock_logger->class,
+        module_id => 'core',
+        config => {
+            whitelist_cmds => 1,
+
+            # Our allowed commands for testing
+            allowed_cmds => [ 'ls', 'ls --options' ],
+        },
+        config_core => { gorgonecore => { internal_com_crypt => 0 } },
+    );
+
+    my $gorgone = gorgone::modules::core::action::class->new(%options);
+
+    # Check that in all use cases parameters are only shown in debug mode
+
+    $options{data}->{content} = { command => 'pwd --login=login --password=pAs$W@rd' };
+    ($is_debug = 0, $output = '');
+    $gorgone->action_actionengine(%options);
+    ok($output =~ /command not allowed/ && $output =~ /pwd \.\.\./ && $output !~ /--password/, '(action_actionengine) disallowed command does not display parameters');
+
+    ($is_debug = 1, $output = '');
+    $gorgone->action_actionengine(%options);
+    ok($output =~ /command not allowed/ && $output =~ /--password/ && $output !~ /\.\.\./ , '(action_actionengine) in debug mode disallowed command displays parameters');
+    
+    $options{data}->{content} = { command => 'ls --secret=toto' };
+    ($is_debug = 0, $output = '');
+    $gorgone->action_actionengine(%options);
+    ok($output eq "", '(action_actionengine) allowed command display nothing');
+
+    ($is_debug = 1, $output = '');
+    $gorgone->action_actionengine(%options);
+    ok($output eq "", '(action_actionengine) in debug mode allowed command display nothing');
+
+
+    $options{data}->{content} = [ { command => 'ls --secret=toto' }, { command => 'pwd --login=login --password=pAs$W@rd' }, ];
+    ($is_debug = 0, $output = '');
+    $gorgone->action_command(%options);
+    ok($output =~ /command not allowed/ && $output =~ /pwd \.\.\./ && $output !~ /--secret/ , '(action_command) disallowed commands does not display parameters');
+
+    ($is_debug = 1, $output = '');
+    $gorgone->action_command(%options);
+    ok($output =~ /command not allowed/ && $output =~ /--password/ && $output !~ /pwd \.\.\./ && $output !~ /--secret/ , '(action_command) in debug mode disallowed commands does not display parameters');
+
+    $options{data}->{content} = [ { command => 'ls --secret=toto' }, { command => 'ls --options=toto' }, ];
+    ($is_debug = 0, $output = '');
+    $gorgone->action_command(%options);
+    ok($output eq "" , '(action_command) allowed commands display nothing');
+
+    ($is_debug = 1, $output = '');
+    $gorgone->action_command(%options);
+    ok($output eq "" , '(action_command) in debug mode allowed commands display nothing');
+
+    done_testing();
+}
+main;


### PR DESCRIPTION
## Description

Sensitive Credentials Exposed in Logs

**Fixes** # MON-162285 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.10.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master
