### PR TITLE
fix(engine): crash when macro address is not set in contact (#3020)

### DIFF
--- a/common/engine_conf/contact_helper.cc
+++ b/common/engine_conf/contact_helper.cc
@@ -17,6 +17,7 @@
  *
  */
 #include "common/engine_conf/contact_helper.hh"
+#include <charconv>
 
 #include "com/centreon/exceptions/msg_fmt.hh"
 
@@ -38,6 +39,10 @@ contact_helper::contact_helper(Contact* obj)
                      },
                      Contact::descriptor()->field_count()) {
   obj->mutable_obj()->set_register_(true);
+  // add default addresses
+  for (int i = 0; i < 6; ++i) {
+    obj->add_address("");
+  }
 }
 
 /**
@@ -81,8 +86,20 @@ bool contact_helper::hook(std::string_view key, std::string_view value) {
     fill_string_group(obj->mutable_service_notification_commands(), value);
     return true;
   } else if (key.compare(0, 7, "address") == 0) {
-    obj->add_address(value.data(), value.size());
-    return true;
+    // key is "address" + N, Replace corresponding entry.
+    int idx = 0;
+    auto suffix = key.substr(7);
+    auto err_code =
+        std::from_chars(suffix.data(), suffix.data() + suffix.size(), idx);
+    if (err_code.ec != std::errc{} ||
+        err_code.ptr != suffix.data() + suffix.size())
+      return false;
+
+    if (idx >= 1 && idx <= 6) {
+      obj->set_address(idx - 1, std::string(value));
+      return true;
+    }
+    return false;
   }
   return false;
 }

--- a/engine/src/macros.cc
+++ b/engine/src/macros.cc
@@ -577,6 +577,9 @@ int grab_contact_address_macro(unsigned int macro_num,
   if (temp_contact == nullptr)
     return ERROR;
 
+  if (temp_contact->get_addresses().size() <= macro_num)
+    return ERROR;
+
   /* get the macro */
   if (!temp_contact->get_address(macro_num).empty())
     output = temp_contact->get_address(macro_num);

--- a/engine/tests/configuration/applier/applier-pbcontact.cc
+++ b/engine/tests/configuration/applier/applier-pbcontact.cc
@@ -32,8 +32,10 @@
 #include "common/engine_conf/contact_helper.hh"
 #include "common/engine_conf/contactgroup_helper.hh"
 #include "common/engine_conf/message_helper.hh"
+#include "common/engine_conf/parser.hh"
 #include "common/engine_conf/timeperiod_helper.hh"
 #include "helper.hh"
+#include "state.pb.h"
 
 using namespace com::centreon;
 using namespace com::centreon::engine;
