### PR TITLE
Mon 197731 when you move a host or a service it might be removed from cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,12 @@ broker/compile_commands.json
 broker/grpc/grpc_stream.proto
 broker/grpc/src/grpc_bridge.cc
 
+#generated 
+broker/core/cache/inc/com/centreon/broker/cache/protobuf.hh
+broker/core/cache/src/protobuf.cc
+broker/core/cache/test/protobuf_test_classes.cc
+broker/core/cache/test/protobuf_test_classes.hh
+
 
 # clib
 clib/inc/com/centreon/clib/version.hh

--- a/bbdo/neb.proto
+++ b/bbdo/neb.proto
@@ -153,6 +153,7 @@ message Service {
    * here. */
   uint64 internal_id = 86;
   uint64 icon_id = 87;
+  int32 instance_id = 88;
 }
 
 /**

--- a/broker/core/cache/src/global_cache_data.cc
+++ b/broker/core/cache/src/global_cache_data.cc
@@ -472,8 +472,7 @@ void global_cache_data::_process_pb_host(
             _logger,
             "cache: ignoring stale deletion of host {} from poller {} "
             "(currently owned by poller {})",
-            in.host_id(), in.instance_id(),
-            exist->second.first->instance_id());
+            in.host_id(), in.instance_id(), exist->second.first->instance_id());
         return;
       }
       if (exist->second.first) {

--- a/broker/core/cache/src/global_cache_data.cc
+++ b/broker/core/cache/src/global_cache_data.cc
@@ -465,6 +465,17 @@ void global_cache_data::_process_pb_host(
         _set_dirty_and_increment_modif();
       }
     } else {
+      if (in.instance_id() != 0 && exist->second.first &&
+          exist->second.first->instance_id() != 0 &&
+          in.instance_id() != exist->second.first->instance_id()) {
+        SPDLOG_LOGGER_DEBUG(
+            _logger,
+            "cache: ignoring stale deletion of host {} from poller {} "
+            "(currently owned by poller {})",
+            in.host_id(), in.instance_id(),
+            exist->second.first->instance_id());
+        return;
+      }
       if (exist->second.first) {
         _file->get_segment_manager()->destroy_ptr(exist->second.first.get());
       }
@@ -800,6 +811,17 @@ void global_cache_data::_process_pb_service(
         _set_dirty_and_increment_modif();
       }
     } else {
+      if (in.instance_id() != 0 && exist->second.first &&
+          exist->second.first->instance_id() != 0 &&
+          in.instance_id() != exist->second.first->instance_id()) {
+        SPDLOG_LOGGER_DEBUG(
+            _logger,
+            "cache: ignoring stale deletion of service ({},{}) from poller {} "
+            "(currently owned by poller {})",
+            in.host_id(), in.service_id(), in.instance_id(),
+            exist->second.first->instance_id());
+        return;
+      }
       if (exist->second.first) {
         _file->get_segment_manager()->destroy_ptr(exist->second.first.get());
       }

--- a/broker/core/cache/test/global_cache_test.cc
+++ b/broker/core/cache/test/global_cache_test.cc
@@ -1042,3 +1042,86 @@ TEST_F(global_cache_test, EnumerateServiceGroup) {
   obj.reset();
   global_cache::unload();
 }
+
+TEST_F(global_cache_test, HostMovedBetweenPollers) {
+  global_cache::unload();
+  ::remove("/tmp/cache_test.rt");
+  ::remove("/tmp/cache_test.cnf");
+  global_cache::pointer obj =
+      global_cache::load(g_io_context, "/tmp/cache_test");
+
+  // Initial add on poller 10.
+  auto host1 = std::make_shared<neb::pb_host>();
+  host1->mut_obj().set_host_id(1);
+  host1->mut_obj().set_name("host_1");
+  host1->mut_obj().set_instance_id(10);
+  host1->mut_obj().set_enabled(true);
+  obj->write(host1);
+
+  // New poller 20 sends addition first (re-config finished on new side).
+  auto host2 = std::make_shared<neb::pb_host>();
+  host2->mut_obj().set_host_id(1);
+  host2->mut_obj().set_name("host_1");
+  host2->mut_obj().set_instance_id(20);
+  host2->mut_obj().set_enabled(true);
+  obj->write(host2);
+
+  // Old poller 10 sends its stale deletion (re-config still finishing).
+  auto host_del = std::make_shared<neb::pb_host>();
+  host_del->mut_obj().set_host_id(1);
+  host_del->mut_obj().set_instance_id(10);
+  host_del->mut_obj().set_enabled(false);
+  obj->write(host_del);
+
+  // Host must still be present, owned by poller 20.
+  global_cache::lock l;
+  const cache::host* h = obj->get_host(1, l);
+  ASSERT_NE(h, nullptr);
+  ASSERT_EQ(h->instance_id(), 20);
+}
+
+TEST_F(global_cache_test, ServiceMovedBetweenPollers) {
+  global_cache::unload();
+  ::remove("/tmp/cache_test.rt");
+  ::remove("/tmp/cache_test.cnf");
+  global_cache::pointer obj =
+      global_cache::load(g_io_context, "/tmp/cache_test");
+
+  // Need a host entry so get_service can find it.
+  auto host1 = std::make_shared<neb::pb_host>();
+  host1->mut_obj().set_host_id(1);
+  host1->mut_obj().set_enabled(true);
+  obj->write(host1);
+
+  // Initial add on poller 10.
+  auto svc1 = std::make_shared<neb::pb_service>();
+  svc1->mut_obj().set_host_id(1);
+  svc1->mut_obj().set_service_id(2);
+  svc1->mut_obj().set_description("svc_2");
+  svc1->mut_obj().set_instance_id(10);
+  svc1->mut_obj().set_enabled(true);
+  obj->write(svc1);
+
+  // New poller 20 sends addition first.
+  auto svc2 = std::make_shared<neb::pb_service>();
+  svc2->mut_obj().set_host_id(1);
+  svc2->mut_obj().set_service_id(2);
+  svc2->mut_obj().set_description("svc_2");
+  svc2->mut_obj().set_instance_id(20);
+  svc2->mut_obj().set_enabled(true);
+  obj->write(svc2);
+
+  // Old poller 10 sends stale deletion.
+  auto svc_del = std::make_shared<neb::pb_service>();
+  svc_del->mut_obj().set_host_id(1);
+  svc_del->mut_obj().set_service_id(2);
+  svc_del->mut_obj().set_instance_id(10);
+  svc_del->mut_obj().set_enabled(false);
+  obj->write(svc_del);
+
+  // Service must still be present, owned by poller 20.
+  global_cache::lock l;
+  const cache::service* s = obj->get_service(1, 2, l);
+  ASSERT_NE(s, nullptr);
+  ASSERT_EQ(s->instance_id(), 20);
+}

--- a/broker/core/cache/test/protobuf_test.cc
+++ b/broker/core/cache/test/protobuf_test.cc
@@ -519,6 +519,7 @@ TEST_F(protobuf_test, service_to_protobuf) {
   pb.set_type(ServiceType(rand() % 5));
   pb.set_internal_id(rand() + 1);
   pb.set_icon_id(rand() + 1);
+  pb.set_instance_id(rand() + 1);
   for (int i = 1 + rand() % 2; i > 0; --i)
     *pb.add_tags() = create_random_tag_info();
 

--- a/broker/lua/test/lua.cc
+++ b/broker/lua/test/lua.cc
@@ -5239,6 +5239,7 @@ TEST_F(LuaTest, BrokerApi2PbAdaptiveHostJsonEncode) {
 }
 
 TEST_F(LuaTest, ServiceObjectMatchBetweenBbdoVersions) {
+  RemoveFile("/tmp/log");
   config::applier::modules modules(log_v2::instance().get(log_v2::LUA));
   char tmp[256];
   getcwd(tmp, 256);
@@ -5304,10 +5305,10 @@ TEST_F(LuaTest, ServiceObjectMatchBetweenBbdoVersions) {
 
   auto it = l1.begin();
   for (auto it1 = l2.begin(); it1 != l2.end();) {
-    if (*it1 == "host_name" || *it1 == "icon_id" || *it1 == "internal_id" ||
-        *it1 == "is_volatile" || *it1 == "long_output" ||
-        *it1 == "severity_id" || *it1 == "tags" || *it1 == "type" ||
-        *it1 == "command_line") {
+    if (*it1 == "host_name" || *it1 == "icon_id" || *it1 == "instance_id" ||
+        *it1 == "internal_id" || *it1 == "is_volatile" ||
+        *it1 == "long_output" || *it1 == "severity_id" || *it1 == "tags" ||
+        *it1 == "type" || *it1 == "command_line") {
       ++it1;
       continue;
     }
@@ -5327,6 +5328,7 @@ TEST_F(LuaTest, ServiceObjectMatchBetweenBbdoVersions) {
 }
 
 TEST_F(LuaTest, HostObjectMatchBetweenBbdoVersions) {
+  RemoveFile("/tmp/log");
   config::applier::modules modules(log_v2::instance().get(log_v2::LUA));
   char tmp[256];
   getcwd(tmp, 256);

--- a/engine/src/broker.cc
+++ b/engine/src/broker.cc
@@ -1158,6 +1158,7 @@ static void forward_pb_service(int type,
     // Search host ID and service ID.
     srv.set_host_id(es->host_id());
     srv.set_service_id(es->service_id());
+    srv.set_instance_id(cbm->poller_id());
     if (srv.host_id() && srv.service_id())
       SPDLOG_LOGGER_DEBUG(neb_logger,
                           "callbacks: service ({}, {}) has a severity id {}",

--- a/tests/broker-engine/host-service-move.robot
+++ b/tests/broker-engine/host-service-move.robot
@@ -1,0 +1,166 @@
+*** Settings ***
+Documentation       When a host or service is moved between pollers, brokermust not evict it from cache.
+Resource            ../resources/import.resource
+
+Suite Setup         Ctn Clean Before Suite
+Suite Teardown      Ctn Clean After Suite
+Test Setup          Ctn Stop Processes
+Test Teardown       Ctn Save Logs If Failed
+
+
+*** Test Cases ***
+BEMC1
+    [Documentation]    When host_1 is moved from engine0 to engine1, reloading engine1 first
+    ...                (so broker cache records instance_id=2 for host_1) and then reloading
+    ...                engine0 (which sends a DELETE with instance_id=1) must not evict host_1
+    ...                from broker cache. The broker log must contain "ignoring stale deletion".
+    [Tags]    broker    engine    cache    MON-197731
+    Ctn Config Engine    ${2}    ${5}    ${0}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module    ${2}
+    Ctn Config BBDO3    ${2}
+    Ctn Broker Config Log    central    core    debug
+    Ctn Broker Config Log    central    lua    trace
+    Remove File    /tmp/test-LUA.log
+    Ctn Broker Config Add Lua Output    central    test-cache    ${SCRIPTS}dump_host.lua
+    ${start}    Get Current Date
+    Ctn Start Broker
+    Wait Until Created    /tmp/test-LUA.log
+    Ctn Start Engine
+
+    # Wait for both engines to be ready
+    ${content}    Create List    check_for_external_commands()
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    engine0 did not reach check_for_external_commands
+    ${result}    Ctn Find In Log With Timeout    ${engineLog1}    ${start}    ${content}    60
+    Should Be True    ${result}    engine1 did not reach check_for_external_commands
+
+    # Wait for host_1 (owned by engine0 / instance_id=1) to be registered in DB
+    Connect To Database    pymysql    ${DBName}    ${DBUser}    ${DBPass}    ${DBHost}    ${DBPort}
+    FOR    ${index}    IN RANGE    60
+        ${output}    Query    SELECT instance_id FROM hosts WHERE name='host_1' AND enabled=1
+        Sleep    1s
+        IF    "${output}" == "((1,),)"    BREAK
+    END
+    Should Be Equal As Strings    ${output}    ((1,),)
+    Log To Console    "host_1 have the instance" ${output}
+
+    # --- Simulate moving host_1 from engine0 to engine1 ---
+    # Step 1: move host_1 from engine0's config to engine1's config
+    Ctn Engine Config Move Host To Engine    0    1    host_1
+
+    # Step 2: reload engine1 so broker learns host_1 belongs to instance_id=2
+    ${reload1_time}    Get Current Date
+    Ctn Reload Engine    1
+    ${content}    Create List    check_for_external_commands()
+    ${result}    Ctn Find In Log With Timeout    ${engineLog1}    ${reload1_time}    ${content}    60
+    Should Be True    ${result}    engine1 did not complete reload
+
+    FOR    ${index}    IN RANGE    30
+        ${output}    Query    SELECT instance_id FROM hosts WHERE name='host_1' AND enabled=1
+        Sleep    1s
+        IF    "${output}" == "((2,),)"    BREAK
+    END
+    Should Be Equal As Strings    ${output}    ((2,),)
+
+    # Step 3: reload engine0 so it sends DELETE(host_1, instance_id=1)
+    ${reload0_time}    Get Current Date
+    Ctn Reload Engine    0
+    ${content}    Create List    check_for_external_commands()
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${reload0_time}    ${content}    60
+    Should Be True    ${result}    engine0 did not complete reload
+
+    # Verify host_1 is still visible through broker cache after the stale DELETE.
+    FOR    ${index}    IN RANGE    30
+        ${lua_output}    Get File    /tmp/test-LUA.log
+        IF    'host 1 :' in $lua_output    BREAK
+        Sleep    1s
+    END
+    Should Contain    ${lua_output}    host 1 :    host_1 was removed from broker cache after the stale DELETE
+
+    # The guard must fire and log the stale deletion
+    ${content}    Create List    cache: ignoring stale deletion of host
+    ${result}    Ctn Find In Log With Timeout    ${centralLog}    ${reload0_time}    ${content}    30
+    Should Be True    ${result}    Broker did not ignore the stale DELETE for host_1
+
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker
+
+
+BEMC2
+    [Documentation]    When service_1 on host_1 is moved from engine0 to engine1, reloading
+    ...                engine1 first (broker records instance_id=2) and then reloading engine0
+    ...                (DELETE with instance_id=1) must not evict service_1 from broker cache.
+    [Tags]    broker    engine    cache    MON-197731
+    Ctn Config Engine    ${2}    ${5}    ${1}
+    Ctn Config Broker    central
+    Ctn Config Broker    module    ${2}
+    Ctn Config BBDO3    ${2}
+    Ctn Broker Config Log    central    core    debug
+    Ctn Broker Config Log    central    lua    trace
+    Remove File    /tmp/test-LUA.log
+    Ctn Broker Config Add Lua Output    central    test-cache    ${SCRIPTS}dump_service.lua
+    ${start}    Get Current Date
+    Ctn Start Broker
+    Wait Until Created    /tmp/test-LUA.log
+    Ctn Start Engine
+
+    # Wait for both engines to be ready
+    ${content}    Create List    check_for_external_commands()
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    engine0 did not reach check_for_external_commands
+    ${result}    Ctn Find In Log With Timeout    ${engineLog1}    ${start}    ${content}    60
+    Should Be True    ${result}    engine1 did not reach check_for_external_commands
+
+    # Wait for host_1 and service_1 to be registered in DB
+    Connect To Database    pymysql    ${DBName}    ${DBUser}    ${DBPass}    ${DBHost}    ${DBPort}
+    FOR    ${index}    IN RANGE    60
+        ${output}    Query    SELECT count(*) FROM services s JOIN hosts h ON s.host_id=h.host_id WHERE h.name='host_1' AND s.enabled=1
+        Sleep    1s
+        IF    "${output}" == "((1,),)"    BREAK
+    END
+    Should Be Equal As Strings    ${output}    ((1,),)
+
+    # --- Simulate moving host_1 + service_1 from engine0 to engine1 ---
+    # Step 1: move host_1 and its services from engine0's config to engine1's config
+    Ctn Engine Config Move Host To Engine    0    1    host_1
+    Ctn Engine Config Move Services To Engine    0    1    host_1
+
+    # Step 2: reload engine1 so broker learns service_1 belongs to instance_id=2
+    ${reload1_time}    Get Current Date
+    Ctn Reload Engine    1
+    ${content}    Create List    check_for_external_commands()
+    ${result}    Ctn Find In Log With Timeout    ${engineLog1}    ${reload1_time}    ${content}    60
+    Should Be True    ${result}    engine1 did not complete reload
+
+    FOR    ${index}    IN RANGE    30
+        ${output}    Query    SELECT h.instance_id FROM services s JOIN hosts h ON s.host_id=h.host_id WHERE h.name='host_1' AND s.enabled=1
+        Sleep    1s
+        IF    "${output}" == "((2,),)"    BREAK
+    END
+    Should Be Equal As Strings    ${output}    ((2,),)
+
+    # Step 3: reload engine0 — it detects service_1 is gone and sends DELETE(service_1, instance_id=1)
+    Run    truncate -s 0 /tmp/test-LUA.log
+    ${reload0_time}    Get Current Date
+    Ctn Reload Engine    0
+    ${content}    Create List    check_for_external_commands()
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${reload0_time}    ${content}    60
+    Should Be True    ${result}    engine0 did not complete reload
+
+    # Verify service_1 is still visible through broker cache after the stale DELETE.
+    FOR    ${index}    IN RANGE    30
+        ${lua_output}    Get File    /tmp/test-LUA.log
+        IF    'serv 1 :' in $lua_output    BREAK
+        Sleep    1s
+    END
+    Should Contain    ${lua_output}    serv 1 :    service_1 was removed from broker cache after the stale DELETE
+
+    # The guard must fire and log the stale deletion for the service
+    ${content}    Create List    cache: ignoring stale deletion of service
+    ${result}    Ctn Find In Log With Timeout    ${centralLog}    ${reload0_time}    ${content}    30
+    Should Be True    ${result}    Broker did not ignore the stale DELETE for service_1
+
+    Ctn Stop Engine
+    Ctn Kindly Stop Broker

--- a/tests/resources/Engine.py
+++ b/tests/resources/Engine.py
@@ -1669,6 +1669,158 @@ def ctn_engine_config_remove_host(idx: int, host: str):
         f.writelines(lines)
 
 
+def ctn_engine_config_move_host_to_engine(src_idx: int, dest_idx: int, host_name: str):
+    """
+    Move a host block from src engine's hosts.cfg to dest engine's hosts.cfg.
+    The host is removed from src and appended to dest in a single operation.
+
+    Args:
+        src_idx (int): Index of the source engine configuration (from 0)
+        dest_idx (int): Index of the destination engine configuration (from 0)
+        host_name (str): Name of the host to move
+    """
+    src_file = f"{ETC_ROOT}/centreon-engine/config{src_idx}/hosts.cfg"
+    dest_file = f"{ETC_ROOT}/centreon-engine/config{dest_idx}/hosts.cfg"
+
+    with open(src_file, "r") as f:
+        lines = f.readlines()
+
+    host_name_re = re.compile(rf"^\s*host_name\s+{re.escape(host_name)}\s*$")
+    host_begin = re.compile(r"^define host {$")
+    host_end = re.compile(r"^}$")
+
+    block_start = None
+    for i, line in enumerate(lines):
+        if host_begin.match(line):
+            block_start = i
+        elif block_start is not None and host_name_re.match(line):
+            for j in range(i, len(lines)):
+                if host_end.match(lines[j]):
+                    block = lines[block_start:j + 1]
+                    del lines[block_start:j + 1]
+                    with open(src_file, "w") as f:
+                        f.writelines(lines)
+                    with open(dest_file, "a") as f:
+                        f.writelines(block)
+                    return
+        elif block_start is not None and host_end.match(line):
+            block_start = None
+
+
+def ctn_engine_config_move_services_to_engine(src_idx: int, dest_idx: int, host_name: str):
+    """
+    Move all service blocks for host_name from src engine to dest engine.
+    Services are removed from src and appended to dest. Referenced check_command
+    definitions not already in dest commands.cfg are also copied from src.
+
+    Args:
+        src_idx (int): Index of the source engine configuration (from 0)
+        dest_idx (int): Index of the destination engine configuration (from 0)
+        host_name (str): Name of the host whose services to move
+    """
+    src_services = f"{ETC_ROOT}/centreon-engine/config{src_idx}/services.cfg"
+    dest_services = f"{ETC_ROOT}/centreon-engine/config{dest_idx}/services.cfg"
+    src_commands = f"{ETC_ROOT}/centreon-engine/config{src_idx}/commands.cfg"
+    dest_commands = f"{ETC_ROOT}/centreon-engine/config{dest_idx}/commands.cfg"
+
+    with open(src_services, "r") as f:
+        lines = f.readlines()
+
+    host_name_re = re.compile(rf"^\s*host_name\s+{re.escape(host_name)}\s*$")
+    check_cmd_re = re.compile(r"^\s*check_command\s+(\S+)\s*$")
+    serv_begin = re.compile(r"^define service {$")
+    serv_end = re.compile(r"^}$")
+
+    block_ranges = []
+    needed_commands = set()
+    block_start = None
+    found_host = False
+    cmd_in_block = None
+
+    for i, line in enumerate(lines):
+        if serv_begin.match(line):
+            block_start = i
+            found_host = False
+            cmd_in_block = None
+        elif block_start is not None:
+            if host_name_re.match(line):
+                found_host = True
+            m = check_cmd_re.match(line)
+            if m:
+                cmd_in_block = m.group(1)
+            if serv_end.match(line):
+                if found_host:
+                    block_ranges.append((block_start, i + 1))
+                    if cmd_in_block:
+                        needed_commands.add(cmd_in_block)
+                block_start = None
+
+    if not block_ranges:
+        return
+
+    service_blocks = [lines[s:e] for s, e in block_ranges]
+
+    remaining = []
+    prev = 0
+    for start, end in block_ranges:
+        remaining.extend(lines[prev:start])
+        prev = end
+    remaining.extend(lines[prev:])
+
+    with open(src_services, "w") as f:
+        f.writelines(remaining)
+    with open(dest_services, "a") as f:
+        for block in service_blocks:
+            f.writelines(block)
+
+    if not needed_commands:
+        return
+
+    with open(src_commands, "r") as f:
+        src_cmd_lines = f.readlines()
+    with open(dest_commands, "r") as f:
+        dest_cmd_lines = f.readlines()
+
+    cmd_begin = re.compile(r"^define command \{")
+    cmd_name_re = re.compile(r"^\s*command_name\s+(\S+)\s*$")
+    cmd_end = re.compile(r"^\}")
+
+    existing_commands = set()
+    block_start = None
+    for line in dest_cmd_lines:
+        if cmd_begin.match(line):
+            block_start = True
+        elif block_start is not None:
+            m = cmd_name_re.match(line)
+            if m:
+                existing_commands.add(m.group(1))
+            if cmd_end.match(line):
+                block_start = None
+
+    block_start = None
+    cmd_name_in_block = None
+    commands_to_copy = []
+
+    for i, line in enumerate(src_cmd_lines):
+        if cmd_begin.match(line):
+            block_start = i
+            cmd_name_in_block = None
+        elif block_start is not None:
+            m = cmd_name_re.match(line)
+            if m:
+                cmd_name_in_block = m.group(1)
+            if cmd_end.match(line):
+                if (cmd_name_in_block in needed_commands and
+                        cmd_name_in_block not in existing_commands):
+                    commands_to_copy.append(src_cmd_lines[block_start:i + 1])
+                block_start = None
+
+    if commands_to_copy:
+        with open(dest_commands, "a") as f:
+            for block in commands_to_copy:
+                f.writelines(block)
+
+
 def ctn_engine_config_rename_host(idx: int, old_host_name: str, new_host_name: str):
     """
     Rename a host from the hosts.cfg configuration file.


### PR DESCRIPTION
fix(broker): cache verify the instance_id before deleting

REFS: MON-197731

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Included instance_id in protobuf acknowledgements sent by broker engine
* Added robot test that reproduced and guarded against stale deletions

**🐛 Bugfixes**
* Verified instance_id before deleting cache entries to prevent stale removals


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112750058?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->