### PR TITLE
enh(version): ensure 26.04 is no longer considered an onprem version

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -82,12 +82,12 @@ runs:
 
         MAJOR_LEFT=$( echo $MAJOR_VERSION | cut -d "." -f1 )
         MAJOR_RIGHT=$( echo $MAJOR_VERSION | cut -d "-" -f1 | cut -d "." -f2 )
-        if [ "$MAJOR_RIGHT" = "04" ]; then
-          BUMP_MAJOR_LEFT="$MAJOR_LEFT"
-          BUMP_MAJOR_RIGHT="10"
-        else
+        if [ "$MAJOR_RIGHT" = "12" ]; then
           BUMP_MAJOR_LEFT=$(( $MAJOR_LEFT + 1 ))
-          BUMP_MAJOR_RIGHT="04"
+          BUMP_MAJOR_RIGHT="01"
+        else
+          BUMP_MAJOR_LEFT=$MAJOR_LEFT
+          BUMP_MAJOR_RIGHT=$(( $MAJOR_RIGHT + 1 ))
         fi
 
         export NEXT_MAJOR_VERSION="$BUMP_MAJOR_LEFT.$BUMP_MAJOR_RIGHT"

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -518,11 +518,11 @@ jobs:
             const developMajorVersion = "${{ steps.latest_major_version.outputs.latest_major_version }}";
             const currentMajorVersion = "${{ steps.get_version.outputs.major_version }}";
             // if major version is higher than develop major version => it is a cloud version
-            // if month number is not 04 or 10 => it is a cloud version
+            // if month number is not 10 => it is a cloud version
             // anything else => onprem
             const isCloudCandidate =
               Number(currentMajorVersion) >= Number(developMajorVersion) ||
-              !currentMajorVersion.match(/\.(04|10)$/);
+              !currentMajorVersion.match(/\.10$/);
 
             let releaseScope = "unknown";
 


### PR DESCRIPTION
## Description

**Fixes** # MON-197843

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).



<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Changed CI workflow to run on ubuntu-24.04 runner
* Adjusted package action logic to compute next major version


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103651859?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->