### PR TITLE
chore: enforce LF line endings via .gitattributes (#3275)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Add * text=auto eol=lf to normalize line endings and prevent CRLF from being committed.

**Fixes** Refs: MON-32897
**Backports** https://github.com/centreon/centreon-collect/pull/3275