### PR TITLE
MON-197101-gorgone-conf-allow-to-configure-pullwss-by-env-variable

### DIFF
--- a/gorgone/docs/configuration.md
+++ b/gorgone/docs/configuration.md
@@ -140,3 +140,20 @@ https://github.com/centreon/centreon-collect/blob/develop/perl-libs/lib/centreon
 ## *modules*
 
 See the *configuration* titles of the modules documentations listed [here](../docs/modules.md).
+
+## environment variables
+
+Gorgone can be configured with environment variables. This is useful when using Gorgone in a containerized environment, for example.
+
+The configuration file is loaded after environment variables, so any value set in the configuration file will override the one set in environment variables.
+
+2 type of variables are supported. The command line arguments can be set with this format : 
+`GORGONE_INIT_CONFIG`, `GORGONE_INIT_VAULT`, `GORGONE_INIT_LOGFILE`, `GORGONE_INIT_SEVERITY`. See `gorgone --help` for an updated list of supported arguments.
+
+the configuration files variables can be set with the format `gorgone__gorgone__modules__proxy__pool=10` to set the pool directive of the proxy module to 10. The format is `gorgone__` followed by the path to the directive in the configuration file, with each level separated by `__`.
+
+The case follow the configuration file case, so POOL is not the same as pool.
+
+you can use environment variable for the database configuration too : `gorgone__centreon__database__db_configuration__username='centreon'`
+
+

