### PR TITLE
fix(broker): fixed a crash in broker if an old engine disconnects

### DIFF
--- a/broker/core/bbdo/stream.cc
+++ b/broker/core/bbdo/stream.cc
@@ -1072,7 +1072,10 @@ void stream::_handle_bbdo_event(const std::shared_ptr<io::data>& d) {
                              ->obj()
                              .acknowledged_events());
       break;
-    case stop::static_type():
+    case stop::static_type(): {
+      SPDLOG_LOGGER_INFO(_logger, "BBDO: received stop from peer");
+      send_event_acknowledgement();
+    } break;
     case pb_stop::static_type(): {
       SPDLOG_LOGGER_INFO(
           _logger, "BBDO: received stop from peer with ID {}",


### PR DESCRIPTION
## Description

If an old poller is connected to broker and disconnects, when broker receives the "stop" event, it crashes. This patch fixes that.

REFS: MON-175872