### PR TITLE
fix(gorgone): centreontrapd.sdb on poller has wrong permissions

### DIFF
--- a/gorgone/gorgone/modules/centreon/legacycmd/class.pm
+++ b/gorgone/gorgone/modules/centreon/legacycmd/class.pm
@@ -354,6 +354,8 @@ sub execute_cmd {
                     cache_dir => $cache_dir,
                     owner => 'centreon',
                     group => 'centreon',
+                    # With SYNCTRAP the destination file must have permissions 0664
+                    mode => '0664',
                     metadata => {
                         centcore_proxy => 1,
                         centcore_cmd => 'SYNCTRAP'

--- a/gorgone/gorgone/modules/core/action/class.pm
+++ b/gorgone/gorgone/modules/core/action/class.pm
@@ -635,7 +635,6 @@ sub action_processcopy {
                     $self->{logger}->writeLogError("[action] Copy processing - Can't copy file to $dest_filename, $!");
                     return -1
                 }
-
                 my $uid = getpwnam($options{data}->{content}->{owner});
                 my $gid = getgrnam($options{data}->{content}->{group});
                 my $chown_status = chown($uid, $gid, $dest_filename);
@@ -643,6 +642,10 @@ sub action_processcopy {
                 # this should be logged but not quiting the sub, as most of the time it will fail, as we can't change ownership as centreon-gorgone user.
                 if ($chown_status == 0) {
                     $self->{logger}->writeLogError("[action] Copy processing - can't change permission of file $dest_filename: $!");
+                }
+                if ($options{data}->{content}->{mode}) {
+                    chmod(oct($options{data}->{content}->{mode}), $dest_filename) or
+                        $self->{logger}->writeLogError("[action] Copy processing - can't change mode of file $dest_filename: $!");
                 }
             }
         } else {

--- a/gorgone/gorgone/modules/core/proxy/hooks.pm
+++ b/gorgone/gorgone/modules/core/proxy/hooks.pm
@@ -1123,12 +1123,18 @@ sub prepare_remote_copy {
         $owner = $options{data}->{content}->{owner} if (defined($options{data}->{content}->{owner}) && $options{data}->{content}->{owner} ne '');
         my $group;
         $group = $options{data}->{content}->{group} if (defined($options{data}->{content}->{group}) && $options{data}->{content}->{group} ne '');
+        my $mode;
+        $mode = $options{data}->{content}->{mode} if (defined($options{data}->{content}->{mode}) && $options{data}->{content}->{mode} ne '');
         foreach my $file (@inventory) {
             next if ($file eq '.');
             $tar->add_files($file);
             if (defined($owner) || defined($group)) {
                 $tar->chown($file, $owner, $group);
             }
+            if (defined($mode)) {
+                $tar->chmod($file, "$mode");
+            }
+
         }
 
         unless (chdir($options{data}->{content}->{cache_dir})) {
@@ -1199,7 +1205,11 @@ sub prepare_remote_copy {
             destination => $dst,
             cache_dir => $options{data}->{content}->{cache_dir},
             owner => $options{data}->{content}->{owner},
-            group => $options{data}->{content}->{group}
+            group => $options{data}->{content}->{group},
+            # We only handle mode for regular files because the permissions of the files
+            # contained in a TAR archive are already managed within the archive
+            $type eq 'regular' ? ( mode => $options{data}->{content}->{mode} // undef )
+                               : ()
         },
         parameters => { no_fork => 1 }
     });


### PR DESCRIPTION
## Description

centreontrapd.sdb on poller has wrong permissions

**Fixes** # MON-22070

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.10.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master