### PR TITLE
fix(engine): host escalation not applied when using host_name instead of hostgroup_name

### DIFF
--- a/engine/src/configuration/applier/hostescalation.cc
+++ b/engine/src/configuration/applier/hostescalation.cc
@@ -104,11 +104,14 @@ void applier::hostescalation::expand_objects(configuration::State& s) {
         e->CopyFrom(he);
         fill_string_group(e->mutable_hosts(), n);
       }
-    } else {
+    } else if (he.hosts().data().size() > 0) {
       /* No hostgroup: escalation targets host_name directly, pass through. */
       resolved.emplace_back(std::make_unique<Hostescalation>());
       resolved.back()->CopyFrom(he);
-    }
+    } else
+      throw engine_error()
+          << "Could not expand host escalation: neither hostgroups nor hosts "
+             "are defined";
   }
   s.clear_hostescalations();
   for (auto& e : resolved)

--- a/engine/src/configuration/applier/hostescalation.cc
+++ b/engine/src/configuration/applier/hostescalation.cc
@@ -18,9 +18,6 @@
  */
 
 #include "com/centreon/engine/configuration/applier/hostescalation.hh"
-#include <spdlog/spdlog.h>
-#include <fstream>
-#include <string>
 #include "com/centreon/engine/broker.hh"
 #include "com/centreon/engine/config.hh"
 #include "com/centreon/engine/configuration/applier/state.hh"

--- a/engine/src/configuration/applier/hostescalation.cc
+++ b/engine/src/configuration/applier/hostescalation.cc
@@ -18,6 +18,9 @@
  */
 
 #include "com/centreon/engine/configuration/applier/hostescalation.hh"
+#include <spdlog/spdlog.h>
+#include <fstream>
+#include <string>
 #include "com/centreon/engine/broker.hh"
 #include "com/centreon/engine/config.hh"
 #include "com/centreon/engine/configuration/applier/state.hh"
