### PR TITLE
fix(gorgone): handle uid as self-target for external commands

### DIFF
--- a/gorgone/gorgone/class/core.pm
+++ b/gorgone/gorgone/class/core.pm
@@ -647,7 +647,9 @@ sub message_run {
     my ($action, $token, $target) = ($options->{frame}->getAction(), $options->{frame}->getToken(), $options->{frame}->getTarget());
 
     # Check if not myself ;)
-    if (defined($target) && ($target eq '' || (defined($self->{id}) && $target eq $self->{id}))) {
+    if (defined($target) && ($target eq '' ||
+        (defined($self->{id})  && $target eq $self->{id}) ||
+        (defined($self->{uid}) && $target eq $self->{uid}))) {
         $target = undef;
     }
 

--- a/gorgone/gorgone/modules/centreon/nodes/class.pm
+++ b/gorgone/gorgone/modules/centreon/nodes/class.pm
@@ -146,12 +146,13 @@ sub action_centreonnodessync {
         return 1;
     }
 
-    my $core_id;
+    my ($core_id, $core_uid);
     my $register_temp = {};
     my $register_nodes = [];
     foreach my $node (values %$datas) {
         if ($node->{localhost} == 1) {
-            $core_id = $node->{id};
+            $core_id  = $node->{id};
+            $core_uid = $node->{uid};
             next;
         }
 
@@ -218,7 +219,7 @@ sub action_centreonnodessync {
     # as we can now specify communication type in the database, the register module become useless.
     # to avoid breaking existing config, the node module now read the register config file and apply it.
     # using a single module allows to simplify the overriding compute, and stop doing it in multiples interposed zmq messages.
-    my $file_nodes = $self->get_register_module_config();
+    my $file_nodes = $self->get_register_module_config() // [];
     for my $file_node (@$file_nodes) {
         next unless $file_node->{prevail};
         my $db_node;
@@ -246,7 +247,7 @@ sub action_centreonnodessync {
         scalar(@$unregister_nodes)));
 
 
-    $self->send_internal_action({ action => 'SETCOREID', data => { id => $core_id } }) if (defined($core_id));
+    $self->send_internal_action({ action => 'SETCOREID', data => { id => $core_id, uid => $core_uid } }) if (defined($core_id));
     $self->send_internal_action({ action => 'REGISTERNODESFROMDB', data => { nodes => $register_nodes } });
     $self->send_internal_action({ action => 'UNREGISTERNODES', data => { nodes => $unregister_nodes } });
 

--- a/gorgone/gorgone/standard/library.pm
+++ b/gorgone/gorgone/standard/library.pm
@@ -419,12 +419,15 @@ sub setmodulekey {
 sub setcoreid {
     my (%options) = @_;
 
+    my $data = $options{frame}->decodeData();
+    if (defined($data) && defined($data->{uid})) {
+        $options{gorgone}->{uid} = $data->{uid};
+    }
+
     if (defined($options{gorgone}->{config}->{configuration}->{gorgone}->{gorgonecore}->{id}) &&
         $options{gorgone}->{config}->{configuration}->{gorgone}->{gorgonecore}->{id} =~ /\d+/) {
         return (GORGONE_ACTION_FINISH_OK, { action => 'setcoreid', message => 'setcoreid unchanged, use config value' })
     }
-
-    my $data = $options{frame}->decodeData();
     if (!defined($data)) {
         return (GORGONE_ACTION_FINISH_KO, { message => 'request not well formatted' });
     }

--- a/gorgone/tests/unit/modules/centreon/nodes.t
+++ b/gorgone/tests/unit/modules/centreon/nodes.t
@@ -19,7 +19,7 @@ sub main {
 
 my $check_action_ran = {};
 my $action_expected = {
-    'SETCOREID'     => { id => 1 },
+    'SETCOREID'     => { id => 1, uid => '' },
     'UNREGISTERNODES'     => { nodes =>[]},
     'REGISTERNODESFROMDB' => {
         'nodes' => [


### PR DESCRIPTION
Since the central server's uid (snowflake) was introduced, centreon-web sends external commands with the uid as target instead of the legacy integer id. The core's self-identity check only compared against the integer id, so commands were forwarded to the proxy, which had no registration for that uid, causing "unknown target" errors.

Three fixes:

- nodes/class.pm: capture the central's uid alongside its id when reading nagios_server, pass it in the SETCOREID message, and guard against get_register_module_config() returning undef (crash before REGISTERNODESFROMDB was sent on platforms without the register module configured).

- standard/library.pm: store the uid from the SETCOREID payload into gorgone->{uid} before the early-return that skips id update when the id is already set in config.

- class/core.pm: extend the self-target check to also match against gorgone->{uid}, so commands targeting the central by uid are handled locally instead of being routed to the proxy.

Refs: MON-197880

Assisted-by: Claude Code (claude-sonnet-4-6)

## Description

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

