### PR TITLE
enh(ci): add github cache clean (#3267)

### DIFF
--- a/.github/workflows/clean-cache.yml
+++ b/.github/workflows/clean-cache.yml
@@ -1,0 +1,35 @@
+name: clean-cache-on-pr-close
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  clean-cache:
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+    steps:
+      - name: Delete all caches for closed PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO="${{ github.repository }}"
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+
+          echo "Fetching cache keys for: $BRANCH"
+          mapfile -t cache_keys < <(gh cache list --ref "$BRANCH" --json key -q '.[] | .key' -R "$REPO")
+
+          if [ ${#cache_keys[@]} -eq 0 ]; then
+            echo "No caches found for this PR."
+            exit 0
+          fi
+
+          echo "Found ${#cache_keys[@]} cache(s) to delete."
+          set +e
+          for key in "${cache_keys[@]}"; do
+            gh cache delete "$key" --ref "$BRANCH" -R "$REPO"
+            echo "Deleted cache: $key"
+          done
+          echo "Done."


### PR DESCRIPTION
* enh(ci): add github cache scheduled clean and pruning

* move prune cache to another pull request

* update limit to match the 20GB limit of current setup

* Remove check-cache-usage job from collect.yml

Removed the check-cache-usage job from the workflow. Moved to delivery tools

## Description

* add github cache clean and pruning to mitigate cache cap hits
* add a preview of available cache left

**Fixes** #MON-196861
 **Backports** https://github.com/centreon/centreon-collect/pull/3267

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).



<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added GitHub Actions workflow to delete PR caches on close


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98220485?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->