### PR TITLE
revert(ci): remove rebuild-release label (redundant with skip-all-tests)

### DIFF
--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -111,7 +111,6 @@ jobs:
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt
-    secrets: inherit
 
   check-cherry-pick:
     needs: [get-environment, check-status]

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -115,7 +115,6 @@ jobs:
       version_file: CMakeLists.txt
       nightly_manual_trigger: ${{ inputs.nightly_manual_trigger || inputs.robot_pattern != '^((?!cma).)*$' || false }}
       labels: ${{ inputs.labels || '' }}
-    secrets: inherit
 
   get-aws-environment:
     uses: ./.github/workflows/get-aws-environment.yml

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -44,7 +44,6 @@ jobs:
     with:
       version_file: .version.centreon-common
       labels: ${{ inputs.labels || '' }}
-    secrets: inherit
 
   package:
     needs: [get-environment]

--- a/.github/workflows/docker-collect-testing.yml
+++ b/.github/workflows/docker-collect-testing.yml
@@ -34,7 +34,6 @@ jobs:
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt
-    secrets: inherit
 
   dockerize:
     needs: [get-environment]

--- a/.github/workflows/docker-gorgone-testing.yml
+++ b/.github/workflows/docker-gorgone-testing.yml
@@ -28,7 +28,6 @@ jobs:
     needs: [dependency-scan]
     if: github.repository == 'centreon/centreon-collect'
     uses: ./.github/workflows/get-environment.yml
-    secrets: inherit
 
   dockerize:
     needs: [get-environment]

--- a/.github/workflows/docker-packaging.yml
+++ b/.github/workflows/docker-packaging.yml
@@ -28,7 +28,6 @@ jobs:
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt
-    secrets: inherit
 
   dockerize:
     needs: [get-environment]

--- a/.github/workflows/get-changes-triggers.yml
+++ b/.github/workflows/get-changes-triggers.yml
@@ -176,11 +176,6 @@ jobs:
                 triggerUnitTesting = false;
                 triggerE2eTesting = false;
               }
-              if (labels.includes('rebuild-release')) {
-                core.info('Label rebuild-release found: skipping all tests, keeping packaging and delivery only');
-                triggerUnitTesting = false;
-                triggerE2eTesting = false;
-              }
             } catch (e) {
               core.warning(`Could not parse labels: ${e}`);
             }

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -12,9 +12,6 @@ on:
         required: false
         type: string
         default: ""
-    secrets:
-      CENTREON_TECHNIQUE_PAT:
-        required: false
     outputs:
       latest_major_version:
         description: "latest major version"
@@ -157,30 +154,6 @@ jobs:
             core.setOutput('labels', labels);
 
             return hasSkipLabel;
-
-      - name: Check rebuild-release authorization
-        if: contains(steps.has_skip_label.outputs.labels, 'rebuild-release')
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          github-token: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
-          script: |
-            core.info(`Checking release-management team membership for: ${context.actor}`);
-            try {
-              const { data } = await github.rest.teams.getMembershipForUserInOrg({
-                org: 'centreon',
-                team_slug: 'release-management',
-                username: context.actor,
-              });
-              core.info(`API response: state=${data.state}, role=${data.role}`);
-              if (data.state !== 'active') {
-                core.setFailed(`[state-check] User ${context.actor} membership state is "${data.state}" (expected "active"). Cannot use rebuild-release label.`);
-              } else {
-                core.info(`[authorized] User ${context.actor} is an active member of release-management. Proceeding.`);
-              }
-            } catch (e) {
-              core.info(`[api-error] HTTP status: ${e.status ?? 'unknown'} — ${e.message}`);
-              core.setFailed(`[api-error] Cannot verify team membership for ${context.actor}: ${e.message}. Check that CENTREON_TECHNIQUE_PAT has read:org scope.`);
-            }
 
       - name: Checkout sources (current branch)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -48,7 +48,6 @@ jobs:
     with:
       version_file: .version.centreon-gorgone
       labels: ${{ inputs.labels || '' }}
-    secrets: inherit
 
   changes:
     if: |

--- a/.github/workflows/libzmq.yml
+++ b/.github/workflows/libzmq.yml
@@ -31,7 +31,6 @@ jobs:
   get-environment:
     needs: [dependency-scan]
     uses: ./.github/workflows/get-environment.yml
-    secrets: inherit
 
   package-rpm:
     needs: [get-environment]

--- a/.github/workflows/lua-curl.yml
+++ b/.github/workflows/lua-curl.yml
@@ -44,7 +44,6 @@ jobs:
     uses: ./.github/workflows/get-environment.yml
     with:
       labels: ${{ inputs.labels || '' }}
-    secrets: inherit
 
   package:
     needs: [get-environment]

--- a/.github/workflows/monitoring-agent.yml
+++ b/.github/workflows/monitoring-agent.yml
@@ -73,7 +73,6 @@ jobs:
       version_file: CMakeLists.txt
       nightly_manual_trigger: ${{ inputs.nightly_manual_trigger || false }}
       labels: ${{ inputs.labels || '' }}
-    secrets: inherit
 
   get-aws-environment:
     uses: ./.github/workflows/get-aws-environment.yml

--- a/.github/workflows/windows-agent-robot-test.yml
+++ b/.github/workflows/windows-agent-robot-test.yml
@@ -26,7 +26,6 @@ jobs:
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: CMakeLists.txt
-    secrets: inherit
 
   get-aws-environment:
     uses: ./.github/workflows/get-aws-environment.yml


### PR DESCRIPTION
## Summary

Reverts #3369.

The `rebuild-release` label introduced in #3369 is functionally identical to the existing `skip-all-tests` label: both disable unit and E2E tests while keeping packaging and delivery. The only difference was an authorization check (release-management team membership) which is not needed.

Using `skip-all-tests` directly is sufficient.

## Changes reverted

- `get-changes-triggers.yml`: removed `rebuild-release` label handling
- `get-environment.yml`: removed "Check rebuild-release authorization" step
- 11 workflow files: removed `secrets: inherit` additions

Jira: [MON-198596](https://centreon.atlassian.net/browse/MON-198596)

[MON-198596]: https://centreon.atlassian.net/browse/MON-198596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