### PR TITLE
MON-192336-vm-ware-connector-each-configuration-export-restart-the-centreon-vmware-process

### DIFF
--- a/gorgone/gorgone/modules/centreon/legacycmd/class.pm
+++ b/gorgone/gorgone/modules/centreon/legacycmd/class.pm
@@ -364,22 +364,6 @@ sub execute_cmd {
             }
         });
     } elsif ($options{cmd} eq 'ENGINERESTART') {
-        # restart centreon_vwmare
-        $self->send_internal_action({
-            action => 'ACTIONENGINE',
-            target => $options{target},
-            token => $token,
-            data => {
-                logging => $options{logging},
-                content => {
-                    command => 'sudo systemctl restart centreon_vmware.service',
-                    metadata => {
-                        centcore_proxy => 1,
-                        centcore_cmd => 'ENGINERESTART'
-                    }
-                }
-            }
-        });
         # restart centreon-engine
         my $cmd = $self->{pollers}->{$options{target}}->{engine_restart_command};
         $self->send_internal_action({
@@ -399,22 +383,6 @@ sub execute_cmd {
             }
         });
     } elsif ($options{cmd} eq 'RESTART') {
-        # restart centreon_vwmare
-        $self->send_internal_action({
-            action => 'ACTIONENGINE',
-            target => $options{target},
-            token => $token,
-            data => {
-                logging => $options{logging},
-                content => {
-                    command => 'sudo systemctl restart centreon_vmware.service',
-                    metadata => {
-                        centcore_proxy => 1,
-                        centcore_cmd => 'ENGINERESTART'
-                    }
-                }
-            }
-        });
         # restart centreon-engine
         my $cmd = $self->{pollers}->{$options{target}}->{engine_restart_command};
         $self->send_internal_action({
@@ -435,22 +403,6 @@ sub execute_cmd {
             }
         });
     } elsif ($options{cmd} eq 'ENGINERELOAD') {
-        # restart centreon_vwmare
-        $self->send_internal_action({
-            action => 'ACTIONENGINE',
-            target => $options{target},
-            token => $token,
-            data => {
-                logging => $options{logging},
-                content => {
-                    command => 'sudo systemctl restart centreon_vmware.service',
-                    metadata => {
-                        centcore_proxy => 1,
-                        centcore_cmd => 'ENGINERESTART'
-                    }
-                }
-            }
-        });
         my $cmd = $self->{pollers}->{ $options{target} }->{engine_reload_command};
         $self->send_internal_action({
             action => 'ACTIONENGINE',
@@ -469,22 +421,6 @@ sub execute_cmd {
             }
         });
     } elsif ($options{cmd} eq 'RELOAD') {
-        # restart centreon_vwmare
-        $self->send_internal_action({
-            action => 'ACTIONENGINE',
-            target => $options{target},
-            token => $token,
-            data => {
-                logging => $options{logging},
-                content => {
-                    command => 'sudo systemctl restart centreon_vmware.service',
-                    metadata => {
-                        centcore_proxy => 1,
-                        centcore_cmd => 'ENGINERESTART'
-                    }
-                }
-            }
-        });
         my $cmd = $self->{pollers}->{$options{target}}->{engine_reload_command};
         $self->send_internal_action({
             action => 'COMMAND',
@@ -622,8 +558,22 @@ sub execute_cmd {
                 ]
             }
         });
+    }
+    elsif ($options{cmd} eq 'VMWARERESTART') {
+
+        $self->send_internal_action({
+            action => 'ACTIONENGINE',
+            target => $options{target},
+            token => $token,
+            data => {
+                logging => $options{logging},
+                content => {
+                    command => 'sudo systemctl restart centreon_vmware.service',
+                }
+            }
+        });
     } else{
-        $self->{logger}->writeLogError('[legacycmd] Cannot process message type ' . $options{cmd} . "throwing it away.");
+        $self->{logger}->writeLogWarning('[legacycmd] Cannot process message type ' . $options{cmd} . "throwing it away.");
     }
 
     return 0;


### PR DESCRIPTION
## Description

separate engine and vmware process restart when pushing the configuration.

This will allows to push engine configuration without restarting vmware, for the (most often) case where user changed monitoring conf but not vmware daemon conf.

**Fixes** # MON-192336

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [X] master

<h2> How this pull request can be tested ? </h2>


Run a poller and a central (can't be tested on a central only as php is doing the restart in that case) poller should have ID 2

on the central use this command : 
```bash
echo 'VMWARERESTART:2' > /var/lib/centreon/centcore/testManual.cmd

```

Expected behaviour : 

the poller restart the centreon-vmware process

on the central use this command : 
```bash
echo 'ENGINERELOAD:2' > /var/lib/centreon/centcore/testManual.cmd

```

only engine should be restarted, and not centreon-vmware

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

