### PR TITLE
fix(gorgone): centreontrapd.sdb on poller has wrong permissions (#2445)

### DIFF
--- a/gorgone/gorgone/modules/centreon/legacycmd/class.pm
+++ b/gorgone/gorgone/modules/centreon/legacycmd/class.pm
@@ -334,6 +334,8 @@ sub execute_cmd {
                     cache_dir => $cache_dir,
                     owner => 'centreon',
                     group => 'centreon',
+                    # With SYNCTRAP the destination file must have permissions 0664
+                    mode => '0664',
                     metadata => {
                         centcore_proxy => 1,
                         centcore_cmd => 'SYNCTRAP'


### PR DESCRIPTION
## Description

Backport of https://github.com/centreon/centreon-collect/pull/2445 to dev-23.10

Fixes # MON-174526

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.10.x
- [x] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master