### PR TITLE
feat(engine): enhance otl_server configuration : encryption  accept both string and boolean

### DIFF
--- a/engine/modules/opentelemetry/src/grpc_config.cc
+++ b/engine/modules/opentelemetry/src/grpc_config.cc
@@ -39,8 +39,11 @@ static constexpr std::string_view _grpc_config_schema(R"(
             "maximum": 65535
         },
         "encryption": {
-            "description": "true if https",
-            "type": "boolean"
+          "description": "encryption mode: full, insecure, or no",
+            "anyOf": [
+              { "type": "boolean" },
+              { "type": "string", "enum": ["full", "insecure", "no", "true", "false"] }
+            ]
         },
         "public_cert": {
             "description": "path of certificate file .crt",
@@ -125,8 +128,15 @@ grpc_config::grpc_config(const rapidjson::Value& json_config_v) {
   bool compress = false;
   int second_keepalive_interval;
 
-  if (json_config.has_member("encryption"))
-    crypted = json_config.get_bool("encryption");
+  if (json_config.has_member("encryption")) {
+    const auto& encryption_value = json_config_v["encryption"];
+    if (encryption_value.IsString()) {
+      const std::string& encryption = json_config.get_string("encryption");
+      crypted = (encryption == "full" || encryption == "true");
+    } else if (encryption_value.IsBool()) {
+      crypted = encryption_value.GetBool();
+    }
+  }
 
   read_file(json_config_v, "public_cert", certificate);
   read_file(json_config_v, "private_key", cert_key);

--- a/engine/tests/opentelemetry/grpc_config_test.cc
+++ b/engine/tests/opentelemetry/grpc_config_test.cc
@@ -197,3 +197,57 @@ TEST(otl_grpc_config, tokencompare) {
   ASSERT_EQ(c2.compare(c2_minos), 1);
   ASSERT_EQ(c2.compare(c2_plus), -1);
 }
+//  test all allow encryption values
+//  full, insecure, no, true, false
+TEST(otl_grpc_config, encryption_value) {
+  grpc_config conf_full(R"(
+{   
+    "host":"127.0.0.1",
+    "port":2500,
+    "encryption":"full"
+})"_json);
+  grpc_config conf_insecure(R"(
+  {   
+      "host":"127.0.0.1",
+      "port":2500,
+      "encryption":"insecure"
+  })"_json);
+  grpc_config conf_no(R"(
+  {   
+      "host":"127.0.0.1",
+      "port":2500,
+      "encryption":"no"
+  })"_json);
+  grpc_config conf_true_s(R"(
+  {   
+      "host":"127.0.0.1",
+      "port":2500,
+      "encryption":"true"
+  })"_json);
+  grpc_config conf_false_s(R"(
+    {   
+        "host":"127.0.0.1",
+        "port":2500,
+        "encryption":"false"
+    })"_json);
+  grpc_config conf_true(R"(
+      {   
+          "host":"127.0.0.1",
+          "port":2500,
+          "encryption":true
+      })"_json);
+  grpc_config conf_false(R"(
+      {   
+          "host":"127.0.0.1",
+          "port":2500,
+          "encryption":false
+      })"_json);
+
+  ASSERT_TRUE(conf_full.is_crypted());
+  ASSERT_FALSE(conf_insecure.is_crypted());
+  ASSERT_FALSE(conf_no.is_crypted());
+  ASSERT_TRUE(conf_true_s.is_crypted());
+  ASSERT_FALSE(conf_false_s.is_crypted());
+  ASSERT_TRUE(conf_true.is_crypted());
+  ASSERT_FALSE(conf_false.is_crypted());
+}


### PR DESCRIPTION
the "encryption" field from otel_server.json now supports both boolean values (true, false) and string values ("full", "insecure", "no", "true", "false").

REFS: MON-176769