### PR TITLE
MON-196466 no more defer in broker engine

### DIFF
--- a/broker/core/bbdo/precomp_inc/precomp.hh
+++ b/broker/core/bbdo/precomp_inc/precomp.hh
@@ -21,7 +21,10 @@
 
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/spdlog.h>
+#include <boost/asio.hpp>
 #include <deque>
 #include <list>
+
+namespace asio = boost::asio;
 
 #endif /* !CC_CORE_BBDO_PRECOMP_HH */

--- a/broker/core/multiplexing/inc/com/centreon/broker/multiplexing/engine.hh
+++ b/broker/core/multiplexing/inc/com/centreon/broker/multiplexing/engine.hh
@@ -84,6 +84,7 @@ class engine {
   std::shared_ptr<stats::center> _center;
   EngineStats* _stats;
 
+  std::shared_ptr<asio::io_context> _io_context;
   std::atomic_bool _sending_to_subscribers;
 
   std::shared_ptr<spdlog::logger> _logger;

--- a/broker/core/multiplexing/src/engine.cc
+++ b/broker/core/multiplexing/src/engine.cc
@@ -27,7 +27,6 @@
 #include "com/centreon/broker/io/events.hh"
 #include "com/centreon/broker/misc/misc.hh"
 #include "com/centreon/broker/multiplexing/muxer.hh"
-#include "com/centreon/common/defer.hh"
 #include "com/centreon/common/pool.hh"
 #include "common/log_v2/log_v2.hh"
 
@@ -304,6 +303,7 @@ engine::engine(const std::shared_ptr<spdlog::logger>& logger)
       _unprocessed_events{0u},
       _center{config::applier::state::instance().center()},
       _stats{_center->register_engine()},
+      _io_context(common::pool::instance().io_context_ptr()),
       _sending_to_subscribers{false},
       _logger{logger} {
   _center->update(&EngineStats::set_mode, _stats, EngineStats::NOT_STARTED);
@@ -359,6 +359,9 @@ class callback_caller {
       if (_callback) {
         _callback();
       }
+      // if data has arrived during sending => send
+      asio::post(*_parent->_io_context,
+                 [me = _parent]() { me->_send_to_subscribers(nullptr); });
     }
   }
 };
@@ -378,10 +381,6 @@ bool engine::_send_to_subscribers(send_to_mux_callback_type&& callback) {
   // is _send_to_subscriber working? (_sending_to_subscribers=false)
   bool expected = false;
   if (!_sending_to_subscribers.compare_exchange_strong(expected, true)) {
-    // sending  => we will try later
-    common::defer(com::centreon::common::pool::io_context_ptr(),
-                  std::chrono::milliseconds(100),
-                  [me = _instance]() { me->_send_to_subscribers(nullptr); });
     return false;
   }
   // Now we continue and _sending_to_subscribers is true.
@@ -396,6 +395,10 @@ bool engine::_send_to_subscribers(send_to_mux_callback_type&& callback) {
       // nothing to do true => _sending_to_subscribers
       bool expected = true;
       _sending_to_subscribers.compare_exchange_strong(expected, false);
+      return false;
+    }
+    if (_state != state::running) {
+      _sending_to_subscribers.store(false);
       return false;
     }
 
@@ -422,19 +425,18 @@ bool engine::_send_to_subscribers(send_to_mux_callback_type&& callback) {
       } else {
         std::shared_ptr<muxer> mux_to_publish_in_asio = mux.lock();
         if (mux_to_publish_in_asio) {
-          asio::post(com::centreon::common::pool::io_context(),
-                     [kiew, mux_to_publish_in_asio, cb, logger = _logger]() {
-                       try {
-                         mux_to_publish_in_asio->publish(*kiew);
-                       }  // pool threads protection
-                       catch (const std::exception& ex) {
-                         SPDLOG_LOGGER_ERROR(
-                             logger, "publish caught exception: {}", ex.what());
-                       } catch (...) {
-                         SPDLOG_LOGGER_ERROR(
-                             logger, "publish caught unknown exception");
-                       }
-                     });
+          asio::post(*_io_context, [kiew, mux_to_publish_in_asio, cb,
+                                    logger = _logger]() {
+            try {
+              mux_to_publish_in_asio->publish(*kiew);
+            }  // pool threads protection
+            catch (const std::exception& ex) {
+              SPDLOG_LOGGER_ERROR(logger, "publish caught exception: {}",
+                                  ex.what());
+            } catch (...) {
+              SPDLOG_LOGGER_ERROR(logger, "publish caught unknown exception");
+            }
+          });
         }
       }
     }


### PR DESCRIPTION
REFS:MON-196466

## Description

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).



<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Removed use of custom defer utility and its include
* Introduced boost::asio include, alias and io_context member


<sup>[More info](https://app.aikido.dev/featurebranch/scan/92259169?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->