### PR TITLE
fix(broker/bbdo): minimal handling of stop event re-enabled

### DIFF
--- a/broker/core/src/bbdo/stream.cc
+++ b/broker/core/src/bbdo/stream.cc
@@ -1053,7 +1053,10 @@ bool stream::read(std::shared_ptr<io::data>& d, time_t deadline) {
                                ->obj()
                                .acknowledged_events());
         break;
-      case stop::static_type():
+      case stop::static_type(): {
+        SPDLOG_LOGGER_INFO(_logger, "BBDO: received stop from peer");
+        send_event_acknowledgement();
+      } break;
       case pb_stop::static_type(): {
         SPDLOG_LOGGER_INFO(
             _logger, "BBDO: received stop from peer with ID {}",


### PR DESCRIPTION
## Description

Fix concerning the stop event if sent by an old engine version.

REFS: MON-161515