### PR TITLE
fix(ci): remove bullseye-backports repo from docker images

### DIFF
--- a/.github/docker/Dockerfile.packaging-centreon-collect-bullseye
+++ b/.github/docker/Dockerfile.packaging-centreon-collect-bullseye
@@ -38,9 +38,9 @@ apt-get install -y \
     librhash0 \
     libuv1
 
-wget https://cmake.org/files/v3.21/cmake-3.21.7-linux-\$(arch).sh
-bash cmake-3.21.7-linux-\$(arch).sh --skip-license
-rm -f cmake-3.21.7-linux-\$(arch).sh
+wget https://cmake.org/files/v3.25/cmake-3.25.3-linux-\$(arch).sh
+bash cmake-3.25.3-linux-\$(arch).sh --skip-license
+rm -f cmake-3.25.3-linux-\$(arch).sh
 
 apt-get clean
 

--- a/.github/docker/Dockerfile.packaging-centreon-collect-bullseye
+++ b/.github/docker/Dockerfile.packaging-centreon-collect-bullseye
@@ -19,7 +19,6 @@ apt-get update
 apt-get install -y ca-certificates
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
-echo 'deb http://deb.debian.org/debian bullseye-backports main contrib' | tee -a /etc/apt/sources.list
 
 apt-get update
 
@@ -34,9 +33,14 @@ apt-get install -y \
     unzip \
     wget \
     zip \
-    zstd
+    zstd \
+    libjsoncpp24 \
+    librhash0 \
+    libuv1
 
-apt-get install -y -t bullseye-backports cmake
+wget https://cmake.org/files/v3.21/cmake-3.21.7-linux-\$(arch).sh
+bash cmake-3.21.7-linux-\$(arch).sh --skip-license
+rm -f cmake-3.21.7-linux-\$(arch).sh
 
 apt-get clean
 

--- a/.github/docker/Dockerfile.packaging-centreon-collect-bullseye
+++ b/.github/docker/Dockerfile.packaging-centreon-collect-bullseye
@@ -53,7 +53,6 @@ RUN bash -e <<EOF
 apt-get update
 
 apt-get install -y \
-    cmake \
     g++ \
     gcc \
     gdb \


### PR DESCRIPTION
## Description

fix(ci): remove bullseye-backports repo from docker images

**Fixes** MON-177849