### PR TITLE
fix(gorgone): move binary to /usr/bin instead of /usr/local/bin

### DIFF
--- a/gorgone/docs/client_server_zmq.md
+++ b/gorgone/docs/client_server_zmq.md
@@ -29,7 +29,7 @@ Copy the server public key onto the client in a specific directory (for example 
 On the client, execute the following command:
 
 ```bash
-$ perl /usr/local/bin/gorgone_key_thumbprint.pl --key-path='/var/spool/centreon/.gorgone/pubkey.pem'
+$ perl /usr/bin/gorgone_key_thumbprint.pl --key-path='/var/spool/centreon/.gorgone/pubkey.pem'
 2019-09-30 11:00:00 - INFO - File '/var/spool/centreon/.gorgone/pubkey.pem' JWK thumbprint: pnI6EWkiTbazjikJXRkLmjml5wvVECYtQduJUjS4QK4
 ```
 

--- a/gorgone/docs/migration.md
+++ b/gorgone/docs/migration.md
@@ -5,7 +5,7 @@ To build a configuration file based on */etc/centreon/conf.pm*, execute the foll
 If using package:
 
 ```bash
-$ perl /usr/local/bin/gorgone_config_init.pl
+$ perl /usr/bin/gorgone_config_init.pl
 2019-09-30 11:00:00 - INFO - file '/etc/centreon-gorgone/config.yaml' created success
 ```
 

--- a/gorgone/gorgone/modules/core/action/class.pm
+++ b/gorgone/gorgone/modules/core/action/class.pm
@@ -247,7 +247,7 @@ sub install_plugins {
     $self->{logger}->writeLogInfo("[action] validate plugins - install " . join(' ', @{$options{installed}}));
     my ($error, $stdout, $return_code) = gorgone::standard::misc::backtick(
         command => 'sudo',
-        arguments => ['/usr/local/bin/gorgone_install_plugins.pl', '--type=' . $options{type}, @{$options{installed}}],
+        arguments => ['/usr/bin/gorgone_install_plugins.pl', '--type=' . $options{type}, @{$options{installed}}],
         timeout => 300,
         wait_exit => 1,
         redirect_stderr => 1,

--- a/gorgone/packaging/centreon-gorgone.yaml
+++ b/gorgone/packaging/centreon-gorgone.yaml
@@ -126,27 +126,27 @@ contents:
     expand: true
 
   - src: "../contrib/gorgone_config_init.pl"
-    dst: "/usr/local/bin/"
+    dst: "/usr/bin/"
     file_info:
       mode: 0755
 
   - src: "../contrib/gorgone_audit.pl"
-    dst: "/usr/local/bin/"
+    dst: "/usr/bin/"
     file_info:
       mode: 0755
 
   - src: "../contrib/gorgone_install_plugins.pl"
-    dst: "/usr/local/bin/"
+    dst: "/usr/bin/"
     file_info:
       mode: 0750
 
   - src: "../contrib/gorgone_key_thumbprint.pl"
-    dst: "/usr/local/bin/"
+    dst: "/usr/bin/"
     file_info:
       mode: 0750
 
   - src: "../contrib/gorgone_key_generation.pl"
-    dst: "/usr/local/bin/"
+    dst: "/usr/bin/"
     file_info:
       mode: 0750
 

--- a/gorgone/packaging/sudoers.d/centreon-gorgone
+++ b/gorgone/packaging/sudoers.d/centreon-gorgone
@@ -3,4 +3,4 @@
 User_Alias      GORGONE=centreon-gorgone
 Defaults:GORGONE !requiretty
 
-GORGONE ALL = NOPASSWD: /usr/local/bin/gorgone_install_plugins.pl
+GORGONE ALL = NOPASSWD: /usr/bin/gorgone_install_plugins.pl

--- a/gorgone/tests/robot/resources/resources.resource
+++ b/gorgone/tests/robot/resources/resources.resource
@@ -118,7 +118,7 @@ Setup Gorgone Config
     FOR    ${file}    IN    @{file_list}
         Copy File    ${file}    /etc/centreon-gorgone/${gorgone_name}/config.d/
     END
-    ${key_thumbprint}    Run    perl /usr/local/bin/gorgone_key_thumbprint.pl --key-path=/var/lib/centreon-gorgone/.keys/rsakey.priv.pem | cut -d: -f4
+    ${key_thumbprint}    Run    perl /usr/bin/gorgone_key_thumbprint.pl --key-path=/var/lib/centreon-gorgone/.keys/rsakey.priv.pem | cut -d: -f4
 
     ${result}    Run    sed -i -e 's/@UNIQ_ID_FROM_ROBOT_TESTING_CONFIG_FILE@/${gorgone_name}/g' /etc/centreon-gorgone/${gorgone_name}/includer.yaml
 
@@ -177,7 +177,7 @@ Check Poller Communicate
 Setup Two Gorgone Instances
     [Arguments]    ${central_config}=@{EMPTY}    ${poller_config}=@{EMPTY}    ${communication_mode}=push_zmq    ${central_name}=gorgone_central    ${poller_name}=gorgone_poller_2
     ${start_time}   Get Time    str=epoch
-    ${result}    Run    perl /usr/local/bin/gorgone_key_generation.pl
+    ${result}    Run    perl /usr/bin/gorgone_key_generation.pl
     # generate key if there is none.
     # gorgone can generate it's own key, but as we need the thumbprint in the configuration we need to generate them before launching gorgone.
     # this script only create key if the files don't exists, and silently finish if the files already exists.


### PR DESCRIPTION
## Description

move gorgone helper binary to /usr/bin instead of /usr/local/bin

**Fixes** # 

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [X] master

<h2> How this pull request can be tested ? </h2>

test both fresh install and upgrade scenario of the package, in both case the scripts should be present in /usr/bin/ and not in /usr/local/bin after installation

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Moved contributed helper scripts installation destination to /usr/bin.

**🔧 Refactors**
* Updated plugin installer command to invoke /usr/bin/gorgone_install_plugins.pl binary for consistency.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101437168?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->