### PR TITLE
feat(engine): enhance otl_server configuration : encryption  accept both  boolean and string values

### DIFF
--- a/engine/tests/opentelemetry/grpc_config_test.cc
+++ b/engine/tests/opentelemetry/grpc_config_test.cc
@@ -108,3 +108,58 @@ TEST(otl_grpc_config, good_host_port2) {
   ASSERT_TRUE(c.get_ca().empty());
   ASSERT_EQ(c.get_second_keepalive_interval(), 30);
 }
+
+//  test all allow encryption values
+//  full, insecure, no, true, false
+TEST(otl_grpc_config, encryption_value) {
+  grpc_config conf_full(R"(
+{   
+    "host":"127.0.0.1",
+    "port":2500,
+    "encryption":"full"
+})"_json);
+  grpc_config conf_insecure(R"(
+  {   
+      "host":"127.0.0.1",
+      "port":2500,
+      "encryption":"insecure"
+  })"_json);
+  grpc_config conf_no(R"(
+  {   
+      "host":"127.0.0.1",
+      "port":2500,
+      "encryption":"no"
+  })"_json);
+  grpc_config conf_true_s(R"(
+  {   
+      "host":"127.0.0.1",
+      "port":2500,
+      "encryption":"true"
+  })"_json);
+  grpc_config conf_false_s(R"(
+    {   
+        "host":"127.0.0.1",
+        "port":2500,
+        "encryption":"false"
+    })"_json);
+  grpc_config conf_true(R"(
+      {   
+          "host":"127.0.0.1",
+          "port":2500,
+          "encryption":true
+      })"_json);
+  grpc_config conf_false(R"(
+      {   
+          "host":"127.0.0.1",
+          "port":2500,
+          "encryption":false
+      })"_json);
+
+  ASSERT_TRUE(conf_full.is_crypted());
+  ASSERT_FALSE(conf_insecure.is_crypted());
+  ASSERT_FALSE(conf_no.is_crypted());
+  ASSERT_TRUE(conf_true_s.is_crypted());
+  ASSERT_FALSE(conf_false_s.is_crypted());
+  ASSERT_TRUE(conf_true.is_crypted());
+  ASSERT_FALSE(conf_false.is_crypted());
+}


### PR DESCRIPTION
the "encryption" field from otel_server.json now supports both boolean values (true, false) and string values ("full", "insecure", "no", "true", "false").

REFS: MON-176599