### PR TITLE
fix(gorgone): add VACUUM command to DB Cleaner

### DIFF
--- a/gorgone/gorgone/modules/core/dbcleaner/class.pm
+++ b/gorgone/gorgone/modules/core/dbcleaner/class.pm
@@ -127,11 +127,14 @@ sub action_dbclean {
         query => "DELETE FROM gorgone_history WHERE (instant = 1 AND `ctime` <  " . (time() - 86400) . ") OR `ctime` < ?",
         bind_values => [time() - $self->{config}->{purge_history_time}]
     });
+    my ($status3) = $self->{db_gorgone}->query({
+        query => "VACUUM"
+    });
     $self->{purge_timer} = time();
 
     $self->{logger}->writeLogDebug("[dbcleaner] Purge finished");
 
-    if ($status == -1 || $status2 == -1) {
+    if ($status == -1 || $status2 == -1 || $status3 == -1) {
         $self->send_log(
             code => GORGONE_ACTION_FINISH_KO,
             token => $options{token},


### PR DESCRIPTION
## Description

The DB Cleaner module purge entries withtout freeing disk space. The VACUUM command was added to fix this issue.

Fixes: https://centreon.atlassian.net/browse/MON-195930

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [X] master

<h2> How this pull request can be tested ? </h2>

* Wait for the DB Cleaner run (every hour by default, can be changed https://github.com/centreon/centreon-collect/blob/develop/gorgone/docs/modules/core/dbcleaner.md)
* Check /var/lib/centreon-gorgone/history.sdb size
* Apply the fix and restart gorgoned
* Wait for DB Cleaner run
* Check /var/lib/centreon-gorgone/history.sdb size


## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Added VACUUM command to DB cleaner to free disk space


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106094223?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->