### PR TITLE
fix(ci): remove bullseye-backports repo from docker images

### DIFF
--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye
@@ -4,6 +4,8 @@ FROM ${REGISTRY_URL}/debian:bullseye
 
 RUN <<EOF
 
+sed -i '/^deb .*bullseye-backports/d' /etc/apt/sources.list
+
 apt-get update
 
 apt-get -y install cmake \

--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye-test
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye-test
@@ -7,6 +7,8 @@ COPY . /tmp/collect
 
 RUN <<EOF
 
+sed -i '/^deb .*bullseye-backports/d' /etc/apt/sources.list
+
 apt-get update
 
 apt-get -y install curl \


### PR DESCRIPTION
## Description

fix(ci): remove bullseye-backports repo from docker images

**Fixes** MON-177849