### PR TITLE
fix(ci): always use lockfile to install node dependencies (#2996)

### DIFF
--- a/.github/actions/create-jira-ticket/action.yml
+++ b/.github/actions/create-jira-ticket/action.yml
@@ -24,13 +24,9 @@ runs:
   steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-    - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
       with:
-        node-version: 20
-
-    - name: Install DayJS
-      run: npm install dayjs@1.11.18
-      shell: bash
+        node-version: 24
 
     - if: inputs.ticket_reason_for_creation == 'Nightly'
       name: Create nightly epic if it does not exist already
@@ -42,12 +38,12 @@ runs:
         script: |
           const fs = require('fs');
           const { execSync } = require('child_process');
-          const dayjs = require('dayjs');
-          const month = dayjs().format('YYYY-MM');
+          const now = new Date();
+          const month = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
           const path = './epic-payload.json';
 
           let ticket_summary = `centreon-collect nightly incidents on ${month}`
-          let nightly_epic_id, nightly_epic_key
+          let nightly_epic_id, nightly_epic_key;
 
           const encodedJql = encodeURIComponent(`project = "MON" AND summary ~ "${ticket_summary}" AND type = Epic`);
 
@@ -110,14 +106,22 @@ runs:
         script: |
           const fs = require('fs');
           const { execSync } = require('child_process');
-          const dayjs = require('dayjs');
-          const isoWeek = require('dayjs/plugin/isoWeek');
-          dayjs.extend(isoWeek);
-
+          function formatDate(date) {
+            return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+          }
+          function getIsoWeek(date) {
+            const temp = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+            const dayNumber = temp.getUTCDay() || 7;
+            temp.setUTCDate(temp.getUTCDate() + 4 - dayNumber);
+            const yearStart = new Date(Date.UTC(temp.getUTCFullYear(), 0, 1));
+            return Math.ceil((((temp - yearStart) / 86400000) + 1) / 7);
+          }
+          const now = new Date();
+          const date = formatDate(now);
+          const isoWeekNumber = getIsoWeek(now);
           const nightly_epic_id = ${{ steps.get_nightly_epic.outputs.nightly_epic_id }}
           const nightly_epic_key = "${{ steps.get_nightly_epic.outputs.nightly_epic_key }}"
           const JSON_TEMPLATE_FILE = "./.github/actions/create-jira-ticket/nightly-ticket-template.json";
-          const date = dayjs().format('YYYY-MM-DD');
           const path = './ticket-payload.json';
           let contents, data, ticket_summary, ticket_squad_id, ticket_board_id, squad_name, ticket_labels, current_sprint, ticket_data, ticket_key;
 

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ engine/compile_commands.json
 # gorgone
 gorgone/log
 
+# node
+node_modules
+
 # tests
 tests/apps/
 tests/src/config/centreon-engine/*.cfg


### PR DESCRIPTION
## Description

fix(ci): always use lockfile to install node dependencies (#2996)

**Fixes** MON-192219