### PR TITLE
fix(ci): update checkout action call in release action

### DIFF
--- a/.github/actions/release-new/action.yml
+++ b/.github/actions/release-new/action.yml
@@ -41,7 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout sources
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         fetch-depth: 0
         token: ${{ inputs.centreon_technique_pat }}


### PR DESCRIPTION
## Description

* update checkout action version called in release-new action to v6.0.1

**Fixes** #MON-194770

