### PR TITLE
fix(mbi): fix ONLY_FULL_GROUP_BY issues in Gorgone ETL Perl modules

### DIFF
--- a/gorgone/gorgone/modules/centreon/mbi/libs/bi/BIMetric.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/bi/BIMetric.pm
@@ -83,7 +83,7 @@ sub insertMetricsIntoTable {
 	$query .= " s.`sc_id`, s.`sc_name`, s.`host_id`, s.`host_name`, `hc_id`, `hc_name`, `hg_id`, `hg_name`";
 	$query .= " FROM `mod_bi_tmp_today_services` s, `metrics` m, `index_data` i";
 	$query .= " WHERE i.id = m.index_id and i.host_id=s.host_id and i.service_id=s.service_id";
-	$query .= " group by s.hg_id, s.hc_id, s.sc_id, m.index_id, m.metric_id, m.metric_name, m.unit_name, s.service_description, s.sc_name, s.host_name, s.host_id, hc_name, s.hg_name";
+	$query .= " group by s.hg_id, s.hc_id, s.sc_id, m.index_id, m.metric_id, m.metric_name, m.unit_name, s.service_id, s.service_description, s.sc_name, s.host_name, s.host_id, hc_name, s.hg_name";
 	my $sth = $db->query({ query => $query });
 	return $sth;
 }

--- a/gorgone/gorgone/modules/centreon/mbi/libs/bi/MetricDailyValue.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/bi/MetricDailyValue.pm
@@ -94,7 +94,7 @@ sub getMetricCapacityValuesOnPeriod {
 	my ($start_time_id, $end_time_id, $etlProperties) = @_;
 
 	my $query =	" SELECT servicemetric_id, liveservice_id, ";
-	$query .=		" `first_value`,  total";
+	$query .=		" MAX(`first_value`) as `first_value`,  MAX(total) as total";
 	$query .=	" FROM  mod_bi_liveservice l, mod_bi_servicemetrics m, ".$self->{"name"}." v";
 	$query .=	" WHERE timeperiod_id IN (".$etlProperties->{'capacity.include.liveservices'}.")";
 	$query .= " AND l.id = v.liveservice_id";
@@ -113,7 +113,7 @@ sub getMetricCapacityValuesOnPeriod {
 	}
 	
 	$query = 	" SELECT servicemetric_id, liveservice_id, ";
-	$query .= 		"`last_value`, total";
+	$query .= 		"MAX(`last_value`) as `last_value`, MAX(total) as total";
 	$query .= 	" FROM mod_bi_liveservice l, mod_bi_servicemetrics m, ".$self->{"name"}." v";
 	$query .=	" WHERE timeperiod_id IN (".$etlProperties->{'capacity.include.liveservices'}.")";
 	$query .= " AND l.id = v.liveservice_id";

--- a/gorgone/gorgone/modules/centreon/mbi/libs/centstorage/Metrics.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/centstorage/Metrics.pm
@@ -206,11 +206,11 @@ sub getFirstAndLastValues {
     $db->query({ query => $query });
     
     $self->createTempTableMetricDayFirstLastValues($useMemory);
-    $query = "INSERT INTO " . $self->{name_firstlast_tmp} . " SELECT d.value as `first_value`, d2.value as `last_value`, d.id_metric";
+    $query = "INSERT INTO " . $self->{name_firstlast_tmp} . " SELECT MAX(d.value) as `first_value`, MAX(d2.value) as `last_value`, d.id_metric";
     $query .= " FROM data_bin as d, data_bin as d2, " . $self->{name_minmaxctime_tmp} . " as db";
     $query .= " WHERE db.id_metric=d.id_metric AND db.min_val=d.ctime";
     $query .=         " AND db.id_metric=d2.id_metric AND db.max_val=d2.ctime";
-    $query .= " GROUP BY db.id_metric, d.value, d2.value, d.id_metric";
+    $query .= " GROUP BY db.id_metric";
     my $sth = $db->query({ query => $query });
     $self->addIndexTempTableMetricDayFirstLastValues();
     $self->dropTempTableCtimeMinMaxValues();


### PR DESCRIPTION
## Description

Fixes: [MON-199952](https://centreon.atlassian.net/browse/MON-199952)

Backport of #3336.

The Gorgone ETL Perl modules have the same ONLY_FULL_GROUP_BY issues as the ones fixed in
[centreon-modules#7716](https://github.com/centreon/centreon-modules/pull/7716) for the centreon-modules ETL modules.

- **BIMetric.pm**: add missing `s.service_id` to GROUP BY in `insertMetricsIntoTable`
- **MetricDailyValue.pm**: wrap `first_value`, `last_value`, `total` in MAX() aggregates instead of leaving them as bare non-aggregated columns
- **Metrics.pm**: wrap `d.value`, `d2.value` in MAX() instead of adding them to GROUP BY (which changed query semantics); simplify GROUP BY back to just `db.id_metric`

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

## How this pull request can be tested ?

Run MBI ETL with MySQL `ONLY_FULL_GROUP_BY` enabled. Verify that:
1. Metric insertion (`insertMetricsIntoTable`) succeeds without SQL errors
2. Capacity reports (`getMetricCapacityValuesOnPeriod`) return correct first/last values per metric
3. First/last value computation (`getFirstAndLastValues`) returns one row per metric

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

[MON-199952]: https://centreon.atlassian.net/browse/MON-199952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