### PR TITLE
chore: enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Add `* text=auto eol=lf` to normalize line endings and prevent CRLF from being committed.

Refs: MON-32897



