### PR TITLE
MON-201060 fix(engine): timeperiod inheritance - preserve child exceptions and days during template merge relase-25.10

### DIFF
--- a/common/engine_conf/parser.cc
+++ b/common/engine_conf/parser.cc
@@ -652,13 +652,11 @@ void parser::_resolve_template(std::unique_ptr<message_helper>& msg_helper,
   if (days->weekday().empty() && !template_days->weekday().empty()) { \
     days->mutable_##weekday()->Add(template_days->weekday().begin(),  \
                                    template_days->weekday().end());   \
-    msg_helper->set_changed(f->index());                              \
   }
 
 template <class repeated_Daterange_type>
-static bool _merge_exceptions(repeated_Daterange_type* except,
+static void _merge_exceptions(repeated_Daterange_type* except,
                               const repeated_Daterange_type& template_except) {
-  bool at_least_one_added = false;
   for (const Daterange& to_insert : template_except) {
     bool found = false;
     for (const Daterange& to_check : *except) {
@@ -670,10 +668,8 @@ static bool _merge_exceptions(repeated_Daterange_type* except,
     }
     if (!found) {
       except->Add()->CopyFrom(to_insert);
-      at_least_one_added = true;
     }
   }
-  return at_least_one_added;
 }
 
 /**
@@ -842,15 +838,11 @@ void parser::_merge(std::unique_ptr<message_helper>& msg_helper,
                 StringList* lst =
                     static_cast<StringList*>(refl->MutableMessage(msg, f));
                 if (lst->additive()) {
-                  if (!orig_lst->data().empty()) {
-                    for (auto& v : orig_lst->data())
-                      lst->add_data(v);
-                    msg_helper->set_changed(f->index());
-                  }
+                  for (auto& v : orig_lst->data())
+                    lst->add_data(v);
                 } else if (lst->data().empty()) {
                   *lst->mutable_data() = orig_lst->data();
                   lst->set_additive(orig_lst->additive());
-                  msg_helper->set_changed(f->index());
                 }
               } else if (d && d->name() == "PairStringSet") {
                 PairStringSet* orig_pair =
@@ -866,15 +858,12 @@ void parser::_merge(std::unique_ptr<message_helper>& msg_helper,
                         break;
                       }
                     }
-                    if (!found) {
+                    if (!found)
                       pair->add_data()->CopyFrom(v);
-                      msg_helper->set_changed(f->index());
-                    }
                   }
                 } else if (pair->data().empty()) {
                   *pair->mutable_data() = orig_pair->data();
                   pair->set_additive(orig_pair->additive());
-                  msg_helper->set_changed(f->index());
                 }
               } else if (d && d->name() == "ExceptionArray") {
                 const ExceptionArray* template_exceptions =
@@ -882,26 +871,16 @@ void parser::_merge(std::unique_ptr<message_helper>& msg_helper,
                         refl->MutableMessage(tmpl, f));
                 ExceptionArray* exceptions =
                     static_cast<ExceptionArray*>(refl->MutableMessage(msg, f));
-                if (_merge_exceptions(exceptions->mutable_calendar_date(),
-                                      template_exceptions->calendar_date())) {
-                  msg_helper->set_changed(f->index());
-                }
-                if (_merge_exceptions(exceptions->mutable_month_date(),
-                                      template_exceptions->month_date())) {
-                  msg_helper->set_changed(f->index());
-                }
-                if (_merge_exceptions(exceptions->mutable_month_day(),
-                                      template_exceptions->month_day())) {
-                  msg_helper->set_changed(f->index());
-                }
-                if (_merge_exceptions(exceptions->mutable_month_week_day(),
-                                      template_exceptions->month_week_day())) {
-                  msg_helper->set_changed(f->index());
-                }
-                if (_merge_exceptions(exceptions->mutable_week_day(),
-                                      template_exceptions->week_day())) {
-                  msg_helper->set_changed(f->index());
-                }
+                _merge_exceptions(exceptions->mutable_calendar_date(),
+                                  template_exceptions->calendar_date());
+                _merge_exceptions(exceptions->mutable_month_date(),
+                                  template_exceptions->month_date());
+                _merge_exceptions(exceptions->mutable_month_day(),
+                                  template_exceptions->month_day());
+                _merge_exceptions(exceptions->mutable_month_week_day(),
+                                  template_exceptions->month_week_day());
+                _merge_exceptions(exceptions->mutable_week_day(),
+                                  template_exceptions->week_day());
               } else if (d && d->name() == "DaysArray") {
                 const DaysArray* template_days = static_cast<const DaysArray*>(
                     refl->MutableMessage(tmpl, f));
@@ -914,7 +893,6 @@ void parser::_merge(std::unique_ptr<message_helper>& msg_helper,
                 COPY_TIME_RANGE(thursday);
                 COPY_TIME_RANGE(friday);
                 COPY_TIME_RANGE(saturday);
-                msg_helper->set_changed(f->index());
               } else {
                 refl->MutableMessage(msg, f)->CopyFrom(
                     refl->GetMessage(*tmpl, f));

--- a/common/engine_conf/parser.cc
+++ b/common/engine_conf/parser.cc
@@ -27,6 +27,7 @@
 #include "connector_helper.hh"
 #include "contact_helper.hh"
 #include "contactgroup_helper.hh"
+#include "google/protobuf/util/message_differencer.h"
 #include "host_helper.hh"
 #include "hostdependency_helper.hh"
 #include "hostescalation_helper.hh"
@@ -644,6 +645,34 @@ void parser::_resolve_template(std::unique_ptr<message_helper>& msg_helper,
 }
 
 /**
+ * @brief Some helpers to merge timeperiod with ther templates
+ *
+ */
+#define COPY_TIME_RANGE(weekday)                                      \
+  if (days->weekday().empty() && !template_days->weekday().empty()) { \
+    days->mutable_##weekday()->Add(template_days->weekday().begin(),  \
+                                   template_days->weekday().end());   \
+  }
+
+template <class repeated_Daterange_type>
+static void _merge_exceptions(repeated_Daterange_type* except,
+                              const repeated_Daterange_type& template_except) {
+  for (const Daterange& to_insert : template_except) {
+    bool found = false;
+    for (const Daterange& to_check : *except) {
+      if (::google::protobuf::util::MessageDifferencer::Equals(to_insert,
+                                                               to_check)) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      except->Add()->CopyFrom(to_insert);
+    }
+  }
+}
+
+/**
  * @brief For each unchanged field in the Protobuf object stored in
  * msg_helper, we copy the corresponding field from tmpl. This is the key for
  * the inheritence with cfg files.
@@ -836,6 +865,34 @@ void parser::_merge(std::unique_ptr<message_helper>& msg_helper,
                   *pair->mutable_data() = orig_pair->data();
                   pair->set_additive(orig_pair->additive());
                 }
+              } else if (d && d->name() == "ExceptionArray") {
+                const ExceptionArray* template_exceptions =
+                    static_cast<const ExceptionArray*>(
+                        refl->MutableMessage(tmpl, f));
+                ExceptionArray* exceptions =
+                    static_cast<ExceptionArray*>(refl->MutableMessage(msg, f));
+                _merge_exceptions(exceptions->mutable_calendar_date(),
+                                  template_exceptions->calendar_date());
+                _merge_exceptions(exceptions->mutable_month_date(),
+                                  template_exceptions->month_date());
+                _merge_exceptions(exceptions->mutable_month_day(),
+                                  template_exceptions->month_day());
+                _merge_exceptions(exceptions->mutable_month_week_day(),
+                                  template_exceptions->month_week_day());
+                _merge_exceptions(exceptions->mutable_week_day(),
+                                  template_exceptions->week_day());
+              } else if (d && d->name() == "DaysArray") {
+                const DaysArray* template_days = static_cast<const DaysArray*>(
+                    refl->MutableMessage(tmpl, f));
+                DaysArray* days =
+                    static_cast<DaysArray*>(refl->MutableMessage(msg, f));
+                COPY_TIME_RANGE(sunday);
+                COPY_TIME_RANGE(monday);
+                COPY_TIME_RANGE(tuesday);
+                COPY_TIME_RANGE(wednesday);
+                COPY_TIME_RANGE(thursday);
+                COPY_TIME_RANGE(friday);
+                COPY_TIME_RANGE(saturday);
               } else {
                 refl->MutableMessage(msg, f)->CopyFrom(
                     refl->GetMessage(*tmpl, f));

--- a/common/engine_conf/parser.cc
+++ b/common/engine_conf/parser.cc
@@ -652,11 +652,13 @@ void parser::_resolve_template(std::unique_ptr<message_helper>& msg_helper,
   if (days->weekday().empty() && !template_days->weekday().empty()) { \
     days->mutable_##weekday()->Add(template_days->weekday().begin(),  \
                                    template_days->weekday().end());   \
+    msg_helper->set_changed(f->index());                              \
   }
 
 template <class repeated_Daterange_type>
-static void _merge_exceptions(repeated_Daterange_type* except,
+static bool _merge_exceptions(repeated_Daterange_type* except,
                               const repeated_Daterange_type& template_except) {
+  bool at_least_one_added = false;
   for (const Daterange& to_insert : template_except) {
     bool found = false;
     for (const Daterange& to_check : *except) {
@@ -668,8 +670,10 @@ static void _merge_exceptions(repeated_Daterange_type* except,
     }
     if (!found) {
       except->Add()->CopyFrom(to_insert);
+      at_least_one_added = true;
     }
   }
+  return at_least_one_added;
 }
 
 /**
@@ -838,11 +842,15 @@ void parser::_merge(std::unique_ptr<message_helper>& msg_helper,
                 StringList* lst =
                     static_cast<StringList*>(refl->MutableMessage(msg, f));
                 if (lst->additive()) {
-                  for (auto& v : orig_lst->data())
-                    lst->add_data(v);
+                  if (!orig_lst->data().empty()) {
+                    for (auto& v : orig_lst->data())
+                      lst->add_data(v);
+                    msg_helper->set_changed(f->index());
+                  }
                 } else if (lst->data().empty()) {
                   *lst->mutable_data() = orig_lst->data();
                   lst->set_additive(orig_lst->additive());
+                  msg_helper->set_changed(f->index());
                 }
               } else if (d && d->name() == "PairStringSet") {
                 PairStringSet* orig_pair =
@@ -858,12 +866,15 @@ void parser::_merge(std::unique_ptr<message_helper>& msg_helper,
                         break;
                       }
                     }
-                    if (!found)
+                    if (!found) {
                       pair->add_data()->CopyFrom(v);
+                      msg_helper->set_changed(f->index());
+                    }
                   }
                 } else if (pair->data().empty()) {
                   *pair->mutable_data() = orig_pair->data();
                   pair->set_additive(orig_pair->additive());
+                  msg_helper->set_changed(f->index());
                 }
               } else if (d && d->name() == "ExceptionArray") {
                 const ExceptionArray* template_exceptions =
@@ -871,16 +882,26 @@ void parser::_merge(std::unique_ptr<message_helper>& msg_helper,
                         refl->MutableMessage(tmpl, f));
                 ExceptionArray* exceptions =
                     static_cast<ExceptionArray*>(refl->MutableMessage(msg, f));
-                _merge_exceptions(exceptions->mutable_calendar_date(),
-                                  template_exceptions->calendar_date());
-                _merge_exceptions(exceptions->mutable_month_date(),
-                                  template_exceptions->month_date());
-                _merge_exceptions(exceptions->mutable_month_day(),
-                                  template_exceptions->month_day());
-                _merge_exceptions(exceptions->mutable_month_week_day(),
-                                  template_exceptions->month_week_day());
-                _merge_exceptions(exceptions->mutable_week_day(),
-                                  template_exceptions->week_day());
+                if (_merge_exceptions(exceptions->mutable_calendar_date(),
+                                      template_exceptions->calendar_date())) {
+                  msg_helper->set_changed(f->index());
+                }
+                if (_merge_exceptions(exceptions->mutable_month_date(),
+                                      template_exceptions->month_date())) {
+                  msg_helper->set_changed(f->index());
+                }
+                if (_merge_exceptions(exceptions->mutable_month_day(),
+                                      template_exceptions->month_day())) {
+                  msg_helper->set_changed(f->index());
+                }
+                if (_merge_exceptions(exceptions->mutable_month_week_day(),
+                                      template_exceptions->month_week_day())) {
+                  msg_helper->set_changed(f->index());
+                }
+                if (_merge_exceptions(exceptions->mutable_week_day(),
+                                      template_exceptions->week_day())) {
+                  msg_helper->set_changed(f->index());
+                }
               } else if (d && d->name() == "DaysArray") {
                 const DaysArray* template_days = static_cast<const DaysArray*>(
                     refl->MutableMessage(tmpl, f));
@@ -893,6 +914,7 @@ void parser::_merge(std::unique_ptr<message_helper>& msg_helper,
                 COPY_TIME_RANGE(thursday);
                 COPY_TIME_RANGE(friday);
                 COPY_TIME_RANGE(saturday);
+                msg_helper->set_changed(f->index());
               } else {
                 refl->MutableMessage(msg, f)->CopyFrom(
                     refl->GetMessage(*tmpl, f));

--- a/engine/src/configuration/applier/timeperiod.cc
+++ b/engine/src/configuration/applier/timeperiod.cc
@@ -148,7 +148,7 @@ void applier::timeperiod::remove_object(ssize_t idx) {
 void applier::timeperiod::resolve_object(const configuration::Timeperiod& obj,
                                          error_cnt& err) {
   // Logging.
-  config_logger->debug("Resolving time period '{}'.", obj.ShortDebugString());
+  config_logger->debug("Resolving time period '{}'.", obj.timeperiod_name());
 
   // Find time period.
   timeperiod_map::iterator it =

--- a/engine/src/configuration/applier/timeperiod.cc
+++ b/engine/src/configuration/applier/timeperiod.cc
@@ -154,8 +154,8 @@ void applier::timeperiod::resolve_object(const configuration::Timeperiod& obj,
   timeperiod_map::iterator it =
       engine::timeperiod::timeperiods.find(obj.timeperiod_name());
   if (engine::timeperiod::timeperiods.end() == it || !it->second)
-    throw engine_error() << "Cannot resolve non-existing " << "time period '"
-                         << obj.timeperiod_name() << "'";
+    throw engine_error() << "Cannot resolve non-existing "
+                         << "time period '" << obj.timeperiod_name() << "'";
 
   // Resolve time period.
   it->second->resolve(err.config_warnings, err.config_errors);

--- a/engine/src/configuration/applier/timeperiod.cc
+++ b/engine/src/configuration/applier/timeperiod.cc
@@ -148,14 +148,14 @@ void applier::timeperiod::remove_object(ssize_t idx) {
 void applier::timeperiod::resolve_object(const configuration::Timeperiod& obj,
                                          error_cnt& err) {
   // Logging.
-  config_logger->debug("Resolving time period '{}'.", obj.timeperiod_name());
+  config_logger->debug("Resolving time period '{}'.", obj.ShortDebugString());
 
   // Find time period.
   timeperiod_map::iterator it =
       engine::timeperiod::timeperiods.find(obj.timeperiod_name());
   if (engine::timeperiod::timeperiods.end() == it || !it->second)
-    throw engine_error() << "Cannot resolve non-existing "
-                         << "time period '" << obj.timeperiod_name() << "'";
+    throw engine_error() << "Cannot resolve non-existing " << "time period '"
+                         << obj.timeperiod_name() << "'";
 
   // Resolve time period.
   it->second->resolve(err.config_warnings, err.config_errors);

--- a/tests/engine/timeperiod_inheritance.robot
+++ b/tests/engine/timeperiod_inheritance.robot
@@ -52,11 +52,6 @@ TIMEPERIOD_INHERITANCE_EXCEPTION
     [Tags]    engine    timeperiod    MON-200794
 
     Ctn Config Engine    ${1}    ${1}    ${2}
-    Ctn Engine Config Set Value    0    log_level_checks    trace
-    Ctn Engine Config Set Value    0    log_level_functions    trace
-    Ctn Engine Config Set Value    0    log_level_config    trace
-    Ctn Engine Config Set Value    0    log_level_runtime    trace
-    Ctn Engine Config Set Value    0    log_level_events    trace
     Ctn Config Broker    rrd
     Ctn Config Broker    central
     Ctn Config Broker    module
@@ -83,7 +78,7 @@ TIMEPERIOD_INHERITANCE_EXCEPTION
 
     ${result}    Ctn Check Service Status With Timeout    host_1    service_1    0    60    HARD
 
-    Should Be True    ${result}       service_1 must remained unknown and not checked
+    Should Be True    ${result}       service_1 must be OK and checked
 
 
 TIMEPERIOD_MERGE

--- a/tests/engine/timeperiod_inheritance.robot
+++ b/tests/engine/timeperiod_inheritance.robot
@@ -44,3 +44,86 @@ TIMEPERIOD_INHERITANCE
     ${result}    Ctn Check Service Status With Timeout    host_1    service_1    0    180    HARD
     
     Should Not Be True    ${result}       service_1 must remained unknown and not checked 
+
+
+
+TIMEPERIOD_INHERITANCE_EXCEPTION
+    [Documentation]    Given two timeperiods, one inherit from the second. First one allow H24, second one has only one exception, checks must be executed in next minute
+    [Tags]    engine    timeperiod    MON-200794
+
+    Ctn Config Engine    ${1}    ${1}    ${2}
+    Ctn Engine Config Set Value    0    log_level_checks    trace
+    Ctn Engine Config Set Value    0    log_level_functions    trace
+    Ctn Engine Config Set Value    0    log_level_config    trace
+    Ctn Engine Config Set Value    0    log_level_runtime    trace
+    Ctn Engine Config Set Value    0    log_level_events    trace
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module
+    Ctn Config BBDO3    1
+    Ctn Clear Retention
+
+    
+    ${start_plus_one_day}    Get Current Date    increment=1d
+    Ctn Create Single Day Time Period    0    short_time_period    ${start_plus_one_day}    2
+    Ctn Engine Config Replace Value In Services    0    service_1    check_interval    1
+
+    Ctn Engine Config Add Command    ${0}  echo_command   /bin/echo "OK - 127.0.0.1: rta 0,010ms, lost 0%|rta=0,010ms;200,000;500,000;0; pl=0%;40;80;; rtmax=0,035ms;;;; rtmin=0,003ms;;;;"
+    Ctn Engine Config Replace Value In Services    0    service_1    check_command    echo_command
+    Ctn Add Template To Timeperiod    0    short_time_period    ["24x7"]
+    Ctn Engine Config Set Value    0    interval_length    10
+
+
+
+    ${start_engine}    Get Current Date
+    Ctn Start Engine
+    Ctn Start Broker
+
+    Ctn Wait For Engine To Be Ready    ${start_engine}
+
+    ${result}    Ctn Check Service Status With Timeout    host_1    service_1    0    60    HARD
+
+    Should Be True    ${result}       service_1 must remained unknown and not checked
+
+
+TIMEPERIOD_MERGE
+    [Documentation]    Given a timeperiod with its own calendar exception (active now) and a template
+    ...    with a different calendar exception (active yesterday), the merge must preserve the child's
+    ...    exception. The service using the child timeperiod as check_period must be checked.
+    [Tags]    engine    timeperiod    MON-200794
+
+    Ctn Config Engine    ${1}    ${1}    ${2}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module
+    Ctn Config BBDO3    1
+    Ctn Clear Retention
+
+    # child_tp: calendar exception active now (starts 2 minutes ago, lasts 30 minutes)
+    ${start_now}    Get Current Date    increment=-120s
+    Ctn Create Single Day Time Period    0    child_tp    ${start_now}    30
+
+    # template_tp: calendar exception active yesterday (inactive now)
+    ${yesterday}    Get Current Date    increment=-1d
+    Ctn Create Single Day Time Period    0    template_tp    ${yesterday}    30
+
+    # child_tp uses template_tp as template: merge must keep child's own exception
+    Ctn Add Template To Timeperiod    0    template_tp    ["child_tp"]
+
+    Ctn Engine Config Replace Value In Services    0    service_1    check_period    child_tp
+    Ctn Engine Config Replace Value In Services    0    service_1    check_interval    1
+
+    Ctn Engine Config Add Command    ${0}    echo_command    /bin/echo "OK - 127.0.0.1: rta 0,010ms, lost 0%|rta=0,010ms;200,000;500,000;0; pl=0%;40;80;; rtmax=0,035ms;;;; rtmin=0,003ms;;;;"
+    Ctn Engine Config Replace Value In Services    0    service_1    check_command    echo_command
+    Ctn Engine Config Set Value    0    interval_length    10
+
+    ${start_engine}    Get Current Date
+    Ctn Start Engine
+    Ctn Start Broker
+
+    Ctn Wait For Engine To Be Ready    ${start_engine}
+
+    ${result}    Ctn Check Service Status With Timeout    host_1    service_1    0    60    HARD
+
+    Should Be True    ${result}    service_1 must be checked: child_tp exception is active now and must not be overwritten by template_tp's exception during merge
+


### PR DESCRIPTION
REFS:MON-201060
REFS:#3460

Backport of #3460

## Summary

- Fix template merge for `ExceptionArray`: template exceptions are now merged into child (instead of overwriting child's own exceptions)
- Fix template merge for `DaysArray`: only inherit weekly time ranges from template for days the child does not define (instead of overwriting all child ranges)
- Add `TIMEPERIOD_MERGE` robot test validating that a child timeperiod's own calendar exception survives the merge with a template

## Root cause

In `parser::_merge()`, `ExceptionArray` and `DaysArray` fields were falling through to the generic `CopyFrom` branch, which replaced the child's entire field with the template's. This caused:
- A child timeperiod's own exceptions to be silently dropped if the template had any exceptions
- A child's custom weekday ranges to be overwritten by the template's ranges

## Test Plan

- [ ] `TIMEPERIOD_INHERITANCE` — child inherits template exception (future window) → service NOT checked
- [ ] `TIMEPERIOD_INHERITANCE_EXCEPTION` — child 24x7 ranges take priority over template future exception → service IS checked
- [ ] `TIMEPERIOD_MERGE` (new) — child's own calendar exception (active now) is preserved after merge with template that has a different exception (yesterday) → service IS checked