@@ -112,9 +114,9 @@ TEST_F(ApplierPbContact, PbRemoveContactFromConfig) {
   configuration::Contact ctct;
   configuration::contact_helper c_helper(&ctct);
   ctct.set_contact_name("test");
-  ctct.add_address("coucou");
-  ctct.add_address("foo");
-  ctct.add_address("bar");
+  c_helper.hook("address1", "coucou");
+  c_helper.hook("address2", "foo");
+  c_helper.hook("address3", "bar");
   fill_string_group(ctct.mutable_contactgroups(), "test_group");
   fill_string_group(ctct.mutable_host_notification_commands(), "cmd1");
   fill_string_group(ctct.mutable_host_notification_commands(), "cmd2");
@@ -127,7 +129,14 @@ TEST_F(ApplierPbContact, PbRemoveContactFromConfig) {
   aply.add_object(ctct);
   aply.expand_objects(pb_config);
   engine::contact* my_contact = engine::contact::contacts.begin()->second.get();
-  ASSERT_EQ(my_contact->get_addresses().size(), 3u);
+  ASSERT_EQ(my_contact->get_addresses().size(), 6u);
+  ASSERT_EQ(my_contact->get_address(0), "coucou");
+  ASSERT_EQ(my_contact->get_address(1), "foo");
+  ASSERT_EQ(my_contact->get_address(2), "bar");
+  ASSERT_EQ(my_contact->get_address(3), "");
+  ASSERT_EQ(my_contact->get_address(4), "");
+  ASSERT_EQ(my_contact->get_address(5), "");
+
   int idx;
   bool found = false;
   for (idx = 0; idx < pb_config.contacts().size(); idx++) {
@@ -184,9 +193,9 @@ TEST_F(ApplierPbContact, PbModifyContactFromConfig) {
   ASSERT_TRUE(ct_it != engine::contact::contacts.end());
   ASSERT_EQ(ct_it->second->get_custom_variables().size(), 2u);
   ASSERT_EQ(ct_it->second->get_custom_variables()["superVar"].value(),
-              std::string_view("Super"));
+            std::string_view("Super"));
   ASSERT_EQ(ct_it->second->get_custom_variables()["superVar1"].value(),
-              std::string_view("Super1"));
+            std::string_view("Super1"));
   ASSERT_EQ(ct_it->second->get_alias(), std::string_view("newAlias"));
   ASSERT_FALSE(ct_it->second->notify_on(notifier::service_notification,
                                         notifier::unknown));
@@ -449,4 +458,120 @@ TEST_F(ApplierPbContact, PbContactWithOnlyServiceRecoveryNotification) {
   aply.resolve_object(ctct, err);
   ASSERT_EQ(err.config_warnings, 1);
   ASSERT_EQ(err.config_errors, 0);
+}
+
+TEST_F(ApplierPbContact, PbaddContact) {
+  // create centengine.cfg
+  std::ofstream cfg_file("/tmp/centengine.cfg");
+  cfg_file << "cfg_file=/tmp/contacts.cfg";
+  cfg_file.close();
+
+  // create contacts.cfg
+  std::ofstream contacts_file("/tmp/contacts.cfg");
+  contacts_file << R"(define contact {
+    contact_name John_Doe
+    alias admin
+    email admin@admin.tld
+    host_notification_period 24x7
+    service_notification_period 24x7
+    host_notification_options d,u,r
+    service_notification_options w,u,c
+  })";
+  contacts_file.close();
+
+  configuration::error_cnt err;
+  configuration::State parsed_config;
+
+  configuration::parser p;
+  p.parse("/tmp/centengine.cfg", &parsed_config, err);
+  ASSERT_EQ(err.config_errors, 0);
+  ASSERT_EQ(err.config_warnings, 0);
+  ASSERT_EQ(parsed_config.contacts_size(), 1);
+  ASSERT_EQ(parsed_config.contacts(0).address(0), "");
+  ASSERT_EQ(parsed_config.contacts(0).address(1), "");
+  ASSERT_EQ(parsed_config.contacts(0).address(2), "");
+  ASSERT_EQ(parsed_config.contacts(0).address(3), "");
+  ASSERT_EQ(parsed_config.contacts(0).address(4), "");
+  ASSERT_EQ(parsed_config.contacts(0).address(5), "");
+
+  configuration::applier::contact aply;
+  aply.add_object(parsed_config.contacts(0));
+
+  engine::contact* my_contact = engine::contact::contacts.begin()->second.get();
+  ASSERT_EQ(my_contact->get_addresses().size(), 6u);
+  ASSERT_EQ(my_contact->get_address(0), "");
+  ASSERT_EQ(my_contact->get_address(1), "");
+  ASSERT_EQ(my_contact->get_address(2), "");
+  ASSERT_EQ(my_contact->get_address(3), "");
+  ASSERT_EQ(my_contact->get_address(4), "");
+  ASSERT_EQ(my_contact->get_address(5), "");
+
+  // Clean up temporary files
+  try {
+    if (std::filesystem::exists("/tmp/centengine.cfg"))
+      std::filesystem::remove("/tmp/centengine.cfg");
+    if (std::filesystem::exists("/tmp/contacts.cfg"))
+      std::filesystem::remove("/tmp/contacts.cfg");
+  } catch (...) {
+    std::cout << "Error cleaning up temporary files" << std::endl;
+  }
+}
+
+TEST_F(ApplierPbContact, ParseContact) {
+  // create centengine.cfg
+  std::ofstream cfg_file("/tmp/centengine.cfg");
+  cfg_file << "cfg_file=/tmp/contacts.cfg";
+  cfg_file.close();
+
+  // create contacts.cfg
+  std::ofstream contacts_file("/tmp/contacts.cfg");
+  contacts_file << R"(define contact {
+    contact_name John_Doe
+    alias admin
+    email admin@admin.tld
+    host_notification_period 24x7
+    service_notification_period 24x7
+    host_notification_options d,u,r
+    service_notification_options w,u,c
+    address1 toto
+    address3 fofo
+  })";
+  contacts_file.close();
+
+  configuration::error_cnt err;
+  configuration::State parsed_config;
+
+  configuration::parser p;
+  p.parse("/tmp/centengine.cfg", &parsed_config, err);
+  ASSERT_EQ(err.config_errors, 0);
+  ASSERT_EQ(err.config_warnings, 0);
+  ASSERT_EQ(parsed_config.contacts_size(), 1);
+  ASSERT_EQ(parsed_config.contacts(0).address(0), "toto");
+  ASSERT_EQ(parsed_config.contacts(0).address(1), "");
+  ASSERT_EQ(parsed_config.contacts(0).address(2), "fofo");
+  ASSERT_EQ(parsed_config.contacts(0).address(3), "");
+  ASSERT_EQ(parsed_config.contacts(0).address(4), "");
+  ASSERT_EQ(parsed_config.contacts(0).address(5), "");
+
+  configuration::applier::contact aply;
+  aply.add_object(parsed_config.contacts(0));
+
+  engine::contact* my_contact = engine::contact::contacts.begin()->second.get();
+  ASSERT_EQ(my_contact->get_addresses().size(), 6u);
+  ASSERT_EQ(my_contact->get_address(0), "toto");
+  ASSERT_EQ(my_contact->get_address(1), "");
+  ASSERT_EQ(my_contact->get_address(2), "fofo");
+  ASSERT_EQ(my_contact->get_address(3), "");
+  ASSERT_EQ(my_contact->get_address(4), "");
+  ASSERT_EQ(my_contact->get_address(5), "");
+
+  // Clean up temporary files
+  try {
+    if (std::filesystem::exists("/tmp/centengine.cfg"))
+      std::filesystem::remove("/tmp/centengine.cfg");
+    if (std::filesystem::exists("/tmp/contacts.cfg"))
+      std::filesystem::remove("/tmp/contacts.cfg");
+  } catch (...) {
+    std::cout << "Error cleaning up temporary files" << std::endl;
+  }
 }

