### PR TITLE
feat(ci): add build state push job

### DIFF
--- a/.github/actions/push-build-state/action.yml
+++ b/.github/actions/push-build-state/action.yml
@@ -1,0 +1,130 @@
+name: "push-build-state"
+description: "Push component build status JSON to the release orchestrator S3 bucket when a release-cloud POC tag is present"
+inputs:
+  component:
+    description: "Component name used in the file name and payload (e.g. centreon-collect)"
+    required: true
+  major_version:
+    description: "Major version (e.g. 25.09)"
+    required: true
+  minor_version:
+    description: "Minor version (e.g. 0)"
+    required: true
+  delivered_packages:
+    description: "Newline-separated list of delivered RPM filenames"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    # Find the most recent release-cloud-YYYYMMNN-AA.BB-pocZ tag for the current major version
+    - name: Detect release-cloud POC tag
+      id: detect-tag
+      env:
+        MAJOR_VERSION: ${{ inputs.major_version }}
+      shell: bash
+      run: |
+        set -eu
+        echo "[INFO] Searching for release-cloud POC tags matching version ${MAJOR_VERSION}"
+
+        git fetch --tags --force
+
+        # Find tags matching release-cloud-YYYYMMNN-AA.BB-pocZ for current major version
+        MATCHING_TAGS=$(git tag --list "release-cloud-*-${MAJOR_VERSION}-poc*" --sort=-creatordate 2>/dev/null || true)
+
+        if [[ -z "$MATCHING_TAGS" ]]; then
+          echo "[INFO] No matching release-cloud POC tags found"
+          echo "tag_found=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # Use the most recent tag
+        TAG=$(echo "$MATCHING_TAGS" | head -n 1)
+        echo "[INFO] Most recent matching tag: $TAG"
+
+        # Validate tag format: release-cloud-YYYYMMNN-AA.BB-pocZ
+        if ! echo "$TAG" | grep -qP '^release-cloud-\d{8}-\d+\.\d+-poc\d+$'; then
+          echo "[WARN] Tag $TAG does not match expected format, skipping"
+          echo "tag_found=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # Resolve the commit SHA the tag points to
+        COMMIT_SHA=$(git rev-list -n 1 "$TAG")
+        echo "[INFO] Tag $TAG points to commit $COMMIT_SHA"
+
+        # Verify the tag commit is reachable from a release-* or hotfix-* branch
+        BRANCHES=$(git branch -r --contains "$COMMIT_SHA" 2>/dev/null | grep -E 'origin/(release-|hotfix-)' || true)
+
+        if [[ -z "$BRANCHES" ]]; then
+          echo "[INFO] Tag $TAG commit is not on any release/hotfix branch, skipping"
+          echo "tag_found=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        echo "[INFO] Tag $TAG is on branches: $(echo $BRANCHES | tr '\n' ' ')"
+        echo "tag_found=true" >> $GITHUB_OUTPUT
+        echo "tag_name=$TAG" >> $GITHUB_OUTPUT
+        echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
+
+    # Build the component build status JSON file
+    - name: Build build status JSON
+      if: steps.detect-tag.outputs.tag_found == 'true'
+      id: build-json
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
+        COMPONENT: ${{ inputs.component }}
+        MAJOR_VERSION: ${{ inputs.major_version }}
+        MINOR_VERSION: ${{ inputs.minor_version }}
+        COMMIT_SHA: ${{ steps.detect-tag.outputs.commit_sha }}
+        DELIVERED_PACKAGES: ${{ inputs.delivered_packages }}
+      with:
+        script: |
+          const fs = require('fs');
+
+          const component = process.env.COMPONENT;
+          const componentVersion = `${process.env.MAJOR_VERSION}.${process.env.MINOR_VERSION}`;
+          const commit = process.env.COMMIT_SHA;
+          const deliveredPackages = process.env.DELIVERED_PACKAGES || '';
+          // ISO 8601 timestamp without milliseconds (e.g. 2025-09-19T12:30:00Z)
+          const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+          core.info(`[INFO] Building status file for component ${component} version ${componentVersion}`);
+
+          // Split newline-separated package list into a JSON array
+          const packages = deliveredPackages
+            .split('\n')
+            .map(p => p.trim())
+            .filter(p => p.length > 0);
+          core.info(`[INFO] Packages: ${JSON.stringify(packages)}`);
+
+          const buildStatus = {
+            component,
+            component_version: componentVersion,
+            commit,
+            packages,
+            status: 'success',
+            timestamp,
+          };
+
+          const fileName = `${component}-build-status.json`;
+          fs.writeFileSync(fileName, JSON.stringify(buildStatus, null, 2));
+
+          core.info('[INFO] Build status JSON:');
+          core.info(fs.readFileSync(fileName, 'utf-8'));
+
+          core.setOutput('file_name', fileName);
+
+    # Upload the build status JSON to the release-orchestrator S3 bucket
+    - name: Upload build status to S3
+      if: steps.detect-tag.outputs.tag_found == 'true'
+      shell: bash
+      env:
+        TAG_NAME: ${{ steps.detect-tag.outputs.tag_name }}
+        FILE_NAME: ${{ steps.build-json.outputs.file_name }}
+      run: |
+        set -eu
+        S3_PATH="s3://release-orchestrator/incoming/${TAG_NAME}/${FILE_NAME}"
+        echo "[INFO] Uploading ${FILE_NAME} to ${S3_PATH}"
+        aws s3 cp "${FILE_NAME}" "$S3_PATH"
+        echo "[INFO] Upload complete"

