### PR TITLE
fix(nightly-docker): remove usermod from centreon-poller dockerfile

### DIFF
--- a/.github/docker/Dockerfile.centreon-collect-mysql-alma9-test
+++ b/.github/docker/Dockerfile.centreon-collect-mysql-alma9-test
@@ -16,7 +16,7 @@ dnf install -y epel-release
 #we force mysql8.4 install
 dnf install -y wget
 wget https://dev.mysql.com/get/mysql84-community-release-el9-1.noarch.rpm
-# add mysql 8.4 repo 
+# add mysql 8.4 repo
 rpm -ivh mysql84-community-release-el9-1.noarch.rpm
 #disable native mysql package from platform vendor
 yum module -y disable mysql

--- a/.github/docker/centreon-poller/alma9/Dockerfile
+++ b/.github/docker/centreon-poller/alma9/Dockerfile
@@ -35,12 +35,6 @@ fi
 
 dnf install -y /tmp/packages-centreon/centreon-*.rpm centreon-gorgone
 
-# temporary fix and inspired by from centreon-poller-postinstall.sh
-usermod centreon-engine -a -G centreon,centreon-broker,centreon-gorgone
-usermod centreon-broker -a -G centreon
-usermod centreon -a -G centreon-engine,centreon-broker
-usermod centreon-gorgone -a -G centreon-engine,centreon-broker,centreon
-
 systemctl stop gorgoned
 systemctl stop centengine
 


### PR DESCRIPTION
fix(nightly-docker): remove usermod temporary fix from centreon-poller dockerfile

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🔧 Refactors**
* Removed temporary usermod commands from centreon-poller Dockerfile setup
* Fixed comment formatting when adding MySQL 8.4 repo in Dockerfile


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99406835?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->