### PR TITLE
Mon 180697 refactor(engine/agent): update payload schema to allow null expiration and adjust token creation logic

### DIFF
--- a/common/crypto/jwt.cc
+++ b/common/crypto/jwt.cc
@@ -51,24 +51,20 @@ static constexpr std::string_view _payload_schema(R"(
     "title": "jwt payload",
     "type": "object",
     "properties": {
-        "iss": {
-            "description": "issuer",
+        "name": {
+            "description": "token name",
             "type": "string"
         },
         "exp": {
             "description": "expiration time",
-            "type": "integer"
+            "type": ["integer","null"]
         },
         "iat": {
             "description": "issued at",
             "type": "integer"
         }
     },
-    "required": [
-        "iss",
-        "exp",
-        "iat"
-    ]
+    "required": [ "exp", "iat" ]
 }
 )");
 
@@ -148,10 +144,14 @@ jwt::jwt(const std::string& token)
 
   // check the experation date used
   if (payload_json.has_member("exp")) {
-    _exp_str = std::to_string(payload_json.get_uint64_t("exp"));
-    _exp = std::chrono::system_clock::time_point(
-        std::chrono::seconds(payload_json.get_uint64_t("exp")));
+    if (payload_json.get_member("exp").IsNull()) {
+      _exp = std::chrono::system_clock::time_point::max();
+    } else {
+      _exp = std::chrono::system_clock::time_point(
+          std::chrono::seconds(payload_json.get_uint64_t("exp")));
+    }
   }
+
   if (payload_json.has_member("iat")) {
     _iat = std::chrono::system_clock::time_point(
         std::chrono::seconds(payload_json.get_uint64_t("iat")));

--- a/common/tests/jwt_test.cc
+++ b/common/tests/jwt_test.cc
@@ -176,3 +176,29 @@ TEST(TestJWT, ConstructorInvalidJsonPayload) {
     FAIL() << "Expected msg_fmt but got some other exception type.";
   }
 }
+
+// Test: never_expired
+// Purpose: Ensure that a JWT token with a null expiration time is handled
+// correctly, allowing the token to be considered valid indefinitely.
+// Note: This test checks that the expiration time is set to max when "exp" is
+// null in the payload.
+TEST(TestJWT, Never_expired) {
+  try {
+    const std::string metadata =
+        "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJuYW1lIjoidG9rZW4xIiwiaWF0IjoxNzU1NTM0MjY5LCJleHAiOm51bGx9."
+        "6_m-qL0qdY8-p7bHdinYAlPHPdEwNsfJ--9BUvxgCVQ";
+    jwt jwt(metadata);
+    ASSERT_EQ(jwt.get_header(), "{\"alg\":\"HS256\",\"typ\":\"JWT\"}");
+    std::cout << "payload: " << jwt.get_payload() << std::endl;
+    ASSERT_EQ(jwt.get_payload(),
+              "{\"name\":\"token1\",\"iat\":1755534269,\"exp\":null}");
+    ASSERT_EQ(jwt.get_exp(), system_clock::time_point::max());
+  } catch (const msg_fmt& ex) {
+    EXPECT_TRUE(
+        std::string(ex.what()).find("forbidden values in jwt payload: document "
+                                    "doesn't respect this schema:") == 0);
+  } catch (...) {
+    FAIL() << "Expected msg_fmt but got some other exception type.";
+  }
+}

