### PR TITLE
fix(gorgone): Support all JDBC URL query params in MBI db parser (#3389)

### DIFF
--- a/gorgone/gorgone/modules/centreon/mbi/etl/class.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/etl/class.pm
@@ -151,7 +151,7 @@ sub db_parse_xml {
                     $dbcon->{$name}->{port} = $2;
                     $dbcon->{$name}->{port} =~ s/\://;
                 }
-                $dbcon->{$name}->{db} =~ s/\?autoReconnect\=true//;
+                $dbcon->{$name}->{db} =~ s/[?&].*//;
             } elsif ($prop->{name} eq 'odaUser') {
                 $dbcon->{$name}->{user} = $prop->{value};
             } elsif ($prop->{name} eq 'odaPassword') {

--- a/gorgone/gorgone/modules/centreon/mbi/libs/bi/DBConfigParser.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/bi/DBConfigParser.pm
@@ -67,7 +67,7 @@ sub parseFile {
 						$connProfiles{$base."_port"} = '3306';
 					}
 					$connProfiles{$base."_db"} = $3;
-				   $connProfiles{$base."_db"} =~ s/\?autoReconnect\=true//;
+				   $connProfiles{$base."_db"} =~ s/[?&].*//;
 				}
 			}
 			if ($name eq 'odaUser') {

--- a/gorgone/tests/unit/modules/centreon/mbi/etl/class.t
+++ b/gorgone/tests/unit/modules/centreon/mbi/etl/class.t
@@ -4,19 +4,128 @@ use warnings;
 use Test2::V0;
 use Test2::Plugin::NoWarnings echo => 1;
 use Test2::Tools::Compare qw{is like match};
+use File::Temp qw(tempfile);
 use FindBin;
 use lib "$FindBin::Bin/../../../../../../";
 use gorgone::modules::centreon::mbi::etl::class;
-sub main {
-        eval {
-            gorgone::modules::centreon::mbi::etl::class::db_parse_xml(undef, 'file', 'FileThatDoesNotExist.xml');
 
-        };
-        if ($@) {
-            like($@, qr/FileThatDoesNotExist.xml/, 'FileThatDoesNotExist.xml does not exist');
-        }else {
-            fail('FileThatDoesNotExist.xml should not exist and send an error.');
-        }
+sub write_profile_xml {
+    my ($oda_url_centreon, $oda_url_censtorage) = @_;
+    my ($fh, $filename) = tempfile(SUFFIX => '.xml', UNLINK => 1);
+    print $fh <<"XML";
+<?xml version="1.0" encoding="UTF-8"?>
+<DataTools.ServerProfiles>
+  <profile autoconnect="No" name="Centreon" providerID="org.eclipse.birt.report.data.oda.jdbc">
+    <baseproperties>
+      <property name="odaURL" value="$oda_url_centreon"/>
+      <property name="odaUser" value="centreonbi"/>
+      <property name="odaPassword" value="centreonbi"/>
+    </baseproperties>
+  </profile>
+  <profile autoconnect="No" name="Censtorage" providerID="org.eclipse.birt.report.data.oda.jdbc">
+    <baseproperties>
+      <property name="odaURL" value="$oda_url_censtorage"/>
+      <property name="odaUser" value="centreonbi"/>
+      <property name="odaPassword" value="centreonbi"/>
+    </baseproperties>
+  </profile>
+</DataTools.ServerProfiles>
+XML
+    close $fh;
+    return $filename;
+}
+
+sub test_missing_file {
+    eval {
+        gorgone::modules::centreon::mbi::etl::class::db_parse_xml(
+            undef, file => 'FileThatDoesNotExist.xml'
+        );
+    };
+    if ($@) {
+        like($@, qr/FileThatDoesNotExist.xml/, 'FileThatDoesNotExist.xml does not exist');
+    } else {
+        fail('FileThatDoesNotExist.xml should not exist and send an error.');
+    }
+}
+
+sub test_db_parse_xml {
+    my @cases = (
+        {
+            name        => 'plain URL without query params',
+            url         => 'jdbc:mariadb://db:3306/centreon',
+            storage_url => 'jdbc:mariadb://db:3306/centreon_storage',
+            host        => 'db',
+            port        => '3306',
+            db          => 'centreon',
+            storage_db  => 'centreon_storage',
+        },
+        {
+            name        => 'URL with autoReconnect only (legacy default)',
+            url         => 'jdbc:mariadb://db:3306/centreon?autoReconnect=true',
+            storage_url => 'jdbc:mariadb://db:3306/centreon_storage?autoReconnect=true',
+            host        => 'db',
+            port        => '3306',
+            db          => 'centreon',
+            storage_db  => 'centreon_storage',
+        },
+        {
+            name        => 'URL with sslMode only',
+            url         => 'jdbc:mariadb://db:3306/centreon?sslMode=trust',
+            storage_url => 'jdbc:mariadb://db:3306/centreon_storage?sslMode=trust',
+            host        => 'db',
+            port        => '3306',
+            db          => 'centreon',
+            storage_db  => 'centreon_storage',
+        },
+        {
+            name        => 'URL with autoReconnect and sslMode (centreon-mbi 26.05 production case)',
+            url         => 'jdbc:mariadb://db:3306/centreon?autoReconnect=true&amp;sslMode=trust',
+            storage_url => 'jdbc:mariadb://db:3306/centreon_storage?autoReconnect=true&amp;sslMode=trust',
+            host        => 'db',
+            port        => '3306',
+            db          => 'centreon',
+            storage_db  => 'centreon_storage',
+        },
+        {
+            name        => 'URL with params in reverse order',
+            url         => 'jdbc:mariadb://db:3306/centreon?sslMode=trust&amp;autoReconnect=true',
+            storage_url => 'jdbc:mariadb://db:3306/centreon_storage?sslMode=trust&amp;autoReconnect=true',
+            host        => 'db',
+            port        => '3306',
+            db          => 'centreon',
+            storage_db  => 'centreon_storage',
+        },
+        {
+            name        => 'MySQL connector URL (legacy migration source)',
+            url         => 'jdbc:mysql://db:3306/centreon?autoReconnect=true',
+            storage_url => 'jdbc:mysql://db:3306/centreon_storage?autoReconnect=true',
+            host        => 'db',
+            port        => '3306',
+            db          => 'centreon',
+            storage_db  => 'centreon_storage',
+        },
+    );
+
+    for my $case (@cases) {
+        my $file = write_profile_xml($case->{url}, $case->{storage_url});
+        my $dbcon = gorgone::modules::centreon::mbi::etl::class::db_parse_xml(
+            undef, file => $file
+        );
+        is($dbcon->{centreon}->{db}, $case->{db},
+            "$case->{name}: centreon db name has no query params");
+        is($dbcon->{centreon}->{host}, $case->{host},
+            "$case->{name}: centreon host extracted correctly");
+        is($dbcon->{centreon}->{port}, $case->{port},
+            "$case->{name}: centreon port extracted correctly");
+        is($dbcon->{centstorage}->{db}, $case->{storage_db},
+            "$case->{name}: centstorage db name has no query params");
+    }
+}
+
+sub main {
+    test_missing_file();
+    test_db_parse_xml();
     done_testing();
 }
+
 main;

--- a/gorgone/tests/unit/modules/centreon/mbi/libs/bi/DBConfigParser.t
+++ b/gorgone/tests/unit/modules/centreon/mbi/libs/bi/DBConfigParser.t
@@ -1,0 +1,112 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test2::V0;
+use Test2::Plugin::NoWarnings echo => 1;
+use Test2::Tools::Compare qw{is like match};
+use File::Temp qw(tempfile);
+use FindBin;
+use lib "$FindBin::Bin/../../../../../../../";
+use gorgone::modules::centreon::mbi::libs::bi::DBConfigParser;
+
+package TestLogger;
+sub new { bless {}, shift }
+sub writeLog {
+    my ($self, $level, $msg) = @_;
+    warn "[$level] $msg\n" if $ENV{TEST_VERBOSE};
+}
+package main;
+
+sub write_profile_xml {
+    my ($oda_url) = @_;
+    my ($fh, $filename) = tempfile(SUFFIX => '.xml', UNLINK => 1);
+    print $fh <<"XML";
+<?xml version="1.0" encoding="UTF-8"?>
+<DataTools.ServerProfiles>
+  <profile autoconnect="No" name="Centreon" providerID="org.eclipse.birt.report.data.oda.jdbc">
+    <baseproperties>
+      <property name="odaURL" value="$oda_url"/>
+      <property name="odaUser" value="centreonbi"/>
+      <property name="odaPassword" value="centreonbi"/>
+    </baseproperties>
+  </profile>
+</DataTools.ServerProfiles>
+XML
+    close $fh;
+    return $filename;
+}
+
+sub test_parseFile {
+    my $parser = gorgone::modules::centreon::mbi::libs::bi::DBConfigParser->new(TestLogger->new);
+
+    my @cases = (
+        {
+            name => 'plain URL without query params',
+            url  => 'jdbc:mariadb://db:3306/centreon',
+            db   => 'centreon',
+            host => 'db',
+            port => '3306',
+        },
+        {
+            name => 'URL with autoReconnect only (legacy default)',
+            url  => 'jdbc:mariadb://db:3306/centreon?autoReconnect=true',
+            db   => 'centreon',
+            host => 'db',
+            port => '3306',
+        },
+        {
+            name => 'URL with sslMode only',
+            url  => 'jdbc:mariadb://db:3306/centreon?sslMode=trust',
+            db   => 'centreon',
+            host => 'db',
+            port => '3306',
+        },
+        {
+            name => 'URL with autoReconnect and sslMode (centreon-mbi 26.05 production case)',
+            url  => 'jdbc:mariadb://db:3306/centreon?autoReconnect=true&amp;sslMode=trust',
+            db   => 'centreon',
+            host => 'db',
+            port => '3306',
+        },
+        {
+            name => 'URL with params in reverse order',
+            url  => 'jdbc:mariadb://db:3306/centreon?sslMode=trust&amp;autoReconnect=true',
+            db   => 'centreon',
+            host => 'db',
+            port => '3306',
+        },
+        {
+            name => 'URL without explicit port',
+            url  => 'jdbc:mariadb://localhost/centreon_storage?sslMode=trust',
+            db   => 'centreon_storage',
+            host => 'localhost',
+            port => '3306',
+        },
+        {
+            name => 'MySQL connector URL (legacy migration source)',
+            url  => 'jdbc:mysql://db:3306/centreon?autoReconnect=true',
+            db   => 'centreon',
+            host => 'db',
+            port => '3306',
+        },
+    );
+
+    for my $case (@cases) {
+        my $file = write_profile_xml($case->{url});
+        my $profiles = $parser->parseFile($file);
+
+        is($profiles->{'Centreon_db'},   $case->{db},
+            "$case->{name}: db name has no query params");
+        is($profiles->{'Centreon_host'}, $case->{host},
+            "$case->{name}: host extracted correctly");
+        is($profiles->{'Centreon_port'}, $case->{port},
+            "$case->{name}: port extracted correctly");
+    }
+}
+
+sub main {
+    test_parseFile();
+    done_testing();
+}
+
+main;


### PR DESCRIPTION
REF #https://centreon.atlassian.net/browse/MON-200410

* fix(gorgone): Support all JDBC URL query params in MBI db parser

* test(gorgone): cover JDBC URL query param parsing for MBI db parsers

[JIRA](https://centreon.atlassian.net/browse/MON-200410)

Backport of #3389

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master
