### PR TITLE
Mon 176101 ci remove hardcoded version from collect testing docker image for noble

### DIFF
--- a/.github/docker/Dockerfile.centreon-collect-mariadb-noble-test
+++ b/.github/docker/Dockerfile.centreon-collect-mariadb-noble-test
@@ -4,7 +4,7 @@ FROM ${REGISTRY_URL}/ubuntu:noble
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN --mount=type=bind,src=.,dst=/tmp/collect bash -e <<EOF
+RUN --mount=type=bind,src=.,dst=/tmp/collect bash -e <<'EOF'
 
 apt-get update
 

--- a/.github/docker/Dockerfile.centreon-collect-mariadb-noble-test
+++ b/.github/docker/Dockerfile.centreon-collect-mariadb-noble-test
@@ -4,7 +4,7 @@ FROM ${REGISTRY_URL}/ubuntu:noble
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN --mount=type=bind,src=.,dst=/tmp/collect bash -e <<'EOF'
+RUN --mount=type=bind,src=.,dst=/tmp/collect bash -e <<EOF
 
 apt-get update
 
@@ -43,7 +43,7 @@ python3 -m venv .venv
 source .venv/bin/activate
 # Install Robotframework
 apt-get install -y python3 python3-dev python3-pip
-.venv/bin/pip3 install -U robotframework robotframework-databaselibrary==2.0.4 robotframework-httpctrl robotframework-examples pymysql python-dateutil psutil
+.venv/bin/pip3 install -U robotframework robotframework-databaselibrary robotframework-httpctrl robotframework-examples pymysql python-dateutil psutil
 .venv/bin/pip3 install grpcio grpcio_tools py-cpuinfo cython gitpython boto3 robotframework-requests
 
 localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8


### PR DESCRIPTION
## Description

* remove hardcoded version for robotframwork database as it was a workaround and is not needed anymore

**Fixes** #MON-176101

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.10.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

