### PR TITLE
ci: use runner's role instead of an access key

### DIFF
--- a/.github/workflows/centreon-collect.yml
+++ b/.github/workflows/centreon-collect.yml
@@ -128,6 +128,9 @@ jobs:
       version_file: CMakeLists.txt
       nightly_manual_trigger: ${{ inputs.nightly_manual_trigger || inputs.robot_pattern != '^((?!cma).)*$' || false }}
 
+  get-aws-environment:
+    uses: ./.github/workflows/get-aws-environment.yml
+
   check-version-consistency:
     runs-on: ubuntu-24.04
     needs: [get-environment]
@@ -197,7 +200,7 @@ jobs:
       labels: ${{ needs.get-environment.outputs.labels }}
 
   unit-test:
-    needs: [get-environment, changes]
+    needs: [get-environment, get-aws-environment, changes]
     if: |
       (
         needs.changes.outputs.trigger_unit_testing == 'true' ||
@@ -214,8 +217,6 @@ jobs:
       SCCACHE_PATH: "/usr/bin/sccache"
       SCCACHE_BUCKET: "centreon-github-sccache"
       SCCACHE_REGION: "eu-west-1"
-      AWS_ACCESS_KEY_ID: ${{ secrets.COLLECT_S3_ACCESS_KEY }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.COLLECT_S3_SECRET_KEY }}
 
     container:
       image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/packaging-centreon-collect-vcpkg-${{ matrix.operating_system }}:${{ needs.get-environment.outputs.packaging_img_version }}
@@ -223,6 +224,11 @@ jobs:
         username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
         password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
       options: --cpus 8
+      env:
+        AWS_WEB_IDENTITY_TOKEN_FILE: ${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}
+        AWS_ROLE_ARN: ${{ needs.get-aws-environment.outputs.aws_role_arn }}
+      volumes:
+        - ${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}:${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}
 
     name: unit test ${{ matrix.operating_system }} ${{ matrix.arch }}
 
@@ -313,7 +319,7 @@ jobs:
           retention-days: 1
 
   package:
-    needs: [get-environment, changes, check-version-consistency]
+    needs: [get-environment, get-aws-environment, changes, check-version-consistency]
     if: |
       needs.changes.outputs.trigger_packaging == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
@@ -347,9 +353,9 @@ jobs:
       arch: ${{ matrix.arch }}
       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
       only_robot_cma: false
+      aws_role_arn: ${{ needs.get-aws-environment.outputs.aws_role_arn }}
+      aws_web_identity_token_file: ${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}
     secrets:
-      collect_s3_access_key: ${{ secrets.COLLECT_S3_ACCESS_KEY }}
-      collect_s3_secret_key: ${{ secrets.COLLECT_S3_SECRET_KEY }}
       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
       rpm_gpg_key: ${{ secrets.RPM_GPG_SIGNING_KEY }}
@@ -442,7 +448,7 @@ jobs:
             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
 
   robot-test:
-    needs: [get-environment, changes, package]
+    needs: [get-environment, get-aws-environment, changes, package]
     if: |
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
@@ -468,11 +474,11 @@ jobs:
       tests_params: ${{ matrix.tests_params }}
       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
       features_pattern: ${{ inputs.robot_pattern }}
+      aws_role_arn: ${{ needs.get-aws-environment.outputs.aws_role_arn }}
+      aws_web_identity_token_file: ${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}
     secrets:
       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-      collect_s3_access_key: ${{ secrets.COLLECT_S3_ACCESS_KEY }}
-      collect_s3_secret_key: ${{ secrets.COLLECT_S3_SECRET_KEY }}
       xray_client_id: ${{ secrets.XRAY_CLIENT_ID }}
       xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
       jira_base_url: ${{ secrets.JIRA_BASE_URL }}

--- a/.github/workflows/get-aws-environment.yml
+++ b/.github/workflows/get-aws-environment.yml
@@ -1,0 +1,23 @@
+on:
+  workflow_call:
+    outputs:
+      aws_role_arn:
+        description: "the ARN of the IAM role used by the self-hosted runner"
+        value: ${{ jobs.get-environment.outputs.aws_role_arn }}
+      aws_web_identity_token_file:
+        description: "the location of the web identity token file used to assume the IAM role"
+        value: ${{ jobs.get-environment.outputs.aws_web_identity_token_file }}
+
+jobs:
+  get-environment:
+    runs-on: centreon-collect
+    outputs:
+      aws_role_arn: ${{ steps.get_aws_env.outputs.aws_role_arn }}
+      aws_web_identity_token_file: ${{ steps.get_aws_env.outputs.aws_web_identity_token_file }}
+
+    steps:
+      - name: Get runner's AWS environment variables
+        id: get_aws_env
+        run: |
+          echo "aws_role_arn=$AWS_ROLE_ARN" >> $GITHUB_OUTPUT
+          echo "aws_web_identity_token_file=$AWS_WEB_IDENTITY_TOKEN_FILE" >> $GITHUB_OUTPUT

