### PR TITLE
fix(gorgone): fix log retrieval minor bug

### DIFF
--- a/gorgone/gorgone/modules/core/proxy/hooks.pm
+++ b/gorgone/gorgone/modules/core/proxy/hooks.pm
@@ -630,7 +630,7 @@ sub setlogs {
     $constatus_ping->{ $options{data}->{data}->{id} }->{last_ping_recv} = time();
     $last_pong->{ $options{data}->{data}->{id} } = time() if (defined($last_pong->{ $options{data}->{data}->{id} }));
 
-    if (!defined($node_status->{total_msg} or $node_status->{total_msg} == -1)) {
+    if (!defined($node_status->{total_msg}) or $node_status->{total_msg} == -1) {
         $node_status->{total_msg} = $options{data}->{data}->{nb_total_msg} // 1;
         # if not defined it probably mean we are connected to an older node that does not support multipart messages, so there is only one part.
     }


### PR DESCRIPTION
## Description

A condition in the central part of the log retrieval process was not correct, making the log retrieval waiting one more minute for each message (very rare as logs very often fit in a single message)

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).



<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed incorrect condition causing log retrieval to wait extra minute


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106091585?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->