### PR TITLE
fix no_shell_interpretation when binary executed don't exist

### DIFF
--- a/gorgone/gorgone/standard/misc.pm
+++ b/gorgone/gorgone/standard/misc.pm
@@ -252,8 +252,7 @@ sub backtick {
             # This Does not work as it keep the quotes around the arguments
             #my @lcommand_list = (split(/ /, $arg{command}));
             exec {$command_list[0]} @command_list, @{$arg{arguments}};
-        }
-        if (scalar(@{$arg{arguments}}) <= 0) {
+        } elsif (scalar(@{$arg{arguments}}) <= 0) {
             exec($arg{command});
         } else {
             exec($arg{command}, @{$arg{arguments}});

--- a/gorgone/tests/unit/standard/misc.t
+++ b/gorgone/tests/unit/standard/misc.t
@@ -125,6 +125,16 @@ sub test_unix_execute {
         );
         is($output, $test->{expect}, $test->{msg});
     }
+    # If the binary executed is not found, the command should not be rerun with a shell
+    unlink('/tmp/injected_commandUnitTest.txt');
+    my ($status, $output, $status_code) = gorgone::standard::misc::backtick(
+        logger                    => $logger,
+        wait_exit                 => 1,
+        command                   => './binary_not_found with args ; echo "injected command from binary_not_found" >> /tmp/injected_commandUnitTest.txt',
+        'no_shell_interpretation' => 1,
+    );
+    # is($status, 127, 'Command not found returns 127');
+    ok(!-r '/tmp/injected_commandUnitTest.txt', 'No binary interpretation and no binary does not execute the command, no file created');
 }
 chdir($FindBin::Bin);
 chmod(0755, './showArgs.sh');


### PR DESCRIPTION
## Description

Backport of #2644 to release-25.07-next

**Fixes** # MON-176602

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.10.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [X] 25.05.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

See automated test, using a binary that does not exist should not allow shell interpretation

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