@@ -80,8 +83,8 @@ void applier::hostescalation::expand_objects(configuration::State& s) {
   std::list<std::unique_ptr<Hostescalation> > resolved;
   for (auto& he : *s.mutable_hostescalations()) {
     if (he.hostgroups().data().size() > 0) {
-      absl::flat_hash_set<std::string_view> host_names;
-      for (auto& hname : he.hosts().data())
+      absl::flat_hash_set<std::string> host_names;
+      for (const auto& hname : he.hosts().data())
         host_names.emplace(hname);
       for (auto& hg_name : he.hostgroups().data()) {
         auto found_hg =
@@ -105,9 +108,19 @@ void applier::hostescalation::expand_objects(configuration::State& s) {
         fill_string_group(e->mutable_hosts(), n);
       }
     } else if (he.hosts().data().size() > 0) {
-      /* No hostgroup: escalation targets host_name directly, pass through. */
-      resolved.emplace_back(std::make_unique<Hostescalation>());
-      resolved.back()->CopyFrom(he);
+      absl::flat_hash_set<std::string> host_names;
+      for (const auto& hname : he.hosts().data())
+        host_names.emplace(hname);
+
+      he.mutable_hostgroups()->clear_data();
+      he.mutable_hosts()->clear_data();
+
+      for (auto& host : host_names) {
+        resolved.emplace_back(std::make_unique<Hostescalation>());
+        auto& e = resolved.back();
+        e->CopyFrom(he);
+        e->mutable_hosts()->add_data(host);
+      }
     } else
       throw engine_error()
           << "Could not expand host escalation: neither hostgroups nor hosts "

--- a/engine/src/configuration/applier/hostescalation.cc
+++ b/engine/src/configuration/applier/hostescalation.cc
@@ -104,6 +104,10 @@ void applier::hostescalation::expand_objects(configuration::State& s) {
         e->CopyFrom(he);
         fill_string_group(e->mutable_hosts(), n);
       }
+    } else {
+      /* No hostgroup: escalation targets host_name directly, pass through. */
+      resolved.emplace_back(std::make_unique<Hostescalation>());
+      resolved.back()->CopyFrom(he);
     }
   }
   s.clear_hostescalations();

--- a/tests/engine/escalation_inheritance.robot
+++ b/tests/engine/escalation_inheritance.robot
@@ -1176,3 +1176,160 @@ EESI11
     Ctn Stop Engine
     Ctn Kindly Stop Broker
 
+EESI12
+    [Documentation]    Verify host escalation configured with host_name directly (not hostgroup_name)
+    ...    is properly linked to the host and triggers escalation contacts.
+    [Tags]    engine    hostescalation    MON-197927
+
+    Ctn Config Engine    ${1}    ${5}    ${1}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module
+    Ctn Config BBDO3    1
+
+    Ctn Config Engine Add Cfg File    ${0}    escalations.cfg
+    Ctn Config Engine Add Cfg File    ${0}    contacts.cfg
+    Ctn Config Engine Add Cfg File    ${0}    contactgroups.cfg
+
+    Ctn Engine Config Set Value    0    interval_length    1    True
+
+    Ctn Engine Config Add Command    0    command_notif    /usr/bin/true
+    Ctn Engine Config Set Value In Hosts    0    host_1    notifications_enabled    1
+    Ctn Engine Config Set Value In Hosts    0    host_1    notification_options    d,r
+    Ctn Engine Config Set Value In Hosts    0    host_1    notification_period    24x7
+    Ctn Engine Config Set Value In Hosts    0    host_1    notification_interval    1
+    Ctn Engine Config Set Value In Hosts    0    host_1    contacts    John_Doe
+    Ctn Engine Config Set Value In Hosts    0    host_1    check_interval    1
+    Ctn Engine Config Set Value In Hosts    0    host_1    retry_interval    1
+
+    Ctn Engine Config Set Value In Contacts    0    John_Doe    host_notification_commands    command_notif
+    Ctn Engine Config Set Value In Contacts    0    John_Doe    service_notification_commands    command_notif
+
+    Ctn Add Contact Group    ${0}    ${1}    ["U1","U2"]
+
+    # create a escalation with a dummy hostgroup (deleted after)
+    Ctn Create Escalations File    0    1    dummy_hostgroup    contactgroup_1    host
+    Ctn Engine Config Delete Key In Cfg    0    esc1    hostgroup_name    escalations.cfg
+
+    Ctn Engine Config Set Key Value In Cfg    0    esc1    host_name    host_1    escalations.cfg
+    Ctn Engine Config Set Value In Escalations    0    esc1    first_notification    2
+    Ctn Engine Config Set Value In Escalations    0    esc1    last_notification    0
+    Ctn Engine Config Set Value In Escalations    0    esc1    notification_interval    1
+
+    Ctn Config Host Command Status    ${0}    checkh1    2
+
+    ${start}    Get Current Date
+    Ctn Start Broker
+    Ctn Start Engine
+
+    ${output}    Ctn Get Host Escalation Info Grpc    host_1
+
+    Log To Console    "Verify that the escalation host_1 is created"
+
+    Should Be Equal As Strings    ${output}[hostName]    host_1    hostName
+    Should Contain    ${output}[contactGroup]    contactgroup_1    contactGroup
+    Should Be Equal As Strings    ${output}[escalationPeriod]    24x7    escalationPeriod
+    Should Be Equal As Numbers    ${output}[firstNotification]    2    firstNotification
+    Should Be Equal As Numbers    ${output}[lastNotification]    0    lastNotification
+    Should Be Equal As Numbers    ${output}[notificationInterval]    1    notificationInterval
+
+    # Notification #1 goes to the host's direct contact (John_Doe).
+    ${content}    Create List    HOST NOTIFICATION: John_Doe;host_1;DOWN;command_notif;
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    First notification to John_Doe was not sent
+
+    # Notification #2+ comes from the escalation contactgroup_1 (U1, U2).
+    ${content}    Create List    HOST NOTIFICATION: U1;host_1;DOWN;command_notif;
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    Escalation notification to U1 was not sent
+
+    ${content}    Create List    HOST NOTIFICATION: U2;host_1;DOWN;command_notif;
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    Escalation notification to U2 was not sent
+
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker
+
+EESI13
+    [Documentation]    Verify service escalation configured with host_name and service_description directly
+    ...    (not servicegroup_name) is properly linked to the service and triggers escalation contacts.
+    [Tags]    engine    serviceescalation    MON-197927
+
+    Ctn Clear Commands Status
+    Ctn Config Engine    ${1}    ${5}    ${1}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module
+    Ctn Config BBDO3    1
+
+    Ctn Config Engine Add Cfg File    ${0}    escalations.cfg
+    Ctn Config Engine Add Cfg File    ${0}    contacts.cfg
+    Ctn Config Engine Add Cfg File    ${0}    contactgroups.cfg
+
+    Ctn Engine Config Set Value    0    interval_length    1    True
+
+    Ctn Engine Config Add Command    0    command_notif    /usr/bin/true
+    Ctn Engine Config Set Value In Contacts    0    John_Doe    host_notification_commands    command_notif
+    Ctn Engine Config Set Value In Contacts    0    John_Doe    service_notification_commands    command_notif
+
+    # Service_1 notifications: direct contact is John_Doe (first notification),
+    # escalation contactgroup_1 fires from notification #2 onwards.
+    Ctn Engine Config Set Value In Services    0    service_1    notifications_enabled    1
+    Ctn Engine Config Set Value In Services    0    service_1    notification_options    w,c,r
+    Ctn Engine Config Set Value In Services    0    service_1    notification_period    24x7
+    Ctn Engine Config Set Value In Services    0    service_1    notification_interval    1
+    Ctn Engine Config Set Value In Services    0    service_1    contacts    John_Doe
+    Ctn Engine Config Replace Value In Services    0    service_1    check_command    command_44
+    Ctn Engine Config Replace Value In Services    0    service_1    check_interval    1
+    Ctn Engine Config Replace Value In Services    0    service_1    retry_interval    1
+
+    Ctn Add Contact Group    ${0}    ${1}    ["U1","U2","U3"]
+
+    Ctn Create Escalations File    0    1    dummy_servicegroup    contactgroup_1    service
+    Ctn Engine Config Delete Key In Cfg    0    esc1    servicegroup_name    escalations.cfg
+    Ctn Engine Config Set Key Value In Cfg    0    esc1    host_name    host_1    escalations.cfg
+    Ctn Engine Config Set Key Value In Cfg    0    esc1    service_description    service_1    escalations.cfg
+    Ctn Engine Config Set Value In Escalations    0    esc1    first_notification    2
+    Ctn Engine Config Set Value In Escalations    0    esc1    last_notification    0
+    Ctn Engine Config Set Value In Escalations    0    esc1    notification_interval    1
+
+    ${start}    Get Current Date
+    Ctn Start Broker
+    Ctn Start Engine
+    
+    # Force service_1's check command to return CRITICAL so it reaches HARD CRITICAL.
+    Ctn Set Command Status    ${44}    ${2}
+
+    ${output}    Ctn Get Service Escalation Info Grpc    host_1    service_1
+
+    Log To Console    "Verify that the escalation (host_1, service_1) is created"
+
+    Should Be Equal As Strings    ${output}[host]    host_1    host
+    Should Be Equal As Strings    ${output}[serviceDescription]    service_1    serviceDescription
+    Should Contain    ${output}[contactGroup]    contactgroup_1    contactGroup
+    Should Be Equal As Strings    ${output}[escalationPeriod]    24x7    escalationPeriod
+    Should Be Equal As Numbers    ${output}[firstNotification]    2    firstNotification
+    Should Be Equal As Numbers    ${output}[lastNotification]    0    lastNotification
+    Should Be Equal As Numbers    ${output}[notificationInterval]    1    notificationInterval
+
+
+    # Notification #1 goes to the service's direct contact (John_Doe).
+    ${content}    Create List    SERVICE NOTIFICATION: John_Doe;host_1;service_1;CRITICAL;command_notif;
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    First notification to John_Doe was not sent
+
+    # Notification #2+ comes from the escalation contactgroup_1 (U1, U2, U3).
+    ${content}    Create List    SERVICE NOTIFICATION: U1;host_1;service_1;CRITICAL;command_notif;
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    Escalation notification to U1 was not sent
+
+    ${content}    Create List    SERVICE NOTIFICATION: U2;host_1;service_1;CRITICAL;command_notif;
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    Escalation notification to U2 was not sent
+
+    ${content}    Create List    SERVICE NOTIFICATION: U3;host_1;service_1;CRITICAL;command_notif;
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    Escalation notification to U3 was not sent
+
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker


### PR DESCRIPTION
fix(engine): host escalation not applied when using host_name instead of hostgroup_name

REFS: MON-197927

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Fixed host escalation not applied when host_name was used
* Added error when expanding host escalation with neither hosts nor hostgroups

**🔧 Refactors**
* Replaced absl::flat_hash_set<std::string_view> with std::string for hosts


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107000202?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->