### PR TITLE
MON-194258 Template Injection in GitHub Workflows Action - centreon-c…

### DIFF
--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -53,11 +53,12 @@ runs:
       env:
         JF_URL: https://packages.centreon.com
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
+        GH_HEAD_REF: ${{ github.event.pull_request.head.ref }}
       run: |
         set -eu
         . .version
         major_version=$(grep -E "MAJOR" .version | cut -d '=' -f2)
-        feature_ticket=$(echo "${{ github.event.pull_request.head.ref }}" | grep -oE 'MON-[0-9]+')
+        feature_ticket=$(echo "$GH_HEAD_REF" | grep -oE 'MON-[0-9]+')
         echo "[INFO] Creating a rpm feature repository if it does not exist"
 
         curl -X POST \
@@ -97,6 +98,7 @@ runs:
       env:
         JF_URL: https://packages.centreon.com
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
+        GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
       run: |
         set -eux
 
@@ -147,7 +149,7 @@ runs:
         done
 
         if [[ "${{ inputs.delivery_type }}" == "feature" ]]; then
-          ROOT_REPO_PATH="rpm-standard-feature-$(echo "${{ github.head_ref || github.ref_name }}" | grep -oP '^.*MON-[0-9]+')"
+          ROOT_REPO_PATH="rpm-standard-feature-$(echo "$GH_HEAD_REF" | grep -oP '^.*MON-[0-9]+')"
         elif [[ "${{ inputs.is_cloud }}" == "true" ]]; then
           ROOT_REPO_PATH="rpm-standard-internal"
         else

--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -54,6 +54,7 @@ runs:
         JF_URL: https://packages.centreon.com
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
         GH_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        CENTREON_TECHNIQUE_PAT: ${{ inputs.centreon_technique_pat }}
       run: |
         set -eu
         . .version
@@ -62,7 +63,7 @@ runs:
         echo "[INFO] Creating a rpm feature repository if it does not exist"
 
         curl -X POST \
-            -H "Authorization: Bearer ${{ inputs.centreon_technique_pat }}" \
+            -H "Authorization: Bearer $CENTREON_TECHNIQUE_PAT" \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/centreon/delivery-tooling/dispatches \
             -d "$(jq -n \
@@ -99,38 +100,45 @@ runs:
         JF_URL: https://packages.centreon.com
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
         GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        VERSION: ${{ inputs.version }}
+        STABILITY: ${{ inputs.stability }}
+        RELEASE_TYPE: ${{ inputs.release_type }}
+        IS_CLOUD: ${{ inputs.is_cloud }}
+        DELIVERY_TYPE: ${{ inputs.delivery_type }}
       run: |
         set -eux
 
         FILES="*.rpm"
 
-        if [ -z "${{ inputs.module_name }}" ]; then
+        if [ -z "$MODULE_NAME" ]; then
           echo "::error::module name is required"
           exit 1
         fi
 
-        if [ -z "${{ inputs.distrib }}" ]; then
+        if [ -z "$DISTRIB" ]; then
           echo "::error::distrib is required"
           exit 1
         fi
 
         # DEBUG
-        echo "[DEBUG] - Version: ${{ inputs.version }}"
-        echo "[DEBUG] - Distrib: ${{ inputs.distrib }}"
-        echo "[DEBUG] - module_name: ${{ inputs.module_name }}"
-        echo "[DEBUG] - is_cloud: ${{ inputs.is_cloud }}"
-        echo "[DEBUG] - release_type: ${{ inputs.release_type }}"
-        echo "[DEBUG] - stability: ${{ inputs.stability }}"
-        echo "[DEBUG] - delivery_type: ${{ inputs.delivery_type }}"
+        echo "[DEBUG] - Version: $VERSION"
+        echo "[DEBUG] - Distrib: $DISTRIB"
+        echo "[DEBUG] - module_name: $MODULE_NAME"
+        echo "[DEBUG] - is_cloud: $IS_CLOUD"
+        echo "[DEBUG] - release_type: $RELEASE_TYPE"
+        echo "[DEBUG] - stability: $STABILITY"
+        echo "[DEBUG] - delivery_type: $DELIVERY_TYPE"
 
         # Make sure all required inputs are NOT empty
