### PR TITLE
enh(gorgone) send to clapi the timeout used by gorgone from the action module

### DIFF
--- a/gorgone/gorgone/modules/centreon/legacycmd/class.pm
+++ b/gorgone/gorgone/modules/centreon/legacycmd/class.pm
@@ -602,10 +602,20 @@ sub execute_cmd {
         if (!defined($self->{clapi_password})) {
             return (-1, 'need centreon clapi password to execute STARTWORKER command');
         }
+        my $task_timeout;
+        # need to send to clapi the timeout that gorgone is using from the action module
+        foreach my $module (@{$self->{config_core}->{modules}}) {
+            if ($module->{package} eq 'gorgone::modules::core::action::hooks') {
+                $task_timeout = $module->{command_timeout};
+                last
+            }
+        }
+        $task_timeout ||= 60;
+
         my $centreon_dir = (defined($connector->{config}->{centreon_dir})) ?
             $connector->{config}->{centreon_dir} : '/usr/share/centreon';
         my $cmd = $centreon_dir . '/bin/centreon -u "' . $self->{clapi_user} . '" -p "' .
-            $self->{clapi_password} . '" -w -o CentreonWorker -a processQueue';
+            $self->{clapi_password} . '" -w -o CentreonWorker -a processQueue --commandTimeout '.$task_timeout;
         $self->send_internal_action({
             action => 'COMMAND',
             target => undef,
@@ -615,6 +625,7 @@ sub execute_cmd {
                 content => [
                     {
                         command => $cmd,
+                        timeout => $task_timeout,
                         metadata => {
                             centcore_cmd => 'STARTWORKER'
                         }
@@ -638,7 +649,7 @@ sub action_addimporttaskwithparent {
             token => $options{token},
             logging => $options{data}->{logging},
             data => {
-                message => "expected parent_id task ID, found '" . $options{data}->{content}->{parent_id} . "'",
+                message => "expected parent_id task ID",
             }
         );
         return -1;
@@ -662,10 +673,20 @@ sub action_addimporttaskwithparent {
         return -1;
     }
 
-    my $centreon_dir = (defined($connector->{config}->{centreon_dir})) ?
-        $connector->{config}->{centreon_dir} : '/usr/share/centreon';
+    my $task_timeout;
+    foreach my $module (@{$self->{config_core}->{modules}}) {
+        # need to send to clapi the timeout that gorgone is using from the action module
+        if ($module->{package} eq 'gorgone::modules::core::action::hooks') {
+            $task_timeout = $module->{command_timeout};
+            last
+        }
+    }
+
+    $task_timeout ||= 60;
+
+    my $centreon_dir = $connector->{config}->{centreon_dir} // '/usr/share/centreon';
     my $cmd = $centreon_dir . '/bin/centreon -u "' . $self->{clapi_user} . '" -p "' .
-        $self->{clapi_password} . '" -w -o CentreonWorker -a processQueue';
+        $self->{clapi_password} . '" -w -o CentreonWorker -a processQueue --commandTimeout '.$task_timeout;
     $self->send_internal_action({
         action => 'COMMAND',
         token => $options{token},
@@ -673,7 +694,8 @@ sub action_addimporttaskwithparent {
             logging => $options{data}->{logging},
             content => [
                 {
-                    command => $cmd
+                    command => $cmd,
+                    timeout => $task_timeout,
                 }
             ],
             parameters => { no_fork => 1 }

--- a/gorgone/packaging/configuration/whitelist.conf.d/centreon.yaml
+++ b/gorgone/packaging/configuration/whitelist.conf.d/centreon.yaml
@@ -12,6 +12,7 @@
 - ^mkdir
 - ^/usr/share/centreon/(www/modules/centreon-autodiscovery-server/script|bin)/run_save_discovered_host
 - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
+- ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue --commandTimeout \d+$
 - ^/usr/bin/php (-q )?/usr/share/centreon/cron/[\w,\s.-]+ >> /var/log/centreon-gorgone/[\w,\s.-]+\s+2>&1$
 - ^/usr/bin/php -q /usr/share/centreon/www/modules/centreon-bi-server/tools/purgeArchivesFiles\.php >> /var/log/centreon-gorgone/centreon-bi-archive-retention\.log 2>&1$
 - ^/usr/share/centreon/cron/eventReportBuilder --config=/etc/centreon/conf\.pm >> /var/log/centreon-gorgone/eventReportBuilder\.log 2>&1$


### PR DESCRIPTION
## Description

Send to clapi the timeout used by gorgone from the action module


**Fixes** #MON-198656

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Allowed Centreon processQueue command to include --commandTimeout numeric argument
* Sent Gorgone action module timeout to clapi in requests


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112814595?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->