### PR TITLE
fix(ci): deduplicate alma9 in gorgone packaging matrix

### DIFF
--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -785,7 +785,8 @@ jobs:
             let cmaMatrix = [activeConfig];
 
             if (isFullRun) {
-              matrix = { ...matrix, operating_systems: configs };
+              const uniqueOsConfigs = [...new Map(configs.map(c => [`${c.operating_system}-${c.arch}`, c])).values()];
+              matrix = { ...matrix, operating_systems: uniqueOsConfigs };
               collectMatrix = configs;
               cmaMatrix = cmaConfigs;
             }


### PR DESCRIPTION
## Problem

In full run mode (`unstable`, `testing`, `stable` stability), `configs` contains two alma9 entries:
- `{alma9, mariadb:10.11, amd64}`
- `{alma9, mysql:8.0, amd64}`

These are fed directly into `os_and_database_matrix.operating_systems` which is used by all four jobs in `gorgone.yml`:
- `unit-test-perl`
- `package`
- `dockerize`
- `robot-test`

None of these jobs use `matrix.database`. As a result, all four jobs run **twice** for alma9, and the two `package` runs produce packages with **identical cache keys** (since the key doesn't include the database), causing one to silently overwrite the other.

## Fix

Apply the same deduplication by `os+arch` that already exists for `collectMatrix` (line ~809), so `operating_systems` contains only one entry per distro.

```js
const uniqueOsConfigs = [...new Map(configs.map(c => [`${c.operating_system}-${c.arch}`, c])).values()];
matrix = { ...matrix, operating_systems: uniqueOsConfigs };
```

`collectMatrix` (used by `collect.yml`) is left unchanged — it keeps the full `configs` list and gets its own deduplication step later.

## Impact

- `package`, `dockerize`, `unit-test-perl`, `robot-test` in `gorgone.yml` will now run once per distro instead of twice for alma9.
- No functional change for `collect.yml` or any other workflow.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Deduplicated operating_systems entries to prevent duplicate alma9 jobs


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101426323?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->