### PR TITLE
feat(gorgone): trigger nodesync on RS after config import

### DIFF
--- a/gorgone/config/gorgoned-remote-zmq.yml
+++ b/gorgone/config/gorgoned-remote-zmq.yml
@@ -29,6 +29,10 @@ configuration:
         enable: true
         config_file: config/registernodes-remote.yml
 
+      - name: nodes
+        package: gorgone::modules::centreon::nodes::hooks
+        enable: true
+
       - name: legacycmd
         package: gorgone::modules::centreon::legacycmd::hooks
         enable: true

--- a/gorgone/gorgone/modules/centreon/legacycmd/class.pm
+++ b/gorgone/gorgone/modules/centreon/legacycmd/class.pm
@@ -664,11 +664,26 @@ sub action_addimporttaskwithparent {
 
     my $centreon_dir = (defined($connector->{config}->{centreon_dir})) ?
         $connector->{config}->{centreon_dir} : '/usr/share/centreon';
+
+    my $worker_token = $self->generate_token();
+
+    $self->send_internal_action({
+        action => 'ADDLISTENER',
+        data => [
+            {
+                identity => 'gorgone-legacycmd',
+                event => 'LEGACYCMDNODESYNCLISTENER',
+                token => $worker_token,
+                timeout => 300
+            }
+        ]
+    });
+
     my $cmd = $centreon_dir . '/bin/centreon -u "' . $self->{clapi_user} . '" -p "' .
         $self->{clapi_password} . '" -w -o CentreonWorker -a processQueue';
     $self->send_internal_action({
         action => 'COMMAND',
-        token => $options{token},
+        token => $worker_token,
         data => {
             logging => $options{data}->{logging},
             content => [
@@ -679,6 +694,7 @@ sub action_addimporttaskwithparent {
             parameters => { no_fork => 1 }
         }
     });
+
     $self->send_internal_action({
         action => 'COMMAND',
         token => $options{token},
@@ -700,6 +716,21 @@ sub action_addimporttaskwithparent {
             message => 'Task inserted on Remote Server',
         }
     );
+
+    return 0;
+}
+
+sub action_legacycmdnodesynclistener {
+    my ($self, %options) = @_;
+
+    return 0 if ($options{data}->{code} != GORGONE_ACTION_FINISH_OK);
+
+    $self->{logger}->writeLogDebug('[legacycmd] -class- triggering nodesync after import task completion');
+    $self->send_internal_action({
+        action => 'CENTREONNODESSYNC',
+        token => $self->generate_token(),
+        data => {}
+    });
 
     return 0;
 }

--- a/gorgone/gorgone/modules/centreon/legacycmd/hooks.pm
+++ b/gorgone/gorgone/modules/centreon/legacycmd/hooks.pm
@@ -31,7 +31,8 @@ use constant NAME => 'legacycmd';
 use constant EVENTS => [
     { event => 'CENTREONCOMMAND', uri => '/command', method => 'POST' },
     { event => 'LEGACYCMDREADY' },
-    { event => 'ADDIMPORTTASKWITHPARENT' }
+    { event => 'ADDIMPORTTASKWITHPARENT' },
+    { event => 'LEGACYCMDNODESYNCLISTENER' }
 ];
 
 my $config_core;


### PR DESCRIPTION
## Description

When the central Gorgone syncs configuration to a Remote Server (RS) via `SENDEXPORTFILE`, the RS database gets updated with new poller/server information. However, the RS's Gorgone `nodes` module is unaware of these changes until its next periodic resync (every 600 seconds by default). This means newly added or removed pollers behind the RS are not discovered promptly.

This PR triggers a `CENTREONNODESSYNC` action on the RS **after** the CentreonWorker import completes, so the RS immediately discovers node changes. It uses the same `ADDLISTENER` + callback pattern as the statistics module.

**Fixes** [MON-194473](https://centreon.atlassian.net/browse/MON-194473)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

1. Set up a Central + Remote Server (ZMQ or SSH) with at least one poller behind the RS.
2. Add a new poller behind the RS in the Central UI.
3. Deploy the configuration to the RS (triggering `SENDEXPORTFILE`).
4. Check RS Gorgone logs for the following sequence:
   - `[listener] add token '<worker_token>'` — listener registered
   - `[listener] trigger event '<worker_token>'` — CentreonWorker completed
   - `[legacycmd] -class- triggering nodesync after import task completion`
   - `[nodes] action nodesresync proceed` / `[nodes] Finish resync`
5. Verify the newly added poller appears in the RS's proxy connections **without** waiting for the 600s periodic resync cycle.

**Edge cases to verify:**
- If CentreonWorker fails, nodesync should **not** be triggered (check `GORGONE_ACTION_FINISH_OK` guard).
- If the `nodes` module is not loaded on the RS, the import and broker reload should still succeed (non-fatal "unknown action" error).

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

[MON-194473]: https://centreon.atlassian.net/browse/MON-194473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