### PR TITLE
enh(broker/lua): new streamconnector cache get_hostgroup_alias function

### DIFF
--- a/broker/lua/src/macro_cache.cc
+++ b/broker/lua/src/macro_cache.cc
@@ -342,6 +342,7 @@ const std::string& macro_cache::get_host_group_alias(uint64_t id) const {
                             id);
     throw msg_fmt("lua: could not find information on host group {}", id);
   }
+
   return found->second.first->obj().alias();
 }
 


### PR DESCRIPTION
## Description

New cache function for streamconnector: get_hostgroup_alias()

REFS: MON-173342
