### PR TITLE
enh(engine): add alias field to PB_SERVICE_GROUP protobuf message

### DIFF
--- a/bbdo/neb.proto
+++ b/bbdo/neb.proto
@@ -708,6 +708,7 @@ message ServiceGroup {
   uint64 servicegroup_id = 3;
   string name = 4;
   uint64 poller_id = 5;
+  string alias = 6;
 }
 
 /* io::neb, neb::de_pb_host_group_member, 25 */

--- a/broker/core/cache/src/global_cache_data.cc
+++ b/broker/core/cache/src/global_cache_data.cc
@@ -690,6 +690,9 @@ void global_cache_data::_process_pb_host_group_member(
       if (hg.name().empty()) {
         hg.set_name(hg_exist->second->name().c_str());
       }
+      // The member event carries no alias: keep the one already cached from the
+      // full host group event so it is not erased.
+      hg.set_alias(hg_exist->second->alias().c_str());
       dirty = hg_exist->second->update(hg, *_allocators);
     }
     dirty |= _host_group_members
@@ -1045,6 +1048,9 @@ void global_cache_data::_process_pb_service_group_member(
       if (sg.name().empty()) {
         sg.set_name(sg_exist->second->name().c_str());
       }
+      // The member event carries no alias: keep the one already cached from the
+      // full service group event so it is not erased.
+      sg.set_alias(sg_exist->second->alias().c_str());
       dirty = sg_exist->second->update(sg, *_allocators);
     }
     dirty |= _service_group_members

--- a/broker/core/cache/test/global_cache_test.cc
+++ b/broker/core/cache/test/global_cache_test.cc
@@ -385,6 +385,48 @@ TEST_F(global_cache_test, Group) {
   }
 }
 
