### PR TITLE
enh(broker/lua): new cache hostgroup cache function to get their alias

### DIFF
--- a/bbdo/neb.proto
+++ b/bbdo/neb.proto
@@ -716,6 +716,7 @@ message HostGroup {
   uint64 hostgroup_id = 3;
   string name = 4;
   uint64 poller_id = 5;
+  string alias = 6;
 }
 
 /* io::neb, neb::de_pb_service_group, 24 */

--- a/broker/lua/inc/com/centreon/broker/lua/macro_cache.hh
+++ b/broker/lua/inc/com/centreon/broker/lua/macro_cache.hh
@@ -100,6 +100,7 @@ class macro_cache {
   int32_t get_severity(uint64_t host_id, uint64_t service_id) const;
   std::string_view get_check_command(uint64_t host_id,
                                      uint64_t service_id = 0) const;
+  const std::string& get_host_group_alias(uint64_t id) const;
   const std::string& get_host_group_name(uint64_t id) const;
   absl::btree_map<std::pair<uint64_t, uint64_t>,
                   std::shared_ptr<io::data>> const&

--- a/broker/lua/src/broker_cache.cc
+++ b/broker/lua/src/broker_cache.cc
@@ -172,7 +172,30 @@ static int l_broker_cache_get_hostgroup_name(lua_State* L) {
 
   try {
     std::string const& hg{cache->get_host_group_name(id)};
-    lua_pushstring(L, hg.c_str());
+    lua_pushlstring(L, hg.c_str(), hg.length());
+  } catch (std::exception const& e) {
+    (void)e;
+    lua_pushnil(L);
+  }
+  return 1;
+}
+
+/**
+ *  The get_hostgroup_alias() method available in the Lua interpreter
+ *  It returns a string.
+ *
+ *  @param L The Lua interpreter
+ *
+ *  @return 1
+ */
+static int l_broker_cache_get_hostgroup_alias(lua_State* L) {
+  macro_cache const* cache(
+      *static_cast<macro_cache**>(luaL_checkudata(L, 1, "lua_broker_cache")));
+  int id(luaL_checkinteger(L, 2));
+
+  try {
+    std::string const& hg{cache->get_host_group_alias(id)};
+    lua_pushlstring(L, hg.c_str(), hg.length());
   } catch (std::exception const& e) {
     (void)e;
     lua_pushnil(L);
@@ -700,6 +723,7 @@ void broker_cache::broker_cache_reg(lua_State* L,
       {"get_action_url", l_broker_cache_get_action_url},
       {"get_severity", l_broker_cache_get_severity},
       {"get_check_command", l_broker_cache_get_check_command},
+      {"get_hostgroup_alias", l_broker_cache_get_hostgroup_alias},
       {nullptr, nullptr}};
 
   if (api_version == 2) {

--- a/broker/lua/src/macro_cache.cc
+++ b/broker/lua/src/macro_cache.cc
@@ -328,6 +328,24 @@ const std::string& macro_cache::get_host_group_name(uint64_t id) const {
 }
 
 /**
+ *  Get the alias of a host group.
+ *
+ *  @param[in] id  The id of the host group.
+ *
+ *  @return             The alias of the host group.
+ */
+const std::string& macro_cache::get_host_group_alias(uint64_t id) const {
+  const auto found = _host_groups.find(id);
+
+  if (found == _host_groups.end()) {
+    _cache->logger()->error("lua: could not find information on host group {}",
+                            id);
+    throw msg_fmt("lua: could not find information on host group {}", id);
+  }
+  return found->second.first->obj().alias();
+}
+
+/**
  *  Get the description of a service.
  *
  *  @param[in] host_id  The id of the host.

--- a/broker/neb/src/callbacks.cc
+++ b/broker/neb/src/callbacks.cc
@@ -1484,14 +1484,16 @@ int neb::callback_pb_group(int callback_type, void* data) {
         static_cast<engine::hostgroup*>(group_data->object_ptr));
     if (!host_group->get_group_name().empty()) {
       auto new_hg{std::make_shared<neb::pb_host_group>()};
-      new_hg->mut_obj().set_poller_id(
+      auto& obj = new_hg->mut_obj();
+      obj.set_poller_id(
           config::applier::state::instance().poller_id());
-      new_hg->mut_obj().set_hostgroup_id(host_group->get_id());
-      new_hg->mut_obj().set_enabled(group_data->type !=
+      obj.set_hostgroup_id(host_group->get_id());
+      obj.set_enabled(group_data->type !=
                                         NEBTYPE_HOSTGROUP_DELETE &&
                                     !host_group->members.empty());
-      new_hg->mut_obj().set_name(
+      obj.set_name(
           common::check_string_utf8(host_group->get_group_name()));
+      obj.set_alias(host_group->get_alias());
 
       // Send host group event.
       if (host_group->get_id()) {


### PR DESCRIPTION
## Description

New get_hostgroup_alias() function for the lua streamconnector cache.

REFS: MON-173343
