### PR TITLE
fix(mbi): use array ref for fallback service category

### DIFF
--- a/gorgone/gorgone/modules/centreon/mbi/libs/centreon/Service.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/centreon/Service.pm
@@ -88,7 +88,7 @@ sub getServicesWithHostAndCategory {
 			}
     	}
    		if (!scalar(@categoriesTable)) {
-   			#ToDo push @categoriesTable, "0;NULL";
+   			push @categoriesTable, [0, "NoCategory"];
    		}	
     	if (defined($serviceHostTable)) {
 		foreach my $hostInfos (@$serviceHostTable) {
@@ -130,7 +130,7 @@ sub getServicesWithHostAndCategory {
 			}
     	}
    		if (!scalar(@categoriesTable)) {
-   			push @categoriesTable, "0;NULL";
+   			push @categoriesTable, [0, "NoCategory"];
    		}	
     	if (defined($serviceHostTable)) {
 		foreach my $hostInfos (@$serviceHostTable) {


### PR DESCRIPTION
## Description

When a service has no service category (and none of its parent templates do either), the dimensions calculation crashes with:
```
Can't use string ("0;NULL") as an ARRAY ref while "strict refs" in use at Service.pm line 138.
```

The hostgroup code path pushed the string `"0;NULL"` as a fallback, but the rest of the function dereferences each entry as an array ref (`@$_`). The host code path had the fallback commented out with `#ToDo`, silently dropping uncategorized services.

This fix uses `[0, "NoCategory"]` in both code paths, consistent with the fallback used in `Host.pm`'s `getHostGroupAndCategories`.

**Fixes** [MON-192873](https://centreon.atlassian.net/browse/MON-192873)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

1. Set up a Centreon environment with MBI
2. Create a Host Group, then create a service by host group using a template that has **no service category** (e.g., `OS-Linux-Disks-NRPE4-custom`)
3. Save, export, and import the configuration:
   ```
   /usr/share/centreon-bi/etl/importData.pl -r --centreon-only
   ```
4. Run the dimensions calculation:
   ```
   /usr/share/centreon-bi/etl/dimensionsBuilder.pl -r
   ```
5. Verify it completes without crashing

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

[MON-192873]: https://centreon.atlassian.net/browse/MON-192873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