### PR TITLE
feat(ci): add rebuild-release label for stable release rebuild

### DIFF
--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -111,6 +111,7 @@ jobs:
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt
+    secrets: inherit
 
   check-cherry-pick:
     needs: [get-environment, check-status]

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -115,6 +115,7 @@ jobs:
       version_file: CMakeLists.txt
       nightly_manual_trigger: ${{ inputs.nightly_manual_trigger || inputs.robot_pattern != '^((?!cma).)*$' || false }}
       labels: ${{ inputs.labels || '' }}
+    secrets: inherit
 
   get-aws-environment:
     uses: ./.github/workflows/get-aws-environment.yml

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -44,6 +44,7 @@ jobs:
     with:
       version_file: .version.centreon-common
       labels: ${{ inputs.labels || '' }}
+    secrets: inherit
 
   package:
     needs: [get-environment]

--- a/.github/workflows/docker-collect-testing.yml
+++ b/.github/workflows/docker-collect-testing.yml
@@ -34,6 +34,7 @@ jobs:
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt
+    secrets: inherit
 
   dockerize:
     needs: [get-environment]

--- a/.github/workflows/docker-gorgone-testing.yml
+++ b/.github/workflows/docker-gorgone-testing.yml
@@ -28,6 +28,7 @@ jobs:
     needs: [dependency-scan]
     if: github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/get-environment.yml
+    secrets: inherit
 
   dockerize:
     needs: [get-environment]

--- a/.github/workflows/docker-packaging.yml
+++ b/.github/workflows/docker-packaging.yml
@@ -28,6 +28,7 @@ jobs:
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt
+    secrets: inherit
 
   dockerize:
     needs: [get-environment]

--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -179,6 +179,11 @@ jobs:
                 triggerUnitTesting = false;
                 triggerE2eTesting = false;
               }
