### PR TITLE
fix(ci): fetch tags when input base sha is given

### DIFF
--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -50,13 +50,10 @@ jobs:
 
     steps:
       - name: Checkout sources
-        if: github.event_name == 'pull_request' || inputs.base_sha != ''
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Fetch tags
         if: inputs.base_sha != ''
-        run: git fetch origin tag ${{ inputs.base_sha }} --no-tags || true
-        shell: bash
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-tags: true
 
       - name: Convert inputs to yaml list
         if: github.event_name == 'pull_request' || inputs.base_sha != ''


### PR DESCRIPTION
## Description

fix(ci): fetch tags when input base sha is given

**Fixes** MON-198652

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 1 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Enabled fetching Git tags during checkout when base SHA provided


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112821981?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->