--- a/common/tests/jwt_test.cc
+++ b/common/tests/jwt_test.cc
@@ -183,22 +183,14 @@ TEST(TestJWT, ConstructorInvalidJsonPayload) {
 // Note: This test checks that the expiration time is set to max when "exp" is
 // null in the payload.
 TEST(TestJWT, Never_expired) {
-  try {
-    const std::string metadata =
-        "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
-        "eyJuYW1lIjoidG9rZW4xIiwiaWF0IjoxNzU1NTM0MjY5LCJleHAiOm51bGx9."
-        "6_m-qL0qdY8-p7bHdinYAlPHPdEwNsfJ--9BUvxgCVQ";
-    jwt jwt(metadata);
-    ASSERT_EQ(jwt.get_header(), "{\"alg\":\"HS256\",\"typ\":\"JWT\"}");
-    std::cout << "payload: " << jwt.get_payload() << std::endl;
-    ASSERT_EQ(jwt.get_payload(),
-              "{\"name\":\"token1\",\"iat\":1755534269,\"exp\":null}");
-    ASSERT_EQ(jwt.get_exp(), system_clock::time_point::max());
-  } catch (const msg_fmt& ex) {
-    EXPECT_TRUE(
-        std::string(ex.what()).find("forbidden values in jwt payload: document "
-                                    "doesn't respect this schema:") == 0);
-  } catch (...) {
-    FAIL() << "Expected msg_fmt but got some other exception type.";
-  }
+  const std::string metadata =
+      "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+      "eyJuYW1lIjoidG9rZW4xIiwiaWF0IjoxNzU1NTM0MjY5LCJleHAiOm51bGx9."
+      "6_m-qL0qdY8-p7bHdinYAlPHPdEwNsfJ--9BUvxgCVQ";
+  jwt jwt(metadata);
+  ASSERT_EQ(jwt.get_header(), "{\"alg\":\"HS256\",\"typ\":\"JWT\"}");
+  std::cout << "payload: " << jwt.get_payload() << std::endl;
+  ASSERT_EQ(jwt.get_payload(),
+            "{\"name\":\"token1\",\"iat\":1755534269,\"exp\":null}");
+  ASSERT_EQ(jwt.get_exp(), system_clock::time_point::max());
 }

--- a/engine/modules/opentelemetry/src/centreon_agent/agent_impl.cc
+++ b/engine/modules/opentelemetry/src/centreon_agent/agent_impl.cc
@@ -326,6 +326,7 @@ template <class bireactor_class>
 void agent_impl<bireactor_class>::OnReadDone(bool ok) {
   if (ok) {
     if (_exp_time != std::chrono::system_clock::time_point::min() &&
+        _exp_time != std::chrono::system_clock::time_point::max() &&
         _exp_time <= std::chrono::system_clock::now()) {
       SPDLOG_LOGGER_ERROR(_logger, "{:p} {} token expired",
                           static_cast<void*>(this), _class_name);

--- a/tests/broker-engine/cma.robot
+++ b/tests/broker-engine/cma.robot
@@ -1776,7 +1776,7 @@ BEOTEL_CENTREON_AGENT_TOKEN
     
     Ctn Engine Config Set Value    0    log_level_checks    trace
 
-    ${token1}    Ctn Create Jwt Token    ${60}
+    ${token1}    Ctn Create Jwt Token    ${-1}
 
     Ctn Add Token Otl Server Module    0    ${token1}
 
@@ -2322,7 +2322,7 @@ BEOTEL_CENTREON_AGENT_TOKEN_REVERSE
     Ctn Engine Config Set Value    0    log_level_config    error
     Ctn Engine Config Set Value    0    log_level_events    error
 
-    ${token1}    Ctn Create Jwt Token    ${60}
+    ${token1}    Ctn Create Jwt Token    ${-1}
 
     ${cur_dir}    Ctn Workspace Win
     IF    '${cur_dir}' == 'None'

--- a/tests/resources/Common.py
+++ b/tests/resources/Common.py
@@ -2394,10 +2394,15 @@ def ctn_create_jwt_token(exp_s: int, secret: str = "centreon"):
     Returns: jwt token
     """
     value = random.randint(0, 100000)
+    now = datetime.now()
     payload = {
-        "iss": f"centreon{value}",
-        "iat": int(datetime.now().timestamp()),
-        "exp": int((datetime.now() + timedelta(seconds=exp_s)).timestamp())
+        "name": f"centreon{value}",
+        "iat": int(now.timestamp())
     }
+    # if exp_s == -1, set exp to None (null in JWT)
+    if exp_s != -1:
+        payload["exp"] = int((now + timedelta(seconds=exp_s)).timestamp())
+    else:
+        payload["exp"] = None
     logger.console(payload)
     return jwt.encode(payload, secret, algorithm="HS256")


### PR DESCRIPTION
update payload schema to allow null expiration and adjust token creation logic
Refs: MON-180697