### PR TITLE
MON-196549 Gorgone - Disable Hooks::EndOfScope::XS module on Alma10

### DIFF
--- a/gorgone/gorgone/class/db.pm
+++ b/gorgone/gorgone/class/db.pm
@@ -24,6 +24,14 @@ use strict;
 use warnings;
 use DBI;
 
+BEGIN {
+    if (-f "/etc/redhat-release" && open(my $fic, "/etc/redhat-release")) {
+        # Disable Hooks::EndOfScope::XS module on Alma10 MON-196549
+        $ENV{B_HOOKS_ENDOFSCOPE_IMPLEMENTATION} = 'PP' if <$fic> =~ /release 10/;
+        close($fic);
+    }
+}
+
 sub new {
     my ($class, %options) = @_;
     my %defaults = (


### PR DESCRIPTION
## Description

tests/unit/modules/centreon/mbi/etl/mbietl.t failed on alma10

**Fixes** #  MON-196549

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)



<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Disabled Hooks::EndOfScope::XS on Alma10 by setting environment variable


<sup>[More info](https://app.aikido.dev/featurebranch/scan/93478787?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->