### PR TITLE
chore(deps): bump actions/checkout to 6.0.2

### DIFF
--- a/.github/actions/create-jira-ticket/action.yml
+++ b/.github/actions/create-jira-ticket/action.yml
@@ -22,7 +22,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
       with:

--- a/.github/actions/release-new/action.yml
+++ b/.github/actions/release-new/action.yml
@@ -41,7 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout sources
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
         token: ${{ inputs.centreon_technique_pat }}


### PR DESCRIPTION
## Description

* bump missing locations to actions/checkout v6+

**Fixes** #MON-195546

