### PR TITLE
fix(packaging): handle package split of centreon-perl-libs into centr…

### DIFF
--- a/perl-libs/packaging/centreon-perl-libs-common.yaml
+++ b/perl-libs/packaging/centreon-perl-libs-common.yaml
@@ -54,6 +54,12 @@ overrides:
       - libdigest-sha-perl
       - libgd-perl
       - libcrypt-urandom-perl
+    replaces:
+      - centreon-perl-libs (<< 25.10.0)
+
+deb:
+  breaks:
+    - centreon-perl-libs (<< 25.10.0)
 
 rpm:
   summary: Centreon Perl libraries Common


### PR DESCRIPTION
…… (#2931)

- fix package ownership transition
- The old package (centreon-perl-libs) still owns /usr/share/perl5/centreon/common/db.pm.
- The new package (centreon-perl-libs-common) tries to install that same file.

Fixes #MON-191662 #MON-191739

## Description

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