-        if [[ -z "${{ inputs.module_name }}" || -z "${{ inputs.distrib }}" || -z ${{ inputs.stability }} || -z ${{ inputs.version }} || -z "${{ inputs.is_cloud }}" ]]; then
+        if [[ -z "$MODULE_NAME" || -z "$DISTRIB" || -z "$STABILITY" || -z "$VERSION" || -z "$IS_CLOUD" ]]; then
           echo "::error::some mandatory inputs are empty, please check the logs."
           exit 1
         fi
 
-        if [[ "${{ inputs.delivery_type }}" != "feature" && "${{ inputs.stability }}" != "testing" && "${{ inputs.stability }}" != "unstable" ]]; then
-          echo "::error::stability must be one of: testing, unstable (got '${{ inputs.stability }}')"
+        if [[ "$DELIVERY_TYPE" != "feature" && "$STABILITY" != "testing" && "$STABILITY" != "unstable" ]]; then
+          echo "::error::stability must be one of: testing, unstable (got '$STABILITY')"
           exit 1
         fi
 
@@ -148,25 +156,25 @@ runs:
           mv "$FILE" "$ARCH"
         done
 
-        if [[ "${{ inputs.delivery_type }}" == "feature" ]]; then
+        if [[ "$DELIVERY_TYPE" == "feature" ]]; then
           ROOT_REPO_PATH="rpm-standard-feature-$(echo "$GH_HEAD_REF" | grep -oP '^.*MON-[0-9]+')"
-        elif [[ "${{ inputs.is_cloud }}" == "true" ]]; then
+        elif [[ "$IS_CLOUD" == "true" ]]; then
           ROOT_REPO_PATH="rpm-standard-internal"
         else
           ROOT_REPO_PATH="rpm-standard"
         fi
 
         for ARCH in "noarch" "x86_64"; do
-          if [[ "${{ inputs.release_type }}" == "hotfix" || "${{ inputs.release_type }}" == "release" ]]; then
-            UPLOAD_REPO_PATH="${{ inputs.version }}/${{ inputs.distrib }}/${{ inputs.stability }}-${{ inputs.release_type }}/$ARCH/${{ inputs.module_name }}/"
-            REINDEX_STABILITY="${{ inputs.stability }}-${{ inputs.release_type }}"
+          if [[ "$RELEASE_TYPE" == "hotfix" || "$RELEASE_TYPE" == "release" ]]; then
+            UPLOAD_REPO_PATH="$VERSION/$DISTRIB/$STABILITY-$RELEASE_TYPE/$ARCH/$MODULE_NAME/"
+            REINDEX_STABILITY="$STABILITY-$RELEASE_TYPE"
           else
-            UPLOAD_REPO_PATH="${{ inputs.version }}/${{ inputs.distrib }}/${{ inputs.stability }}/$ARCH/${{ inputs.module_name }}/"
-            REINDEX_STABILITY="${{ inputs.stability }}"
+            UPLOAD_REPO_PATH="$VERSION/$DISTRIB/$STABILITY/$ARCH/$MODULE_NAME/"
+            REINDEX_STABILITY="$STABILITY"
           fi
           if [ "$(ls -A $ARCH)" ]; then
             jf rt upload "$ARCH/*.rpm" "$ROOT_REPO_PATH/$UPLOAD_REPO_PATH" --sync-deletes="$ROOT_REPO_PATH/$UPLOAD_REPO_PATH" --flat  --detailed-summary
           fi
 
-          curl -H "Authorization: Bearer ${{ env.JF_ACCESS_TOKEN }}" -X POST "${{ env.JF_URL }}/artifactory/api/yum/$ROOT_REPO_PATH?path=/${{ inputs.version }}/${{ inputs.distrib }}/${REINDEX_STABILITY}/$ARCH&async=1"
+          curl -H "Authorization: Bearer $JF_ACCESS_TOKEN" -X POST "$JF_URL/artifactory/api/yum/$ROOT_REPO_PATH?path=/$VERSION/$DISTRIB/${REINDEX_STABILITY}/$ARCH&async=1"
         done


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                              
  - Fix template injection vulnerability in `.github/actions/rpm-delivery/action.yml` (MON-194258)
  - `github.event.pull_request.head.ref` and `github.head_ref || github.ref_name` were directly interpolated into shell `run` blocks, allowing a malicious branch name to inject arbitrary shell commands                                                                                                                                                           
  - Both values are now passed via `env:` variables (`GH_HEAD_REF`) so they are treated as data, not executable code

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 2 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Replaced inline input interpolations with environment variables for scripts

**🔧 Refactors**
* Prevented template injection by passing GitHub refs through env variables


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101956877?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->