--- a/.github/workflows/monitoring-agent.yml
+++ b/.github/workflows/monitoring-agent.yml
@@ -79,6 +79,9 @@ jobs:
       version_file: CMakeLists.txt
       nightly_manual_trigger: ${{ inputs.nightly_manual_trigger || false }}
 
+  get-aws-environment:
+    uses: ./.github/workflows/get-aws-environment.yml
+
   check-version-consistency:
     runs-on: ubuntu-24.04
     needs: [get-environment]
@@ -282,7 +285,7 @@ jobs:
             build_windows\agent\Release\centagent.pdb
 
   unit-test-linux:
-    needs: [get-environment, changes, check-version-consistency]
+    needs: [get-environment, get-aws-environment, changes, check-version-consistency]
     if: |
       (
         github.event.inputs.unit_tests == 'true' ||
@@ -302,8 +305,6 @@ jobs:
       SCCACHE_PATH: "/usr/bin/sccache"
       SCCACHE_BUCKET: "centreon-github-sccache"
       SCCACHE_REGION: "eu-west-1"
-      AWS_ACCESS_KEY_ID: ${{ secrets.COLLECT_S3_ACCESS_KEY }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.COLLECT_S3_SECRET_KEY }}
 
     container:
       image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/packaging-centreon-collect-vcpkg-${{ matrix.operating_system }}:${{ needs.get-environment.outputs.packaging_img_version }}
@@ -311,6 +312,11 @@ jobs:
         username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
         password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
       options: --cpus 8
+      env:
+        AWS_WEB_IDENTITY_TOKEN_FILE: ${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}
+        AWS_ROLE_ARN: ${{ needs.get-aws-environment.outputs.aws_role_arn }}
+      volumes:
+        - ${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}:${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}
 
     name: unit test ${{ matrix.operating_system }} ${{ matrix.arch }}
 
@@ -398,7 +404,7 @@ jobs:
           retention-days: 1
 
   package-linux:
-    needs: [get-environment, changes, check-version-consistency]
+    needs: [get-environment, get-aws-environment, changes, check-version-consistency]
     if: |
       needs.changes.outputs.trigger_packaging == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
@@ -432,9 +438,9 @@ jobs:
       arch: ${{ matrix.arch }}
       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
       only_robot_cma: true
+      aws_role_arn: ${{ needs.get-aws-environment.outputs.aws_role_arn }}
+      aws_web_identity_token_file: ${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}
     secrets:
-      collect_s3_access_key: ${{ secrets.COLLECT_S3_ACCESS_KEY }}
-      collect_s3_secret_key: ${{ secrets.COLLECT_S3_SECRET_KEY }}
       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
       rpm_gpg_key: ${{ secrets.RPM_GPG_SIGNING_KEY }}
@@ -445,7 +451,7 @@ jobs:
       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
 
   robot-test:
-    needs: [get-environment, changes, package-linux]
+    needs: [get-environment, get-aws-environment, changes, package-linux]
     if: |
       needs.changes.outputs.trigger_e2e_testing == 'true' &&
       needs.get-environment.outputs.skip_workflow == 'false' &&
@@ -472,11 +478,11 @@ jobs:
       tests_params: ${{ matrix.tests_params }}
       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
       features_pattern: 'cma.*\.robot'
+      aws_role_arn: ${{ needs.get-aws-environment.outputs.aws_role_arn }}
+      aws_web_identity_token_file: ${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}
     secrets:
       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-      collect_s3_access_key: ${{ secrets.COLLECT_S3_ACCESS_KEY }}
-      collect_s3_secret_key: ${{ secrets.COLLECT_S3_SECRET_KEY }}
       xray_client_id: ${{ secrets.XRAY_CLIENT_ID }}
       xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
       jira_base_url: ${{ secrets.JIRA_BASE_URL }}

--- a/.github/workflows/package-collect.yml
+++ b/.github/workflows/package-collect.yml
@@ -52,11 +52,13 @@ on:
         required: false
         type: boolean
         default: false
+      aws_role_arn:
+        required: true
+        type: string
+      aws_web_identity_token_file:
+        required: true
+        type: string
     secrets:
-      collect_s3_access_key:
-        required: true
-      collect_s3_secret_key:
-        required: true
       registry_username:
         required: true
       registry_password:
@@ -81,8 +83,6 @@ jobs:
       SCCACHE_PATH: "/usr/bin/sccache"
       SCCACHE_BUCKET: "centreon-github-sccache"
       SCCACHE_REGION: "eu-west-1"
-      AWS_ACCESS_KEY_ID: ${{ secrets.collect_s3_access_key }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.collect_s3_secret_key }}
       ONLY_ROBOT_CMA: ${{ inputs.only_robot_cma && 'ON' || 'OFF' }}
 
     container:
@@ -91,6 +91,11 @@ jobs:
         username: ${{ secrets.registry_username }}
         password: ${{ secrets.registry_password }}
       options: --cpus 8
+      env:
+        AWS_WEB_IDENTITY_TOKEN_FILE: ${{ inputs.aws_web_identity_token_file }}
+        AWS_ROLE_ARN: ${{ inputs.aws_role_arn }}
+      volumes:
+        - ${{ inputs.aws_web_identity_token_file }}:${{ inputs.aws_web_identity_token_file }}
 
     name: package
 

--- a/.github/workflows/robot-test.yml
+++ b/.github/workflows/robot-test.yml
@@ -23,14 +23,16 @@ on:
         required: false
         type: string
         default: .robot
+      aws_role_arn:
+        required: true
+        type: string
+      aws_web_identity_token_file:
+        required: true
+        type: string
     secrets:
       registry_username:
         required: true
       registry_password:
-        required: true
-      collect_s3_access_key:
-        required: true
-      collect_s3_secret_key:
         required: true
       xray_client_id:
         required: true
@@ -143,9 +145,6 @@ jobs:
 
       #  pam sshd authentication doesn't work with privileged containers
       - name: ${{ matrix.feature == 'connector_ssh/connector_ssh.robot' && format('Test {0} (without privileges)', matrix.feature) || format('Test {0}', matrix.feature) }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.collect_s3_access_key }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.collect_s3_secret_key }}
         run: |
           privilege_status=""
           if [[ ${{ matrix.feature }} != 'connector_ssh/connector_ssh.robot' ]]; then
@@ -153,8 +152,9 @@ jobs:
           fi
           docker run --rm $privilege_status --ulimit core=-1 --ulimit nofile=524288:1048576 --security-opt seccomp=unconfined \
             -v $(pwd):/test_collect  \
-            --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-            --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+            -v  ${{ inputs.aws_web_identity_token_file }}:${{ inputs.aws_web_identity_token_file }} \
+            --env AWS_WEB_IDENTITY_TOKEN_FILE=${{ inputs.aws_web_identity_token_file }} \
+            --env AWS_ROLE_ARN=${{ inputs.aws_role_arn }} \
             --env AWS_BUCKET=centreon-collect-robot-report \
             --workdir /test_collect \
             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.IMAGE_NAME }}:${{ inputs.test_img_version }} \

--- a/.github/workflows/windows-agent-robot-test.yml
+++ b/.github/workflows/windows-agent-robot-test.yml
@@ -23,8 +23,11 @@ jobs:
     with:
       version_file: CMakeLists.txt
 
+  get-aws-environment:
+    uses: ./.github/workflows/get-aws-environment.yml
+
   build-collect:
-    needs: [get-environment]
+    needs: [get-environment, get-aws-environment]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable' &&
@@ -48,9 +51,9 @@ jobs:
       distrib: noble
       arch: amd64
       only_robot_cma: true
+      aws_role_arn: ${{ needs.get-aws-environment.outputs.aws_role_arn }}
+      aws_web_identity_token_file: ${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}
     secrets:
-      collect_s3_access_key: ${{ secrets.COLLECT_S3_ACCESS_KEY }}
-      collect_s3_secret_key: ${{ secrets.COLLECT_S3_SECRET_KEY }}
       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
       rpm_gpg_key: ${{ secrets.RPM_GPG_SIGNING_KEY }}
@@ -69,9 +72,6 @@ jobs:
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
     runs-on: windows-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.COLLECT_S3_ACCESS_KEY }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.COLLECT_S3_SECRET_KEY }}
     steps:
       - name: nocrlf conversion
         run: git config --system core.autocrlf false


### PR DESCRIPTION
https://centreon.atlassian.net/browse/INFRA-2235

Use self-hosted runners' IAM role to interact with AWS services instead of an access key. This removes the risk of the access key leaking.

The access key is still used in one job which runs on a public Windows runner. We'll have to think about a solution in the future.