### PR TITLE
fix(gorgone): 25.10 add VACUUM command to database cleanup process

### DIFF
--- a/gorgone/gorgone/modules/core/dbcleaner/class.pm
+++ b/gorgone/gorgone/modules/core/dbcleaner/class.pm
@@ -127,11 +127,14 @@ sub action_dbclean {
         query => "DELETE FROM gorgone_history WHERE (instant = 1 AND `ctime` <  " . (time() - 86400) . ") OR `ctime` < ?",
         bind_values => [time() - $self->{config}->{purge_history_time}]
     });
+    my ($status3) = $self->{db_gorgone}->query({
+        query => "VACUUM"
+    });
     $self->{purge_timer} = time();
 
     $self->{logger}->writeLogDebug("[dbcleaner] Purge finished");
 
-    if ($status == -1 || $status2 == -1) {
+    if ($status == -1 || $status2 == -1 || $status3 == -1) {
         $self->send_log(
             code => GORGONE_ACTION_FINISH_KO,
             token => $options{token},

--- a/gorgone/gorgone/modules/core/dbcleaner/class.pm
+++ b/gorgone/gorgone/modules/core/dbcleaner/class.pm
@@ -39,6 +39,8 @@ sub new {
     bless $connector, $class;
 
     $connector->{purge_timer} = time();
+    $connector->{purge_vacuum_timer} = time();
+
 
     $connector->set_signal_handlers();
     return $connector;

--- a/gorgone/gorgone/modules/core/dbcleaner/class.pm
+++ b/gorgone/gorgone/modules/core/dbcleaner/class.pm
@@ -101,6 +101,44 @@ sub exit_process {
     exit(0);
 }
 
+# apply vacuum on the database every week
+sub action_dbvacuum {
+      my ($self, %options) = @_;
+
+    $options{token} = $self->generate_token() if (!defined($options{token}));
+
+    if (defined($options{cycle})) {
+        return 0 if ((time() - $self->{purge_vacuum_timer}) < 3600*24*7); # doing vacuum every week as it can be slow on some database
+    }
+    $self->{logger}->writeLogDebug("[dbcleaner] vacuum database in progress...");
+    my ($status) = $self->{db_gorgone}->query({
+        query => "VACUUM"
+    });
+    $self->{purge_vacuum_timer} = time();
+
+    $self->{logger}->writeLogDebug("[dbcleaner] vacuum finished");
+
+    if ($status == -1) {
+        $self->send_log(
+            code => GORGONE_ACTION_FINISH_KO,
+            token => $options{token},
+            data => {
+                message => 'action db vacuum failed'
+            }
+        );
+        return 0;
+    }
+
+    $self->send_log(
+        code => GORGONE_ACTION_FINISH_OK,
+        token => $options{token},
+        data => {
+            message => 'action db vacuum finished'
+        }
+    );
+    return 0;
+}
+# purge database
 sub action_dbclean {
     my ($self, %options) = @_;
 
@@ -127,14 +165,12 @@ sub action_dbclean {
         query => "DELETE FROM gorgone_history WHERE (instant = 1 AND `ctime` <  " . (time() - 86400) . ") OR `ctime` < ?",
         bind_values => [time() - $self->{config}->{purge_history_time}]
     });
-    my ($status3) = $self->{db_gorgone}->query({
-        query => "VACUUM"
-    });
+
     $self->{purge_timer} = time();
 
     $self->{logger}->writeLogDebug("[dbcleaner] Purge finished");
 
-    if ($status == -1 || $status2 == -1 || $status3 == -1) {
+    if ($status == -1 || $status2 == -1) {
         $self->send_log(
             code => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
@@ -161,6 +197,7 @@ sub periodic_exec {
     }
 
     $connector->action_dbclean(cycle => 1);
+    $connector->action_dbvacuum(cycle => 1);
 }
 
 sub run {


### PR DESCRIPTION
## Description

Backport to 25.10 of vacuum command for the sqlite db

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

