### PR TITLE
fix(promote): fix SRC_PATHS pattern used for deb packages promotion

### DIFF
--- a/.github/actions/promote-to-stable/action.yml
+++ b/.github/actions/promote-to-stable/action.yml
@@ -167,7 +167,7 @@ runs:
             ;;
         esac
 
-        SRC_PATHS=$(jf rt search --include-dirs "$SOURCE_ROOT_REPO_PATH/pool/${{ inputs.major_version }}/testing/${{ inputs.release_type }}/${{ inputs.module }}/${SEARCH_PATTERN}" | jq -r '.[].path')
+        SRC_PATHS=$(jf rt search --include-dirs "$SOURCE_ROOT_REPO_PATH/pool/${{ inputs.major_version }}/testing/${{ inputs.release_type }}/${{ inputs.module_name }}/${SEARCH_PATTERN}" | jq -r '.[].path')
 
         if [[ ${SRC_PATHS[@]} ]]; then
           for SRC_PATH in ${SRC_PATHS[@]}; do


### PR DESCRIPTION
## Description

* fix SRC_PATHS patterns used for promote
* inputs is now module_name instead of module

Fixes #MON-190557
Backports https://github.com/centreon/centreon-collect/pull/2862

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

