### PR TITLE
fix(ci): remove bullseye-backports repo from docker images

### DIFF
--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye
@@ -1,6 +1,9 @@
 ARG REGISTRY_URL
 
 FROM ${REGISTRY_URL}/debian:bullseye
+
+ENV DEBIAN_FRONTEND=noninteractive
+
 ARG TRIPLET
 
 RUN bash -e <<EOF
@@ -43,11 +46,9 @@ apt-get -y install git \
     perl-base \
     wget
 
-CMAKE_ARCH="\$(arch)"
-wget https://cmake.org/files/v3.21/cmake-3.21.0-linux-\$CMAKE_ARCH.tar.gz
-tar zxf cmake-3.21.0-linux-\$CMAKE_ARCH.tar.gz
-mv cmake-3.21.0-linux-\$CMAKE_ARCH/bin/cmake /usr/bin/cmake
-rm -rf cmake-3.21.0*
+wget https://cmake.org/files/v3.21/cmake-3.21.0-linux-\$(arch).sh
+bash cmake-3.21.0-linux-\$(arch).sh --skip-license
+rm -f cmake-3.21.0-linux-\$(arch).sh
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 

--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye
@@ -40,7 +40,13 @@ apt-get -y install git \
     zip \
     libcurl4-openssl-dev \
     sudo \
-    perl-base
+    perl-base \
+    wget
+
+wget https://cmake.org/files/v3.21/cmake-3.21.0-linux-x86_64.tar.gz
+tar zxf cmake-3.21.0-linux-x86_64.tar.gz
+mv cmake-3.21.0-linux-x86_64/bin/cmake /usr/bin/cmake
+rm -f cmake-3.21.0*
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 

--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye
@@ -11,7 +11,6 @@ RUN bash -e <<EOF
 apt-get update
 
 apt-get -y install git \
-    cmake \
     curl \
     gcc \
     g++ \

--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye
@@ -43,12 +43,7 @@ apt-get -y install git \
     perl-base \
     wget
 
-if [ "${TRIPLET}" = "arm64-linux" ] ; then
-  CMAKE_ARCH="aarch64"
-else
-  CMAKE_ARCH="x86_64"
-fi
-
+CMAKE_ARCH="$(arch)"
 wget https://cmake.org/files/v3.21/cmake-3.21.0-linux-$CMAKE_ARCH.tar.gz
 tar zxf cmake-3.21.0-linux-$CMAKE_ARCH.tar.gz
 mv cmake-3.21.0-linux-$CMAKE_ARCH/bin/cmake /usr/bin/cmake

--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye
@@ -42,11 +42,10 @@ apt-get -y install git \
     perl-base
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
-echo 'deb http://deb.debian.org/debian bullseye-backports main contrib' | tee -a /etc/apt/sources.list
 
 apt-get update
 apt-get install -y nfpm=2.41.1
-apt-get install -y -t bullseye-backports cmake
+apt-get install -y -t cmake
 
 apt-get clean
 

--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye
@@ -44,11 +44,14 @@ apt-get -y install git \
     libcurl4-openssl-dev \
     sudo \
     perl-base \
-    wget
+    wget \
+    libjsoncpp24 \
+    librhash0 \
+    libuv1
 
-wget https://cmake.org/files/v3.21/cmake-3.21.0-linux-\$(arch).sh
-bash cmake-3.21.0-linux-\$(arch).sh --skip-license
-rm -f cmake-3.21.0-linux-\$(arch).sh
+wget https://cmake.org/files/v3.21/cmake-3.21.7-linux-\$(arch).sh
+bash cmake-3.21.7-linux-\$(arch).sh --skip-license
+rm -f cmake-3.21.7-linux-\$(arch).sh
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 

--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye
@@ -8,6 +8,7 @@ RUN bash -e <<EOF
 apt-get update
 
 apt-get -y install git \
+    cmake \
     curl \
     gcc \
     g++ \
@@ -45,7 +46,6 @@ echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sourc
 
 apt-get update
 apt-get install -y nfpm=2.41.1
-apt-get install -y -t cmake
 
 apt-get clean
 

--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye
@@ -43,9 +43,15 @@ apt-get -y install git \
     perl-base \
     wget
 
-wget https://cmake.org/files/v3.21/cmake-3.21.0-linux-x86_64.tar.gz
-tar zxf cmake-3.21.0-linux-x86_64.tar.gz
-mv cmake-3.21.0-linux-x86_64/bin/cmake /usr/bin/cmake
+if [ "${TRIPLET}" = "arm64-linux" ] ; then
+  CMAKE_ARCH="aarch64"
+else
+  CMAKE_ARCH="x86_64"
+fi
+
+wget https://cmake.org/files/v3.21/cmake-3.21.0-linux-$CMAKE_ARCH.tar.gz
+tar zxf cmake-3.21.0-linux-$CMAKE_ARCH.tar.gz
+mv cmake-3.21.0-linux-$CMAKE_ARCH/bin/cmake /usr/bin/cmake
 rm -rf cmake-3.21.0*
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list

--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye
@@ -46,7 +46,7 @@ apt-get -y install git \
 wget https://cmake.org/files/v3.21/cmake-3.21.0-linux-x86_64.tar.gz
 tar zxf cmake-3.21.0-linux-x86_64.tar.gz
 mv cmake-3.21.0-linux-x86_64/bin/cmake /usr/bin/cmake
-rm -f cmake-3.21.0*
+rm -rf cmake-3.21.0*
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 

--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye
@@ -43,10 +43,10 @@ apt-get -y install git \
     perl-base \
     wget
 
-CMAKE_ARCH="$(arch)"
-wget https://cmake.org/files/v3.21/cmake-3.21.0-linux-$CMAKE_ARCH.tar.gz
-tar zxf cmake-3.21.0-linux-$CMAKE_ARCH.tar.gz
-mv cmake-3.21.0-linux-$CMAKE_ARCH/bin/cmake /usr/bin/cmake
+CMAKE_ARCH="\$(arch)"
+wget https://cmake.org/files/v3.21/cmake-3.21.0-linux-\$CMAKE_ARCH.tar.gz
+tar zxf cmake-3.21.0-linux-\$CMAKE_ARCH.tar.gz
+mv cmake-3.21.0-linux-\$CMAKE_ARCH/bin/cmake /usr/bin/cmake
 rm -rf cmake-3.21.0*
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list


### PR DESCRIPTION
## Description

fix(ci): remove bullseye-backports repo from docker images

**Fixes** MON-177849