### PR TITLE
fix(mbi): when getting service category avoid infinite loop if service templates have circular reference

### DIFF
--- a/gorgone/gorgone/modules/centreon/mbi/libs/centreon/Service.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/centreon/Service.pm
@@ -152,33 +152,37 @@ sub getServicesTemplatesCategories {
 	my $query = "SELECT service_id, service_description, service_template_model_stm_id FROM service WHERE service_register = '0'";
 	my $sth = $db->query({ query => $query });
     while(my $row = $sth->fetchrow_hashref()) {
+		my $loop_services = { $row->{service_id} => 1 };
 		my $currentTemplate = $row->{"service_id"};
 		my $categories = $self->getServiceCategories($row->{"service_id"});
 		my $parentId = $row->{"service_template_model_stm_id"};
-		if (defined($parentId)) {
-			my $hasParent = 1;
-			# getting all parent templates category relations
-			while ($hasParent) {
-				my $parentQuery = "SELECT service_id, service_template_model_stm_id ";
-				$parentQuery .= "FROM service ";
-				$parentQuery .= "WHERE service_register = '0' and service_id=".$parentId;
-				my $sthparentQuery = $db->query({ query => $parentQuery });
-	   			if(my $parentQueryRow = $sthparentQuery->fetchrow_hashref()) {
-	   				my $newCategories = $self->getServiceCategories($parentQueryRow->{"service_id"});
-	   				while(my ($sc_id, $sc_name) = each(%$newCategories)) {
-	   					if (!defined($categories->{$sc_id})) {
-	   						$categories->{$sc_id} = $sc_name;
-	   					}
-	   				}
-	   				if (!defined($parentQueryRow->{'service_template_model_stm_id'})) {
-	   					$hasParent = 0;
-	   					last;
-	   				}
-	   				$parentId = $parentQueryRow->{'service_template_model_stm_id'};
-	   				$sthparentQuery->finish();
-	   			}else {
-	   				$hasParent = 0;
-	   			}
+		# getting all parent templates category relations
+		while (defined($parentId)) {
+			if (defined($loop_services->{$parentId})) {
+				$self->{logger}->writeLog("INFO", "Loop detected in service template with id = $currentTemplate");
+				last;
+			}
+			$loop_services->{$parentId} = 1;
+
+			my $parentQuery = "SELECT service_id, service_template_model_stm_id ";
+			$parentQuery .= "FROM service ";
+			$parentQuery .= "WHERE service_register = '0' and service_id=" . $parentId;
+			my $sthparentQuery = $db->query({ query => $parentQuery });
+			if (my $parentQueryRow = $sthparentQuery->fetchrow_hashref()) {
+				my $newCategories = $self->getServiceCategories($parentQueryRow->{"service_id"});
+				while (my ($sc_id, $sc_name) = each(%$newCategories)) {
+					if (!defined($categories->{$sc_id})) {
+						$categories->{$sc_id} = $sc_name;
+					}
+				}
+				if (!defined($parentQueryRow->{'service_template_model_stm_id'})) {
+					last;
+				}
+				$parentId = $parentQueryRow->{'service_template_model_stm_id'};
+				$sthparentQuery->finish();
+			} else {
+				$self->{logger}->writeLog("INFO", "The service template with id = $currentTemplate have a parent $parentId but this id don't exist in database!");
+				last;
 			}
 		}
 		$results{$currentTemplate} = $categories;


### PR DESCRIPTION
## Description

Backport of  #2031 to 23.10

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.10.x
- [X] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

