### PR TITLE
feat(engine): enhance otl_server configuration : encryption  accept boolean and string values (#2588)

### DIFF
--- a/engine/tests/opentelemetry/grpc_config_test.cc
+++ b/engine/tests/opentelemetry/grpc_config_test.cc
@@ -197,48 +197,47 @@ TEST(otl_grpc_config, tokencompare) {
   ASSERT_EQ(c2.compare(c2_minos), 1);
   ASSERT_EQ(c2.compare(c2_plus), -1);
 }
-
 //  test all allow encryption values
 //  full, insecure, no, true, false
 TEST(otl_grpc_config, encryption_value) {
   grpc_config conf_full(R"(
-{
+{   
     "host":"127.0.0.1",
     "port":2500,
     "encryption":"full"
 })"_json);
   grpc_config conf_insecure(R"(
-  {
+  {   
       "host":"127.0.0.1",
       "port":2500,
       "encryption":"insecure"
   })"_json);
   grpc_config conf_no(R"(
-  {
+  {   
       "host":"127.0.0.1",
       "port":2500,
       "encryption":"no"
   })"_json);
   grpc_config conf_true_s(R"(
-  {
+  {   
       "host":"127.0.0.1",
       "port":2500,
       "encryption":"true"
   })"_json);
   grpc_config conf_false_s(R"(
-    {
+    {   
         "host":"127.0.0.1",
         "port":2500,
         "encryption":"false"
     })"_json);
   grpc_config conf_true(R"(
-      {
+      {   
           "host":"127.0.0.1",
           "port":2500,
           "encryption":true
       })"_json);
   grpc_config conf_false(R"(
-      {
+      {   
           "host":"127.0.0.1",
           "port":2500,
           "encryption":false


### PR DESCRIPTION
- Enhance otl_server configuration encryption  accept boolean and string values 

REFS: MON-176770
REFS:  #2588 