### PR TITLE
enh(ci): add and update latest tag on release events

### DIFF
--- a/.github/actions/release-new/action.yml
+++ b/.github/actions/release-new/action.yml
@@ -209,6 +209,12 @@ runs:
         git tag -a "${{ inputs.release_bundle_tag }}" -m "${{ inputs.release_bundle_tag }}"
         git push origin "${{ inputs.release_bundle_tag }}"
 
+        # Update old special tag "latest" to target the new release bundle tag
+        # Will create it if not existing, will update it if existing
+        echo "::notice::Updating special latest tag to target ${{ inputs.release_bundle_tag }}."
+        git tag -f "$NEW_MAJOR_VERSION-latest" ${{ inputs.release_bundle_tag }}^{}
+        git push origin "$NEW_MAJOR_VERSION-latest" -f
+
         # Add new component release tags on release branch for each release component
         # Abort if no tags or existing tag
         echo "Creating component release tags on branch ${{ inputs.release_branch }}."


### PR DESCRIPTION
## Description

* add and update latest tag on release events
* it should aim at the same commit as the release bundle tag

**Fixes** #MON-191548

