### PR TITLE
fix(release): fix previous release bundle tag pattern to match proper…

### DIFF
--- a/.github/actions/release-new/action.yml
+++ b/.github/actions/release-new/action.yml
@@ -37,6 +37,8 @@ inputs:
   centreon_technique_pat:
     description: "Token used to handle release."
     required: true
+  major_version:
+    description: "Major version for the release branch being released."
 
 runs:
   using: "composite"
@@ -62,13 +64,17 @@ runs:
         # Define new stable bundle tag
         NEW_STABLE_BUNDLE_TAG="${{ inputs.release_bundle_tag }}"
 
+        # Define major_version for tag pattern
+        # We need it to be the same as the previous stable bundle tag
+        RELEASE_BRANCH_MAJOR_VERSION="${{ inputs.major_version }}"
+
         # Get previous and new release bundle tags
         PREVIOUS_STABLE_BUNDLE_TAG=""
         # Previous release bundle tag
         if [[ $RELEASE_CLOUD -eq 1 ]]; then
-          PREVIOUS_STABLE_BUNDLE_TAG=$(git tag -l --sort=-version:refname "release-cloud-*" | head -n 1)
+          PREVIOUS_STABLE_BUNDLE_TAG=$(git tag -l --sort=-version:refname "release-cloud-*-${RELEASE_BRANCH_MAJOR_VERSION}" | head -n 1)
         else
-          PREVIOUS_STABLE_BUNDLE_TAG=$(git tag -l --sort=-version:refname "release-onprem-*" | head -n 1)
+          PREVIOUS_STABLE_BUNDLE_TAG=$(git tag -l --sort=-version:refname "release-onprem-*-${RELEASE_BRANCH_MAJOR_VERSION}" | head -n 1)
         fi
 
         echo "#====#"

--- a/.github/workflows/release-new.yml
+++ b/.github/workflows/release-new.yml
@@ -97,6 +97,7 @@ jobs:
 
           # Output to GITHUB_ENV
           echo "new_release_bundle_tag=$NEW_RELEASE_BUNDLE_TAG" >> "$GITHUB_OUTPUT"
+          echo "major_version=$MAJOR_VERSION" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Check ref where release workflow is hosted
@@ -130,3 +131,4 @@ jobs:
           release_bundle_tag: ${{ steps.build_release_bundle_tag.outputs.new_release_bundle_tag }}
           release_branch: ${{ inputs.release_branch }}
           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+          major_version: ${{ steps.build_release_bundle_tag.outputs.major_version }}


### PR DESCRIPTION
…… (#2903)

* fix(release): fix previous release bundle tag pattern to match proper major_version

* use major_version input for RELEASE_BRANCH_MAJOR_VERSION

## Description

* fix tag pattern for previous release bundle listing to match only the release branch input targeted by the action runs

Fixes #MON-191553

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

