### PR TITLE
chore(ci): harden pnpm install with supply chain security flags (#3297)

### DIFF
--- a/.github/docker/gorgone/alma9/Dockerfile.testing-dependencies
+++ b/.github/docker/gorgone/alma9/Dockerfile.testing-dependencies
@@ -25,7 +25,11 @@ dnf install -y nodejs
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=${PNPM_VERSION} sh -
 source ~/.bashrc
 cd /usr/local/src
-pnpm install --frozen-lockfile
+pnpm install \
+  --frozen-lockfile \
+  --config.trustPolicy=no-downgrade \
+  --config.minimumReleaseAge=2880 \
+  --config.blockExoticSubdeps=true
 
 dnf install -y \
   "perl-Libssh-Session" \

--- a/.github/docker/gorgone/bookworm/Dockerfile.testing-dependencies
+++ b/.github/docker/gorgone/bookworm/Dockerfile.testing-dependencies
@@ -41,7 +41,11 @@ apt-get install -y nodejs
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=${PNPM_VERSION} SHELL="$(which bash)" sh -
 source ~/.bashrc
 cd /usr/local/src
-pnpm install --frozen-lockfile
+pnpm install \
+  --frozen-lockfile \
+  --config.trustPolicy=no-downgrade \
+  --config.minimumReleaseAge=2880 \
+  --config.blockExoticSubdeps=true
 
 VERSION_CODENAME=\$(
   . /etc/os-release


### PR DESCRIPTION
Add --config.trustPolicy=no-downgrade, --config.minimumReleaseAge=2880, and --config.blockExoticSubdeps=true to pnpm install commands in gorgone testing Dockerfiles.

## Description

Add supply chain security flags to all `pnpm install` commands:
- `--config.trustPolicy=no-downgrade`
- `--config.minimumReleaseAge=2880`
- `--config.blockExoticSubdeps=true`

**Backports** MON-197308
**Fixes** MON-197661

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Hardened pnpm install commands with supply chain security flags


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101861117?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->