### PR TITLE
MON-181828: do not package and deliver bullseye for cloud release branche

### DIFF
--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -787,7 +787,9 @@ jobs:
             if (isFullRun) {
               matrix = { ...matrix, operating_systems: configs };
               collectMatrix = configs;
-              cmaMatrix = cmaConfigs;
+              cmaMatrix = isCloud
+                ? cmaConfigs.filter(c => c.operating_system !== 'bullseye')
+                : cmaConfigs;
             }
 
             console.log('matrix', matrix);

--- a/.github/workflows/monitoring-agent.yml
+++ b/.github/workflows/monitoring-agent.yml
@@ -551,6 +551,7 @@ jobs:
 
     steps:
       - name: Checkout sources
+        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Publish DEB packages
@@ -627,6 +628,7 @@ jobs:
 
     steps:
       - name: Checkout sources
+        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Promote ${{ matrix.distrib }} to stable
@@ -644,6 +646,7 @@ jobs:
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
       - name: Parse distrib name
+        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
         id: parse-distrib
         uses: ./.github/actions/parse-distrib
         with:

--- a/.github/workflows/monitoring-agent.yml
+++ b/.github/workflows/monitoring-agent.yml
@@ -554,6 +554,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Publish DEB packages
+        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
         uses: ./.github/actions/deb-delivery
         with:
           module_name: monitoring-agent
@@ -629,6 +630,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Promote ${{ matrix.distrib }} to stable
+        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
         uses: ./.github/actions/promote-to-stable
         with:
           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}


### PR DESCRIPTION
## Description

Bullseye (Debian 11) skip for cloud build

## Changes

  - `get-environment.yml`: filter bullseye out of `cmaMatrix` when `isCloud` is true
  - `monitoring-agent.yml`: skip DEB delivery step for bullseye on cloud
  - `monitoring-agent.yml`: skip promote-to-stable step for bullseye on cloud

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Excluded bullseye packaging and delivery steps for cloud release branches

**🔧 Refactors**
* Wrapped non-essential workflow steps with conditional checks to skip


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101526688?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->