### PR TITLE
fix(engine) : copy Subject alt name when generating cert. (#3221) 

### DIFF
--- a/broker/core/sql/src/database_config.cc
+++ b/broker/core/sql/src/database_config.cc
@@ -285,6 +285,7 @@ database_config::database_config(
 
   // SSL/TLS configuration
   _ssl_enabled = false;
+  _ssl_verify_cert = true;
   found = cfg.params.find("db_ssl_enabled");
   if (found != cfg.params.end()) {
     if (!absl::SimpleAtob(found->second, &_ssl_enabled)) {
@@ -330,9 +331,7 @@ database_config::database_config(
         _config_logger->info("TLS version: {}", _tls_version);
       }
     }
-
     // SSL certificate verification (default to true for security)
-    _ssl_verify_cert = true;
     found = cfg.params.find("db_ssl_verify_cert");
     if (found != cfg.params.end()) {
       if (!absl::SimpleAtob(found->second, &_ssl_verify_cert)) {

--- a/common/crypto/cert_tree.cc
+++ b/common/crypto/cert_tree.cc
@@ -51,6 +51,37 @@ class ssl_exception : public std::runtime_error {
 
 using namespace com::centreon::common::crypto;
 
+namespace {
+static void copy_subject_alt_name_extensions(const X509* source, X509* target) {
+  if (!source || !target) {
+    return;
+  }
+
+  for (int ext_index = X509_get_ext_by_NID(source, NID_subject_alt_name, -1);
+       ext_index >= 0; ext_index = X509_get_ext_by_NID(
+                           source, NID_subject_alt_name, ext_index)) {
+    X509_EXTENSION* source_ext = X509_get_ext(source, ext_index);
+    if (!source_ext) {
+      throw com::centreon::exceptions::msg_fmt(
+          "unable to read source subjectAltName extension");
+    }
+
+    X509_EXTENSION* copied_ext = X509_EXTENSION_dup(source_ext);
+    if (!copied_ext) {
+      throw com::centreon::exceptions::msg_fmt(
+          "unable to duplicate source subjectAltName extension");
+    }
+
+    const int add_status = X509_add_ext(target, copied_ext, -1);
+    X509_EXTENSION_free(copied_ext);
+    if (add_status != 1) {
+      throw com::centreon::exceptions::msg_fmt(
+          "unable to add subjectAltName extension to generated certificate");
+    }
+  }
+}
+}  // namespace
+
 /**
  * @brief load a certificate from pem format file
  *
@@ -286,6 +317,7 @@ X509* cert_tree::generate_cert(const EVP_PKEY* pkey,
   // Issuer
   if (ca_cert) {
     X509_set_issuer_name(x509, X509_get_subject_name(ca_cert));
+    copy_subject_alt_name_extensions(ca_cert, x509);
   } else {
     X509_set_issuer_name(x509, name);  // auto-signé
     // Extension : Basic Constraints = CA:TRUE

--- a/engine/modules/opentelemetry/src/open_telemetry.cc
+++ b/engine/modules/opentelemetry/src/open_telemetry.cc
@@ -16,8 +16,8 @@
  * For more information : contact@centreon.com
  */
 
+#include <openssl/x509v3.h>
 #include "centreon_agent/agent_service.hh"
-#include "com/centreon/exceptions/msg_fmt.hh"
 
 #include "centreon_agent/agent_impl.hh"
 #include "com/centreon/common/http/https_connection.hh"

--- a/tests/broker-engine/cma.robot
+++ b/tests/broker-engine/cma.robot
@@ -1181,6 +1181,68 @@ BEOTEL_CENTREON_AGENT_CHECK_HOST_CRYPTED_MANY_AGENT
 
     [teardown]    Run Keywords     Ctn Kindly Stop Agent    ${2}     AND     Ctn Stop Engine Broker And Save Logs
 
+BEOTEL_CENTREON_AGENT_CHECK_HOST_CRYPTED_SAN_IP
+    [Documentation]    Given an engine with an encrypted otel server using a self-signed cert
+    ...    whose CN does not match the hostname but has IP:127.0.0.1 and DNS:<hostname> in SAN,
+    ...    with minute_certificate_ttl triggering cert regeneration,
+    ...    the agent should connect successfully because SANs are copied to the generated cert.
+    [Tags]    broker    engine    opentelemetry    MON-195905    Only_linux
+
+    ${run_env}    Ctn Run Env
+    Pass Execution If    "${run_env}" == "WSL"    "This test is only for linux"
+
+    Ctn Config Engine    ${1}    ${2}    ${2}
+
+    # Create a self-signed cert with CN=san-test (wrong) but SAN=DNS:<hostname>,IP:127.0.0.1
+    # Without the SAN copy fix, the generated cert would only have CN=san-test => peer verification fails
+    ${host_name}    Ctn Host Hostname
+    Run    openssl ecparam -genkey -name prime256v1 -noout -out /tmp/server_san.key
+    Run    openssl req -new -x509 -key /tmp/server_san.key -out /tmp/server_san.crt -days 1 -subj '/CN=xxxxx' -addext 'subjectAltName=DNS:${host_name},IP:127.0.0.1'
+
+    Ctn Add Otl ServerModule
+    ...    0
+    ...    {"otel_server":{"host": "0.0.0.0","port": 4318, "encryption": "full", "public_cert": "/tmp/server_san.crt", "private_key": "/tmp/server_san.key"}, "centreon_agent":{"export_period":5}}
+    Ctn Config Add Otl Connector
+    ...    0
+    ...    OTEL connector
+    ...    opentelemetry --processor=centreon_agent --extractor=attributes --host_path=resource_metrics.resource.attributes.host.name --service_path=resource_metrics.resource.attributes.service.name
+    Ctn Engine Config Replace Value In Hosts    ${0}    host_1    check_command    otel_check_icmp
+
+    ${echo_command}    Ctn Echo Command    "OK - 127.0.0.1: rta 0,010ms, lost 0%|rta=0,010ms;200,000;500,000;0; pl=0%;40;80;; rtmax=0,035ms;;;; rtmin=0,003ms;;;;"
+    Ctn Engine Config Add Command    ${0}    otel_check_icmp    ${echo_command}    OTEL connector
+    Ctn Set Hosts Passive    ${0}    host_1
+    Ctn Engine Config Set Value    0    interval_length    10
+    Ctn Engine Config Set Value In Hosts    ${0}    host_1    check_interval    1
+
+    Ctn Engine Config Set Value    0    log_level_checks    trace
+
+    Ctn Config Broker    central
+    Ctn Config Broker    module
+    Ctn Config Broker    rrd
+    ${token}    Ctn Create Jwt Token    ${3600}
+    Ctn Config Centreon Agent    ${None}    ${None}    /tmp/server_san.crt    ${token}
+    Ctn Add Token Otl Server Module    0    ${token}
+    Ctn Broker Config Log    central    sql    trace
+
+    Ctn Config BBDO3    1
+    Ctn Clear Retention
+
+    ${start}    Get Current Date
+    ${start_int}    Ctn Get Round Current Date
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Start Agent
+
+    # Let's wait for the otel server start
+    ${content}    Create List    ] encrypted server listening on 0.0.0.0:4318
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    20
+    Should Be True    ${result}    "encrypted server listening on 0.0.0.0:4318" should be available.
+    Sleep    1
+
+    # Agent must connect: the generated cert has SANs (DNS:<hostname>,IP:127.0.0.1) copied from the CA
+    ${result}    Ctn Check Host Output Resource Status With Timeout    host_1    120    ${start_int}    0  HARD  OK - 127.0.0.1
+    Should Be True    ${result}    resources table not updated - SAN was not copied to generated cert
+
 BEOTEL_CENTREON_AGENT_CHECK_HOST_CRYPTED_RENEW_CERT
     [Documentation]    Given an engine with an encrypted otel server with one minute ttl, we expect that otel server
     ...    will restart after on minute, then we recreate certificates and otel server must restart also


### PR DESCRIPTION
* fix(engine): copy Subject alt name when generating cert. (#3221) 

REFS: MON-196387

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added routine to copy SubjectAltName extensions between certificates.

**🐛 Bugfixes**
* Copied SAN extensions from CA cert into newly generated certificates.
* Fixed uninitialized boolean to avoid undefined behavior at startup.

**🔧 Refactors**
* Included openssl/x509v3 header in open_telemetry to support SAN handling.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/92185900?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->