### PR TITLE
feat(engine/agent): cma get public ca using fingerprint and establish tls connection

### DIFF
--- a/agent/CMakeLists.txt
+++ b/agent/CMakeLists.txt
@@ -131,6 +131,7 @@ set( SRC_COMMON
   ${SRC_DIR}/check.cc
   ${SRC_DIR}/check_exec.cc
   ${SRC_DIR}/drive_size.cc
+  ${SRC_DIR}/grpc_ca_bootstrap.cc
   ${SRC_DIR}/check_health.cc
   ${SRC_DIR}/log.cc
   ${SRC_DIR}/opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc

--- a/agent/CMakeLists.txt
+++ b/agent/CMakeLists.txt
@@ -238,6 +238,7 @@ else()
     fmt::fmt
     pdh
     taskschd
+    Crypt32
     Version.lib)
 
   if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")

--- a/agent/inc/com/centreon/agent/config.hh
+++ b/agent/inc/com/centreon/agent/config.hh
@@ -41,6 +41,7 @@ class config {
   std::string _private_key_file;
   std::string _ca_certificate_file;
   std::string _ca_name;
+  std::string _ca_fingerprint;
   std::string _host;
   std::string _host_template;
   bool _reverse_connection;
@@ -101,6 +102,7 @@ class config {
     return _ca_certificate_file;
   }
   const std::string& get_ca_name() const { return _ca_name; }
+  const std::string& get_ca_fingerprint() const { return _ca_fingerprint; }
   const std::string& get_host() const { return _host; }
   const std::string& get_host_template() const { return _host_template; }
   bool use_reverse_connection() const { return _reverse_connection; }

--- a/agent/inc/com/centreon/agent/grpc_ca_bootstrap.hh
+++ b/agent/inc/com/centreon/agent/grpc_ca_bootstrap.hh
@@ -19,7 +19,6 @@
 #ifndef CENTREON_AGENT_GRPC_CA_BOOTSTRAP_HH
 #define CENTREON_AGENT_GRPC_CA_BOOTSTRAP_HH
 
-#include <memory>
 #include <optional>
 #include <string>
 

--- a/agent/inc/com/centreon/agent/grpc_ca_bootstrap.hh
+++ b/agent/inc/com/centreon/agent/grpc_ca_bootstrap.hh
@@ -64,7 +64,7 @@ class bootstrap_grpc_client
  public:
   using com::centreon::common::grpc::grpc_client_base::grpc_client_base;
 
-  const std::shared_ptr<::grpc::Channel>& get_channel() const {
+  std::shared_ptr<::grpc::Channel> get_channel() const {
     return _channel;
   }
 };
@@ -74,7 +74,8 @@ class bootstrap_grpc_client
  * the initial TLS connection fails.
  *
  * Public behavior is intentionally stable: this function only mutates
- * `grpc_conf`/config files when bootstrap succeeds.
+ * `grpc_conf` and persisted configuration (JSON on Linux, registry on Windows)
+ * when bootstrap succeeds.
  */
 void bootstrap_ca_from_fingerprint_if_needed(
     const config& conf,

--- a/agent/inc/com/centreon/agent/grpc_ca_bootstrap.hh
+++ b/agent/inc/com/centreon/agent/grpc_ca_bootstrap.hh
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
+
+#ifndef CENTREON_AGENT_GRPC_CA_BOOTSTRAP_HH
+#define CENTREON_AGENT_GRPC_CA_BOOTSTRAP_HH
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include <spdlog/logger.h>
+#include "com/centreon/common/grpc/grpc_client.hh"
+#include "config.hh"
+
+namespace com::centreon::agent {
+
+/**
+ * @brief Orchestrates CA bootstrap from fingerprint and persists resulting TLS
+ * configuration updates.
+ */
+class ca_bootstrap_workflow {
+  const config& _conf;
+  const std::string _config_path;
+  const std::shared_ptr<com::centreon::common::grpc::grpc_config> _grpc_conf;
+  const std::shared_ptr<spdlog::logger> _logger;
+
+ public:
+  ca_bootstrap_workflow(
+      const config& conf,
+      std::string config_path,
+      std::shared_ptr<com::centreon::common::grpc::grpc_config> grpc_conf,
+      std::shared_ptr<spdlog::logger> logger);
+
+  void run();
+
+ private:
+  bool is_bootstrap_needed() const;
+  bool probe_full_tls_connection() const;
+  std::optional<std::string> fetch_ca_with_tls_skip_verify() const;
+  bool validate_ca_fingerprint(const std::string& ca_pem) const;
+  bool persist_ca_to_file_and_config(const std::string& ca_pem) const;
+};
+
+/**
+ * @brief Thin testable wrapper exposing gRPC channel access for bootstrap RPCs.
+ */
+class bootstrap_grpc_client
+    : public com::centreon::common::grpc::grpc_client_base {
+ public:
+  using com::centreon::common::grpc::grpc_client_base::grpc_client_base;
+
+  const std::shared_ptr<::grpc::Channel>& get_channel() const {
+    return _channel;
+  }
+};
+
+/**
+ * @brief Bootstrap the remote CA certificate from a configured fingerprint when
+ * the initial TLS connection fails.
+ *
+ * Public behavior is intentionally stable: this function only mutates
+ * `grpc_conf`/config files when bootstrap succeeds.
+ */
+void bootstrap_ca_from_fingerprint_if_needed(
+    const config& conf,
+    const std::string& config_path,
+    const std::shared_ptr<com::centreon::common::grpc::grpc_config>& grpc_conf,
+    const std::shared_ptr<spdlog::logger>& logger);
+
+std::string read_file_content(const std::string& file_path,
+                              const std::shared_ptr<spdlog::logger>& logger);
+}  // namespace com::centreon::agent
+
+#endif

--- a/agent/inc/com/centreon/agent/grpc_ca_bootstrap.hh
+++ b/agent/inc/com/centreon/agent/grpc_ca_bootstrap.hh
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Centreon
+ * Copyright 2026 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,9 +64,7 @@ class bootstrap_grpc_client
  public:
   using com::centreon::common::grpc::grpc_client_base::grpc_client_base;
 
-  std::shared_ptr<::grpc::Channel> get_channel() const {
-    return _channel;
-  }
+  std::shared_ptr<::grpc::Channel> get_channel() const { return _channel; }
 };
 
 /**

--- a/agent/proto/agent.proto
+++ b/agent/proto/agent.proto
@@ -33,6 +33,11 @@ service ReversedAgentService {
   rpc Import(stream MessageToAgent) returns (stream MessageFromAgent) {}
 }
 
+// Dedicated service for CA certificate retrieval
+service CACertificateService {
+  rpc GetCACertificate(CACertificateRequest) returns (CACertificateResponse) {}
+}
+
 // Message sent to agent reversed connection or not
 message MessageToAgent {
   oneof content {
@@ -111,4 +116,14 @@ message Service {
 message ForceCheck {
   uint64 host_id = 1;
   uint64 serv_id = 2;
+}
+
+// Request to get CA root certificate from engine
+message CACertificateRequest {
+}
+
+// Response containing CA root certificate
+message CACertificateResponse {
+  // CA certificate in PEM format
+  string certificate_pem = 1;
 }

--- a/agent/src/config.cc
+++ b/agent/src/config.cc
@@ -71,6 +71,10 @@ const std::string_view config::config_schema(R"(
             "description": "CA Common Name (CN). This is used to verify the server certificate. Don't use it if unsure.",
             "type": "string"
         },
+        "fingerprint": {
+            "description": "Expected SHA256 fingerprint of the CA certificate. If provided without ca_certificate, the agent will retrieve the CA from the server using insecure TLS.",
+            "type": "string"
+        },
         "reversed_grpc_streaming": {
             "description": "Set to true to make Engine connect to the agent. Requires the agent to be configured as a server. Default: false",
             "type": "boolean"
@@ -187,6 +191,7 @@ config::config(const std::string& path) {
   if (_ca_name.empty()) {
     _ca_name = json_config.get_string("ca_name", "");
   }
+  _ca_fingerprint = json_config.get_string("fingerprint", "");
   _host = json_config.get_string("host", "");
   if (_host.empty()) {
     _host = boost::asio::ip::host_name();

--- a/agent/src/config_win.cc
+++ b/agent/src/config_win.cc
@@ -112,6 +112,7 @@ config::config(const std::string& registry_key) {
   _private_key_file = get_sz_reg_or_default("private_key", "");
   _ca_certificate_file = get_sz_reg_or_default("ca_certificate", "");
   _ca_name = get_sz_reg_or_default("ca_name", "");
+  _ca_fingerprint = get_sz_reg_or_default("fingerprint", "");
   _host = get_sz_reg_or_default("host", "");
   if (_host.empty()) {
     _host = boost::asio::ip::host_name();

--- a/agent/src/grpc_ca_bootstrap.cc
+++ b/agent/src/grpc_ca_bootstrap.cc
@@ -17,6 +17,7 @@
  */
 
 #include "grpc_ca_bootstrap.hh"
+#include "spdlog/spdlog.h"
 
 #if defined(__linux__)
 #include <pwd.h>
@@ -35,6 +36,8 @@
 #include "agent.grpc.pb.h"
 #include "com/centreon/common/rapidjson_helper.hh"
 #include "common/crypto/cert_tree.hh"
+
+#include <filesystem>
 
 namespace com::centreon::agent {
 
@@ -105,6 +108,7 @@ static bool persist_ca_path_in_registry(
  */
 static bool add_ca_to_windows_store(
     const std::string& ca_pem,
+    const std::string& service_name,
     const std::shared_ptr<spdlog::logger>& logger) {
   DWORD der_size = 0;
   if (!::CryptStringToBinaryA(ca_pem.c_str(), static_cast<DWORD>(ca_pem.size()),
@@ -136,28 +140,31 @@ static bool add_ca_to_windows_store(
     return false;
   }
 
+  const std::wstring service_root_store =
+      std::wstring(service_name.begin(), service_name.end()) + L"\\ROOT";
   HCERTSTORE cert_store = ::CertOpenStore(CERT_STORE_PROV_SYSTEM_W, 0, 0,
-                                          CERT_SYSTEM_STORE_LOCAL_MACHINE |
+                                          CERT_SYSTEM_STORE_SERVICES |
                                               CERT_STORE_OPEN_EXISTING_FLAG |
-                                              CERT_STORE_MAXIMUM_ALLOWED,
-                                          L"ROOT");
+                                              CERT_STORE_MAXIMUM_ALLOWED_FLAG,
+                                          service_root_store.c_str());
   if (!cert_store) {
     const DWORD error_code = ::GetLastError();
     SPDLOG_LOGGER_WARN(
         logger,
-        "Unable to open LocalMachine ROOT store ({}), trying CurrentUser ROOT",
-        win_error_message(error_code));
+        "Unable to open service ROOT store '{}' ({}), trying CurrentService "
+        "ROOT",
+        service_name, win_error_message(error_code));
     cert_store = ::CertOpenStore(CERT_STORE_PROV_SYSTEM_W, 0, 0,
-                                 CERT_SYSTEM_STORE_CURRENT_USER |
+                                 CERT_SYSTEM_STORE_CURRENT_SERVICE |
                                      CERT_STORE_OPEN_EXISTING_FLAG |
-                                     CERT_STORE_MAXIMUM_ALLOWED,
+                                     CERT_STORE_MAXIMUM_ALLOWED_FLAG,
                                  L"ROOT");
   }
 
   if (!cert_store) {
     const DWORD error_code = ::GetLastError();
     SPDLOG_LOGGER_ERROR(logger,
-                        "Unable to open Windows ROOT certificate store: {}",
+                        "Unable to open Windows service-scoped ROOT store: {}",
                         win_error_message(error_code));
     ::CertFreeCertificateContext(cert_context);
     return false;
@@ -173,12 +180,29 @@ static bool add_ca_to_windows_store(
                         win_error_message(error_code));
   } else {
     SPDLOG_LOGGER_INFO(
-        logger, "CA certificate added to Windows ROOT certificate store");
+        logger,
+        "CA certificate added to Windows service-scoped ROOT certificate "
+        "store");
   }
 
   ::CertCloseStore(cert_store, 0);
   ::CertFreeCertificateContext(cert_context);
   return add_status == TRUE;
+}
+
+/**
+ * @brief Extract service name from registry path.
+ *
+ * Expected format: SOFTWARE\\Centreon\\<ServiceName>
+ */
+static std::string extract_service_name_from_registry_key(
+    const std::string& registry_key) {
+  static const std::string k_prefix = "SOFTWARE\\Centreon\\";
+  if (registry_key.size() > k_prefix.size() &&
+      registry_key.compare(0, k_prefix.size(), k_prefix) == 0) {
+    return registry_key.substr(k_prefix.size());
+  }
+  return "CentreonMonitoringAgent";
 }
 #endif
 
@@ -191,30 +215,30 @@ static bool add_ca_to_windows_store(
 static bool set_owner_to_agent_user(
     const std::filesystem::path& file_path,
     const std::shared_ptr<spdlog::logger>& logger) {
-  auto k_agent_user = "centreon-monitoring-agent";
-  // struct passwd* user = ::getpwnam(k_agent_user);
-  // if (!user) {
-  //   SPDLOG_LOGGER_ERROR(logger, "Unable to resolve user {}", k_agent_user);
-  //   return false;
-  // }
+  const auto k_agent_user = "centreon-monitoring-agent";
+  struct passwd* user = ::getpwnam(k_agent_user);
+  if (!user) {
+    SPDLOG_LOGGER_ERROR(logger, "Unable to resolve user {}", k_agent_user);
+    return false;
+  }
 
-  // struct stat st {};
-  // if (::stat(file_path.c_str(), &st) != 0) {
-  //   SPDLOG_LOGGER_ERROR(logger,
-  //                       "Unable to stat CA file {} before ownership update",
-  //                       file_path.string());
-  //   return false;
-  // }
+  struct stat st {};
+  if (::stat(file_path.c_str(), &st) != 0) {
+    SPDLOG_LOGGER_ERROR(logger,
+                        "Unable to stat CA file {} before ownership update",
+                        file_path.string());
+    return false;
+  }
 
-  // if (st.st_uid == user->pw_uid && st.st_gid == user->pw_gid) {
-  //   return true;
-  // }
+  if (st.st_uid == user->pw_uid && st.st_gid == user->pw_gid) {
+    return true;
+  }
 
-  // if (::chown(file_path.c_str(), user->pw_uid, user->pw_gid) != 0) {
-  //   SPDLOG_LOGGER_ERROR(logger, "Unable to set CA file owner to {} for {}",
-  //                       k_agent_user, file_path.string());
-  //   return false;
-  // }
+  if (::chown(file_path.c_str(), user->pw_uid, user->pw_gid) != 0) {
+    SPDLOG_LOGGER_ERROR(logger, "Unable to set CA file owner to {} for {}",
+                        k_agent_user, file_path.string());
+    return false;
+  }
 
   SPDLOG_LOGGER_INFO(logger, "Set CA file owner to {}", k_agent_user);
   return true;
@@ -293,7 +317,7 @@ static std::filesystem::path get_default_bootstrap_ca_path(
   char module_path[MAX_PATH] = {};
   DWORD module_path_len = ::GetModuleFileNameA(nullptr, module_path, MAX_PATH);
   if (module_path_len > 0 && module_path_len < MAX_PATH) {
-    return std::filesystem::path(module_path).parent_path() / "otel-ca.pem";
+    return std::filesystem::path(module_path).parent_path() / "cma-ca.pem";
   }
 
   const DWORD error_code = ::GetLastError();
@@ -303,9 +327,9 @@ static std::filesystem::path get_default_bootstrap_ca_path(
       win_error_message(error_code));
   return std::filesystem::path(
              "C:\\Program Files\\Centreon\\CentreonMonitoringAgent") /
-         "otel-ca.pem";
+         "cma-ca.pem";
 #else
-  return std::filesystem::path("/etc/centreon-monitoring-agent/otel-ca.crt");
+  return std::filesystem::path("/etc/centreon-monitoring-agent/cma-ca.crt");
 #endif
 }
 
@@ -317,15 +341,18 @@ static std::filesystem::path get_default_bootstrap_ca_path(
  */
 static bool try_platform_direct_ca_persist(
     const std::string& ca_pem [[maybe_unused]],
+    const std::string& config_reference [[maybe_unused]],
     bool& done_without_file,
     const std::shared_ptr<spdlog::logger>& logger [[maybe_unused]]) {
 #if defined(_WIN32)
-  done_without_file = add_ca_to_windows_store(ca_pem, logger);
+  const std::string service_name =
+      extract_service_name_from_registry_key(config_reference);
+  done_without_file = add_ca_to_windows_store(ca_pem, service_name, logger);
   if (!done_without_file) {
     SPDLOG_LOGGER_WARN(
         logger,
-        "Unable to persist CA in Windows certificate store; fallback to file "
-        "and registry persistence");
+        "Unable to persist CA in Windows service-scoped certificate store; "
+        "fallback to file and registry persistence");
   }
   return true;
 #else
@@ -433,7 +460,13 @@ void ca_bootstrap_workflow::run() {
       _logger,
       "[SECURITY] CA bootstrap succeeded from fingerprint for endpoint {}",
       _conf.get_endpoint());
-  persist_ca_to_file_and_config(*ca_pem);
+  if (!persist_ca_to_file_and_config(*ca_pem)) {
+    SPDLOG_LOGGER_WARN(
+        _logger,
+        "CA bootstrap succeeded but persistence failed for endpoint {}; "
+        "TLS will work this session only",
+        _conf.get_endpoint());
+  }
 }
 
 /**
@@ -494,7 +527,7 @@ ca_bootstrap_workflow::fetch_ca_with_tls_skip_verify() const {
 
   const std::string& fingerprint = _conf.get_ca_fingerprint();
   if (!fingerprint.empty()) {
-    context.AddMetadata("x-token", fingerprint.substr(0, 6));
+    context.AddMetadata("x-token", fingerprint);
   }
 
   const ::grpc::Status status =
@@ -550,7 +583,8 @@ bool ca_bootstrap_workflow::persist_ca_to_file_and_config(
     const std::string& ca_pem) const {
   try {
     bool done_without_file = false;
-    try_platform_direct_ca_persist(ca_pem, done_without_file, _logger);
+    try_platform_direct_ca_persist(ca_pem, _config_path, done_without_file,
+                                   _logger);
     if (done_without_file) {
       SPDLOG_LOGGER_INFO(
           _logger,
@@ -578,7 +612,7 @@ bool ca_bootstrap_workflow::persist_ca_to_file_and_config(
     }
 
     if (!apply_platform_ca_post_file_persist(ca_path, _logger)) {
-      return false;
+      SPDLOG_LOGGER_WARN(_logger, "unable to set the owner for the cert");
     }
 
     const std::string ca_path_string = ca_path.string();

--- a/agent/src/grpc_ca_bootstrap.cc
+++ b/agent/src/grpc_ca_bootstrap.cc
@@ -18,18 +18,16 @@
 
 #include "grpc_ca_bootstrap.hh"
 
-#include <filesystem>
-#include <fstream>
-#include <sstream>
-#include <stdexcept>
-#include <utility>
-
+#if defined(__linux__)
 #include <pwd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#elif defined(_WIN32)
+#include <wincrypt.h>
+#include <windows.h>
+#endif
 
-#include <openssl/evp.h>
 #include <openssl/x509.h>
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
@@ -40,6 +38,151 @@
 
 namespace com::centreon::agent {
 
+#if defined(_WIN32)
+/**
+ * @brief Convert a Win32 error code to a readable string.
+ */
+static std::string win_error_message(DWORD error_code) {
+  LPSTR raw_message = nullptr;
+  const DWORD format_result = ::FormatMessageA(
+      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+          FORMAT_MESSAGE_IGNORE_INSERTS,
+      nullptr, error_code, 0, reinterpret_cast<LPSTR>(&raw_message), 0,
+      nullptr);
+  if (!format_result || !raw_message) {
+    return "Unknown Win32 error";
+  }
+
+  std::string message(raw_message);
+  ::LocalFree(raw_message);
+
+  while (!message.empty() &&
+         (message.back() == '\r' || message.back() == '\n')) {
+    message.pop_back();
+  }
+  return message;
+}
+
+/**
+ * @brief Persist CA certificate path in Windows registry.
+ */
+static bool persist_ca_path_in_registry(
+    const std::string& registry_key,
+    const std::string& ca_path,
+    const std::shared_ptr<spdlog::logger>& logger) {
+  HKEY h_key = nullptr;
+  const LSTATUS create_status =
+      ::RegCreateKeyExA(HKEY_LOCAL_MACHINE, registry_key.c_str(), 0, nullptr, 0,
+                        KEY_SET_VALUE, nullptr, &h_key, nullptr);
+  if (create_status != ERROR_SUCCESS) {
+    SPDLOG_LOGGER_ERROR(logger, "Unable to open/create registry key {}: {}",
+                        registry_key,
+                        win_error_message(static_cast<DWORD>(create_status)));
+    return false;
+  }
+
+  const DWORD value_size =
+      static_cast<DWORD>(ca_path.size() + 1);  // include null terminator
+  const LSTATUS set_status = ::RegSetValueExA(
+      h_key, "ca_certificate", 0, REG_SZ,
+      reinterpret_cast<const BYTE*>(ca_path.c_str()), value_size);
+  ::RegCloseKey(h_key);
+
+  if (set_status != ERROR_SUCCESS) {
+    SPDLOG_LOGGER_ERROR(
+        logger, "Unable to write ca_certificate in registry {}: {}",
+        registry_key, win_error_message(static_cast<DWORD>(set_status)));
+    return false;
+  }
+
+  SPDLOG_LOGGER_INFO(logger, "Updated registry {} with ca_certificate={}",
+                     registry_key, ca_path);
+  return true;
+}
+
+/**
+ * @brief Import PEM CA certificate into Windows certificate store.
+ */
+static bool add_ca_to_windows_store(
+    const std::string& ca_pem,
+    const std::shared_ptr<spdlog::logger>& logger) {
+  DWORD der_size = 0;
+  if (!::CryptStringToBinaryA(ca_pem.c_str(), static_cast<DWORD>(ca_pem.size()),
+                              CRYPT_STRING_ANY, nullptr, &der_size, nullptr,
+                              nullptr)) {
+    const DWORD error_code = ::GetLastError();
+    SPDLOG_LOGGER_ERROR(logger, "Unable to decode PEM certificate: {}",
+                        win_error_message(error_code));
+    return false;
+  }
+
+  std::vector<BYTE> der(der_size);
+  if (!::CryptStringToBinaryA(ca_pem.c_str(), static_cast<DWORD>(ca_pem.size()),
+                              CRYPT_STRING_ANY, der.data(), &der_size, nullptr,
+                              nullptr)) {
+    const DWORD error_code = ::GetLastError();
+    SPDLOG_LOGGER_ERROR(logger, "Unable to decode PEM certificate bytes: {}",
+                        win_error_message(error_code));
+    return false;
+  }
+
+  PCCERT_CONTEXT cert_context = ::CertCreateCertificateContext(
+      X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, der.data(), der_size);
+  if (!cert_context) {
+    const DWORD error_code = ::GetLastError();
+    SPDLOG_LOGGER_ERROR(logger,
+                        "Unable to create cert context from decoded CA: {}",
+                        win_error_message(error_code));
+    return false;
+  }
+
+  HCERTSTORE cert_store = ::CertOpenStore(CERT_STORE_PROV_SYSTEM_W, 0, 0,
+                                          CERT_SYSTEM_STORE_LOCAL_MACHINE |
+                                              CERT_STORE_OPEN_EXISTING_FLAG |
+                                              CERT_STORE_MAXIMUM_ALLOWED,
+                                          L"ROOT");
+  if (!cert_store) {
+    const DWORD error_code = ::GetLastError();
+    SPDLOG_LOGGER_WARN(
+        logger,
+        "Unable to open LocalMachine ROOT store ({}), trying CurrentUser ROOT",
+        win_error_message(error_code));
+    cert_store = ::CertOpenStore(CERT_STORE_PROV_SYSTEM_W, 0, 0,
+                                 CERT_SYSTEM_STORE_CURRENT_USER |
+                                     CERT_STORE_OPEN_EXISTING_FLAG |
+                                     CERT_STORE_MAXIMUM_ALLOWED,
+                                 L"ROOT");
+  }
+
+  if (!cert_store) {
+    const DWORD error_code = ::GetLastError();
+    SPDLOG_LOGGER_ERROR(logger,
+                        "Unable to open Windows ROOT certificate store: {}",
+                        win_error_message(error_code));
+    ::CertFreeCertificateContext(cert_context);
+    return false;
+  }
+
+  const BOOL add_status = ::CertAddCertificateContextToStore(
+      cert_store, cert_context, CERT_STORE_ADD_REPLACE_EXISTING, nullptr);
+
+  if (!add_status) {
+    const DWORD error_code = ::GetLastError();
+    SPDLOG_LOGGER_ERROR(logger,
+                        "Unable to add CA certificate to Windows store: {}",
+                        win_error_message(error_code));
+  } else {
+    SPDLOG_LOGGER_INFO(
+        logger, "CA certificate added to Windows ROOT certificate store");
+  }
+
+  ::CertCloseStore(cert_store, 0);
+  ::CertFreeCertificateContext(cert_context);
+  return add_status == TRUE;
+}
+#endif
+
+#if defined(__linux__)
 /**
  * @brief Ensure the persisted CA file is owned by the agent service account.
  *
@@ -49,33 +192,34 @@ static bool set_owner_to_agent_user(
     const std::filesystem::path& file_path,
     const std::shared_ptr<spdlog::logger>& logger) {
   auto k_agent_user = "centreon-monitoring-agent";
-  struct passwd* user = ::getpwnam(k_agent_user);
-  if (!user) {
-    SPDLOG_LOGGER_ERROR(logger, "Unable to resolve user {}", k_agent_user);
-    return false;
-  }
+  // struct passwd* user = ::getpwnam(k_agent_user);
+  // if (!user) {
+  //   SPDLOG_LOGGER_ERROR(logger, "Unable to resolve user {}", k_agent_user);
+  //   return false;
+  // }
 
-  struct stat st {};
-  if (::stat(file_path.c_str(), &st) != 0) {
-    SPDLOG_LOGGER_ERROR(logger,
-                        "Unable to stat CA file {} before ownership update",
-                        file_path.string());
-    return false;
-  }
+  // struct stat st {};
+  // if (::stat(file_path.c_str(), &st) != 0) {
+  //   SPDLOG_LOGGER_ERROR(logger,
+  //                       "Unable to stat CA file {} before ownership update",
+  //                       file_path.string());
+  //   return false;
+  // }
 
-  if (st.st_uid == user->pw_uid && st.st_gid == user->pw_gid) {
-    return true;
-  }
+  // if (st.st_uid == user->pw_uid && st.st_gid == user->pw_gid) {
+  //   return true;
+  // }
 
-  if (::chown(file_path.c_str(), user->pw_uid, user->pw_gid) != 0) {
-    SPDLOG_LOGGER_ERROR(logger, "Unable to set CA file owner to {} for {}",
-                        k_agent_user, file_path.string());
-    return false;
-  }
+  // if (::chown(file_path.c_str(), user->pw_uid, user->pw_gid) != 0) {
+  //   SPDLOG_LOGGER_ERROR(logger, "Unable to set CA file owner to {} for {}",
+  //                       k_agent_user, file_path.string());
+  //   return false;
+  // }
 
   SPDLOG_LOGGER_INFO(logger, "Set CA file owner to {}", k_agent_user);
   return true;
 }
+#endif
 
 /**
  * @brief Write the CA file path into the JSON configuration document.
@@ -107,6 +251,114 @@ static void set_ca_path_in_config_document(rapidjson::Document& doc,
   value.SetString(ca_path.c_str(),
                   static_cast<rapidjson::SizeType>(ca_path.size()), allocator);
   doc.AddMember(key, value, allocator);
+}
+
+/**
+ * @brief Persist the CA path to the JSON config file.
+ */
+static bool persist_ca_path_in_config_file(
+    const std::string& config_path,
+    const std::string& ca_path,
+    const std::shared_ptr<spdlog::logger>& logger) {
+  rapidjson::Document doc =
+      com::centreon::common::rapidjson_helper::read_from_file(config_path);
+  if (!doc.IsObject()) {
+    SPDLOG_LOGGER_ERROR(logger, "configuration root is not an object in {}",
+                        config_path);
+    return false;
+  }
+
+  set_ca_path_in_config_document(doc, ca_path);
+
+  rapidjson::StringBuffer json_buffer;
+  rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(json_buffer);
+  doc.Accept(writer);
+
+  std::ofstream config_output(config_path, std::ios::trunc);
+  if (!config_output.is_open()) {
+    SPDLOG_LOGGER_ERROR(logger, "unable to open config file {} for writing",
+                        config_path);
+    return false;
+  }
+  config_output << json_buffer.GetString() << '\n';
+  return true;
+}
+
+/**
+ * @brief Resolve platform default target file for a bootstrapped CA.
+ */
+static std::filesystem::path get_default_bootstrap_ca_path(
+    const std::shared_ptr<spdlog::logger>& logger [[maybe_unused]]) {
+#if defined(_WIN32)
+  char module_path[MAX_PATH] = {};
+  DWORD module_path_len = ::GetModuleFileNameA(nullptr, module_path, MAX_PATH);
+  if (module_path_len > 0 && module_path_len < MAX_PATH) {
+    return std::filesystem::path(module_path).parent_path() / "otel-ca.pem";
+  }
+
+  const DWORD error_code = ::GetLastError();
+  SPDLOG_LOGGER_WARN(
+      logger,
+      "Unable to resolve executable directory ({}), defaulting to install path",
+      win_error_message(error_code));
+  return std::filesystem::path(
+             "C:\\Program Files\\Centreon\\CentreonMonitoringAgent") /
+         "otel-ca.pem";
+#else
+  return std::filesystem::path("/etc/centreon-monitoring-agent/otel-ca.crt");
+#endif
+}
+
+/**
+ * @brief Try direct platform persistence that may avoid file/config updates.
+ *
+ * On Windows, importing into certificate store is attempted first. If it
+ * succeeds, file/config persistence is skipped.
+ */
+static bool try_platform_direct_ca_persist(
+    const std::string& ca_pem [[maybe_unused]],
+    bool& done_without_file,
+    const std::shared_ptr<spdlog::logger>& logger [[maybe_unused]]) {
+#if defined(_WIN32)
+  done_without_file = add_ca_to_windows_store(ca_pem, logger);
+  if (!done_without_file) {
+    SPDLOG_LOGGER_WARN(
+        logger,
+        "Unable to persist CA in Windows certificate store; fallback to file "
+        "and registry persistence");
+  }
+  return true;
+#else
+  done_without_file = false;
+  return true;
+#endif
+}
+
+/**
+ * @brief Apply platform-specific side effects after CA file write.
+ */
+static bool apply_platform_ca_post_file_persist(
+    const std::filesystem::path& ca_path [[maybe_unused]],
+    const std::shared_ptr<spdlog::logger>& logger [[maybe_unused]]) {
+#if defined(__linux__)
+  return set_owner_to_agent_user(ca_path, logger);
+#else
+  return true;
+#endif
+}
+
+/**
+ * @brief Persist CA path reference in platform config backend.
+ */
+static bool persist_platform_ca_path_reference(
+    const std::string& config_reference,
+    const std::string& ca_path,
+    const std::shared_ptr<spdlog::logger>& logger) {
+#if defined(_WIN32)
+  return persist_ca_path_in_registry(config_reference, ca_path, logger);
+#else
+  return persist_ca_path_in_config_file(config_reference, ca_path, logger);
+#endif
 }
 
 /**
@@ -197,8 +449,17 @@ bool ca_bootstrap_workflow::is_bootstrap_needed() const {
 bool ca_bootstrap_workflow::probe_full_tls_connection() const {
   try {
     bootstrap_grpc_client client(_grpc_conf, _logger);
-    return client.get_channel()->WaitForConnected(
+    auto channel = client.get_channel();
+    if (!channel) {
+      SPDLOG_LOGGER_WARN(_logger, "TLS probe failed for {}: null channel",
+                         _grpc_conf->get_hostport());
+      return false;
+    }
+
+    const bool connected = channel->WaitForConnected(
         std::chrono::system_clock::now() + std::chrono::seconds(5));
+    channel.reset();
+    return connected;
   } catch (const std::exception& e) {
     SPDLOG_LOGGER_WARN(_logger, "TLS probe failed for {}: {}",
                        _grpc_conf->get_hostport(), e.what());
@@ -280,16 +541,27 @@ bool ca_bootstrap_workflow::validate_ca_fingerprint(
 }
 
 /**
- * @brief Persist fetched CA to disk and update config with the persisted path.
+ * @brief Persist fetched CA to platform trust/config backends.
+ *
+ * On Windows, certificate store persistence is attempted first. If it works,
+ * file and registry updates are skipped.
  */
 bool ca_bootstrap_workflow::persist_ca_to_file_and_config(
     const std::string& ca_pem) const {
   try {
+    bool done_without_file = false;
+    try_platform_direct_ca_persist(ca_pem, done_without_file, _logger);
+    if (done_without_file) {
+      SPDLOG_LOGGER_INFO(
+          _logger,
+          "Persisted CA certificate in platform trust store; skipping file "
+          "and config update");
+      return true;
+    }
+
     const std::filesystem::path ca_path =
-        std::filesystem::path("/etc/centreon-monitoring-agent/otel-ca.pem");
-
+        get_default_bootstrap_ca_path(_logger);
     const std::filesystem::path parent = ca_path.parent_path();
-
     if (!parent.empty()) {
       std::filesystem::create_directories(parent);
     }
@@ -305,29 +577,15 @@ bool ca_bootstrap_workflow::persist_ca_to_file_and_config(
       }
     }
 
-    if (!set_owner_to_agent_user(ca_path, _logger)) {
+    if (!apply_platform_ca_post_file_persist(ca_path, _logger)) {
       return false;
-    }
-
-    rapidjson::Document doc =
-        com::centreon::common::rapidjson_helper::read_from_file(_config_path);
-    if (!doc.IsObject()) {
-      throw std::runtime_error("configuration root is not an object");
     }
 
     const std::string ca_path_string = ca_path.string();
-    set_ca_path_in_config_document(doc, ca_path_string);
-
-    rapidjson::StringBuffer json_buffer;
-    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(json_buffer);
-    doc.Accept(writer);
-
-    std::ofstream config_output(_config_path, std::ios::trunc);
-    if (!config_output.is_open()) {
-      SPDLOG_LOGGER_ERROR(_logger, "unable to open config file for writing");
+    if (!persist_platform_ca_path_reference(_config_path, ca_path_string,
+                                            _logger)) {
       return false;
     }
-    config_output << json_buffer.GetString() << '\n';
 
     SPDLOG_LOGGER_INFO(_logger, "Persisted CA certificate to {} and updated {}",
                        ca_path_string, _config_path);

--- a/agent/src/grpc_ca_bootstrap.cc
+++ b/agent/src/grpc_ca_bootstrap.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Centreon
+ * Copyright 2026 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/agent/src/grpc_ca_bootstrap.cc
+++ b/agent/src/grpc_ca_bootstrap.cc
@@ -21,9 +21,6 @@
 
 #if defined(__linux__)
 #include <pwd.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
 #elif defined(_WIN32)
 #include <wincrypt.h>
 #include <windows.h>

--- a/agent/src/grpc_ca_bootstrap.cc
+++ b/agent/src/grpc_ca_bootstrap.cc
@@ -558,8 +558,7 @@ bool ca_bootstrap_workflow::validate_ca_fingerprint(
         com::centreon::common::crypto::cert_tree::load_cert_from_string(ca_pem),
         &X509_free);
     if (!cert) {
-      SPDLOG_LOGGER_ERROR(
-          _logger, "Unable to validate retrieved CA fingerprint: {}", e.what());
+      SPDLOG_LOGGER_ERROR(_logger, "Unable to load cert from string");
       return false;
     }
     const std::string fingerprint =

--- a/agent/src/grpc_ca_bootstrap.cc
+++ b/agent/src/grpc_ca_bootstrap.cc
@@ -557,6 +557,11 @@ bool ca_bootstrap_workflow::validate_ca_fingerprint(
     std::unique_ptr<X509, decltype(&X509_free)> cert(
         com::centreon::common::crypto::cert_tree::load_cert_from_string(ca_pem),
         &X509_free);
+    if (!cert) {
+      SPDLOG_LOGGER_ERROR(
+          _logger, "Unable to validate retrieved CA fingerprint: {}", e.what());
+      return false;
+    }
     const std::string fingerprint =
         com::centreon::common::crypto::cert_tree::cert_sha(cert.get());
 

--- a/agent/src/grpc_ca_bootstrap.cc
+++ b/agent/src/grpc_ca_bootstrap.cc
@@ -1,0 +1,354 @@
+/**
+ * Copyright 2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
+
+#include "grpc_ca_bootstrap.hh"
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+#include <pwd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <rapidjson/prettywriter.h>
+#include <rapidjson/stringbuffer.h>
+
+#include "agent.grpc.pb.h"
+#include "com/centreon/common/rapidjson_helper.hh"
+#include "common/crypto/cert_tree.hh"
+
+namespace com::centreon::agent {
+
+/**
+ * @brief Ensure the persisted CA file is owned by the agent service account.
+ *
+ * @return true when ownership already matches or was successfully updated.
+ */
+static bool set_owner_to_agent_user(
+    const std::filesystem::path& file_path,
+    const std::shared_ptr<spdlog::logger>& logger) {
+  auto k_agent_user = "centreon-monitoring-agent";
+  struct passwd* user = ::getpwnam(k_agent_user);
+  if (!user) {
+    SPDLOG_LOGGER_ERROR(logger, "Unable to resolve user {}", k_agent_user);
+    return false;
+  }
+
+  struct stat st {};
+  if (::stat(file_path.c_str(), &st) != 0) {
+    SPDLOG_LOGGER_ERROR(logger,
+                        "Unable to stat CA file {} before ownership update",
+                        file_path.string());
+    return false;
+  }
+
+  if (st.st_uid == user->pw_uid && st.st_gid == user->pw_gid) {
+    return true;
+  }
+
+  if (::chown(file_path.c_str(), user->pw_uid, user->pw_gid) != 0) {
+    SPDLOG_LOGGER_ERROR(logger, "Unable to set CA file owner to {} for {}",
+                        k_agent_user, file_path.string());
+    return false;
+  }
+
+  SPDLOG_LOGGER_INFO(logger, "Set CA file owner to {}", k_agent_user);
+  return true;
+}
+
+/**
+ * @brief Write the CA file path into the JSON configuration document.
+ *
+ * Updates `ca` or `ca_certificate` when present, otherwise adds
+ * `ca_certificate`.
+ */
+static void set_ca_path_in_config_document(rapidjson::Document& doc,
+                                           const std::string& ca_path) {
+  auto& allocator = doc.GetAllocator();
+
+  // Reuse a single update path for both accepted config keys.
+  auto set_ca_path_member = [&](const char* member_name) {
+    if (doc.HasMember(member_name)) {
+      doc[member_name].SetString(
+          ca_path.c_str(), static_cast<rapidjson::SizeType>(ca_path.size()),
+          allocator);
+      return true;
+    }
+    return false;
+  };
+
+  if (set_ca_path_member("ca") || set_ca_path_member("ca_certificate")) {
+    return;
+  }
+
+  rapidjson::Value key("ca_certificate", allocator);
+  rapidjson::Value value;
+  value.SetString(ca_path.c_str(),
+                  static_cast<rapidjson::SizeType>(ca_path.size()), allocator);
+  doc.AddMember(key, value, allocator);
+}
+
+/**
+ * @brief Read a whole file into memory.
+ *
+ * @return file content, or an empty string when reading fails.
+ */
+std::string read_file_content(const std::string& file_path,
+                              const std::shared_ptr<spdlog::logger>& logger) {
+  if (file_path.empty()) {
+    return {};
+  }
+  try {
+    std::ifstream file(file_path);
+    if (!file.is_open()) {
+      SPDLOG_LOGGER_ERROR(logger, "fail to open {}", file_path);
+      return {};
+    }
+
+    std::stringstream ss;
+    ss << file.rdbuf();
+    return ss.str();
+  } catch (const std::exception& e) {
+    SPDLOG_LOGGER_ERROR(logger, "fail to read {}: {}", file_path, e.what());
+  }
+  return {};
+}
+
+/**
+ * @brief Build the workflow object with runtime config and logger dependencies.
+ */
+ca_bootstrap_workflow::ca_bootstrap_workflow(
+    const config& conf,
+    std::string config_path,
+    std::shared_ptr<com::centreon::common::grpc::grpc_config> grpc_conf,
+    std::shared_ptr<spdlog::logger> logger)
+    : _conf(conf),
+      _config_path(std::move(config_path)),
+      _grpc_conf(std::move(grpc_conf)),
+      _logger(std::move(logger)) {}
+
+/**
+ * @brief Execute the CA bootstrap flow when fingerprint mode is enabled.
+ */
+void ca_bootstrap_workflow::run() {
+  if (!is_bootstrap_needed()) {
+    return;
+  }
+
+  // First try to connect with the provided configuration. If it works, no need
+  // to do anything.
+  if (probe_full_tls_connection()) {
+    SPDLOG_LOGGER_INFO(_logger,
+                       "Full TLS connection succeeded with existing "
+                       "configuration");
+    return;
+  }
+
+  SPDLOG_LOGGER_WARN(_logger,
+                     "Full TLS connection to {} failed and fingerprint is "
+                     "configured; trying "
+                     "TLS_SKIP_VERIFY_CA CA bootstrap",
+                     _conf.get_endpoint());
+
+  std::optional<std::string> ca_pem = fetch_ca_with_tls_skip_verify();
+  if (!ca_pem || !validate_ca_fingerprint(*ca_pem)) {
+    return;
+  }
+
+  _grpc_conf->set_ca(*ca_pem);
+  SPDLOG_LOGGER_CRITICAL(
+      _logger,
+      "[SECURITY] CA bootstrap succeeded from fingerprint for endpoint {}",
+      _conf.get_endpoint());
+  persist_ca_to_file_and_config(*ca_pem);
+}
+
+/**
+ * @brief Tell whether CA bootstrap should run for the current configuration.
+ */
+bool ca_bootstrap_workflow::is_bootstrap_needed() const {
+  return !_conf.use_reverse_connection() && !_conf.get_ca_fingerprint().empty();
+}
+
+/**
+ * @brief Probe endpoint connectivity using full TLS with current settings.
+ */
+bool ca_bootstrap_workflow::probe_full_tls_connection() const {
+  try {
+    bootstrap_grpc_client client(_grpc_conf, _logger);
+    return client.get_channel()->WaitForConnected(
+        std::chrono::system_clock::now() + std::chrono::seconds(5));
+  } catch (const std::exception& e) {
+    SPDLOG_LOGGER_WARN(_logger, "TLS probe failed for {}: {}",
+                       _grpc_conf->get_hostport(), e.what());
+    return false;
+  }
+}
+
+/**
+ * @brief Fetch the remote CA certificate over TLS_SKIP_VERIFY_CA mode.
+ *
+ * @return remote CA PEM when retrieval succeeds, `std::nullopt` otherwise.
+ */
+std::optional<std::string>
+ca_bootstrap_workflow::fetch_ca_with_tls_skip_verify() const {
+  auto temp_grpc_conf =
+      std::make_shared<com::centreon::common::grpc::grpc_config>(
+          _conf.get_endpoint(),
+          com::centreon::common::grpc::grpc_config::TLS_SKIP_VERIFY_CA,
+          read_file_content(_conf.get_public_cert_file(), _logger),
+          read_file_content(_conf.get_private_key_file(), _logger), "" /* ca */,
+          _conf.get_ca_name(), true, 30,
+          _conf.get_second_max_reconnect_backoff(),
+          _conf.get_max_message_length(), _conf.get_token(),
+          _conf.get_trusted_tokens(), _conf.get_ca_fingerprint());
+
+  bootstrap_grpc_client client(temp_grpc_conf, _logger);
+  auto stub = CACertificateService::NewStub(client.get_channel());
+
+  CACertificateRequest request;
+  CACertificateResponse response;
+  ::grpc::ClientContext context;
+
+  const std::string& fingerprint = _conf.get_ca_fingerprint();
+  if (!fingerprint.empty()) {
+    context.AddMetadata("x-token", fingerprint.substr(0, 6));
+  }
+
+  const ::grpc::Status status =
+      stub->GetCACertificate(&context, request, &response);
+  if (!status.ok()) {
+    SPDLOG_LOGGER_WARN(
+        _logger, "CA bootstrap via TLS_SKIP_VERIFY_CA failed for {}: {} ({})",
+        _conf.get_endpoint(), status.error_message(),
+        static_cast<int>(status.error_code()));
+    return std::nullopt;
+  }
+
+  if (response.certificate_pem().empty()) {
+    SPDLOG_LOGGER_WARN(_logger, "CA bootstrap returned an empty certificate");
+    return std::nullopt;
+  }
+
+  return response.certificate_pem();
+}
+
+/**
+ * @brief Validate the fetched CA certificate against configured fingerprint.
+ */
+bool ca_bootstrap_workflow::validate_ca_fingerprint(
+    const std::string& ca_pem) const {
+  try {
+    std::unique_ptr<X509, decltype(&X509_free)> cert(
+        com::centreon::common::crypto::cert_tree::load_cert_from_string(ca_pem),
+        &X509_free);
+    const std::string fingerprint =
+        com::centreon::common::crypto::cert_tree::cert_sha(cert.get());
+
+    if (_conf.get_ca_fingerprint() != fingerprint) {
+      SPDLOG_LOGGER_ERROR(_logger, "Retrieved CA fingerprint mismatch ");
+      return false;
+    }
+
+    return true;
+  } catch (const std::exception& e) {
+    SPDLOG_LOGGER_ERROR(
+        _logger, "Unable to validate retrieved CA fingerprint: {}", e.what());
+    return false;
+  }
+}
+
+/**
+ * @brief Persist fetched CA to disk and update config with the persisted path.
+ */
+bool ca_bootstrap_workflow::persist_ca_to_file_and_config(
+    const std::string& ca_pem) const {
+  try {
+    const std::filesystem::path ca_path =
+        std::filesystem::path("/etc/centreon-monitoring-agent/otel-ca.pem");
+
+    const std::filesystem::path parent = ca_path.parent_path();
+
+    if (!parent.empty()) {
+      std::filesystem::create_directories(parent);
+    }
+
+    {
+      std::ofstream ca_output(ca_path, std::ios::trunc);
+      if (!ca_output.is_open()) {
+        throw std::runtime_error("unable to open CA file for writing");
+      }
+      ca_output << ca_pem;
+      if (ca_pem.empty() || ca_pem.back() != '\n') {
+        ca_output << '\n';
+      }
+    }
+
+    if (!set_owner_to_agent_user(ca_path, _logger)) {
+      return false;
+    }
+
+    rapidjson::Document doc =
+        com::centreon::common::rapidjson_helper::read_from_file(_config_path);
+    if (!doc.IsObject()) {
+      throw std::runtime_error("configuration root is not an object");
+    }
+
+    const std::string ca_path_string = ca_path.string();
+    set_ca_path_in_config_document(doc, ca_path_string);
+
+    rapidjson::StringBuffer json_buffer;
+    rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(json_buffer);
+    doc.Accept(writer);
+
+    std::ofstream config_output(_config_path, std::ios::trunc);
+    if (!config_output.is_open()) {
+      SPDLOG_LOGGER_ERROR(_logger, "unable to open config file for writing");
+      return false;
+    }
+    config_output << json_buffer.GetString() << '\n';
+
+    SPDLOG_LOGGER_INFO(_logger, "Persisted CA certificate to {} and updated {}",
+                       ca_path_string, _config_path);
+    return true;
+  } catch (const std::exception& e) {
+    SPDLOG_LOGGER_ERROR(
+        _logger, "Failed to persist retrieved CA certificate to config {}: {}",
+        _config_path, e.what());
+    return false;
+  }
+}
+
+/**
+ * @brief Entrypoint helper that runs CA bootstrap when needed.
+ */
+void bootstrap_ca_from_fingerprint_if_needed(
+    const config& conf,
+    const std::string& config_path,
+    const std::shared_ptr<com::centreon::common::grpc::grpc_config>& grpc_conf,
+    const std::shared_ptr<spdlog::logger>& logger) {
+  ca_bootstrap_workflow(conf, config_path, grpc_conf, logger).run();
+}
+
+}  // namespace com::centreon::agent

--- a/agent/src/main.cc
+++ b/agent/src/main.cc
@@ -28,6 +28,7 @@
 
 #include "config.hh"
 #include "drive_size.hh"
+#include "grpc_ca_bootstrap.hh"
 #include "streaming_client.hh"
 #include "streaming_server.hh"
 
@@ -74,26 +75,6 @@ static void signal_handler(const boost::system::error_code& error,
     }
     _signals.async_wait(signal_handler);
   }
-}
-
-static std::string read_file(const std::string& file_path) {
-  if (file_path.empty()) {
-    return {};
-  }
-  try {
-    std::ifstream file(file_path);
-    if (file.is_open()) {
-      std::stringstream ss;
-      ss << file.rdbuf();
-      file.close();
-      return ss.str();
-    } else {
-      SPDLOG_LOGGER_ERROR(g_logger, "fail to open {}", file_path);
-    }
-  } catch (const std::exception& e) {
-    SPDLOG_LOGGER_ERROR(g_logger, "fail to read {}: {}", file_path, e.what());
-  }
-  return "";
 }
 
 int main(int argc, char* argv[]) {
@@ -184,11 +165,12 @@ int main(int argc, char* argv[]) {
 
     grpc_conf = std::make_shared<com::centreon::common::grpc::grpc_config>(
         conf.get_endpoint(), conf.get_security_mode(),
-        read_file(conf.get_public_cert_file()),
-        read_file(conf.get_private_key_file()),
-        read_file(conf.get_ca_certificate_file()), conf.get_ca_name(), true, 30,
-        conf.get_second_max_reconnect_backoff(), conf.get_max_message_length(),
-        conf.get_token(), conf.get_trusted_tokens());
+        read_file_content(conf.get_public_cert_file(), g_logger),
+        read_file_content(conf.get_private_key_file(), g_logger),
+        read_file_content(conf.get_ca_certificate_file(), g_logger),
+        conf.get_ca_name(), true, 30, conf.get_second_max_reconnect_backoff(),
+        conf.get_max_message_length(), conf.get_token(),
+        conf.get_trusted_tokens(), conf.get_ca_fingerprint());
 
   } catch (const std::exception& e) {
     SPDLOG_CRITICAL("fail to parse input params: {}", e.what());
@@ -198,6 +180,8 @@ int main(int argc, char* argv[]) {
   read_os_version();
 
   set_grpc_logger();
+
+  bootstrap_ca_from_fingerprint_if_needed(conf, argv[1], grpc_conf, g_logger);
 
   if (conf.use_reverse_connection()) {
     _streaming_server =

--- a/agent/src/main_win.cc
+++ b/agent/src/main_win.cc
@@ -39,6 +39,7 @@
 
 #include "config.hh"
 #include "drive_size.hh"
+#include "grpc_ca_bootstrap.hh"
 #include "ntdll.hh"
 #include "streaming_client.hh"
 #include "streaming_server.hh"
@@ -96,30 +97,6 @@ static void signal_handler(const boost::system::error_code& error,
     }
     _signals.async_wait(signal_handler);
   }
-}
-
-/**
- * @brief load file in a std::string
- *
- * @param file_path file path
- * @return std::string file content
- */
-static std::string read_file(const std::string& file_path) {
-  if (file_path.empty()) {
-    return {};
-  }
-  try {
-    std::ifstream file(file_path);
-    if (file.is_open()) {
-      std::stringstream ss;
-      ss << file.rdbuf();
-      file.close();
-      return ss.str();
-    }
-  } catch (const std::exception& e) {
-    SPDLOG_LOGGER_ERROR(g_logger, "fail to read {}: {}", file_path, e.what());
-  }
-  return "";
 }
 
 void show_help() {
@@ -234,16 +211,20 @@ int _main(bool service_start) {
 
     grpc_conf = std::make_shared<com::centreon::common::grpc::grpc_config>(
         conf.get_endpoint(), conf.get_security_mode(),
-        read_file(conf.get_public_cert_file()),
-        read_file(conf.get_private_key_file()),
-        read_file(conf.get_ca_certificate_file()), conf.get_ca_name(), true, 30,
-        conf.get_second_max_reconnect_backoff(), conf.get_max_message_length(),
-        conf.get_token(), conf.get_trusted_tokens());
+        read_file_content(conf.get_public_cert_file(), g_logger),
+        read_file_content(conf.get_private_key_file(), g_logger),
+        read_file_content(conf.get_ca_certificate_file(), g_logger),
+        conf.get_ca_name(), true, 30, conf.get_second_max_reconnect_backoff(),
+        conf.get_max_message_length(), conf.get_token(),
+        conf.get_trusted_tokens(), conf.get_ca_fingerprint());
 
   } catch (const std::exception& e) {
     SPDLOG_CRITICAL("fail to parse input params: {}", e.what());
     return -1;
   }
+
+  bootstrap_ca_from_fingerprint_if_needed(conf, registry_path, grpc_conf,
+                                          g_logger);
 
   try {
     load_nt_dll();

--- a/broker/core/src/processing/failover.cc
+++ b/broker/core/src/processing/failover.cc
@@ -181,7 +181,7 @@ void failover::_run() {
       error_retry_delay = _max_retry_delay;
     }
     SPDLOG_LOGGER_ERROR(
-        _logger, " {} Failed to send event to stream, we wait {s} before retry",
+        _logger, " {} Failed to send event to stream, we wait {}s before retry",
         _name, error_retry_delay);
     for (ssize_t i = 0; !should_exit() && i < error_retry_delay * 10; i++) {
       std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/common/crypto/cert_tree.cc
+++ b/common/crypto/cert_tree.cc
@@ -300,42 +300,42 @@ X509* cert_tree::generate_cert(const EVP_PKEY* pkey,
                                unsigned version,
                                const EVP_PKEY* ca_key,
                                const X509* ca_cert) {
-  X509* x509 = X509_new();
+  std::unique_ptr<X509, decltype(&X509_free)> x509(X509_new(), X509_free);
   X509_NAME* name;
 
-  X509_set_version(x509, version);  // 0 = v1, 1 = v2, 2 = v3
-  ASN1_INTEGER_set(X509_get_serialNumber(x509), (long)time(NULL));
-  X509_gmtime_adj(X509_get_notBefore(x509), 0);
-  X509_gmtime_adj(X509_get_notAfter(x509), minute_cert_ttl * 60);
-  X509_set_pubkey(x509, const_cast<EVP_PKEY*>(pkey));
+  X509_set_version(x509.get(), version);  // 0 = v1, 1 = v2, 2 = v3
+  ASN1_INTEGER_set(X509_get_serialNumber(x509.get()), (long)time(NULL));
+  X509_gmtime_adj(X509_get_notBefore(x509.get()), 0);
+  X509_gmtime_adj(X509_get_notAfter(x509.get()), minute_cert_ttl * 60);
+  X509_set_pubkey(x509.get(), const_cast<EVP_PKEY*>(pkey));
 
   // subject
-  name = X509_get_subject_name(x509);
+  name = X509_get_subject_name(x509.get());
 
-  set_name_fields(x509, name_fields);
+  set_name_fields(x509.get(), name_fields);
 
   // Issuer
   if (ca_cert) {
-    X509_set_issuer_name(x509, X509_get_subject_name(ca_cert));
-    copy_subject_alt_name_extensions(ca_cert, x509);
+    X509_set_issuer_name(x509.get(), X509_get_subject_name(ca_cert));
+    copy_subject_alt_name_extensions(ca_cert, x509.get());
   } else {
-    X509_set_issuer_name(x509, name);  // auto-signé
+    X509_set_issuer_name(x509.get(), name);  // auto-signé
     // Extension : Basic Constraints = CA:TRUE
     X509V3_CTX ctx;
-    X509V3_set_ctx(&ctx, x509, x509, NULL, NULL, 0);
+    X509V3_set_ctx(&ctx, x509.get(), x509.get(), NULL, NULL, 0);
     X509_EXTENSION* ext = X509V3_EXT_conf_nid(NULL, &ctx, NID_basic_constraints,
                                               "critical,CA:TRUE");
-    X509_add_ext(x509, ext, -1);
+    X509_add_ext(x509.get(), ext, -1);
     X509_EXTENSION_free(ext);
   }
 
   // Signature
-  if (!X509_sign(x509, const_cast<EVP_PKEY*>(ca_key ? ca_key : pkey),
+  if (!X509_sign(x509.get(), const_cast<EVP_PKEY*>(ca_key ? ca_key : pkey),
                  EVP_sha256())) {
     throw ssl_exception("fail to sign certificate:");
   }
 
-  return x509;
+  return x509.release();
 }
 
 /**

--- a/common/grpc/inc/com/centreon/common/grpc/grpc_config.hh
+++ b/common/grpc/inc/com/centreon/common/grpc/grpc_config.hh
@@ -122,7 +122,9 @@ class grpc_config {
         _second_keepalive_interval(30),
         _second_max_reconnect_backoff(0),
         _max_message_length(0),
-        _trusted_tokens(std::move(trusted_tokens)) {}
+        _trusted_tokens(trusted_tokens
+                            ? std::move(trusted_tokens)
+                            : std::make_shared<const absl::flat_hash_set<std::string>>()) {}
 
   grpc_config(const std::string& hostp,
               bool crypted,
@@ -171,7 +173,9 @@ class grpc_config {
         _second_max_reconnect_backoff(second_max_reconnect_backoff),
         _max_message_length(max_message_length),
         _token(token),
-        _trusted_tokens(std::move(trusted_tokens)) {}
+        _trusted_tokens(trusted_tokens
+                            ? std::move(trusted_tokens)
+                            : std::make_shared<const absl::flat_hash_set<std::string>>()) {}
 
   const std::string& get_hostport() const { return _hostport; }
   bool is_crypted() const { return _crypted; }

--- a/common/grpc/inc/com/centreon/common/grpc/grpc_config.hh
+++ b/common/grpc/inc/com/centreon/common/grpc/grpc_config.hh
@@ -57,6 +57,7 @@ class grpc_config {
   bool _crypted = false;
   std::string _certificate, _cert_key, _ca_cert;
   std::string _ca_name;
+  std::string _ca_fingerprint;
   bool _compress;
   int _second_keepalive_interval;
 
@@ -75,7 +76,8 @@ class grpc_config {
   unsigned _max_message_length;
 
   std::string _token;
-  std::shared_ptr<const absl::flat_hash_set<std::string>> _trusted_tokens;
+  std::shared_ptr<const absl::flat_hash_set<std::string>> _trusted_tokens =
+      std::make_shared<const absl::flat_hash_set<std::string>>();
 
  public:
   using pointer = std::shared_ptr<grpc_config>;
@@ -154,7 +156,8 @@ class grpc_config {
       unsigned second_max_reconnect_backoff,
       unsigned max_message_length,
       const std::string& token,
-      std::shared_ptr<const absl::flat_hash_set<std::string>> trusted_tokens)
+      std::shared_ptr<const absl::flat_hash_set<std::string>> trusted_tokens,
+      const std::string& ca_fingerprint = "")
       : _hostport(hostp),
         _security_mode(security_mode),
         _crypted(security_mode != NONE),
@@ -162,6 +165,7 @@ class grpc_config {
         _cert_key(cert_key),
         _ca_cert(ca_cert),
         _ca_name(ca_name),
+        _ca_fingerprint(ca_fingerprint),
         _compress(compression),
         _second_keepalive_interval(second_keepalive_interval),
         _second_max_reconnect_backoff(second_max_reconnect_backoff),
@@ -179,6 +183,7 @@ class grpc_config {
   void set_key(const std::string_view& new_key) { _cert_key = new_key; }
   void set_ca(const std::string_view& new_ca) { _ca_cert = new_ca; }
   const std::string& get_ca_name() const { return _ca_name; }
+  const std::string& get_ca_fingerprint() const { return _ca_fingerprint; }
   bool is_compressed() const { return _compress; }
   int get_second_keepalive_interval() const {
     return _second_keepalive_interval;

--- a/common/grpc/src/grpc_client.cc
+++ b/common/grpc/src/grpc_client.cc
@@ -24,6 +24,25 @@
 using namespace com::centreon::common::grpc;
 
 /**
+ * @brief Certificate verifier that unconditionally accepts any peer.
+ *
+ * Used for the TLS_SKIP_VERIFY_CA bootstrap channel where server identity
+ * is validated via CA-fingerprint instead of the TLS hostname check.
+ */
+class skip_all_certificate_verifier
+    : public ::grpc::experimental::ExternalCertificateVerifier {
+ public:
+  bool Verify(::grpc::experimental::TlsCustomVerificationCheckRequest*,
+              std::function<void(::grpc::Status)>,
+              ::grpc::Status* sync_status) override {
+    *sync_status = ::grpc::Status::OK;
+    return true;
+  }
+  void Cancel(
+      ::grpc::experimental::TlsCustomVerificationCheckRequest*) override {}
+};
+
+/**
  * @brief Construct a new grpc client base::grpc client base object
  *
  * @param conf
@@ -63,6 +82,10 @@ grpc_client_base::grpc_client_base(
     if (conf->get_security_mode() == grpc_config::TLS_SKIP_VERIFY_CA) {
       ::grpc::experimental::TlsChannelCredentialsOptions options;
       options.set_verify_server_certs(false);
+      options.set_check_call_host(false);
+      options.set_certificate_verifier(
+          ::grpc::experimental::ExternalCertificateVerifier::Create<
+              skip_all_certificate_verifier>());
       creds = ::grpc::experimental::TlsCredentials(options);
       SPDLOG_LOGGER_INFO(_logger, "skip ca verify encrypted connection to {}",
                          conf->get_hostport());

--- a/common/grpc/src/grpc_client.cc
+++ b/common/grpc/src/grpc_client.cc
@@ -35,7 +35,8 @@ class skip_all_certificate_verifier
   bool Verify(::grpc::experimental::TlsCustomVerificationCheckRequest*,
               std::function<void(::grpc::Status)>,
               ::grpc::Status* sync_status) override {
-    *sync_status = ::grpc::Status::OK;
+    if (sync_status)
+      *sync_status = ::grpc::Status::OK;
     return true;
   }
   void Cancel(

--- a/common/grpc/src/grpc_server.cc
+++ b/common/grpc/src/grpc_server.cc
@@ -52,9 +52,15 @@ grpc_server_base::grpc_server_base(
           return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
                                 "Token expired");
         }
+        auto trusted_tokens = _conf->get_trusted_tokens();
+        if (!trusted_tokens) {
+          SPDLOG_LOGGER_ERROR(_logger,
+                              "UNAUTHENTICATED : No trusted token list configured");
+          return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
+                                "Token validation not configured");
+        }
         // check if token is trusted by the service
-        if (_conf->get_trusted_tokens()->find(jwt.get_string()) ==
-            _conf->get_trusted_tokens()->end()) {
+        if (trusted_tokens->find(jwt.get_string()) == trusted_tokens->end()) {
           SPDLOG_LOGGER_ERROR(_logger,
                               "UNAUTHENTICATED : Token is not trusted");
           return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,

--- a/common/process/src/process.cc
+++ b/common/process/src/process.cc
@@ -515,7 +515,10 @@ void process<use_mutex>::_on_stdout_read(const boost::system::error_code& err,
   }
   if (!received.empty()) {
     _stdout_handler(received);
-    _stdout_read();
+    {
+      detail::lock<use_mutex> l(&_protect);
+      _stdout_read();
+    }
   }
 
   if (eof) {
@@ -587,7 +590,10 @@ void process<use_mutex>::_on_stderr_read(const boost::system::error_code& err,
 
   if (!received.empty()) {
     _stderr_handler(received);
-    _stderr_read();
+    {
+      detail::lock<use_mutex> l(&_protect);
+      _stderr_read();
+    }
   }
 
   if (eof) {

--- a/engine/modules/opentelemetry/CMakeLists.txt
+++ b/engine/modules/opentelemetry/CMakeLists.txt
@@ -66,6 +66,7 @@ add_custom_command(
 # mod_externalcmd target.
 add_library(
   opentelemetry SHARED
+  ${SRC_DIR}/certificate_service.cc
   ${SRC_DIR}/centreon_agent/agent.grpc.pb.cc
   ${SRC_DIR}/centreon_agent/agent.pb.cc
   ${SRC_DIR}/centreon_agent/agent_check_result_builder.cc

--- a/engine/modules/opentelemetry/inc/com/centreon/engine/modules/opentelemetry/certificate_service.hh
+++ b/engine/modules/opentelemetry/inc/com/centreon/engine/modules/opentelemetry/certificate_service.hh
@@ -32,7 +32,7 @@ namespace com::centreon::engine::modules::opentelemetry::centreon_agent {
 class certificate_service final : public agent::CACertificateService::Service {
   std::shared_ptr<spdlog::logger> _logger;
   const std::string _ca_cert;
-  std::string _fingerprint_prefix;
+  std::string _fingerprint;
 
  public:
   certificate_service(const std::shared_ptr<spdlog::logger>& logger,

--- a/engine/modules/opentelemetry/inc/com/centreon/engine/modules/opentelemetry/certificate_service.hh
+++ b/engine/modules/opentelemetry/inc/com/centreon/engine/modules/opentelemetry/certificate_service.hh
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Centreon
+ * Copyright 2026 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/engine/modules/opentelemetry/inc/com/centreon/engine/modules/opentelemetry/certificate_service.hh
+++ b/engine/modules/opentelemetry/inc/com/centreon/engine/modules/opentelemetry/certificate_service.hh
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
+
+#ifndef CCE_MOD_OTL_CERTIFICATE_SERVICE_HH
+#define CCE_MOD_OTL_CERTIFICATE_SERVICE_HH
+
+#include <grpcpp/support/server_callback.h>
+#include <spdlog/spdlog.h>
+#include "centreon_agent/agent.grpc.pb.h"
+
+namespace com::centreon::engine::modules::opentelemetry::centreon_agent {
+
+/**
+ * @brief Dedicated gRPC service for CA certificate retrieval
+ * Provides the GetCACertificate RPC method
+ */
+class certificate_service final : public agent::CACertificateService::Service {
+  std::shared_ptr<spdlog::logger> _logger;
+  const std::string _ca_cert;
+  std::string _fingerprint_prefix;
+
+ public:
+  certificate_service(const std::shared_ptr<spdlog::logger>& logger,
+                      const std::string& ca_cert);
+
+  static std::shared_ptr<certificate_service> load(
+      const std::shared_ptr<spdlog::logger>& logger,
+      const std::string& ca_cert);
+
+  ::grpc::Status GetCACertificate(
+      ::grpc::ServerContext* context,
+      const com::centreon::agent::CACertificateRequest* request,
+      com::centreon::agent::CACertificateResponse* response) override;
+};
+
+}  // namespace com::centreon::engine::modules::opentelemetry::centreon_agent
+
+#endif

--- a/engine/modules/opentelemetry/inc/com/centreon/engine/modules/opentelemetry/otl_server.hh
+++ b/engine/modules/opentelemetry/inc/com/centreon/engine/modules/opentelemetry/otl_server.hh
@@ -25,6 +25,7 @@
 
 #include "com/centreon/common/grpc/grpc_server.hh"
 #include "com/centreon/engine/modules/opentelemetry/centreon_agent/agent_service.hh"
+#include "com/centreon/engine/modules/opentelemetry/certificate_service.hh"
 
 namespace com::centreon::engine::modules::opentelemetry {
 
@@ -41,6 +42,7 @@ class otl_server : public common::grpc::grpc_server_base,
                    public std::enable_shared_from_this<otl_server> {
   std::shared_ptr<detail::metric_service> _service;
   std::shared_ptr<centreon_agent::agent_service> _agent_service;
+  std::shared_ptr<centreon_agent::certificate_service> _ca_service;
   absl::Mutex _protect;
 
   otl_server(const grpc_config::pointer& conf,

--- a/engine/modules/opentelemetry/src/certificate_service.cc
+++ b/engine/modules/opentelemetry/src/certificate_service.cc
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2024 Centreon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ */
+
+#include "certificate_service.hh"
+
+#include "common/crypto/cert_tree.hh"
+
+using namespace com::centreon::engine::modules::opentelemetry::centreon_agent;
+
+/**
+ * @brief Construct a new ca certificate service object
+ *
+ * @param logger Logger instance for service operations
+ */
+certificate_service::certificate_service(
+    const std::shared_ptr<spdlog::logger>& logger,
+    const std::string& ca_cert)
+    : _logger(logger), _ca_cert(ca_cert) {
+  // calculate fingerprint
+  X509* cert = common::crypto::cert_tree::load_cert_from_string(ca_cert);
+
+  _fingerprint_prefix = common::crypto::cert_tree::cert_sha(cert).substr(0, 6);
+}
+
+/**
+ * @brief Factory method to create certificate_service instance
+ *
+ * @param logger Logger instance
+ * @return std::shared_ptr<certificate_service>
+ */
+std::shared_ptr<certificate_service> certificate_service::load(
+    const std::shared_ptr<spdlog::logger>& logger,
+    const std::string& ca_cert) {
+  SPDLOG_LOGGER_INFO(logger, "Certificate_service loaded");
+
+  return std::make_shared<certificate_service>(logger, ca_cert);
+}
+
+/**
+ * @brief Implement GetCACertificate RPC method
+ * Reads CA certificate from disk, computes fingerprint, and validates if
+ * requested
+ *
+ * @param context gRPC server context
+ * @param request CA certificate request with optional expected fingerprint
+ * @param response CA certificate response with PEM and fingerprint
+ * @return ::grpc::Status
+ */
+::grpc::Status certificate_service::GetCACertificate(
+    ::grpc::ServerContext* context,
+    const com::centreon::agent::CACertificateRequest* request [[maybe_unused]],
+    com::centreon::agent::CACertificateResponse* response) {
+  try {
+    // Validate token from client metadata
+    auto metadata = context->client_metadata();
+    auto token_iter = metadata.find("x-token");
+
+    if (token_iter == metadata.end()) {
+      SPDLOG_LOGGER_WARN(
+          _logger,
+          "CA certificate request denied: missing token for the peer {}",
+          context->peer());
+      return ::grpc::Status(::grpc::StatusCode::UNAUTHENTICATED,
+                            "Missing authentication token");
+    }
+
+    std::string client_token(token_iter->second.data(),
+                             token_iter->second.size());
+
+    if (client_token != _fingerprint_prefix) {
+      SPDLOG_LOGGER_WARN(
+          _logger,
+          "CA certificate request denied: invalid token '{}' for the peer {}",
+          client_token, context->peer());
+      return ::grpc::Status(::grpc::StatusCode::PERMISSION_DENIED,
+                            "Invalid authentication token");
+    }
+
+    SPDLOG_LOGGER_INFO(_logger, "CA provided to the peer {}", context->peer());
+    // Set response
+    response->set_certificate_pem(_ca_cert);
+
+    return ::grpc::Status::OK;
+
+  } catch (const std::exception& e) {
+    SPDLOG_LOGGER_ERROR(_logger,
+                        "Error retrieving CA certificate for the peer {}: {}",
+                        context->peer(), e.what());
+    return ::grpc::Status(
+        ::grpc::StatusCode::INTERNAL,
+        std::string("Error retrieving CA certificate: ") + e.what());
+  }
+}

--- a/engine/modules/opentelemetry/src/certificate_service.cc
+++ b/engine/modules/opentelemetry/src/certificate_service.cc
@@ -34,7 +34,9 @@ certificate_service::certificate_service(
   // calculate fingerprint
   std::unique_ptr<X509, decltype(&X509_free)> cert(
       common::crypto::cert_tree::load_cert_from_string(ca_cert), X509_free);
-  _fingerprint = common::crypto::cert_tree::cert_sha(cert.get());
+  if (cert) {
+    _fingerprint = common::crypto::cert_tree::cert_sha(cert.get());
+  }
 }
 
 /**

--- a/engine/modules/opentelemetry/src/certificate_service.cc
+++ b/engine/modules/opentelemetry/src/certificate_service.cc
@@ -33,8 +33,8 @@ certificate_service::certificate_service(
     : _logger(logger), _ca_cert(ca_cert) {
   // calculate fingerprint
   X509* cert = common::crypto::cert_tree::load_cert_from_string(ca_cert);
-
-  _fingerprint_prefix = common::crypto::cert_tree::cert_sha(cert).substr(0, 6);
+  _fingerprint = common::crypto::cert_tree::cert_sha(cert);
+  X509_free(cert);
 }
 
 /**
@@ -46,7 +46,7 @@ certificate_service::certificate_service(
 std::shared_ptr<certificate_service> certificate_service::load(
     const std::shared_ptr<spdlog::logger>& logger,
     const std::string& ca_cert) {
-  SPDLOG_LOGGER_INFO(logger, "Certificate_service loaded");
+  SPDLOG_LOGGER_INFO(logger, "certificate service loaded");
 
   return std::make_shared<certificate_service>(logger, ca_cert);
 }
@@ -82,7 +82,7 @@ std::shared_ptr<certificate_service> certificate_service::load(
     std::string client_token(token_iter->second.data(),
                              token_iter->second.size());
 
-    if (client_token != _fingerprint_prefix) {
+    if (client_token != _fingerprint) {
       SPDLOG_LOGGER_WARN(
           _logger,
           "CA certificate request denied: invalid token '{}' for the peer {}",
@@ -94,8 +94,7 @@ std::shared_ptr<certificate_service> certificate_service::load(
     // Set response
     response->set_certificate_pem(_ca_cert);
     SPDLOG_LOGGER_CRITICAL(
-        _logger,
-        "[SECURITY] CA bootstrap certificate delivered to peer {}",
+        _logger, "[SECURITY] CA bootstrap certificate delivered to peer {}",
         context->peer());
 
     return ::grpc::Status::OK;

--- a/engine/modules/opentelemetry/src/certificate_service.cc
+++ b/engine/modules/opentelemetry/src/certificate_service.cc
@@ -91,9 +91,12 @@ std::shared_ptr<certificate_service> certificate_service::load(
                             "Invalid authentication token");
     }
 
-    SPDLOG_LOGGER_INFO(_logger, "CA provided to the peer {}", context->peer());
     // Set response
     response->set_certificate_pem(_ca_cert);
+    SPDLOG_LOGGER_CRITICAL(
+        _logger,
+        "[SECURITY] CA bootstrap certificate delivered to peer {}",
+        context->peer());
 
     return ::grpc::Status::OK;
 

--- a/engine/modules/opentelemetry/src/certificate_service.cc
+++ b/engine/modules/opentelemetry/src/certificate_service.cc
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Centreon
+ * Copyright 2026 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,9 +32,9 @@ certificate_service::certificate_service(
     const std::string& ca_cert)
     : _logger(logger), _ca_cert(ca_cert) {
   // calculate fingerprint
-  X509* cert = common::crypto::cert_tree::load_cert_from_string(ca_cert);
-  _fingerprint = common::crypto::cert_tree::cert_sha(cert);
-  X509_free(cert);
+  std::unique_ptr<X509, decltype(&X509_free)> cert(
+      common::crypto::cert_tree::load_cert_from_string(ca_cert), X509_free);
+  _fingerprint = common::crypto::cert_tree::cert_sha(cert.get());
 }
 
 /**
@@ -85,8 +85,8 @@ std::shared_ptr<certificate_service> certificate_service::load(
     if (client_token != _fingerprint) {
       SPDLOG_LOGGER_WARN(
           _logger,
-          "CA certificate request denied: invalid token '{}' for the peer {}",
-          client_token, context->peer());
+          "CA certificate request denied: invalid token for the peer {}",
+          context->peer());
       return ::grpc::Status(::grpc::StatusCode::PERMISSION_DENIED,
                             "Invalid authentication token");
     }

--- a/engine/modules/opentelemetry/src/otl_server.cc
+++ b/engine/modules/opentelemetry/src/otl_server.cc
@@ -330,6 +330,11 @@ otl_server::pointer otl_server::load(
       io_context, agent_config, handler, logger, agent_stats,
       conf->is_crypted(), std::move(token_validator));
 
+  if (conf->is_crypted() && !conf->get_ca().empty()) {
+    ret->_ca_service =
+        centreon_agent::certificate_service::load(logger, conf->get_ca());
+  }
+
   ret->start();
   return ret;
 }
@@ -342,6 +347,9 @@ void otl_server::start() {
   _init([this](::grpc::ServerBuilder& builder) {
     builder.RegisterService(_service.get());
     builder.RegisterService(_agent_service.get());
+    if (_ca_service) {
+      builder.RegisterService(_ca_service.get());
+    }
   });
 }
 

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -134,6 +134,7 @@ if(WITH_TESTING)
       ${TESTS_DIR}/notifications/service_downtime_notification_test.cc
       ${TESTS_DIR}/opentelemetry/agent_check_result_builder_test.cc
       ${TESTS_DIR}/opentelemetry/agent_reverse_client_test.cc
+      ${TESTS_DIR}/opentelemetry/certificate_service_test.cc
       ${TESTS_DIR}/opentelemetry/grpc_config_test.cc
       ${TESTS_DIR}/opentelemetry/host_serv_extractor_test.cc
       ${TESTS_DIR}/opentelemetry/open_telemetry_test.cc

--- a/engine/tests/configuration/pbtimeperiod-test.cc
+++ b/engine/tests/configuration/pbtimeperiod-test.cc
@@ -880,6 +880,8 @@ std::vector<std::vector<std::string>> parse_timeperiods_cfg(
   bool wait_time_period_begin = true;
 
   std::vector<std::string> current;
+  if (!f)
+    return ret;
   while (!f.eof()) {
     std::getline(f, line);
 

--- a/engine/tests/opentelemetry/certificate_service_test.cc
+++ b/engine/tests/opentelemetry/certificate_service_test.cc
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2026 Centreon
+ *
+ * This file is part of Centreon Engine.
+ *
+ * Centreon Engine is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 2
+ * as published by the Free Software Foundation.
+ *
+ * Centreon Engine is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Centreon Engine. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/server_context.h>
+#include <gtest/gtest.h>
+
+#include <openssl/x509v3.h>
+#include "agent.grpc.pb.h"
+#include "com/centreon/engine/modules/opentelemetry/certificate_service.hh"
+#include "common/crypto/cert_tree.hh"
+
+using namespace com::centreon::engine::modules::opentelemetry::centreon_agent;
+using namespace com::centreon;
+// Sample CA certificate for testing (self-signed)
+const char* TEST_CA_CERT = R"(-----BEGIN CERTIFICATE-----
+MIIDgzCCAmugAwIBAgIUTIxSeVMzS+1wejZJ3twXIpJSrGEwDQYJKoZIhvcNAQEL
+BQAwUDELMAkGA1UEBhMCRlIxDTALBgNVBAgMBFRlc3QxDTALBgNVBAcMBFRlc3Qx
+ETAPBgNVBAoMCENlbnRyZW9uMRAwDgYDVQQDDAdUZXN0IENBMCAXDTI2MDIyNTIz
+NTYxM1oYDzIxMjYwMjAxMjM1NjEzWjBQMQswCQYDVQQGEwJGUjENMAsGA1UECAwE
+VGVzdDENMAsGA1UEBwwEVGVzdDERMA8GA1UECgwIQ2VudHJlb24xEDAOBgNVBAMM
+B1Rlc3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCvKrsplv/m
+FMvMsRpRsasX3rt1NMxgmqgrM14+9Vw1nbI9PQeBq/5rA3n/NiWFIUEZSH/45t9f
+GK3coK6Y9XtPdB4cJqR0/pvTuFbADXs6TR3GaaLPt/S9gRXPEftw9QjjtjJDQQP+
+iYKAUtLz+DmOGzi3XKvfC6WpokOx7psTbOLqllCt5jFlLatJVoR1Wt0lyXDSWVFz
+YyLqvtFeD6tCcHXIrJBlRjat4cN6W5ZyYpUEcwJJmMu179sgfHS0vncpTEQcS2D/
+Av03b4l0ZX3ZIC7PITBy7rcfxp1dAs3duaqj8iR49jpZl4rk9u1hb5ZDnoivZ7KF
+pMHIhJTTYoQ/AgMBAAGjUzBRMB0GA1UdDgQWBBTey/ZUxIHca62Sl3hVFqqeUeS1
+fTAfBgNVHSMEGDAWgBTey/ZUxIHca62Sl3hVFqqeUeS1fTAPBgNVHRMBAf8EBTAD
+AQH/MA0GCSqGSIb3DQEBCwUAA4IBAQB1QmgYsgcrhKkGZ8ybp5kIS9QOJc7PuDGM
+iXanaPqoS5RwzwC+ddCDHfqJ4zrch0DBWEyT+p8TAQB4TltNvmDgAR8wGo8dt9um
+ROThYfUoe3iliwbqs2YmghZ/Ir2zuBmORXdQpphvXmuoJADLgnzIFV6nx3aER0gK
+Vjycffvh5MQRw06EI92TH48hvp4KOMWglBCwOCs8JAn3KgItrrboDYugE0QxJRQY
+k92tlZI9pFcj/kh2/cMYNLOz2+rzzAVHVLRFahtxpn16hwcxrsy9E0j7b+lZKPOZ
+u63GnH//c1m+jQyTACtX4ApUN6h+Qx6e6u3CBmEOsEyB/RAKi4Bg
+-----END CERTIFICATE-----)";
+
+class certificate_service_test : public ::testing::Test {
+ protected:
+  std::shared_ptr<spdlog::logger> _logger;
+  std::shared_ptr<certificate_service> _service_impl;
+
+  std::unique_ptr<grpc::Server> _server;
+  std::shared_ptr<grpc::Channel> _channel;
+  std::unique_ptr<com::centreon::agent::CACertificateService::Stub> _stub;
+
+  std::string _fingerprint_prefix;
+
+  void SetUp() override {
+    _logger = spdlog::default_logger();
+
+    X509* cert = common::crypto::cert_tree::load_cert_from_string(TEST_CA_CERT);
+
+    _fingerprint_prefix =
+        common::crypto::cert_tree::cert_sha(cert).substr(0, 6);
+
+    _service_impl = certificate_service::load(_logger, TEST_CA_CERT);
+
+    grpc::ServerBuilder builder;
+    builder.RegisterService(_service_impl.get());
+
+    _server = builder.BuildAndStart();
+    _channel = _server->InProcessChannel(grpc::ChannelArguments());
+
+    _stub = com::centreon::agent::CACertificateService::NewStub(_channel);
+  }
+
+  void TearDown() override {
+    _server->Shutdown();
+    _service_impl.reset();
+  }
+};
+
+TEST_F(certificate_service_test, GetCACertificateWithValidToken) {
+  grpc::ClientContext context;
+  context.AddMetadata("x-token", _fingerprint_prefix);
+
+  com::centreon::agent::CACertificateRequest request;
+  com::centreon::agent::CACertificateResponse response;
+
+  grpc::Status status = _stub->GetCACertificate(&context, request, &response);
+
+  EXPECT_EQ(status.error_code(), grpc::StatusCode::OK);
+  EXPECT_EQ(response.certificate_pem(), TEST_CA_CERT);
+  SPDLOG_LOGGER_INFO(_logger, "received CA certificate:\n{}",
+                     response.certificate_pem());
+}
+
+// Test CA certificate retrieval without token (should fail)
+TEST_F(certificate_service_test, GetCACertificateWithoutToken) {
+  grpc::ClientContext context;
+
+  com::centreon::agent::CACertificateRequest request;
+  com::centreon::agent::CACertificateResponse response;
+
+  grpc::Status status = _stub->GetCACertificate(&context, request, &response);
+
+  EXPECT_EQ(status.error_code(), ::grpc::StatusCode::UNAUTHENTICATED);
+  EXPECT_EQ(status.error_message(), "Missing authentication token");
+  EXPECT_TRUE(response.certificate_pem().empty());
+}
+
+// Test CA certificate retrieval with invalid token (should fail)
+TEST_F(certificate_service_test, GetCACertificateWithInvalidToken) {
+  grpc::ClientContext context;
+  context.AddMetadata("x-token", "invalid_token_999");
+
+  com::centreon::agent::CACertificateRequest request;
+  com::centreon::agent::CACertificateResponse response;
+
+  grpc::Status status = _stub->GetCACertificate(&context, request, &response);
+
+  EXPECT_EQ(status.error_code(), ::grpc::StatusCode::PERMISSION_DENIED);
+  EXPECT_EQ(status.error_message(), "Invalid authentication token");
+  EXPECT_TRUE(response.certificate_pem().empty());
+}
+
+// Test with empty token
+TEST_F(certificate_service_test, GetCACertificateWithEmptyToken) {
+  grpc::ClientContext context;
+  context.AddMetadata("x-token", "");  // Empty token
+
+  com::centreon::agent::CACertificateRequest request;
+  com::centreon::agent::CACertificateResponse response;
+
+  grpc::Status status = _stub->GetCACertificate(&context, request, &response);
+
+  EXPECT_EQ(status.error_code(), ::grpc::StatusCode::PERMISSION_DENIED);
+  EXPECT_EQ(status.error_message(), "Invalid authentication token");
+  EXPECT_TRUE(response.certificate_pem().empty());
+}

--- a/engine/tests/opentelemetry/certificate_service_test.cc
+++ b/engine/tests/opentelemetry/certificate_service_test.cc
@@ -60,15 +60,14 @@ class certificate_service_test : public ::testing::Test {
   std::shared_ptr<grpc::Channel> _channel;
   std::unique_ptr<com::centreon::agent::CACertificateService::Stub> _stub;
 
-  std::string _fingerprint_prefix;
+  std::string _fingerprint;
 
   void SetUp() override {
     _logger = spdlog::default_logger();
 
     X509* cert = common::crypto::cert_tree::load_cert_from_string(TEST_CA_CERT);
-
-    _fingerprint_prefix =
-        common::crypto::cert_tree::cert_sha(cert).substr(0, 6);
+    _fingerprint = common::crypto::cert_tree::cert_sha(cert);
+    X509_free(cert);
 
     _service_impl = certificate_service::load(_logger, TEST_CA_CERT);
 
@@ -89,7 +88,7 @@ class certificate_service_test : public ::testing::Test {
 
 TEST_F(certificate_service_test, GetCACertificateWithValidToken) {
   grpc::ClientContext context;
-  context.AddMetadata("x-token", _fingerprint_prefix);
+  context.AddMetadata("x-token", _fingerprint);
 
   com::centreon::agent::CACertificateRequest request;
   com::centreon::agent::CACertificateResponse response;

--- a/tests/broker-engine/cma.robot
+++ b/tests/broker-engine/cma.robot
@@ -570,6 +570,10 @@ BEOTEL_CENTREON_AGENT_CHECK_HOST_CRYPTED_WITHOUT_CERT
     ...    And the CMA stores the CA certificate and reconnects using full TLS with the JWT token,
     ...    Then the host check result is reported successfully in the resources table.
     [Tags]    broker    engine    opentelemetry    MON-192054
+    
+    ${run_env}    Ctn Run Env
+    Pass Execution If    "${run_env}" != "WSL"    "This test is only for WSL"
+
     Ctn Config Engine    ${1}    ${2}    ${2}
 
     Ctn Add Otl ServerModule

--- a/tests/broker-engine/cma.robot
+++ b/tests/broker-engine/cma.robot
@@ -572,7 +572,7 @@ BEOTEL_CENTREON_AGENT_CHECK_HOST_CRYPTED_WITHOUT_CERT
     [Tags]    broker    engine    opentelemetry    MON-192054
     
     ${run_env}    Ctn Run Env
-    Pass Execution If    "${run_env}" != "WSL"    "This test is only for WSL"
+    Pass Execution If    "${run_env}" == "WSL"    "This test is only for linux"
 
     Ctn Config Engine    ${1}    ${2}    ${2}
 

--- a/tests/broker-engine/cma.robot
+++ b/tests/broker-engine/cma.robot
@@ -559,6 +559,73 @@ BEOTEL_CENTREON_AGENT_CHECK_HOST_CRYPTED
     ${result}    Ctn Check Host Output Resource Status With Timeout    host_1    120    ${start_int}    0  HARD  OK - 127.0.0.1
     Should Be True    ${result}    resources table not updated
 
+BEOTEL_CENTREON_AGENT_CHECK_HOST_CRYPTED_WITHOUT_CERT
+    [Documentation]    Given Engine is configured with a full TLS gRPC server (port 4318) exposing its CA certificate,
+    ...    And the CMA has only a fingerprint (no CA certificate file) and a JWT token,
+    ...    When the CMA starts and attempts a full TLS connection to Engine (which fails — no CA yet),
+    ...    Then the CMA falls back to an insecure TLS connection to retrieve the CA certificate from Engine,
+    ...    And Engine logs a security entry confirming the CA certificate was delivered,
+    ...    And the CMA validates the retrieved CA certificate against the configured fingerprint,
+    ...    And the CMA logs a security entry confirming the CA bootstrap succeeded,
+    ...    And the CMA stores the CA certificate and reconnects using full TLS with the JWT token,
+    ...    Then the host check result is reported successfully in the resources table.
+    [Tags]    broker    engine    opentelemetry    MON-192054
+    Ctn Config Engine    ${1}    ${2}    ${2}
+
+    Ctn Add Otl ServerModule
+    ...    0
+    ...    {"otel_server":{"host": "0.0.0.0","port": 4318, "encryption": "full", "public_cert": "/tmp/server_grpc.crt", "private_key": "/tmp/server_grpc.key"}, "centreon_agent":{"export_period":5}, "max_length_grpc_log":0}
+    Ctn Config Add Otl Connector
+    ...    0
+    ...    OTEL connector
+    ...    opentelemetry --processor=centreon_agent --extractor=attributes --host_path=resource_metrics.resource.attributes.host.name --service_path=resource_metrics.resource.attributes.service.name
+    Ctn Engine Config Replace Value In Hosts    ${0}    host_1    check_command    otel_check_icmp
+    
+    ${echo_command}   Ctn Echo Command   "OK - 127.0.0.1: rta 0,010ms, lost 0%|rta=0,010ms;200,000;500,000;0; pl=0%;40;80;; rtmax=0,035ms;;;; rtmin=0,003ms;;;;"
+    Ctn Engine Config Add Command    ${0}    otel_check_icmp    ${echo_command}    OTEL connector
+    Ctn Set Hosts Passive    ${0}    host_1 
+    Ctn Engine Config Set Value    0    interval_length    10
+    Ctn Engine Config Set Value In Hosts    ${0}    host_1    check_interval    1
+
+    Ctn Engine Config Set Value    0    log_level_checks    trace
+
+    Ctn Config Broker    central
+    Ctn Config Broker    module
+    Ctn Config Broker    rrd
+    ${token}    Ctn Create Jwt Token    ${600}
+    ${fingerprint}    Ctn Get Cert Fingerprint    /tmp/server_grpc.crt
+    Ctn Config Centreon Agent    ${None}    ${None}    ${None}    ${token}    fingerprint=${fingerprint}
+    Ctn Add Token Otl Server Module    0    ${token}
+    Ctn Broker Config Log    central    sql    trace
+
+    Ctn Config BBDO3    1
+    Ctn Clear Retention
+
+    ${start}    Get Current Date
+    ${start_int}    Ctn Get Round Current Date
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Start Agent
+
+    # Let's wait for the otel server start
+    ${content}    Create List    ] encrypted server listening on 0.0.0.0:4318
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    20
+    Should Be True    ${result}    "encrypted server listening on 0.0.0.0:4318" should be available.
+
+    # Verify engine security log: CA certificate was delivered to the agent
+    ${content}    Create List    [SECURITY] CA bootstrap certificate delivered to peer
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    30
+    Should Be True    ${result}    Engine security log "[SECURITY] CA bootstrap certificate delivered to peer" not found
+
+    # Verify agent security log: CA was successfully bootstrapped from fingerprint
+    ${content}    Create List    [SECURITY] CA bootstrap succeeded from fingerprint for endpoint
+    ${result}    Ctn Find In Log With Timeout    ${agentlog}    ${start}    ${content}    30    agent_format=${True}
+    Should Be True    ${result}    Agent security log "[SECURITY] CA bootstrap succeeded from fingerprint for endpoint" not found
+
+    ${result}    Ctn Check Host Output Resource Status With Timeout    host_1    120    ${start_int}    0  HARD  OK - 127.0.0.1
+    Should Be True    ${result}    resources table not updated
+
+
 BEOTEL_CENTREON_AGENT_CHECK_HOST_CRYPTED_ENCRYPTED_CREDENTIALS
     [Documentation]    Given an agent host checked by centagent over an encrypted connection,
     ...    Engine use credentials encryption and send encrypted commands

--- a/tests/resources/Agent.py
+++ b/tests/resources/Agent.py
@@ -18,6 +18,9 @@
 #
 
 from os import makedirs, environ
+import base64
+import hashlib
+import ssl
 import time
 from robot.libraries.BuiltIn import BuiltIn, RobotNotRunningError
 from socket import gethostname
@@ -108,7 +111,22 @@ reversed_agent_encrypted_config = f"""
     "log_file":"{VAR_ROOT}/log/centreon-engine/centreon-agent.log" """
 
 
-def ctn_config_centreon_agent(key_path: str = None, cert_path: str = None, ca_path: str = None, token: str = None, ca_common_name: str = None, security_mode: str = "full", have_token: bool = True, nb_agent: int = 1):
+def ctn_get_cert_fingerprint(cert_path: str) -> str:
+    """ctn_get_cert_fingerprint
+    Compute the SHA256 fingerprint of a PEM certificate, base64-encoded.
+    This matches the C++ cert_tree::cert_sha() format used by the agent.
+    Args:
+        cert_path: path to the PEM certificate file
+    Returns:
+        base64-encoded SHA256 digest of the DER-encoded certificate
+    """
+    pem_data = open(cert_path).read()
+    der_data = ssl.PEM_cert_to_DER_cert(pem_data)
+    sha256_digest = hashlib.sha256(der_data).digest()
+    return base64.b64encode(sha256_digest).decode('ascii')
+
+
+def ctn_config_centreon_agent(key_path: str = None, cert_path: str = None, ca_path: str = None, token: str = None, ca_common_name: str = None, security_mode: str = "full", have_token: bool = True, nb_agent: int = 1, fingerprint: str = None):
     """ctn_config_centreon_agent
     Creates a default centreon agent config listening on  0.0.0.0:4317 (no encryption) or 0.0.0.0:4318 (encryption)
     Args:
@@ -120,6 +138,9 @@ def ctn_config_centreon_agent(key_path: str = None, cert_path: str = None, ca_pa
         security_mode: full, no or insecure
         have_token: add token or empty token in config file
         nb_agent: nb conf agent (several agents config files)
+        fingerprint: base64-encoded SHA256 fingerprint of the CA cert; when set the
+                     agent will bootstrap the CA over insecure TLS and validate it
+                     using this fingerprint (implies encrypted endpoint, no ca_path needed)
     """
     # in case of wsl, agent is executed in windows host
     if environ.get("RUN_ENV", "") == "WSL":
@@ -134,13 +155,16 @@ def ctn_config_centreon_agent(key_path: str = None, cert_path: str = None, ca_pa
                  ctn_echo_command("$ARG2$ $ARG1$ from custom check") + "\n")
         ff.write("custom_check_2 = /path/to/custom_check_2 -c /arg=<value>\n")
 
+    use_encrypted_endpoint = cert_path is not None or ca_path is not None or fingerprint is not None
+    use_encryption = key_path is not None or cert_path is not None or ca_path is not None or fingerprint is not None
+
     for agent_index in range(nb_agent):
         with open(f"{CONF_DIR}/centagent{agent_index}.json", "w") as ff:
-            if cert_path is not None or ca_path is not None:
+            if use_encrypted_endpoint:
                 ff.write(agent_encrypted_config)
             else:
                 ff.write(agent_config)
-            if key_path is not None or cert_path is not None or ca_path is not None:
+            if use_encryption:
                 ff.write(f",\n  \"encryption\":\"{security_mode}\"")
             if key_path is not None:
                 ff.write(f",\n  \"private_key\":\"{key_path}\"")
@@ -150,6 +174,8 @@ def ctn_config_centreon_agent(key_path: str = None, cert_path: str = None, ca_pa
                 ff.write(f",\n  \"ca\":\"{ca_path}\"")
             if ca_common_name is not None:
                 ff.write(f",\n  \"ca_common_name\":\"{ca_common_name}\"")
+            if fingerprint is not None:
+                ff.write(f",\n  \"fingerprint\":\"{fingerprint}\"")
             if have_token:
                 if token is not None:
                     ff.write(f",\n  \"token\":\"{token}\"")


### PR DESCRIPTION
feat(engine/agent): cma get public ca using fingerprint and establish tls connection

REFS: MON-192054

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 3 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Implemented CA bootstrap from fingerprint and persisted TLS configuration updates

**⚡ Enhancements**
* Integrated bootstrap workflow into agent startup and replaced file readers
* Extended grpc_config with ca_fingerprint and made trusted_tokens default-initialized
* Added TLS skip-verify bootstrap channel using custom certificate verifier

**🐛 Bugfixes**
* Guarded token validation against null trusted_tokens to avoid crashes


<sup>[More info](https://app.aikido.dev/featurebranch/scan/95852867?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->