--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -1,5 +1,9 @@
 name: "rpm-delivery"
 description: "Deliver rpm packages"
+outputs:
+  delivered_packages:
+    description: "Newline-separated list of delivered RPM filenames"
+    value: ${{ steps.list-packages.outputs.delivered_packages }}
 inputs:
   module_name:
     description: "The package module name"
@@ -178,3 +182,23 @@ runs:
 
           curl -H "Authorization: Bearer $JF_ACCESS_TOKEN" -X POST "$JF_URL/artifactory/api/yum/$ROOT_REPO_PATH?path=/$VERSION/$DISTRIB/${REINDEX_STABILITY}/$ARCH&async=1"
         done
+
+    # Collect all delivered RPM filenames for downstream consumption
+    - name: List delivered packages
+      id: list-packages
+      shell: bash
+      run: |
+        PACKAGES=""
+        for ARCH in "noarch" "x86_64"; do
+          if [ -d "$ARCH" ] && [ "$(ls -A "$ARCH" 2>/dev/null)" ]; then
+            for f in "$ARCH"/*.rpm; do
+              PACKAGES="${PACKAGES}$(basename "$f")"$'\n'
+            done
+          fi
+        done
+        PACKAGES=$(echo "$PACKAGES" | sed '/^$/d')
+        echo "[INFO] Delivered RPM packages:"
+        echo "$PACKAGES"
+        echo "delivered_packages<<EOF" >> $GITHUB_OUTPUT
+        echo "$PACKAGES" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -512,6 +512,8 @@ jobs:
 
     needs: [get-environment, changes, robot-test]
     runs-on: centreon-common
+    outputs:
+      delivered_packages: ${{ steps.publish-rpms.outputs.delivered_packages }}
     strategy:
       fail-fast: false
       matrix:
@@ -526,6 +528,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Publish RPM packages
+        id: publish-rpms
         uses: ./.github/actions/rpm-delivery
         with:
           module_name: collect
@@ -538,6 +541,29 @@ jobs:
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+
+  # Push build status to S3 for the release orchestrator
+  push-build-state:
+    needs: [get-environment, deliver-rpm]
+    # Run only for cloud testing builds after successful RPM delivery
+    if: |
+      needs.get-environment.outputs.is_cloud == 'true' &&
+      needs.get-environment.outputs.stability == 'testing'
+    runs-on: centreon-common
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0  # Full history needed for tag detection
+
+      - name: Push build status
+        uses: ./.github/actions/push-build-state
+        with:
+          component: centreon-collect
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          minor_version: ${{ needs.get-environment.outputs.minor_version }}
+          delivered_packages: ${{ needs.deliver-rpm.outputs.delivered_packages }}
 
   promote:
     needs: [get-environment, deliver-rpm]

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -113,6 +113,8 @@ jobs:
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
+    outputs:
+      delivered_packages: ${{ steps.publish-rpms.outputs.delivered_packages }}
 
     strategy:
       matrix:
@@ -123,6 +125,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Delivery
+        id: publish-rpms
         uses: ./.github/actions/rpm-delivery
         with:
           module_name: common
@@ -135,6 +138,29 @@ jobs:
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+
+  # Push build status to S3 for the release orchestrator
+  push-build-state:
+    needs: [get-environment, deliver-rpm]
+    # Run only for cloud testing builds after successful RPM delivery
+    if: |
+      needs.get-environment.outputs.is_cloud == 'true' &&
+      needs.get-environment.outputs.stability == 'testing'
+    runs-on: centreon-common
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0  # Full history needed for tag detection
+
+      - name: Push build status
+        uses: ./.github/actions/push-build-state
+        with:
+          component: centreon-common
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          minor_version: ${{ needs.get-environment.outputs.minor_version }}
+          delivered_packages: ${{ needs.deliver-rpm.outputs.delivered_packages }}
 
   promote:
     needs: [get-environment, deliver-rpm]

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -432,6 +432,8 @@ jobs:
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
+    outputs:
+      delivered_packages: ${{ steps.publish-rpms.outputs.delivered_packages }}
 
     strategy:
       fail-fast: false
@@ -443,6 +445,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Delivery
+        id: publish-rpms
         uses: ./.github/actions/rpm-delivery
         with:
           module_name: gorgone
@@ -455,6 +458,29 @@ jobs:
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+
+  # Push build status to S3 for the release orchestrator
+  push-build-state:
+    needs: [get-environment, deliver-rpm]
+    # Run only for cloud testing builds after successful RPM delivery
+    if: |
+      needs.get-environment.outputs.is_cloud == 'true' &&
+      needs.get-environment.outputs.stability == 'testing'
+    runs-on: centreon-common
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0  # Full history needed for tag detection
+
+      - name: Push build status
+        uses: ./.github/actions/push-build-state
+        with:
+          component: centreon-gorgone
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          minor_version: ${{ needs.get-environment.outputs.minor_version }}
+          delivered_packages: ${{ needs.deliver-rpm.outputs.delivered_packages }}
 
   promote:
     needs: [get-environment, deliver-rpm]

--- a/.github/workflows/libzmq.yml
+++ b/.github/workflows/libzmq.yml
@@ -140,6 +140,8 @@ jobs:
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
     runs-on: centreon-common
+    outputs:
+      delivered_packages: ${{ steps.publish-rpms.outputs.delivered_packages }}
     strategy:
       matrix:
         include:
@@ -153,6 +155,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Publish RPM packages
+        id: publish-rpms
         uses: ./.github/actions/rpm-delivery
         with:
           module_name: libzmq
@@ -165,6 +168,29 @@ jobs:
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+
+  # Push build status to S3 for the release orchestrator
+  push-build-state:
+    needs: [get-environment, deliver-rpm]
+    # Run only for cloud testing builds after successful RPM delivery
+    if: |
+      needs.get-environment.outputs.is_cloud == 'true' &&
+      needs.get-environment.outputs.stability == 'testing'
+    runs-on: centreon-common
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0  # Full history needed for tag detection
+
+      - name: Push build status
+        uses: ./.github/actions/push-build-state
+        with:
+          component: libzmq
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          minor_version: ${{ needs.get-environment.outputs.minor_version }}
+          delivered_packages: ${{ needs.deliver-rpm.outputs.delivered_packages }}
 
   promote:
     needs: [get-environment, deliver-rpm]

--- a/.github/workflows/lua-curl.yml
+++ b/.github/workflows/lua-curl.yml
@@ -132,6 +132,8 @@ jobs:
       ! contains(needs.*.result, 'cancelled')
     needs: [get-environment, package]
     runs-on: ubuntu-24.04
+    outputs:
+      delivered_packages: ${{ steps.publish-rpms.outputs.delivered_packages }}
     strategy:
       matrix:
         include:
@@ -144,6 +146,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Publish RPM packages
+        id: publish-rpms
         uses: ./.github/actions/rpm-delivery
         with:
           module_name: lua-curl
@@ -156,6 +159,29 @@ jobs:
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+
+  # Push build status to S3 for the release orchestrator
+  push-build-state:
+    needs: [get-environment, deliver-rpm]
+    # Run only for cloud testing builds after successful RPM delivery
+    if: |
+      needs.get-environment.outputs.is_cloud == 'true' &&
+      needs.get-environment.outputs.stability == 'testing'
+    runs-on: centreon-common
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0  # Full history needed for tag detection
+
+      - name: Push build status
+        uses: ./.github/actions/push-build-state
+        with:
+          component: lua-curl
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          minor_version: ${{ needs.get-environment.outputs.minor_version }}
+          delivered_packages: ${{ needs.deliver-rpm.outputs.delivered_packages }}
 
   promote:
     needs: [get-environment, deliver-rpm]

--- a/.github/workflows/monitoring-agent.yml
+++ b/.github/workflows/monitoring-agent.yml
@@ -497,6 +497,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Publish RPM packages
+        id: publish-rpms
         uses: ./.github/actions/rpm-delivery
         with:
           module_name: monitoring-agent
@@ -509,6 +510,66 @@ jobs:
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+
+      # Save delivered package list for downstream aggregation
+      - name: Save delivered package list
+        run: |
+          echo "${{ steps.publish-rpms.outputs.delivered_packages }}" > delivered-packages.txt
+          echo "[INFO] Package list for ${{ matrix.distrib }}:"
+          cat delivered-packages.txt
+        shell: bash
+
+      - name: Upload delivered package list
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: delivered-packages-${{ matrix.distrib }}
+          path: delivered-packages.txt
+          retention-days: 1
+
+  # Push build status to S3 for the release orchestrator
+  push-build-state:
+    needs: [get-environment, deliver-rpm]
+    # Run only for cloud testing builds after successful RPM delivery
+    if: |
+      needs.get-environment.outputs.is_cloud == 'true' &&
+      needs.get-environment.outputs.stability == 'testing'
+    runs-on: centreon-common
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0  # Full history needed for tag detection
+
+      # Download package lists from all deliver-rpm matrix entries
+      - name: Download delivered package lists
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          pattern: delivered-packages-*
+          path: package-lists/
+
+      # Merge all per-distrib package lists into a single newline-separated list
+      - name: Merge package lists
+        id: merge-packages
+        run: |
+          set -eu
+          echo "[INFO] Merging package lists from all distributions"
+          cat package-lists/*/delivered-packages.txt | sort -u | sed '/^$/d' > all-packages.txt
+          echo "[INFO] Combined package list:"
+          cat all-packages.txt
+          PACKAGES=$(cat all-packages.txt)
+          echo "packages<<EOF" >> $GITHUB_OUTPUT
+          echo "$PACKAGES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Push build status
+        uses: ./.github/actions/push-build-state
+        with:
+          component: centreon-monitoring-agent
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          minor_version: ${{ needs.get-environment.outputs.minor_version }}
+          delivered_packages: ${{ steps.merge-packages.outputs.packages }}
 
   deliver-deb:
     if: |


### PR DESCRIPTION
## Description

* add push-build-state job and action
Adds a push-build-state job to the collect, common, gorgone, libzmq, lua-curl and monitoring-agent workflows. The job uploads a component build status JSON to the release-orchestrator S3 bucket after a successful RPM delivery on cloud testing builds, when a matching release-cloud POC tag is present on a release/hotfix branch.

Shared logic (tag detection, JSON build, S3 upload) lives in the new ./.github/actions/push-build-state composite action. The rpm-delivery action now exposes delivered_packages as an output so push-build-state can enumerate what was shipped. monitoring-agent uploads per-distrib artifacts that are merged before calling the action.

**Fixes** #MON-195709
