### PR TITLE
feat(broker): database secured tls connection (#3195)

### DIFF
--- a/.github/docker/Dockerfile.centreon-collect-mariadb-bookworm-test
+++ b/.github/docker/Dockerfile.centreon-collect-mariadb-bookworm-test
@@ -20,6 +20,7 @@ apt-get -y install \
     locales \
     mariadb-server \
     openssh-server \
+    openssl \
     perl-base \
     psmisc \
     python3 \
@@ -33,6 +34,64 @@ apt-get -y install \
     zstd
 
 apt-get clean
+
+# Generate TLS certificates for MariaDB
+echo "Generating TLS certificates for MariaDB"
+mkdir -p /etc/mysql/ssl
+mkdir -p /etc/mysql/mariadb.conf.d
+
+# Generate CA certificate
+openssl req -x509 -newkey rsa:4096 -days 3650 -nodes \
+  -keyout /etc/mysql/ssl/ca-key.pem -out /etc/mysql/ssl/ca-cert.pem \
+  -subj "/CN=Centreon-MariaDB-CA"
+
+# Generate server certificate
+openssl req -newkey rsa:4096 -days 3650 -nodes \
+  -keyout /etc/mysql/ssl/server-key.pem -out /etc/mysql/ssl/server-req.pem \
+  -subj "/CN=localhost"
+
+# Sign server certificate with CA
+openssl x509 -req -in /etc/mysql/ssl/server-req.pem -days 3650 \
+  -CA /etc/mysql/ssl/ca-cert.pem -CAkey /etc/mysql/ssl/ca-key.pem -CAcreateserial \
+  -out /etc/mysql/ssl/server-cert.pem -extensions v3_req -extfile <(cat <<'EOFSSL'
+[v3_req]
+subjectAltName = DNS:localhost,IP:127.0.0.1
+EOFSSL
+)
+
+# Generate client certificate
+openssl req -newkey rsa:4096 -days 3650 -nodes \
+  -keyout /etc/mysql/ssl/client-key.pem -out /etc/mysql/ssl/client-req.pem \
+  -subj "/CN=localhost"
+
+# Sign client certificate with CA
+openssl x509 -req -in /etc/mysql/ssl/client-req.pem -days 3650 \
+  -CA /etc/mysql/ssl/ca-cert.pem -CAkey /etc/mysql/ssl/ca-key.pem -CAcreateserial \
+  -out /etc/mysql/ssl/client-cert.pem -extensions v3_req -extfile <(cat <<'EOFSSL'
+[v3_req]
+subjectAltName = DNS:localhost,IP:127.0.0.1
+EOFSSL
+)
+
+# Set proper permissions
+chmod 644 /etc/mysql/ssl/ca-cert.pem /etc/mysql/ssl/server-cert.pem /etc/mysql/ssl/client-cert.pem
+chmod 600 /etc/mysql/ssl/ca-key.pem /etc/mysql/ssl/server-key.pem /etc/mysql/ssl/client-key.pem
+
+# Check if mysql user exists, if so set ownership
+if id mysql > /dev/null 2>&1; then
+    chown mysql:mysql /etc/mysql/ssl/ca-cert.pem /etc/mysql/ssl/server-cert.pem /etc/mysql/ssl/server-key.pem
+fi
+
+# Create MariaDB TLS configuration
+cat > /etc/mysql/mariadb.conf.d/99-tls.cnf <<'EOL'
+[mysqld]
+ssl_ca=/etc/mysql/ssl/ca-cert.pem
+ssl_cert=/etc/mysql/ssl/server-cert.pem
+ssl_key=/etc/mysql/ssl/server-key.pem
+require_secure_transport=OFF
+EOL
+
+echo "TLS certificates generated and MariaDB configured for TLS"
 
 localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
@@ -55,4 +114,11 @@ apt-get autoremove -y
 apt-get clean
 
 EOF
+
+# Set TLS environment variables that persist in the container
+ENV DB_SSL_ENABLED="true"
+ENV DB_SSL_CA="/etc/mysql/ssl/ca-cert.pem"
+ENV DB_SSL_CERT="/etc/mysql/ssl/client-cert.pem"
+ENV DB_SSL_KEY="/etc/mysql/ssl/client-key.pem"
+ENV DB_TLS_VERSION="TLSv1.3"
 

--- a/.github/docker/Dockerfile.centreon-collect-mariadb-bullseye-test
+++ b/.github/docker/Dockerfile.centreon-collect-mariadb-bullseye-test
@@ -20,6 +20,7 @@ apt-get -y install \
     locales \
     mariadb-server \
     openssh-server \
+    openssl \
     perl-base \
     psmisc \
     python3 \
@@ -56,4 +57,5 @@ apt-get autoremove -y
 apt-get clean
 
 EOF
+
 

--- a/.github/docker/Dockerfile.centreon-collect-mysql-alma8-test
+++ b/.github/docker/Dockerfile.centreon-collect-mysql-alma8-test
@@ -24,6 +24,7 @@ dnf install --best -y \
     mysql-server \
     mysql \
     openssh-server \
+    openssl \
     python3.11 \
     python3-devel \
     python3.11-pip \
@@ -40,6 +41,64 @@ dnf install --best -y \
 
 dnf clean all
 
+# Generate TLS certificates for MariaDB
+echo "Generating TLS certificates for MariaDB"
+mkdir -p /etc/mysql/ssl
+
+# Generate CA certificate
+openssl req -x509 -newkey rsa:4096 -days 3650 -nodes \
+  -keyout /etc/mysql/ssl/ca-key.pem -out /etc/mysql/ssl/ca-cert.pem \
+  -subj "/CN=Centreon-MariaDB-CA"
+
+# Generate server certificate
+openssl req -newkey rsa:4096 -days 3650 -nodes \
+  -keyout /etc/mysql/ssl/server-key.pem -out /etc/mysql/ssl/server-req.pem \
+  -subj "/CN=localhost"
+
+# Sign server certificate with CA
+openssl x509 -req -in /etc/mysql/ssl/server-req.pem -days 3650 \
+  -CA /etc/mysql/ssl/ca-cert.pem -CAkey /etc/mysql/ssl/ca-key.pem -CAcreateserial \
+  -out /etc/mysql/ssl/server-cert.pem -extensions v3_req -extfile <(cat <<'EOFSSL'
+[v3_req]
+subjectAltName = DNS:localhost,IP:127.0.0.1
+EOFSSL
+)
+
+# Generate client certificate
+openssl req -newkey rsa:4096 -days 3650 -nodes \
+  -keyout /etc/mysql/ssl/client-key.pem -out /etc/mysql/ssl/client-req.pem \
+  -subj "/CN=localhost"
+
+# Sign client certificate with CA
+openssl x509 -req -in /etc/mysql/ssl/client-req.pem -days 3650 \
+  -CA /etc/mysql/ssl/ca-cert.pem -CAkey /etc/mysql/ssl/ca-key.pem -CAcreateserial \
+  -out /etc/mysql/ssl/client-cert.pem -extensions v3_req -extfile <(cat <<'EOFSSL'
+[v3_req]
+subjectAltName = DNS:localhost,IP:127.0.0.1
+EOFSSL
+)
+
+# Set proper permissions
+chmod 644 /etc/mysql/ssl/ca-cert.pem /etc/mysql/ssl/server-cert.pem /etc/mysql/ssl/client-cert.pem
+chmod 600 /etc/mysql/ssl/ca-key.pem /etc/mysql/ssl/server-key.pem /etc/mysql/ssl/client-key.pem
+
+# Check if mysql user exists, if so set ownership
+if id mysql > /dev/null 2>&1; then
+    chown mysql:mysql /etc/mysql/ssl/ca-cert.pem /etc/mysql/ssl/server-cert.pem /etc/mysql/ssl/server-key.pem
+fi
+
+# Create MariaDB TLS configuration
+cat > /etc/my.cnf.d/99-tls.cnf <<'EOL'
+[mysqld]
+ssl_ca=/etc/mysql/ssl/ca-cert.pem
+ssl_cert=/etc/mysql/ssl/server-cert.pem
+ssl_key=/etc/mysql/ssl/server-key.pem
+require_secure_transport=OFF
+EOL
+
+echo "TLS certificates generated and MariaDB configured for TLS"
+
+
 echo "install robot and dependencies"
 pip3.11 install -U robotframework robotframework-databaselibrary robotframework-httpctrl robotframework-examples pymysql python-dateutil psutil
 pip3.11 install grpcio grpcio_tools py-cpuinfo cython gitpython boto3 robotframework-requests cryptography PyJWT
@@ -53,3 +112,11 @@ dnf remove -y gcc gcc-c++ python3-devel
 dnf clean all
 
 EOF
+
+# Set TLS environment variables that persist in the container
+ENV DB_SSL_ENABLED="true"
+ENV DB_SSL_CA="/etc/mysql/ssl/ca-cert.pem"
+ENV DB_SSL_CERT="/etc/mysql/ssl/client-cert.pem"
+ENV DB_SSL_KEY="/etc/mysql/ssl/client-key.pem"
+ENV DB_TLS_VERSION="TLSv1.3"
+

--- a/.github/workflows/robot-test.yml
+++ b/.github/workflows/robot-test.yml
@@ -206,12 +206,19 @@ jobs:
       - name: Move reports
         if: ${{ failure() }}
         run: |
-          mkdir reports
+          mkdir -p reports
           FILE_PREFIX=`echo "${{ matrix.feature }}" | sed -e "s#/#__#g"`-${{ needs.robot-test-list.outputs.test_group_name }}
           if [ -d tests/failed ] ; then
             cp -rp tests/failed reports/$FILE_PREFIX-failed
+          fi
+          if [ -f tests/log.html ] ; then
             cp tests/log.html reports/$FILE_PREFIX-log.html
+          fi
+          if [ -f tests/output.xml ] ; then
             cp tests/output.xml reports/$FILE_PREFIX-output.xml
+          fi
+          if [ -f tests/report.html ] ; then
+            cp tests/report.html reports/$FILE_PREFIX-report.html
           fi
 
       - name: Replace / with - in the feature path

--- a/broker/core/sql/inc/com/centreon/broker/sql/database_config.hh
+++ b/broker/core/sql/inc/com/centreon/broker/sql/database_config.hh
@@ -56,6 +56,13 @@ class database_config {
   // where mariadb will find extension such as caching_sha2_password.so
   std::string _extension_directory;
   std::shared_ptr<spdlog::logger> _config_logger;
+  // SSL/TLS configuration
+  bool _ssl_enabled;
+  std::string _ssl_ca;
+  std::string _ssl_cert;
+  std::string _ssl_key;
+  std::string _tls_version;
+  bool _ssl_verify_cert;
 
   void _internal_copy(database_config const& other);
 
@@ -97,6 +104,12 @@ class database_config {
   const std::string& get_extension_directory() const {
     return _extension_directory;
   }
+  bool get_ssl_enabled() const { return _ssl_enabled; }
+  std::string const& get_ssl_ca() const { return _ssl_ca; }
+  std::string const& get_ssl_cert() const { return _ssl_cert; }
+  std::string const& get_ssl_key() const { return _ssl_key; }
+  std::string const& get_tls_version() const { return _tls_version; }
+  bool get_ssl_verify_cert() const { return _ssl_verify_cert; }
 
   void set_type(std::string const& type);
   void set_host(std::string const& host);

--- a/broker/core/sql/inc/com/centreon/broker/sql/mysql_connection.hh
+++ b/broker/core/sql/inc/com/centreon/broker/sql/mysql_connection.hh
@@ -86,6 +86,12 @@ class mysql_connection {
   const int _port;
   const std::string _extension_directory;
   const unsigned _max_second_commit_delay;
+  const bool _ssl_enabled;
+  const std::string _ssl_ca;
+  const std::string _ssl_cert;
+  const std::string _ssl_key;
+  const std::string _tls_version;
+  const bool _ssl_verify_cert;
   time_t _last_commit;
   std::atomic<connection_state> _state;
 

--- a/broker/core/sql/src/database_config.cc
+++ b/broker/core/sql/src/database_config.cc
@@ -58,7 +58,9 @@ database_config::database_config()
       _connections_count(1),
       _category(SHARED),
       _extension_directory(DEFAULT_MARIADB_EXTENSION_DIR),
-      _config_logger{log_v2::instance().get(log_v2::CONFIG)} {}
+      _config_logger{log_v2::instance().get(log_v2::CONFIG)},
+      _ssl_enabled(false),
+      _ssl_verify_cert(true) {}
 
 /**
  *  Constructor.
@@ -101,7 +103,9 @@ database_config::database_config(const std::string& type,
       _max_commit_delay(max_commit_delay),
       _category(SHARED),
       _extension_directory(DEFAULT_MARIADB_EXTENSION_DIR),
-      _config_logger{log_v2::instance().get(log_v2::CONFIG)} {}
+      _config_logger{log_v2::instance().get(log_v2::CONFIG)},
+      _ssl_enabled(false),
+      _ssl_verify_cert(true) {}
 
 /**
  *  Build a database configuration from a configuration set.
@@ -278,6 +282,70 @@ database_config::database_config(
   if (found != cfg.params.end()) {
     _extension_directory = found->second;
   }
+
+  // SSL/TLS configuration
+  _ssl_enabled = false;
+  found = cfg.params.find("db_ssl_enabled");
+  if (found != cfg.params.end()) {
+    if (!absl::SimpleAtob(found->second, &_ssl_enabled)) {
+      _config_logger->error(
+          "db_ssl_enabled must be a boolean, got '{}'. Defaulting to false.",
+          found->second);
+      _ssl_enabled = false;
+    }
+  }
+  if (_ssl_enabled) {
+    _config_logger->info("SSL/TLS enabled for database connection");
+
+    found = cfg.params.find("db_ssl_ca");
+    if (found != cfg.params.end()) {
+      _ssl_ca = found->second;
+      if (!_ssl_ca.empty()) {
+        _config_logger->info("SSL/TLS CA certificate: {}", _ssl_ca);
+      }
+    }
+
+    found = cfg.params.find("db_ssl_cert");
+    if (found != cfg.params.end()) {
+      _ssl_cert = found->second;
+      if (!_ssl_cert.empty()) {
+        _config_logger->info("SSL/TLS client certificate: {}", _ssl_cert);
+      }
+    }
+
+    found = cfg.params.find("db_ssl_key");
+    if (found != cfg.params.end()) {
+      _ssl_key = found->second;
+      if (!_ssl_key.empty()) {
+        _config_logger->info("SSL/TLS client key configured");
+      }
+    }
+
+    // TLS version configuration (default to TLSv1.2,TLSv1.3)
+    _tls_version = "TLSv1.2,TLSv1.3";
+    found = cfg.params.find("db_tls_version");
+    if (found != cfg.params.end()) {
+      _tls_version = found->second;
+      if (!_tls_version.empty()) {
+        _config_logger->info("TLS version: {}", _tls_version);
+      }
+    }
+
+    // SSL certificate verification (default to true for security)
+    _ssl_verify_cert = true;
+    found = cfg.params.find("db_ssl_verify_cert");
+    if (found != cfg.params.end()) {
+      if (!absl::SimpleAtob(found->second, &_ssl_verify_cert)) {
+        _config_logger->error(
+            "db_ssl_verify_cert must be a boolean, got '{}'. Defaulting to "
+            "true.",
+            found->second);
+        _ssl_verify_cert = true;
+      }
+      _config_logger->info("SSL certificate verification: {}",
+                           _ssl_verify_cert ? "enabled" : "disabled");
+    }
+  }
 }
 
 /**
@@ -317,7 +385,11 @@ bool database_config::operator==(database_config const& other) const {
                 _name == other._name &&
                 _queries_per_transaction == other._queries_per_transaction &&
                 _connections_count == other._connections_count &&
-                _max_commit_delay == other._max_commit_delay};
+                _max_commit_delay == other._max_commit_delay &&
+                _ssl_enabled == other._ssl_enabled &&
+                _ssl_ca == other._ssl_ca && _ssl_cert == other._ssl_cert &&
+                _ssl_key == other._ssl_key &&
+                _ssl_verify_cert == other._ssl_verify_cert};
     if (!retval) {
       auto logger = log_v2::instance().get(log_v2::SQL);
       if (_type != other._type)
@@ -619,6 +691,11 @@ void database_config::_internal_copy(database_config const& other) {
   _connections_count = other._connections_count;
   _max_commit_delay = other._max_commit_delay;
   _extension_directory = other._extension_directory;
+  _ssl_enabled = other._ssl_enabled;
+  _ssl_ca = other._ssl_ca;
+  _ssl_cert = other._ssl_cert;
+  _ssl_key = other._ssl_key;
+  _ssl_verify_cert = other._ssl_verify_cert;
 }
 
 /**

--- a/broker/core/sql/src/mysql_connection.cc
+++ b/broker/core/sql/src/mysql_connection.cc
@@ -197,6 +197,28 @@ bool mysql_connection::_try_to_reconnect() {
   mysql_optionsv(_conn, MYSQL_PLUGIN_DIR,
                  (const void*)_extension_directory.c_str());
 
+  // Configure SSL/TLS if enabled
+  if (_ssl_enabled) {
+    mysql_ssl_set(_conn, _ssl_key.empty() ? nullptr : _ssl_key.c_str(),
+                  _ssl_cert.empty() ? nullptr : _ssl_cert.c_str(),
+                  _ssl_ca.empty() ? nullptr : _ssl_ca.c_str(), nullptr,
+                  nullptr);
+
+    if (!_tls_version.empty()) {
+      mysql_options(_conn, MYSQL_OPT_TLS_VERSION, _tls_version.c_str());
+    }
+
+    // Configure certificate verification based on configuration
+    if (_ssl_verify_cert) {
+      bool verify = true;
+      mysql_options(_conn, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &verify);
+    }
+    SPDLOG_LOGGER_INFO(
+        _logger,
+        "mysql_connection: configuring SSL/TLS for reconnection (verify={})",
+        _ssl_verify_cert);
+  }
+
   if (!mysql_real_connect(_conn, _host.c_str(), _user.c_str(), _pwd.c_str(),
                           _name.c_str(), _port,
                           (_socket == "" ? nullptr : _socket.c_str()),
@@ -855,6 +877,28 @@ void mysql_connection::_run() {
     mysql_optionsv(_conn, MYSQL_PLUGIN_DIR,
                    (const void*)_extension_directory.c_str());
 
+    // Configure SSL/TLS if enabled
+    if (_ssl_enabled) {
+      mysql_ssl_set(_conn, _ssl_key.empty() ? nullptr : _ssl_key.c_str(),
+                    _ssl_cert.empty() ? nullptr : _ssl_cert.c_str(),
+                    _ssl_ca.empty() ? nullptr : _ssl_ca.c_str(), nullptr,
+                    nullptr);
+
+      if (!_tls_version.empty()) {
+        mysql_options(_conn, MYSQL_OPT_TLS_VERSION, _tls_version.c_str());
+      }
+
+      // Configure certificate verification based on configuration
+      if (_ssl_verify_cert) {
+        bool verify = true;
+        mysql_options(_conn, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &verify);
+      }
+      SPDLOG_LOGGER_INFO(
+          _logger,
+          "mysql_connection: configuring SSL/TLS connection (verify={})",
+          _ssl_verify_cert);
+    }
+
     while (config::applier::mode != config::applier::finished &&
            !mysql_real_connect(_conn, _host.c_str(), _user.c_str(),
                                _pwd.c_str(), _name.c_str(), _port,
@@ -1105,6 +1149,12 @@ mysql_connection::mysql_connection(
       _port(db_cfg.get_port()),
       _extension_directory(db_cfg.get_extension_directory()),
       _max_second_commit_delay(db_cfg.get_max_commit_delay()),
+      _ssl_enabled(db_cfg.get_ssl_enabled()),
+      _ssl_ca(db_cfg.get_ssl_ca()),
+      _ssl_cert(db_cfg.get_ssl_cert()),
+      _ssl_key(db_cfg.get_ssl_key()),
+      _tls_version(db_cfg.get_tls_version()),
+      _ssl_verify_cert(db_cfg.get_ssl_verify_cert()),
       _last_commit(db_cfg.get_queries_per_transaction() > 1
                        ? 0
                        : std::numeric_limits<time_t>::max()),
@@ -1249,8 +1299,12 @@ bool mysql_connection::match_config(database_config const& db_cfg) const {
          db_cfg.get_user() == _user && db_cfg.get_password() == _pwd &&
          db_cfg.get_name() == _name && db_cfg.get_port() == _port &&
          db_cfg.get_queries_per_transaction() == _qps &&
-         db_cfg.get_category() == _category;
-  ;
+         db_cfg.get_category() == _category &&
+         db_cfg.get_ssl_enabled() == _ssl_enabled &&
+         db_cfg.get_ssl_ca() == _ssl_ca && db_cfg.get_ssl_cert() == _ssl_cert &&
+         db_cfg.get_ssl_key() == _ssl_key &&
+         db_cfg.get_ssl_verify_cert() == _ssl_verify_cert &&
+         db_cfg.get_tls_version() == _tls_version;
 }
 
 int mysql_connection::get_tasks_count() const {

--- a/broker/doc/tls_database.md
+++ b/broker/doc/tls_database.md
@@ -1,0 +1,110 @@
+# TLS/SSL Database Connection Configuration
+Centreon Broker now supports secured TLS 1.2/1.3 connections to MySQL/MariaDB databases. This feature allows you to encrypt the communication between Centreon Broker and the database servers.
+
+## Configuration Parameters
+
+The following parameters can be added to any database output configuration (unified_sql, sql, storage) in your Centreon Broker configuration file:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `db_ssl_enabled` | boolean | No | `false` | Enable SSL/TLS for database connection |
+| `db_ssl_ca` | string | No | - | Path to the Certificate Authority (CA) certificate file in PEM format |
+| `db_ssl_cert` | string | No | - | Path to the client certificate file in PEM format |
+| `db_ssl_key` | string | No | - | Path to the client private key file in PEM format |
+| `db_tls_version` | string | No | `TLSv1.3` | TLS protocol version(s) to use (e.g., "TLSv1.2", "TLSv1.3", "TLSv1.2,TLSv1.3") |
+| `db_ssl_verify_cert` | boolean | No | `true` | Enable certificate verification (identity check) |
+
+### Minimal TLS Configuration (Server Authentication Only)
+
+If you only want to verify the server's identity without client certificate authentication:
+
+```json
+{
+  "centreon-broker-unified-sql": {
+    "type": "unified_sql",
+    "db_type": "mysql",
+    "db_host": "database.example.com",
+    "db_port": "3306",
+    "db_user": "centreon",
+    "db_password": "password",
+    "db_name": "centreon_storage",
+    "db_ssl_enabled": "true",
+    "db_ssl_ca": "/etc/centreon-broker/ssl/ca-cert.pem",
+    "db_ssl_verify_cert": "true"
+  }
+}
+```
+
+### TLS without Certificate Verification
+
+```json
+{
+  "centreon-broker-unified-sql": {
+    "type": "unified_sql",
+    "db_type": "mysql",
+    "db_host": "database.example.com",
+    "db_port": "3306",
+    "db_user": "centreon",
+    "db_password": "password",
+    "db_name": "centreon_storage",
+    "db_ssl_enabled": "true",
+    "db_ssl_verify_cert": "false"
+  }
+}
+```
+### MariaDB/MySQL Server Configuration
+
+Configure your MariaDB/MySQL server to support SSL connections:
+
+### Database Configuration 
+mariadb (`/etc/mysql/mariadb.conf.d/99-tls.cnf`)
+mysql (`/etc/my.cnf.d/99-tls.cnf`)
+
+```ini
+[mysqld]
+ssl_ca=/path/to/ca-cert.pem
+ssl_cert=/path/to/server-cert.pem
+ssl_key=/path/to/server-key.pem
+
+# Optional: Require SSL for specific users
+# In MySQL/MariaDB console:
+# ALTER USER 'centreon'@'%' REQUIRE SSL;
+# Or for mutual TLS authentication:
+# ALTER USER 'centreon'@'%' REQUIRE X509;
+```
+
+Restart MariaDB after configuration changes:
+```bash
+systemctl restart mariadb
+```
+
+### Verify Server SSL Configuration
+
+```bash
+mysql -u root -p -e "SHOW VARIABLES LIKE '%ssl%';"
+```
+
+You should see `have_ssl` set to `YES`.
+
+## Verification
+
+### Check Broker Logs
+
+After enabling SSL, check the Centreon Broker logs for SSL-related messages:
+
+```bash
+grep -i ssl /var/log/centreon-broker/central-broker-master.log
+```
+
+Expected log entries:
+```
+[2026-02-17 10:00:00] [info] SSL/TLS enabled for database connection
+```
+
+**Test connection manually**:
+```bash
+mysql --ssl-ca=/path/to/ca-cert.pem \
+         --ssl-cert=/path/to/client-cert.pem \
+         --ssl-key=/path/to/client-key.pem \
+         -h <host> -u <user> -p
+```

--- a/tests/broker-database/tls_connection.robot
+++ b/tests/broker-database/tls_connection.robot
@@ -1,0 +1,47 @@
+*** Settings ***
+Documentation       Centreon Broker database TLS/SSL connection tests
+
+Resource            ../resources/import.resource
+
+Suite Setup         Ctn Clean Before Suite
+Suite Teardown      Ctn Clean After Suite
+Test Setup          Ctn Stop Processes
+Test Teardown       Ctn Stop Engine Broker And Save Logs
+
+
+*** Test Cases ***
+BDBTSSLC1
+    [Documentation]    Verify broker establishes TLS connection to database when DB_SSL_ENABLED is true
+    [Tags]    broker    database    tls    MON-191981
+    Skip If    '${DBSslEnabled}' != 'true'    Test requires DB_SSL_ENABLED=true
+
+    Ctn Config Engine    ${1}
+    Ctn Config Broker    central
+    Ctn Config Broker    module
+    Ctn Config Broker Sql Output    central    unified_sql
+    Ctn Broker Config Log    central    sql    debug
+    Ctn Config Broker Sql Output    central    unified_sql
+    Ctn Broker Config Output Set    central    central-broker-unified-sql    db_host    127.0.0.1
+    Ctn Broker Config Output Set    central    central-broker-unified-sql    db_ssl_enabled    ${DBSslEnabled}
+    Ctn Broker Config Output Set    central    central-broker-unified-sql    db_ssl_verify_cert    true
+
+
+    ${start}    Get Current Date
+    Ctn Start Broker
+    Ctn Start Engine
+
+    # Check for TLS configuration message in broker logs
+    ${content}    Create List    mysql_connection: configuring SSL/TLS connection
+    ${result}    Ctn Find In Log With Timeout    ${centralLog}    ${start}    ${content}    30
+    Should Be True    ${result}    msg=TLS configuration message not found in broker logs
+
+    # Verify database connection was established successfully (not just configured)
+    ${content}    Create List    unified sql: stream class instanciation
+    ${result}    Ctn Find In Log With Timeout    ${centralLog}    ${start}    ${content}    30
+    Should Be True    ${result}    msg=Database connection not established
+
+    # Verify the connection is working by checking for SQL queries in logs
+    # This confirms the SSL connection was successful and broker can communicate with DB
+    ${content}    Create List    run query:
+    ${result}    Ctn Find In Log With Timeout    ${centralLog}    ${start}    ${content}    30
+    Should Be True    ${result}    msg=No SQL queries executed - TLS connection may have failed

--- a/tests/resources/Broker.py
+++ b/tests/resources/Broker.py
@@ -39,7 +39,7 @@ import broker_pb2
 import broker_pb2_grpc
 from google.protobuf import empty_pb2
 from google.protobuf.json_format import MessageToJson, MessageToDict
-from Common import DB_NAME_STORAGE, DB_NAME_CONF, DB_USER, DB_PASS, DB_HOST, DB_PORT, VAR_ROOT, ETC_ROOT, TESTS_PARAMS
+from Common import DB_NAME_STORAGE, DB_NAME_CONF, DB_USER, DB_PASS, DB_HOST, DB_PORT, VAR_ROOT, ETC_ROOT, TESTS_PARAMS, DB_SSL_ENABLED, DB_SSL_CA, DB_SSL_CERT, DB_SSL_KEY, DB_TLS_VERSION
 
 TIMEOUT = 30
 
@@ -909,8 +909,23 @@ def ctn_config_broker_sql_output(name, output, queries_per_transaction: int = 20
         if v["type"] == "sql" or v["type"] == "storage" or v["type"] == "unified_sql":
             output_dict.pop(i)
     str_queries_per_transaction = str(queries_per_transaction)
+
+    # Add TLS configuration if enabled
+    tls_config = {}
+    if DB_SSL_ENABLED and DB_SSL_ENABLED.lower() in ['true', 'yes', '1']:
+        tls_config["db_ssl_enabled"] = "true"
+        tls_config["db_ssl_verify"] = "true"
+        if DB_SSL_CA:
+            tls_config["db_ssl_ca"] = DB_SSL_CA
+        if DB_SSL_CERT:
+            tls_config["db_ssl_cert"] = DB_SSL_CERT
+        if DB_SSL_KEY:
+            tls_config["db_ssl_key"] = DB_SSL_KEY
+        if DB_TLS_VERSION:
+            tls_config["db_tls_version"] = DB_TLS_VERSION
+
     if output == 'unified_sql':
-        output_dict.append({
+        unified_sql_output = {
             "name": "central-broker-unified-sql",
             "db_type": "mysql",
             "db_host": DB_HOST,
@@ -929,9 +944,11 @@ def ctn_config_broker_sql_output(name, output, queries_per_transaction: int = 20
             "type": "unified_sql",
             "store_in_data_bin": "yes",
             "insert_in_index_data": "1"
-        })
+        }
+        unified_sql_output.update(tls_config)
+        output_dict.append(unified_sql_output)
     elif output == 'sql/perfdata':
-        output_dict.append({
+        sql_output = {
             "name": "central-broker-master-sql",
             "db_type": "mysql",
             "retry_interval": "5",
@@ -945,8 +962,11 @@ def ctn_config_broker_sql_output(name, output, queries_per_transaction: int = 20
             "connections_count": "3",
             "read_timeout": "1",
             "type": "sql"
-        })
-        output_dict.append({
+        }
+        sql_output.update(tls_config)
+        output_dict.append(sql_output)
+
+        storage_output = {
             "name": "central-broker-master-perfdata",
             "interval": "60",
             "retry_interval": "5",
@@ -965,7 +985,9 @@ def ctn_config_broker_sql_output(name, output, queries_per_transaction: int = 20
             "connections_count": "3",
             "insert_in_index_data": "1",
             "type": "storage"
-        })
+        }
+        storage_output.update(tls_config)
+        output_dict.append(storage_output)
     with open(f"{ETC_ROOT}/centreon-broker/{filename}", "w") as f:
         f.write(json.dumps(conf, indent=2))
 

--- a/tests/resources/Common.py
+++ b/tests/resources/Common.py
@@ -65,6 +65,11 @@ DB_USER = ""
 DB_PASS = ""
 DB_HOST = ""
 DB_PORT = ""
+DB_SSL_ENABLED = os.environ.get("DB_SSL_ENABLED", "")
+DB_SSL_CA = os.environ.get("DB_SSL_CA", "")
+DB_SSL_CERT = os.environ.get("DB_SSL_CERT", "")
+DB_SSL_KEY = os.environ.get("DB_SSL_KEY", "")
+DB_TLS_VERSION = os.environ.get("DB_TLS_VERSION", "")
 VAR_ROOT = ""
 ETC_ROOT = ""
 

--- a/tests/resources/db_variables.resource
+++ b/tests/resources/db_variables.resource
@@ -9,3 +9,8 @@ ${DBPass}           centreon
 ${DBPort}           3306
 ${DBUserRoot}       root_centreon
 ${DBPassRoot}       centreon
+${DBSslEnabled}     %{DB_SSL_ENABLED=}
+${DBSslCa}          %{DB_SSL_CA=}
+${DBSslCert}        %{DB_SSL_CERT=}
+${DBSslKey}         %{DB_SSL_KEY=}
+${DBTlsVersion}     %{DB_TLS_VERSION=TLSv1.3}


### PR DESCRIPTION
* feat(broker): TLS configuration support for database connections
* refactor(Dockerfile):  TLS certificate generation and configuration for MariaDB bulleye to bookworm
* fix(tests): disable require_secure_transport / python script don't use tls

REFS: MON-196287


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Enabled TLS configuration and certificates for database connections in Broker

**🔧 Refactors**
* Adjusted GitHub Actions workflow to create reports directory safely


<sup>[More info](https://app.aikido.dev/featurebranch/scan/91145840?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->