+// The service group alias (neb.proto field 6, PB_SERVICE_GROUP) is carried by
+// the full ServiceGroup event but not by the ServiceGroupMember event. A member
+// event arriving after the group event must not erase the cached alias.
+TEST_F(global_cache_test, ServiceGroupAlias) {
+  global_cache::unload();
+  ::remove("/tmp/cache_test.rt");
+  ::remove("/tmp/cache_test.cnf");
+  global_cache::pointer obj =
+      global_cache::load(g_io_context, "/tmp/cache_test");
+
+  auto serv_group = std::make_shared<neb::pb_service_group>();
+  serv_group->mut_obj().set_servicegroup_id(42);
+  serv_group->mut_obj().set_name("servicegroup_42");
+  serv_group->mut_obj().set_alias("alias_42");
+  serv_group->mut_obj().set_enabled(true);
+  obj->write(serv_group);
+
+  {
+    global_cache::lock l;
+    const service_group* sg = obj->get_service_group(42, l);
+    ASSERT_NE(sg, nullptr);
+    ASSERT_STREQ(sg->alias().c_str(), "alias_42");
+  }
+
+  // A member event carries no alias; it must keep the previously cached one.
+  auto serv_grp_member = std::make_shared<neb::pb_service_group_member>();
+  serv_grp_member->mut_obj().set_servicegroup_id(42);
+  serv_grp_member->mut_obj().set_name("servicegroup_42");
+  serv_grp_member->mut_obj().set_host_id(1);
+  serv_grp_member->mut_obj().set_service_id(2);
+  serv_grp_member->mut_obj().set_poller_id(0);
+  serv_grp_member->mut_obj().set_enabled(true);
+  obj->write(serv_grp_member);
+
+  {
+    global_cache::lock l;
+    const service_group* sg = obj->get_service_group(42, l);
+    ASSERT_NE(sg, nullptr);
+    ASSERT_STREQ(sg->alias().c_str(), "alias_42");
+  }
+}
+
 TEST_F(global_cache_test, Tag) {
   global_cache::unload();
   ::remove("/tmp/cache_test.rt");

--- a/broker/core/cache/test/protobuf_test.cc
+++ b/broker/core/cache/test/protobuf_test.cc
@@ -1073,6 +1073,7 @@ TEST_F(protobuf_test, service_group_to_protobuf) {
   pb.set_servicegroup_id(rand() + 1);
   pb.set_name(random_string());
   pb.set_poller_id(rand() + 1);
+  pb.set_alias(random_string());
 
   auto file_map = simple_global_cache::load(file_path);
   service_group* converted = file_map->file().construct<service_group>(

--- a/broker/lua/src/broker_cache.cc
+++ b/broker/lua/src/broker_cache.cc
@@ -512,6 +512,31 @@ static int l_broker_cache_get_servicegroup_name(lua_State* L) {
 }
 
 /**
+ *  The get_servicegroup_alias() method available in the Lua interpreter
+ *  It returns a string.
+ *
+ *  @param L The Lua interpreter
+ *
+ *  @return 1
+ */
+static int l_broker_cache_get_servicegroup_alias(lua_State* L) {
+  int id(luaL_checkinteger(L, 2));
+  auto cache_instance = cache::global_cache::instance_ptr();
+  if (!cache_instance) {
+    lua_pushnil(L);
+  } else {
+    cache::global_cache::lock l;
+    const cache::service_group* sg = cache_instance->get_service_group(id, l);
+    if (sg) {
+      lua_pushstring(L, sg->alias().c_str());
+    } else {
+      lua_pushnil(L);
+    }
+  }
+  return 1;
+}
+
+/**
  *  The get_servicegroups() method available in the Lua interpreter
  *  It returns an array of objects, each one containing group_id and
  * group_name.
@@ -792,6 +817,7 @@ void broker_cache::broker_cache_reg(lua_State* L, uint32_t api_version) {
       {"get_metric_mapping", l_broker_cache_get_metric_mapping_v1},
       {"get_service_description", l_broker_cache_get_service_description},
       {"get_servicegroup_name", l_broker_cache_get_servicegroup_name},
+      {"get_servicegroup_alias", l_broker_cache_get_servicegroup_alias},
       {"get_servicegroups", l_broker_cache_get_servicegroups},
       {"get_notes_url", l_broker_cache_get_notes_url},
       {"get_notes", l_broker_cache_get_notes},

--- a/engine/src/broker.cc
+++ b/engine/src/broker.cc
@@ -2186,6 +2186,7 @@ static void forward_pb_group(int type, const G* group_data) {
                       (type == NEBTYPE_SERVICEGROUP_UPDATE &&
                        !group_data->members.empty()));
       obj.set_name(common::check_string_utf8(group_data->get_group_name()));
+      obj.set_alias(group_data->get_alias());
 
       // Send service group event.
       if (group_data->get_id()) {

--- a/tests/broker-engine/servicegroups.robot
+++ b/tests/broker-engine/servicegroups.robot
@@ -171,6 +171,17 @@ EBNSGU3_${test_label}
 
     Should Be True    len("""${grep_result}""") > 10    servicegroup_1 not found in /tmp/lua-engine.log
 
+    # The alias is carried only by the protobuf ServiceGroup event (neb.proto
+    # field 6, PB_SERVICE_GROUP).
+    IF    ${Use_BBDO3}
+        FOR    ${loop_index}    IN RANGE    30
+            ${grep_result}    Grep File    /tmp/lua-engine.log    service_group_alias:servicegroup_1
+            IF    len("""${grep_result}""") > 10    BREAK
+            Sleep    1s
+        END
+        Should Be True    len("""${grep_result}""") > 10    servicegroup_1 alias not found in /tmp/lua-engine.log
+    END
+
     Ctn Rename Service Group    ${0}    servicegroup_1    servicegroup_test
     Ctn Rename Service Group    ${1}    servicegroup_1    servicegroup_test
     Ctn Rename Service Group    ${2}    servicegroup_1    servicegroup_test

--- a/tests/resources/scripts/test-dump-groups.lua
+++ b/tests/resources/scripts/test-dump-groups.lua
@@ -7,12 +7,18 @@ end
 
 function write(e)
     local service_group_name = broker_cache:get_servicegroup_name(1)
+    local service_group_alias = broker_cache:get_servicegroup_alias(1)
     local host_group_name = broker_cache:get_hostgroup_name(1)
 
     if service_group_name then
         broker_log:info(0, "service_group_name:" .. service_group_name)
     else
         broker_log:info(0, "no service_group_name 1")
+    end
+    if service_group_alias then
+        broker_log:info(0, "service_group_alias:" .. service_group_alias)
+    else
+        broker_log:info(0, "no service_group_alias 1")
     end
     if host_group_name then
         broker_log:info(0, "host_group_name:" .. host_group_name)


### PR DESCRIPTION
## Description

Add `alias` (field 6) to the `ServiceGroup` protobuf message so BBDO consumers receive the service group description directly from the stream, matching the existing `HostGroup.alias` pattern.

Without this field, BBDO consumers (e.g. MAP) must fetch the service group description from the centreon DB via lazy-fetch / export reload.

Fixes: [MON-197566](https://centreon.atlassian.net/browse/MON-197566)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

1. Create a service group with a description/alias in the Centreon UI.
2. Observe the PB_SERVICE_GROUP BBDO messages: they should now carry the `alias` field with the service group description.
3. Verify that BBDO consumers can read the alias directly from the message without needing a DB query.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

[MON-197566]: https://centreon.atlassian.net/browse/MON-197566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added alias field to ServiceGroup protobuf message for BBDO


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101481367?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->