--- a/tests/broker-engine/notifications.robot
+++ b/tests/broker-engine/notifications.robot
@@ -104,6 +104,62 @@ not1
     Ctn Stop Engine
     Ctn Kindly Stop Broker
 
+not1_2
+    [Documentation]    Scenario: Service notification command expands contact macros
+    ...    Given a single service 'service_1' is assigned to contact 'John_Doe' with notifications enabled, options (w,c,r), and period 24x7
+    ...    And 'service_1' has check/retry intervals of 1 and max check attempts of 1
+    ...    And contact 'John_Doe' uses notification command 'command_with_macro' with macros
+    ...    When the broker and engine are started and the service is driven to a HARD CRITICAL state
+    ...    Then the service reaches HARD CRITICAL
+    ...    And a service notification is logged for 'service_1' in CRITICAL state using 'command_with_macro'
+    ...    And the processed notification command in logs is "/bin/echo pager address5 " showing macros are expanded
+    [Tags]    broker    engine    services    hosts    notification    MON-192591
+    Ctn Clear Commands Status
+    Ctn Config Engine    ${1}    ${1}    ${1}
+    Ctn Config Notifications
+    Ctn Engine Config Set Value In Services    0    service_1    contacts    John_Doe
+    Ctn Engine Config Set Value In Services    0    service_1    notification_options    w,c,r
+    Ctn Engine Config Set Value In Services    0    service_1    notifications_enabled    1
+    Ctn Engine Config Set Value In Services    0    service_1    notification_period    24x7
+    Ctn Engine Config Replace Value In Services    0    service_1    check_interval    1
+    Ctn Engine Config Replace Value In Services    0    service_1    retry_interval    1
+    Ctn Engine Config Replace Value In Services    0    service_1    max_check_attempts    1
+    Ctn Engine Config Set Value In Contacts    0    John_Doe    host_notification_commands    command_with_macro
+    Ctn Engine Config Set Value In Contacts    0    John_Doe    service_notification_commands    command_with_macro
+    Ctn Engine Config Set Value In Contacts    0    John_Doe    pager    pager
+    Ctn Engine Config Set Value In Contacts    0    John_Doe    address5    address5
+
+    Ctn Engine Config Add Command    ${0}    command_with_macro   /bin/echo $CONTACTPAGER$ $CONTACTADDRESS5$ $CONTACTADDRESS1$ $CONTACTADDRESS6$   ${None}
+
+    ${start}    Get Current Date
+    Ctn Start Broker
+    Ctn Start Engine
+
+    # Let's wait for the external command check start
+    Ctn Wait For Engine To Be Ready    ${1}
+
+    ${cmd_service_1}    Ctn Get Service Command Id    ${1}
+    Ctn Set Command Status    ${cmd_service_1}    ${2}
+    ## Time to set the service to CRITICAL HARD.
+    Ctn Process Service Result Hard    host_1    service_1    ${2}    The service_1 is CRITICAL
+
+    ${result}    Ctn Check Service Resource Status With Timeout    host_1    service_1    ${2}    60    HARD
+    Should Be True    ${result}    Service (host_1,service_1) should be CRITICAL HARD
+
+    ${content}    Create List    SERVICE NOTIFICATION: John_Doe;host_1;service_1;CRITICAL;command_with_macro;
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    No notification has been sent concerning a critical service
+
+
+    ## Check for processed notification command
+    ${content}    Create List    Processed notification command: /bin/echo pager address5 
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    Notification command with macros was not processed correctly
+
+
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker
+
 not1_WL_OK
     [Documentation]    This test case configures a single service. When it is in non-OK HARD state
     ...    a notification is sent because it is allowed by the whitelist


### PR DESCRIPTION
Engine crashes when notifications are enabled and core-dumps.

REFS: MON-192906
