### PR TITLE
enh(engine): add instance_id to PB_SERVICE protobuf message

### DIFF
--- a/bbdo/neb.proto
+++ b/bbdo/neb.proto
@@ -153,6 +153,7 @@ message Service {
    * here. */
   uint64 internal_id = 86;
   uint64 icon_id = 87;
+  uint64 instance_id = 88;
 }
 
 /**

--- a/broker/lua/test/lua.cc
+++ b/broker/lua/test/lua.cc
@@ -4375,10 +4375,10 @@ TEST_F(LuaTest, ServiceObjectMatchBetweenBbdoVersions) {
 
   auto it = l1.begin();
   for (auto it1 = l2.begin(); it1 != l2.end();) {
-    if (*it1 == "host_name" || *it1 == "icon_id" || *it1 == "internal_id" ||
-        *it1 == "is_volatile" || *it1 == "long_output" ||
-        *it1 == "severity_id" || *it1 == "tags" || *it1 == "type" ||
-        *it1 == "command_line") {
+    if (*it1 == "host_name" || *it1 == "icon_id" || *it1 == "instance_id" ||
+        *it1 == "internal_id" || *it1 == "is_volatile" ||
+        *it1 == "long_output" || *it1 == "severity_id" || *it1 == "tags" ||
+        *it1 == "type" || *it1 == "command_line") {
       ++it1;
       continue;
     }

--- a/engine/src/broker.cc
+++ b/engine/src/broker.cc
@@ -1147,6 +1147,7 @@ static void forward_pb_service(int type,
                                : engine::notifier::hard));
     srv.set_severity_id(es->get_severity() ? es->get_severity()->id() : 0);
     srv.set_icon_id(es->get_icon_id());
+    srv.set_instance_id(cbm->poller_id());
 
     for (auto& tg : es->tags()) {
       com::centreon::broker::TagInfo* ti = srv.mutable_tags()->Add();


### PR DESCRIPTION
## Description

Add `instance_id` (field 88) to the `Service` protobuf message so BBDO consumers can identify which poller sent a PB_SERVICE packet. This is needed to filter stale removal packets when hosts move between pollers.

The `Host` proto already has `instance_id` (field 62) for this purpose. This change brings parity to services.

Fixes: [MON-197564](https://centreon.atlassian.net/browse/MON-197564)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

1. Move a host from poller A to poller B.
2. Observe the PB_SERVICE BBDO messages: they should now carry `instance_id` matching the sending poller's ID.
3. Verify that services on the moved host correctly show the new poller's `instance_id` and that stale packets from the old poller can be identified by their different `instance_id`.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

[MON-197564]: https://centreon.atlassian.net/browse/MON-197564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added instance_id (field 88) to Service protobuf message

**🔧 Refactors**
* Updated Lua BBDO version match test to skip instance_id


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101494537?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->