### PR TITLE
MON-172159-service-discovery-impossible-with-nrpe-missing-whitelist

### DIFF
--- a/gorgone/packaging/configuration/whitelist.conf.d/centreon.yaml
+++ b/gorgone/packaging/configuration/whitelist.conf.d/centreon.yaml
@@ -5,6 +5,7 @@
 - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/+centengine\.cfg\s*$
 - ^cat\s+/var/lib/centreon-engine/+[a-zA-Z0-9\-]+-stats\.json\s*$
 - ^(sudo\s+)?/usr/lib/centreon/plugins/.*$
+- ^(sudo\s+)?/usr/lib(64)?/nagios/plugins/.*$ # NRPE Plugins, can be installed in /usr/lib or /usr/lib64 (RHEL based)
 - ^/bin/perl /usr/share/centreon/bin/anomaly_detection --seasonality >> /var/log/centreon/anomaly_detection\.log 2>&1\s*$
 - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
 - ^centreon

--- a/gorgone/tests/robot/tests/core/action.robot
+++ b/gorgone/tests/robot/tests/core/action.robot
@@ -92,7 +92,7 @@ Test Async Action Module
 
     # need to get the data from the token with getlog.
     # this call multiples time the api until the response is available.
-    ${status}    ${logs}    Ctn Get Api Log With Timeout    token=${action_api_result.json()}[token]    node_path=${node_path}    timeout=5
+    ${status}    ${logs}    Ctn Get Api Log With Timeout    token=${action_api_result.json()}[token]    node_path=${node_path}    timeout=90
     Check Action Api Do Something    ${status}    ${logs}    ${node_path}    ${EMPTY}
     ${return}=    Ctn Check Plugin Is Installed And Remove It    ${plugin_install}
     Should Be True    ${return}    Plugin don't seem to be correctly installed or purge didn't work.

--- a/gorgone/tests/robot/tests/core/action.robot
+++ b/gorgone/tests/robot/tests/core/action.robot
@@ -99,7 +99,7 @@ Test Async Action Module
 
 
 Post Action Endpoint
-    [Arguments]    ${node_path}=${EMPTY}    ${get_params}=${EMPTY}    ${plugin_install}=${EMPTY}    ${plugin_version}=20250401
+    [Arguments]    ${node_path}=${EMPTY}    ${get_params}=${EMPTY}    ${plugin_install}=${EMPTY}    ${plugin_version}=20250900
 
     # Ideally, Gorgone should not allow any bash interpretation on command it execute.
     # As there is a whitelist in gorgone, if there was no bash interpretation we could allow only our required binary and be safe.


### PR DESCRIPTION


## Description

Add whitelist for nrpe plugin

Ref:MON-172159

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.10.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [X] master

<h2> How this pull request can be tested ? </h2>


check gorgone still start, can execute standard discovery

Check nrpe discovery specificaly work with the new whitelist version : it should work without error.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

