### PR TITLE
chore(ci): fix missing node24 bumps on actions

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -143,7 +143,7 @@ runs:
 
     - if: inputs.upload_artifacts == 'true'
       name: Upload package artifacts
-      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: ${{ inputs.module_name }}-${{ inputs.arch != '' && format('packages-{0}-{1}', inputs.distrib, inputs.arch) || format('packages-{0}', inputs.distrib) }}-${{ inputs.stability }}
         path: ./*.${{ inputs.package_extension }}

--- a/.github/actions/release-detect-changed-components/action.yml
+++ b/.github/actions/release-detect-changed-components/action.yml
@@ -40,7 +40,7 @@ runs:
       run: |
         .github/scripts/release/release-generate-commit-lists.sh "$BASE_SHA" "$HEAD_SHA"
 
-    - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+    - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: component-commit-lists
         path: artifacts

--- a/.github/workflows/windows-agent-robot-test.yml
+++ b/.github/workflows/windows-agent-robot-test.yml
@@ -131,7 +131,7 @@ jobs:
         run: wsl --list --online
 
       - name: install Ubuntu noble 24.04
-        uses: Vampire/setup-wsl@6a8db447be7ed35f2f499c02c6e60ff77ef11278 # v6.0.0
+        uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
         with:
           wsl-version: 2
           distribution: Ubuntu-24.04


### PR DESCRIPTION
## Description

* fixed missing bumps on github actions to be node24 compliant

**Fixes** #MON-199376