+              if (labels.includes('rebuild-release')) {
+                core.info('Label rebuild-release found: skipping all tests, keeping packaging and delivery only');
+                triggerUnitTesting = false;
+                triggerE2eTesting = false;
+              }
             } catch (e) {
               core.warning(`Could not parse labels: ${e}`);
             }

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -159,14 +159,19 @@ jobs:
         if: contains(steps.has_skip_label.outputs.labels, 'rebuild-release')
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          github-token: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
           script: |
             try {
-              await github.rest.teams.getMembershipForUserInOrg({
+              const { data } = await github.rest.teams.getMembershipForUserInOrg({
                 org: 'centreon',
                 team_slug: 'release-management',
                 username: context.actor,
               });
-              core.info(`User ${context.actor} is authorized to use rebuild-release label.`);
+              if (data.state !== 'active') {
+                core.setFailed(`User ${context.actor} is NOT an active member of the release-management team. Cannot use rebuild-release label.`);
+              } else {
+                core.info(`User ${context.actor} is authorized to use rebuild-release label.`);
+              }
             } catch (e) {
               core.setFailed(`User ${context.actor} is NOT in the release-management team. Cannot use rebuild-release label.`);
             }

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -12,6 +12,9 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      CENTREON_TECHNIQUE_PAT:
+        required: false
     outputs:
       latest_major_version:
         description: "latest major version"

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -155,6 +155,22 @@ jobs:
 
             return hasSkipLabel;
 
+      - name: Check rebuild-release authorization
+        if: contains(steps.has_skip_label.outputs.labels, 'rebuild-release')
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            try {
+              await github.rest.teams.getMembershipForUserInOrg({
+                org: 'centreon',
+                team_slug: 'release-management',
+                username: context.actor,
+              });
+              core.info(`User ${context.actor} is authorized to use rebuild-release label.`);
+            } catch (e) {
+              core.setFailed(`User ${context.actor} is NOT in the release-management team. Cannot use rebuild-release label.`);
+            }
+
       - name: Checkout sources (current branch)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -164,19 +164,22 @@ jobs:
         with:
           github-token: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
           script: |
+            core.info(`Checking release-management team membership for: ${context.actor}`);
             try {
               const { data } = await github.rest.teams.getMembershipForUserInOrg({
                 org: 'centreon',
                 team_slug: 'release-management',
                 username: context.actor,
               });
+              core.info(`API response: state=${data.state}, role=${data.role}`);
               if (data.state !== 'active') {
-                core.setFailed(`User ${context.actor} is NOT an active member of the release-management team. Cannot use rebuild-release label.`);
+                core.setFailed(`[state-check] User ${context.actor} membership state is "${data.state}" (expected "active"). Cannot use rebuild-release label.`);
               } else {
-                core.info(`User ${context.actor} is authorized to use rebuild-release label.`);
+                core.info(`[authorized] User ${context.actor} is an active member of release-management. Proceeding.`);
               }
             } catch (e) {
-              core.setFailed(`User ${context.actor} is NOT in the release-management team. Cannot use rebuild-release label.`);
+              core.info(`[api-error] HTTP status: ${e.status ?? 'unknown'} — ${e.message}`);
+              core.setFailed(`[api-error] Cannot verify team membership for ${context.actor}: ${e.message}. Check that CENTREON_TECHNIQUE_PAT has read:org scope.`);
             }
 
       - name: Checkout sources (current branch)

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -48,6 +48,7 @@ jobs:
     with:
       version_file: .version.centreon-gorgone
       labels: ${{ inputs.labels || '' }}
+    secrets: inherit
 
   changes:
     if: |

--- a/.github/workflows/libzmq.yml
+++ b/.github/workflows/libzmq.yml
@@ -31,6 +31,7 @@ jobs:
   get-environment:
     needs: [dependency-scan]
     uses: ./.github/workflows/get-environment.yml
+    secrets: inherit
 
   package-rpm:
     needs: [get-environment]

--- a/.github/workflows/lua-curl.yml
+++ b/.github/workflows/lua-curl.yml
@@ -44,6 +44,7 @@ jobs:
     uses: ./.github/workflows/get-environment.yml
     with:
       labels: ${{ inputs.labels || '' }}
+    secrets: inherit
 
   package:
     needs: [get-environment]

--- a/.github/workflows/monitoring-agent.yml
+++ b/.github/workflows/monitoring-agent.yml
@@ -73,6 +73,7 @@ jobs:
       version_file: CMakeLists.txt
       nightly_manual_trigger: ${{ inputs.nightly_manual_trigger || false }}
       labels: ${{ inputs.labels || '' }}
+    secrets: inherit
 
   get-aws-environment:
     uses: ./.github/workflows/get-aws-environment.yml

--- a/.github/workflows/windows-agent-robot-test.yml
+++ b/.github/workflows/windows-agent-robot-test.yml
@@ -26,6 +26,7 @@ jobs:
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt
+    secrets: inherit
 
   get-aws-environment:
     uses: ./.github/workflows/get-aws-environment.yml


### PR DESCRIPTION
## Summary

- Adds `rebuild-release` label support to the CI dispatch label system
- When label is present, all tests (`trigger_unit_testing`, `trigger_e2e_testing`) are forced to `false` while packaging and delivery remain active
- Restricts usage to members of the `release-management` GitHub team via an authorization check step in `get-environment.yml`

## Context

Implements the "Force rebuild of previous stable release" procedure (Confluence) without requiring manual CLI flags to skip tests. Part of MON-193030.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/get-changes-triggers.yml` | Add `rebuild-release` block in dispatch label handling |
| `.github/workflows/get-environment.yml` | Add authorization step checking `release-management` team membership |

## Test plan

- [x] Dispatch a workflow with `labels='["rebuild-release"]'` from a non-`release-management` account → step should fail with clear error
- [x] Dispatch from a `release-management` member → `trigger_unit_testing=false`, `trigger_e2e_testing=false`, `trigger_packaging=true`, `trigger_delivery=true`
- [x] Open a normal PR (no label) → authorization step is skipped, pipeline unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added rebuild-release label to dispatch handling to skip tests
* Added authorization check requiring release-management team membership for rebuild-release
* Propagated secrets: inherit to get-environment workflow callers across workflows


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112408568?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->