### PR TITLE
fix(ci): remove bullseye-backports repo from docker images (#2613)

### DIFF
--- a/.github/docker/Dockerfile.centreon-collect-debian-bullseye
+++ b/.github/docker/Dockerfile.centreon-collect-debian-bullseye
@@ -1,6 +1,9 @@
 ARG REGISTRY_URL
 
 FROM ${REGISTRY_URL}/debian:bullseye
+
+ENV DEBIAN_FRONTEND=noninteractive
+
 ARG TRIPLET
 
 RUN bash -e <<EOF
@@ -39,14 +42,20 @@ apt-get -y install git \
     zip \
     libcurl4-openssl-dev \
     sudo \
-    perl-base
+    perl-base \
+    wget \
+    libjsoncpp24 \
+    librhash0 \
+    libuv1
+
+wget https://cmake.org/files/v3.21/cmake-3.21.7-linux-\$(arch).sh
+bash cmake-3.21.7-linux-\$(arch).sh --skip-license
+rm -f cmake-3.21.7-linux-\$(arch).sh
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
-echo 'deb http://deb.debian.org/debian bullseye-backports main contrib' | tee -a /etc/apt/sources.list
 
 apt-get update
 apt-get install -y nfpm=2.41.1
-apt-get install -y -t bullseye-backports cmake
 
 apt-get clean
 


### PR DESCRIPTION
## Description

fix(ci): remove bullseye-backports repo from docker images (#2613)

**Fixes** MON-177849