### PR TITLE
fix(gorgone): reduce log file permissions

### DIFF
--- a/gorgone/gorgone/class/script.pm
+++ b/gorgone/gorgone/class/script.pm
@@ -73,6 +73,10 @@ sub init {
         $self->{logger}->file_mode($self->{log_file});
     }
     $self->{logger}->flush_output(enabled => $self->{flushoutput});
+    if ($self->{severity} =~ /debug/i && $ENV{ALLOW_PASSWORD_IN_LOG} ){
+        # debug logs should not show password, you can enable "trace" level with all logs by adding the env variable ALLOW_PASSWORD_IN_LOG=1
+        $self->{severity} = 8;
+    }
     $self->{logger}->severity($self->{severity});
     $self->{logger}->force_default_severity();
 

--- a/gorgone/packaging/scripts/centreon-gorgone-postinstall.sh
+++ b/gorgone/packaging/scripts/centreon-gorgone-postinstall.sh
@@ -8,6 +8,12 @@ startGorgoned() {
   systemctl restart gorgoned.service ||:
 }
 
+# Change the gorgone default log file to be 640, it was 644 before.
+# New gorgone version create it as 640 but do not change existing log file.
+if [[ -e /var/log/centreon-gorgone/gorgoned.log ]] ; then
+  chmod 640 /var/log/centreon-gorgone/gorgoned.log
+fi
+
 action="$1"
 if  [ "$1" = "configure" ] && [ -z "$2" ]; then
   # Alpine linux does not pass args, and deb passes $1=configure

--- a/perl-libs/lib/centreon/common/logger.pm
+++ b/perl-libs/lib/centreon/common/logger.pm
@@ -103,12 +103,16 @@ sub file_mode($$) {
     if (defined($self->{filehandler})) {
         $self->{filehandler}->close();
     }
+    # Use umask to set the file permissions to 0640 and reset it right after to avoid changing other code area.
+    my $old_umask = umask(0027);
     if (open($self->{filehandler}, ">>", $file)){
+        umask($old_umask);
         $self->{log_mode} = 1;
         $self->{filehandler}->autoflush(1);
         $self->{file_name} = $file;
         return 1;
     }
+    umask($old_umask);
     $self->{filehandler} = undef;
     print STDERR "Cannot open file $file: $!\n";
     return 0;

--- a/perl-libs/lib/centreon/common/logger.pm
+++ b/perl-libs/lib/centreon/common/logger.pm
@@ -71,7 +71,8 @@ my %human_severities = (
     4 => 'WARNING',
     5 => 'NOTICE',
     6 => 'INFO',
-    7 => 'DEBUG'
+    7 => 'DEBUG',
+    8 => 'TRACE'
 );
 
 sub new {
@@ -196,6 +197,8 @@ sub severity {
             $self->{severity} = 6;
         } elsif ($input_severity eq "debug") {
             $self->{severity} = 7;
+        }elsif ($input_severity eq "trace") {
+            $self->{severity} = 8;
         } else {
             $self->writeLogError("Wrong severity value set.");
             return -1;
@@ -256,6 +259,10 @@ sub writeLog($$$%) {
     } else {
         print STDERR "Unknown log mode '$self->{log_mode}' or log file unavailable for the following log :\n $datedmsg\n";
     }
+}
+
+sub writeLogTrace {
+    shift->writeLog(8, @_);
 }
 
 sub writeLogDebug {


### PR DESCRIPTION
## Description

set gorgone log permissions to 640 instead of 644

**Fixes** # MON-192925

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [X] master

<h2> How this pull request can be tested ? </h2>

need to test both update and new install : log file should be 640 in both case.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