--- a/gorgone/docs/configuration.md
+++ b/gorgone/docs/configuration.md
@@ -145,15 +145,22 @@ See the *configuration* titles of the modules documentations listed [here](../do
 
 Gorgone can be configured with environment variables. This is useful when using Gorgone in a containerized environment, for example.
 
-The configuration file is loaded after environment variables, so any value set in the configuration file will override the one set in environment variables.
+The order of precedence for configuration values is the following (from lowest to highest) : default values, configuration files, long environment variables, short environment variables, command line arguments.
+Each higer level of precedence will override the previous one.
 
 2 type of variables are supported. The command line arguments can be set with this format : 
-`GORGONE_INIT_CONFIG`, `GORGONE_INIT_VAULT`, `GORGONE_INIT_LOGFILE`, `GORGONE_INIT_SEVERITY`. See `gorgone --help` for an updated list of supported arguments.
+`GORGONE_CONFIG`, `GORGONE_VAULT_FILE`, `GORGONE_LOGFILE`, `GORGONE_LOG_LEVEL`. See `gorgone --help` for an updated list of supported arguments.
 
-the configuration files variables can be set with the format `gorgone__gorgone__modules__proxy__pool=10` to set the pool directive of the proxy module to 10. The format is `gorgone__` followed by the path to the directive in the configuration file, with each level separated by `__`.
-
-The case follow the configuration file case, so POOL is not the same as pool.
+the configuration files variables can be set with the format `GORGONE__GORGONE__MODULES__PULLWSS__ADDRESS=1.1.1.1` to set the address directive of the pullwss module for exemple. The format is `GORGONE__` followed by the path to the directive in the configuration file, with each level separated by 2 underscore `__`. for a complete list of available directives, see individual module documentation.
 
 you can use environment variable for the database configuration too : `gorgone__centreon__database__db_configuration__username='centreon'`
 
+some configuration can be made with shorter variable name : 
+
+| short name        | full name                                   |
+|:------------------|:--------------------------------------------|
+| GORGONE_UID       | GORGONE__GORGONE__GORGONE_CORE__ID          |
+| GORGONE_TOKEN     | GORGONE__GORGONE__MODULES__PULLWSS__TOKEN   | 
+| CENTRAL_HOST      | GORGONE__GORGONE__MODULES__PULLWSS__ADDRESS | 
+| CENTRAL_PORT      | GORGONE__GORGONE__MODULES__PULLWSS__PORT    |
 

--- a/gorgone/docs/configuration.md
+++ b/gorgone/docs/configuration.md
@@ -149,7 +149,7 @@ The order of precedence for configuration values is the following (from lowest t
 Each higer level of precedence will override the previous one.
 
 2 type of variables are supported. The command line arguments can be set with this format : 
-`GORGONE_CONFIG`, `GORGONE_VAULT_FILE`, `GORGONE_LOGFILE`, `GORGONE_LOG_LEVEL`. See `gorgone --help` for an updated list of supported arguments.
+`GORGONE_CONFIG`, `GORGONE_VAULT_FILE`, `GORGONE_LOG_FILE`, `GORGONE_LOG_LEVEL`. See `gorgone --help` for an updated list of supported arguments.
 
 the configuration files variables can be set with the format `GORGONE__GORGONE__MODULES__PULLWSS__ADDRESS=1.1.1.1` to set the address directive of the pullwss module for exemple. The format is `GORGONE__` followed by the path to the directive in the configuration file, with each level separated by 2 underscore `__`. for a complete list of available directives, see individual module documentation.
 

--- a/gorgone/docs/modules/core/pullwss.md
+++ b/gorgone/docs/modules/core/pullwss.md
@@ -10,14 +10,15 @@ The proxy module has to bind to a tcp port for the pullwss module to connect to.
 
 ## Configuration
 
-| Directive    | Description                                        | Default value |
-|:-------------|:---------------------------------------------------|:--------------|
-| ssl          | should the connection be made over TLS/SSL or not  | `false`       |
-| address      | IP address to connect to                           |               |
-| port         | TCP port to connect to                             |               |
-| token        | token to authenticate to the central gorgone       |               |
-| proxy        | HTTP(S) proxy to access central gorgone            |               |
-| max_msg_size | max message size to send to the central Gorgone    | `130000`      |
+| Directive            | Description                                                                    | Default value |
+|:---------------------|:-------------------------------------------------------------------------------|:--------------|
+| ssl                  | should the connection be made over TLS/SSL or not                              | `false`       |
+| address              | IP address to connect to                                                       |               |
+| port                 | TCP port to connect to                                                         |               |
+| token                | token to authenticate to the central gorgone                                   |               |
+| proxy                | HTTP(S) proxy to access central gorgone                                        |               |
+| https_cert_no_verify | if ssl=true, if ssl=true, should certificate host name verification be skipped | `true`        |
+| max_msg_size         | max message size to send to the central Gorgone                                | `130000`      |
 ### Example
 
 ```yaml

--- a/gorgone/gorgone/class/core.pm
+++ b/gorgone/gorgone/class/core.pm
@@ -173,6 +173,7 @@ sub init {
         # the filter is used to remove anything from the configuration not related to gorgone or centreon
         filter => '!($ariane eq "configuration##" || $ariane =~ /^configuration##(?:gorgone|centreon)##/)'
     );
+    $self->load_env_config();
 
     $self->init_server_keys();
     $self->{config}->{configuration}->{gorgone}->{gorgonecore}->{external_com_zmq_tcp_keepalive} =

--- a/gorgone/gorgone/class/script.pm
+++ b/gorgone/gorgone/class/script.pm
@@ -299,15 +299,15 @@ sub yaml_load_config {
 
 # this function check all environment variables for default value to add to the configuration.
 # This function should be called AFTER yaml_load_config.
-# as gorgone don't have a consolidated list of allowed configuration option, this parse every env variable which name start as gorgone__
+# as gorgone don't have a consolidated list of allowed configuration option, this parse every env variable which name start as GORGONE__
 # and expect every level of the hashmap to be separated by double underscore.
 # it should be done after the yaml loading because modules definition are in an array, and we can't set 2 array element for a single gorgone module.
-# The env variables name respect the yaml syntax case, see the documentation for all recognized variable definition.
-# (lowercase env variable is permitted for application https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html)
+# The env variables name case don't matter, it is lc() before use. See the documentation for all recognized variable definition.
 sub load_env_config {
     my $self = shift;
 
     for my $key_env (keys %ENV){
+        $key_env = lc($key_env);
         next if $key_env !~ /^gorgone__/;
         $self->{logger}->writeLogDebug("config - checking if env variable $key_env should update configuration...");
 
@@ -336,7 +336,7 @@ sub load_env_config {
             if ($arianne eq $key_env) {
                 # As this configuration can come only from config file, env variable take precedence and override any value.
                 $self->{logger}->writeLogDebug("config - updated the configuration from $arianne environment variable.");
-                $conf->{$path} = $ENV{$key_env};
+                $conf->{$path} = $ENV{uc($key_env)};
             } else { # still not on the leaf, we continue to create the hash map if needed. for now we can't process array leaf like action whitelist.
                 if (!$conf->{$path}) {
                     $conf->{$path} = {};
@@ -347,6 +347,42 @@ sub load_env_config {
 
         }
     }
+
+    # as the full name of each parameter is long, we make some short alias for basic use
+    my $conf = $self->{config}->{configuration}->{gorgone};
+
+    if ($ENV{GORGONE_UID}){
+        $conf->{gorgonecore}->{id} = $ENV{GORGONE_UID};
+    }
+    my $pullwss_ref = undef;
+    for my $module (@{$conf->{modules}}) {
+        if ($module->{name} eq "pullwss") {
+            $pullwss_ref = $module;
+        }
+    }
+
+    if ($ENV{GORGONE_TOKEN}) {
+        if (!defined($pullwss_ref)) {
+            $pullwss_ref = {name => "pullwss"};
+            push @{$conf->{modules}}, $pullwss_ref;
+        }
+        $pullwss_ref->{token} = $ENV{GORGONE_TOKEN};
+    }
+    if ($ENV{CENTRAL_HOST}) {
+        if (!defined($pullwss_ref)) {
+            $pullwss_ref = {name => "pullwss"};
+            push @{$conf->{modules}}, $pullwss_ref;
+        }
+        $pullwss_ref->{address} = $ENV{CENTRAL_HOST};
+    }
+    if ($ENV{CENTRAL_PORT}) {
+        if (!defined($pullwss_ref)) {
+            $pullwss_ref = {name => "pullwss"};
+            push @{$conf->{modules}}, $pullwss_ref;
+        }
+        $pullwss_ref->{port} = $ENV{CENTRAL_PORT};
+    }
+
 }
 
 1;

--- a/gorgone/gorgone/class/script.pm
+++ b/gorgone/gorgone/class/script.pm
@@ -263,6 +263,7 @@ sub yaml_parse_config {
         if ($self->{vault} and $self->{vault}->can('get_secret')) {
             ${$options{config}} = $self->{vault}->get_secret( ${$options{config}});
         }
+        # let's check
     } else {
         $self->{logger}->writeLogError("config - unknown type of data: " . ref(${$options{config}}));
     }
@@ -294,6 +295,60 @@ sub yaml_load_config {
         ariane => defined($options{ariane}) ? $options{ariane} : ''
     );
     return $config;
+}
+
+# this function check all environment variables for default value to add to the configuration.
+# This function SHOULD be called after yaml_load_config.
+# as gorgone don't have a consolidated list of allowed configuration option, this parse every env variable which name start as gorgone__
+# and expect every level of the hashmap to be separated by double underscore.
+# it should be done after the yaml loading because modules definition are in an array, and we can't set 2 array element for a single gorgone module.
+# The variables name shall be lowercase following the name defined by the yaml syntax
+# (lowercase env variable is permitted for application https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html)
+sub load_env_config {
+    my $self = shift;
+
+    for my $key_env (keys %ENV){
+        next if $key_env !~ /^gorgone__/;
+        $self->{logger}->writeLogDebug("config - checking if env variable $key_env should update configuration...");
+
+        my $key = substr($key_env, 9);
+        my $conf = $self->{config}->{configuration};
+        my $arianne = "gorgone";
+        for my $path (split(/__/, $key)){
+            if ($arianne eq "gorgone__gorgone__modules"){
+                # we need to search the correct module in the array of module
+                my $module_ref = undef;
+                for my $module (@$conf){
+                    if ($module->{name} eq $path){
+                        $module_ref = $module;
+                    }
+                }
+                if (!defined($module_ref)){
+                    # the module don't exist, so we create it in the array, and then jump in.
+                    push(@$conf,{name => $path});
+                }
+                $conf = $module_ref;
+                $arianne .= "__$path";
+                next;
+            }
+            $arianne .= "__$path";
+            if ($arianne eq $key_env){
+                # last iteration, change the configuration only if the value don't exist,
+                # as config file (load before by yaml_load_config) take precedence
+                if (! exists $conf->{$path}){
+                    $self->{logger}->writeLogDebug("config - updated the configuration from $arianne environment variable.");
+                    $conf->{$path} = $ENV{$key_env};
+                }
+            } else { # still not on the leaf, we continue to create the hash map if needed. for now we can't process array leaf like action whitelist.
+                if (!$conf->{$path}) {
+                    $conf->{$path} = {};
+                }
+                $conf = $conf->{$path};
+            }
+
+
+        }
+    }
 }
 
 1;

--- a/gorgone/gorgone/class/script.pm
+++ b/gorgone/gorgone/class/script.pm
@@ -57,7 +57,7 @@ sub new {
     # if both env variables and argv are present, argv will be used.
     $self->{config_file} = $ENV{"GORGONE_CONFIG"} if $ENV{"GORGONE_CONFIG"};
     $self->{vault_config_file} = $ENV{"GORGONE_VAULT_FILE"} if $ENV{"GORGONE_VAULT_FILE"};
-    $self->{log_file} = $ENV{"GORGONE_LOGFILE"} if $ENV{"GORGONE_LOGFILE"};;
+    $self->{log_file} = $ENV{"GORGONE_LOG_FILE"} if $ENV{"GORGONE_LOG_FILE"};;
     $self->{severity} = $ENV{"GORGONE_LOG_LEVEL"} if $ENV{"GORGONE_LOG_LEVEL"} ;
 
     $self->{options} = {

--- a/gorgone/gorgone/class/script.pm
+++ b/gorgone/gorgone/class/script.pm
@@ -55,10 +55,10 @@ sub new {
     $self->{name} = $name;
     $self->{logger} = centreon::common::logger->new();
     # if both env variables and argv are present, argv will be used.
-    $self->{config_file} = $ENV{"GORGONE_INIT_CONFIG"} if $ENV{"GORGONE_INIT_CONFIG"};
-    $self->{vault_config_file} = $ENV{"GORGONE_INIT_VAULT"} if $ENV{"GORGONE_INIT_VAULT"};
-    $self->{log_file} = $ENV{"GORGONE_INIT_LOGFILE"} if $ENV{"GORGONE_INIT_LOGFILE"};;
-    $self->{severity} = $ENV{"GORGONE_INIT_SEVERITY"} if $ENV{"GORGONE_INIT_SEVERITY"} ;
+    $self->{config_file} = $ENV{"GORGONE_CONFIG"} if $ENV{"GORGONE_CONFIG"};
+    $self->{vault_config_file} = $ENV{"GORGONE_VAULT_FILE"} if $ENV{"GORGONE_VAULT_FILE"};
+    $self->{log_file} = $ENV{"GORGONE_LOGFILE"} if $ENV{"GORGONE_LOGFILE"};;
+    $self->{severity} = $ENV{"GORGONE_LOG_LEVEL"} if $ENV{"GORGONE_LOG_LEVEL"} ;
 
     $self->{options} = {
         'config=s'    => \$self->{config_file},

--- a/gorgone/gorgone/class/script.pm
+++ b/gorgone/gorgone/class/script.pm
@@ -333,13 +333,10 @@ sub load_env_config {
                 next;
             }
             $arianne .= "__$path";
-            if ($arianne eq $key_env){
-                # last iteration, change the configuration only if the value don't exist,
-                # as config file (load before by yaml_load_config) take precedence
-                if (! exists $conf->{$path}){
-                    $self->{logger}->writeLogDebug("config - updated the configuration from $arianne environment variable.");
-                    $conf->{$path} = $ENV{$key_env};
-                }
+            if ($arianne eq $key_env) {
+                # As this configuration can come only from config file, env variable take precedence and override any value.
+                $self->{logger}->writeLogDebug("config - updated the configuration from $arianne environment variable.");
+                $conf->{$path} = $ENV{$key_env};
             } else { # still not on the leaf, we continue to create the hash map if needed. for now we can't process array leaf like action whitelist.
                 if (!$conf->{$path}) {
                     $conf->{$path} = {};

--- a/gorgone/gorgone/class/script.pm
+++ b/gorgone/gorgone/class/script.pm
@@ -298,11 +298,11 @@ sub yaml_load_config {
 }
 
 # this function check all environment variables for default value to add to the configuration.
-# This function SHOULD be called after yaml_load_config.
+# This function should be called AFTER yaml_load_config.
 # as gorgone don't have a consolidated list of allowed configuration option, this parse every env variable which name start as gorgone__
 # and expect every level of the hashmap to be separated by double underscore.
 # it should be done after the yaml loading because modules definition are in an array, and we can't set 2 array element for a single gorgone module.
-# The variables name shall be lowercase following the name defined by the yaml syntax
+# The env variables name respect the yaml syntax case, see the documentation for all recognized variable definition.
 # (lowercase env variable is permitted for application https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html)
 sub load_env_config {
     my $self = shift;

--- a/gorgone/gorgone/class/script.pm
+++ b/gorgone/gorgone/class/script.pm
@@ -54,6 +54,12 @@ sub new {
     bless $self, $class;
     $self->{name} = $name;
     $self->{logger} = centreon::common::logger->new();
+    # if both env variables and argv are present, argv will be used.
+    $self->{config_file} = $ENV{"GORGONE_INIT_CONFIG"} if $ENV{"GORGONE_INIT_CONFIG"};
+    $self->{vault_config_file} = $ENV{"GORGONE_INIT_VAULT"} if $ENV{"GORGONE_INIT_VAULT"};
+    $self->{log_file} = $ENV{"GORGONE_INIT_LOGFILE"} if $ENV{"GORGONE_INIT_LOGFILE"};;
+    $self->{severity} = $ENV{"GORGONE_INIT_SEVERITY"} if $ENV{"GORGONE_INIT_SEVERITY"} ;
+
     $self->{options} = {
         'config=s'    => \$self->{config_file},
         'vault=s'     => \$self->{vault_config_file},
@@ -133,6 +139,7 @@ sub parse_options {
         print "version: " . $self->get_version() . "\n";
         exit(0);
     }
+
 }
 
 sub run {

--- a/gorgone/gorgone/class/script.pm
+++ b/gorgone/gorgone/class/script.pm
@@ -325,7 +325,8 @@ sub load_env_config {
                 }
                 if (!defined($module_ref)){
                     # the module don't exist, so we create it in the array, and then jump in.
-                    push(@$conf,{name => $path});
+                    $module_ref = {name => $path};
+                    push(@$conf,$module_ref);
                 }
                 $conf = $module_ref;
                 $arianne .= "__$path";

--- a/gorgone/gorgone/modules/core/pullwss/class.pm
+++ b/gorgone/gorgone/modules/core/pullwss/class.pm
@@ -159,7 +159,7 @@ sub wss_connect {
     my $proto = 'ws';
     if (defined($self->{config}->{ssl}) && $self->{config}->{ssl} eq 'true') {
         $proto = 'wss';
-        $self->{ua}->insecure(1);
+        $self->{ua}->insecure($self->{config}->{https_cert_no_verify} // 1);
     }
 
     $self->{ua}->websocket(

--- a/gorgone/gorgoned
+++ b/gorgone/gorgoned
@@ -40,6 +40,8 @@ gorgoned [options]
 
 =head1 OPTIONS
 
+Every option may be set as an environment variable, using the form GORGONE_INIT_OPTIONNAME, for exemple GORGONE_INIT_SEVERITY to change the log level. Command line configuration override environment variable.
+
 =over 8
 
 =item B<--config>
@@ -49,6 +51,19 @@ Specify the path to the yaml configuration file (default: '').
 =item B<--vault>
 
 Specify the path to the vault json configuration file (default: '/var/lib/centreon/vault/vault.json').
+
+=item B<--logfile>
+
+Specify the path to logfile to use (default: stdout).
+
+=item B<--severity>
+
+minimum log level to print a message
+(either a digit from 2 to 7 or the string equivalent : 'fatal','error','warning',notice,'info','debug' ) (default: info).
+
+=item B<--flushoutput>
+
+for output to be printed without caching when writing logs.
 
 =item B<--help>
 

--- a/gorgone/gorgoned
+++ b/gorgone/gorgoned
@@ -40,26 +40,29 @@ gorgoned [options]
 
 =head1 OPTIONS
 
-Every option may be set as an environment variable, using the form GORGONE_INIT_OPTIONNAME, for exemple GORGONE_INIT_SEVERITY to change the log level. Command line configuration override environment variable.
+Every option may be set as an environment variable. Command line configuration override environment variable.
 
 =over 8
 
 =item B<--config>
 
 Specify the path to the yaml configuration file (default: '').
+Environment variable : GORGONE_CONFIG
 
 =item B<--vault>
 
 Specify the path to the vault json configuration file (default: '/var/lib/centreon/vault/vault.json').
-
+Environment variable : GORGONE_VAULT_FILE
 =item B<--logfile>
 
 Specify the path to logfile to use (default: stdout).
+Environment variable : GORGONE_LOGFILEt
 
 =item B<--severity>
 
 minimum log level to print a message
 (either a digit from 2 to 7 or the string equivalent : 'fatal','error','warning',notice,'info','debug' ) (default: info).
+Environment variable : GORGONE_LOG_LEVEL
 
 =item B<--flushoutput>
 

--- a/gorgone/gorgoned
+++ b/gorgone/gorgoned
@@ -56,7 +56,7 @@ Environment variable : GORGONE_VAULT_FILE
 =item B<--logfile>
 
 Specify the path to logfile to use (default: stdout).
-Environment variable : GORGONE_LOGFILEt
+Environment variable : GORGONE_LOG_FILE
 
 =item B<--severity>
 

--- a/gorgone/tests/unit/class/core.t
+++ b/gorgone/tests/unit/class/core.t
@@ -112,10 +112,51 @@ sub test_yaml_get_include {
           'filter' => '!($ariane eq "configuration##" || $ariane =~ /^configuration##(?:gorgone|centreon)##/)');
     is(scalar(@emptyResult), 0, 'no file found return empty');
 }
+
+sub test_new_env_configuration {
+    my @argv_backup = @ARGV;
+    my @tests = (
+        {env => undef, argv=> undef, res => undef},
+        {env => "env", argv=> undef, res => "env"},
+        {env => "env", argv=> "", res => "env"},
+        {env => "env", argv=> "arg", res => "arg"},
+        {env => undef, argv=> "arg", res => "arg"},
+        );
+    my @variables_names = (
+        ["config", "config_file"],
+        ["vault","vault_config_file"],
+        ["logfile", "log_file"],
+        ["severity", "severity"]);
+    # pub is the public name, used in command line, private is the variable name mapped to it.
+    for my $ref (@variables_names) {
+        my ($pub, $private) = @$ref;
+        for my $t (@tests){
+            @ARGV = ();
+            @ARGV = ("--$pub" , $t->{argv}) if $t->{argv};
+            $ENV{"GORGONE_INIT_" . uc($pub)} = $t->{env};
+            # severity is the only argument that have a default value.
+            if ($pub eq "severity") {
+                if (!defined($t->{res})) {
+                    $t->{res} = "info";
+                }
+                if (!defined($t->{env})) {
+                    $t->{env} = "info";
+                }
+            }
+
+            my $obj = gorgone::class::core->new();
+            is($obj->{$private}, $t->{env}, "$pub is taken from env");
+            $obj->parse_options();
+            is($obj->{$private}, $t->{res}, "$pub is taken from ARGV if needed");
+        }
+    }
+    @ARGV = @argv_backup;
+}
 sub main {
     my $set = create_data_set();
     test_yaml_get_include($set);
     test_configuration_read($set);
+    test_new_env_configuration();
 
     print "\n";
     done_testing;

--- a/gorgone/tests/unit/class/core.t
+++ b/gorgone/tests/unit/class/core.t
@@ -108,19 +108,19 @@ sub test_new_env_configuration {
         {env => undef, argv=> "arg", res => "arg"},
         );
     my @variables_names = (
-        ["config", "config_file"],
-        ["vault","vault_config_file"],
-        ["logfile", "log_file"],
-        ["severity", "severity"]);
+        ["GORGONE_CONFIG", "config", "config_file"],
+        ["GORGONE_VAULT_FILE","vault", "vault_config_file"],
+        ["GORGONE_LOG_FILE","logfile", "log_file"],
+        ["GORGONE_LOG_LEVEL", "severity", "severity"]);
     # pub is the public name, used in command line, private is the variable name mapped to it.
     for my $ref (@variables_names) {
-        my ($pub, $private) = @$ref;
+        my ($env, $cli, $private) = @$ref;
         for my $t (@tests){
             @ARGV = ();
-            @ARGV = ("--$pub" , $t->{argv}) if $t->{argv};
-            $ENV{"GORGONE_INIT_" . uc($pub)} = $t->{env};
+            @ARGV = ("--$cli" , $t->{argv}) if $t->{argv};
+            $ENV{$env} = $t->{env};
             # severity is the only argument that have a default value.
-            if ($pub eq "severity") {
+            if ($env eq "GORGONE_LOG_LEVEL") {
                 if (!defined($t->{res})) {
                     $t->{res} = "info";
                 }
@@ -130,9 +130,9 @@ sub test_new_env_configuration {
             }
 
             my $obj = gorgone::class::core->new();
-            is($obj->{$private}, $t->{env}, "$pub is taken from env");
+            is($obj->{$private}, $t->{env}, "$cli is taken from env");
             $obj->parse_options();
-            is($obj->{$private}, $t->{res}, "$pub is taken from ARGV if needed");
+            is($obj->{$private}, $t->{res}, "$cli is taken from ARGV if needed");
         }
     }
     @ARGV = @argv_backup;

--- a/gorgone/tests/unit/class/core.t
+++ b/gorgone/tests/unit/class/core.t
@@ -140,6 +140,9 @@ sub test_new_env_configuration {
 sub test_config_from_env {
     $ENV{"gorgone__gorgone__modules__action__command_timeout"} = 5;
     $ENV{"gorgone__gorgone__modules__action__New_Argument"} = "value";
+    $ENV{"gorgone__gorgone__modules__proxy__httpserver__ssl"} = 1;
+    $ENV{"gorgone__gorgone__modules__newmodule__name"} = "newmodule";
+    $ENV{"gorgone__gorgone__modules__newmodule__param"} = "new_module_value";
 
     my $gorgone = gorgone::class::core->new();
     $gorgone->{config} = $gorgone->yaml_load_config(
@@ -149,23 +152,38 @@ sub test_config_from_env {
     $gorgone->load_env_config();
     my $modules = $gorgone->{config}->{configuration}->{gorgone}->{modules};
     my $action_module = undef;
+    my $proxy_module = undef;
+    my $new_module = undef;
+
     for my $module (@$modules){
-        if ($module->{name} ne "action"){
-        next;
-        }
+        if ($module->{name} eq "action"){
         $action_module = $module;
+        }
+        if ($module->{name} eq "proxy"){
+            $proxy_module = $module;
+        }
+        if ($module->{name} eq "newmodule"){
+            $new_module = $module;
+        }
     }
+
     isnt($action_module, undef, "action module should exist");
     is($action_module->{command_timeout}, 30, "env variable should not override yaml config");
     is($action_module->{New_Argument}, "value", "new variable creation is possible");
 
+    isnt($proxy_module, undef, "proxy module should exist");
+    is($proxy_module->{httpserver}->{ssl}, 1, "set sub module configuration");
+
+    isnt($new_module, undef, "new module should exist");
+    print(Dumper($modules));
+    is($new_module->{param}, "new_module_value", "set sub module configuration");
 
 }
 sub main {
     my $set = create_data_set();
-    #test_yaml_get_include($set);
-    #test_configuration_read($set);
-    #test_new_env_configuration();
+    test_yaml_get_include($set);
+    test_configuration_read($set);
+    test_new_env_configuration();
     test_config_from_env();
 
     print "\n";

--- a/gorgone/tests/unit/class/core.t
+++ b/gorgone/tests/unit/class/core.t
@@ -138,12 +138,13 @@ sub test_new_env_configuration {
     @ARGV = @argv_backup;
 }
 sub test_config_from_env {
-    $ENV{"gorgone__gorgone__modules__action__command_timeout"} = 5;
-    $ENV{"gorgone__gorgone__modules__action__New_Argument"} = "value";
-    $ENV{"gorgone__gorgone__modules__proxy__httpserver__ssl"} = 1;
-    $ENV{"gorgone__gorgone__modules__newmodule__name"} = "newmodule";
-    $ENV{"gorgone__gorgone__modules__newmodule__param"} = "new_module_value";
-
+    $ENV{"GORGONE__GORGONE__MODULES__ACTION__COMMAND_TIMEOUT"} = 5;
+    $ENV{"GORGONE__GORGONE__MODULES__ACTION__NEW_ARGUMENT"} = "value";
+    $ENV{"GORGONE__GORGONE__MODULES__PROXY__HTTPSERVER__SSL"} = 1;
+    $ENV{"GORGONE__GORGONE__MODULES__NEWMODULE__NAME"} = "newmodule";
+    $ENV{"GORGONE__GORGONE__MODULES__NEWMODULE__PARAM__SUB_PARAM"} = "new_module_value";
+    $ENV{"GORGONE__GORGONE__MODULES__PULLWSS_TOKEN"} = "token_from_long_env_variable";
+    $ENV{GORGONE_TOKEN} = "new_token!";
     my $gorgone = gorgone::class::core->new();
     $gorgone->{config} = $gorgone->yaml_load_config(
             file   => './config_examples/centreon-gorgone/config.yaml',
@@ -154,6 +155,7 @@ sub test_config_from_env {
     my $action_module = undef;
     my $proxy_module = undef;
     my $new_module = undef;
+    my $pullwss_module = undef;
 
     for my $module (@$modules){
         if ($module->{name} eq "action"){
@@ -165,19 +167,25 @@ sub test_config_from_env {
         if ($module->{name} eq "newmodule"){
             $new_module = $module;
         }
+        if ($module->{name} eq "pullwss"){
+            $pullwss_module = $module;
+        }
     }
 
     isnt($action_module, undef, "action module should exist");
+        print(Dumper($action_module));
+
     is($action_module->{command_timeout}, 5, "env variable should override yaml config");
-    is($action_module->{New_Argument}, "value", "new variable creation is possible");
+    is($action_module->{new_argument}, "value", "new variable creation is possible");
 
     isnt($proxy_module, undef, "proxy module should exist");
     is($proxy_module->{httpserver}->{ssl}, 1, "set sub module configuration");
 
     isnt($new_module, undef, "new module should exist");
-    print(Dumper($modules));
-    is($new_module->{param}, "new_module_value", "set sub module configuration");
+    is($new_module->{param}->{sub_param}, "new_module_value", "set sub module configuration");
 
+    isnt($pullwss_module, undef, "pullwss module should exist");
+    is($pullwss_module->{token}, "new_token!", "shorter option name override longer one");
 }
 sub main {
     my $set = create_data_set();

--- a/gorgone/tests/unit/class/core.t
+++ b/gorgone/tests/unit/class/core.t
@@ -1,22 +1,5 @@
 #!/usr/bin/perl
 
-# we can't use mock() on a non loaded package, so we need to create the class we want to mock first.
-# We could have set centreon-common as a dependancy for the test, but it's not that package we are testing right now, so let mock it.
-BEGIN {
-    package centreon::common::centreonvault;
-    sub get_secret {};
-    sub new {};
-    $INC{ (__PACKAGE__ =~ s{::}{/}rg) . ".pm" } = 1;
-}
-
-# same here, gorgone use a logger, but we don't want to test it right now, so we mock it.
-BEGIN {
-    package centreon::common::logger;
-    sub severity {};
-    sub new {};
-    $INC{ (__PACKAGE__ =~ s{::}{/}rg) . ".pm" } = 1; # this allow the module to be available for other modules anywhere in the code.
-}
-
 package main;
 
 use strict;
@@ -27,6 +10,8 @@ use Test2::Tools::Compare qw{is like match};
 use Data::Dumper;
 use FindBin;
 use lib "$FindBin::Bin/../../../";
+use tests::unit::lib::mockLogger;
+use tests::unit::lib::mockCentreonvault;
 use gorgone::class::script;
 use gorgone::class::core;
 
@@ -152,11 +137,36 @@ sub test_new_env_configuration {
     }
     @ARGV = @argv_backup;
 }
+sub test_config_from_env {
+    $ENV{"gorgone__gorgone__modules__action__command_timeout"} = 5;
+    $ENV{"gorgone__gorgone__modules__action__New_Argument"} = "value";
+
+    my $gorgone = gorgone::class::core->new();
+    $gorgone->{config} = $gorgone->yaml_load_config(
+            file   => './config_examples/centreon-gorgone/config.yaml',
+            filter => '!($ariane eq "configuration##" || $ariane =~ /^configuration##(?:gorgone|centreon)##/)'
+        );
+    $gorgone->load_env_config();
+    my $modules = $gorgone->{config}->{configuration}->{gorgone}->{modules};
+    my $action_module = undef;
+    for my $module (@$modules){
+        if ($module->{name} ne "action"){
+        next;
+        }
+        $action_module = $module;
+    }
+    isnt($action_module, undef, "action module should exist");
+    is($action_module->{command_timeout}, 30, "env variable should not override yaml config");
+    is($action_module->{New_Argument}, "value", "new variable creation is possible");
+
+
+}
 sub main {
     my $set = create_data_set();
-    test_yaml_get_include($set);
-    test_configuration_read($set);
-    test_new_env_configuration();
+    #test_yaml_get_include($set);
+    #test_configuration_read($set);
+    #test_new_env_configuration();
+    test_config_from_env();
 
     print "\n";
     done_testing;

--- a/gorgone/tests/unit/class/core.t
+++ b/gorgone/tests/unit/class/core.t
@@ -97,7 +97,7 @@ sub test_yaml_get_include {
           'filter' => '!($ariane eq "configuration##" || $ariane =~ /^configuration##(?:gorgone|centreon)##/)');
     is(scalar(@emptyResult), 0, 'no file found return empty');
 }
-
+# check that the argument in argv can have a value from env variable, argv override env.
 sub test_new_env_configuration {
     my @argv_backup = @ARGV;
     my @tests = (
@@ -168,7 +168,7 @@ sub test_config_from_env {
     }
 
     isnt($action_module, undef, "action module should exist");
-    is($action_module->{command_timeout}, 30, "env variable should not override yaml config");
+    is($action_module->{command_timeout}, 5, "env variable should override yaml config");
     is($action_module->{New_Argument}, "value", "new variable creation is possible");
 
     isnt($proxy_module, undef, "proxy module should exist");


### PR DESCRIPTION
## Description

user can now use environment variable to configure any parameter.
argv and configuration file override env variables.


**Fixes** # MON-197101

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [X] master

<h2> How this pull request can be tested ? </h2>

see unit tests, you can add any key in the configuration with environment variable

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

