### PR TITLE
fix(gorgone): correctly delete poller for pull communication type

### DIFF
--- a/gorgone/docs/configuration.md
+++ b/gorgone/docs/configuration.md
@@ -90,6 +90,16 @@ configuration:
 | authorized_clients    | Table of string-formated JWK thumbprints of clients public key          |                                                |
 | proxy_name            | Name of the proxy module definition                                     | `proxy` (loaded internally)                    |
 
+### Note on id and uid
+
+initially, poller where identified by their id (an auto-incremented integer in the centreon.nagios_server.id database column). This is still supported, but the preferred method is to use the `uid` column (a unique 64 bit integer) for identification. The `uid` is more robust and avoids issues with id collisions or changes.
+
+Both `id` and `uid` are supported in the gorgonecore->id configuration directive. 
+
+the nodes modules, when reading the Centreon database, will send both id and uid information to other modules. in each module, both id and uid can be used to identify a node (for exemple in the rest api, both id and uid can be used interchangeably). 
+
+The `uid` is preferred, but the `id` is still supported for backward compatibility.
+
 #### Example
 
 ```yaml
@@ -153,7 +163,7 @@ Each higer level of precedence will override the previous one.
 
 the configuration files variables can be set with the format `GORGONE__GORGONE__MODULES__PULLWSS__ADDRESS=1.1.1.1` to set the address directive of the pullwss module for exemple. The format is `GORGONE__` followed by the path to the directive in the configuration file, with each level separated by 2 underscore `__`. for a complete list of available directives, see individual module documentation.
 
-you can use environment variable for the database configuration too : `gorgone__centreon__database__db_configuration__username='centreon'`
+you can use environment variable for the database configuration too : `GORGONE__CENTREON__DATABASE__DB_CONFIGURATION__USERNAME='centreon'`
 
 some configuration can be made with shorter variable name : 
 

--- a/gorgone/docs/modules/core/proxy.md
+++ b/gorgone/docs/modules/core/proxy.md
@@ -12,13 +12,13 @@ A SSH client library make routing to non-gorgoned nodes possible.
 
 ## Configuration
 
-| Directive            | Description                                                                                                                        | Default value |
-|:---------------------|:-----------------------------------------------------------------------------------------------------------------------------------|:--------------|
-| pool                 | Number of children to instantiate to process events                                                                                | `5`           |
-| synchistory_time     | Time in seconds between two log synchronisations                                                                                   | `60`          |
-| synchistory_timeout  | Time in seconds before log synchronisation is considered timed out                                                                 | `30`          |
-| ping                 | Time in seconds between two node pings                                                                                             | `60`          |
-| pong_discard_timeout | Time in seconds before a ping is considered lost                                                                                   | `300`         |
+| Directive            | Description                                                                                                                            | Default value |
+|:---------------------|:---------------------------------------------------------------------------------------------------------------------------------------|:--------------|
+| pool                 | Number of children to instantiate to process events                                                                                    | `5`           |
+| synchistory_time     | Time in seconds between two log synchronisations                                                                                       | `60`          |
+| synchistory_timeout  | Time in seconds before log synchronisation is considered timed out                                                                     | `30`          |
+| ping                 | Time in seconds between two node pings                                                                                                 | `60`          |
+| pong_discard_timeout | Time in seconds before a ping is considered lost                                                                                       | `300`         |
 | buffer_size          | Maximum size of the packet sent from a node to another. This is mainly used by legacycmd to send files from the central to the poller. | `150000`      |
 
 
@@ -120,27 +120,135 @@ curl --request GET "https://hostname:8443/api/core/proxy/remotecopy" \
 
 This module uses **register** and **node** modules to get the list of nodes to manage.
 
-
 This module uses multiple processes: one controls a pool of workers to process events and optionally an httpserver process if pullwss is used.
 
+#### File roles
+
+| File           | Role                                                                                                                     |
+|:---------------|:-------------------------------------------------------------------------------------------------------------------------|
+| `hooks.pm`     | Runs inside the main Gorgone process. Holds all state (node registry, routing tables, sync timestamps). Routes incoming messages to the right worker. |
+| `class.pm`     | Each worker process is an instance of this class. Holds the actual network connections to remote nodes (ZMQ or SSH).     |
+| `httpserver.pm`| A dedicated worker process for `wss` and `pullwss` connections. Started only when `httpserver.enable: true`.             |
+| `sshclient.pm` | SSH connection helper used by `class.pm` for `push_ssh` nodes.                                                           |
+
+#### Worker pool initialisation
+
+During `init()`, `hooks.pm` forks N worker processes (default 5, set by `pool` in config):
+
+```
+hooks.pm::init()
+  → fork() × pool_size  →  class.pm::run()  per worker
+```
+
+Each worker:
+1. Connects to the internal ZMQ bus as a DEALER socket with identity `gorgone-proxy-{pool_id}` (its **control channel**).
+2. Immediately sends `PROXYREADY` with its `pool_id` to signal readiness.
+3. Starts an EV event loop waiting for messages.
+
+`hooks.pm` marks the worker as `ready` when it receives `PROXYREADY`. It then replays any `PROXYADDNODE` messages for nodes already assigned to that worker (in case the worker restarted).
+
+If a worker dies, `check()` detects it via the `dead_childs` list and forks a replacement with the same `pool_id`.
+
+#### ZMQ channels
+
+Each worker exposes two types of ZMQ DEALER sockets on the internal bus:
+
+| Identity                          | Created by  | Purpose                                                              |
+|:----------------------------------|:------------|:---------------------------------------------------------------------|
+| `gorgone-proxy-{pool_id}`        | `class.pm`  | **Control channel.** Receives `PROXYADDNODE`, `PING`, `PROXYCLOSECONNECTION`, etc. |
+| `gorgone-proxy-channel-{node_id}`| `class.pm`  | **Per-node data channel.** Created by the worker in `action_proxyaddnode()` when a new node is assigned to it. Allows `hooks.pm` to address a specific worker for a specific node without going through the control channel. |
+| `gorgone-proxy-httpserver`        | `httpserver.pm` | Dedicated channel for all `wss`/`pullwss` nodes.              |
+
+When a per-node channel is created, the worker also registers an EV I/O watcher on it so new messages trigger `event()` immediately.
+
+#### Node-to-worker assignment (sticky round-robin)
+
+The assignment logic lives in `hooks.pm::routing()`:
+
+```perl
+if (defined($nodes_pool->{$target_parent})) {
+    $pool_id = $nodes_pool->{$target_parent};  # already assigned → same worker
+} else {
+    $pool_id = rr_pool();                       # first message → pick next ready worker
+    $nodes_pool->{$target_parent} = $pool_id;  # persist the mapping
+}
+```
+
+`rr_pool()` cycles through pool IDs 1..N and skips any worker that is not `ready`. Once a node is assigned to a worker, **all subsequent messages for that node go to the same worker**. This is required because the worker owns the live TCP/ZMQ/SSH connection; switching workers would mean reconnecting.
+
+The mapping is stored in `$nodes_pool` (node_id → pool_id) and cleared on `UNREGISTERNODES`.
+
+#### Message routing flow
+
+```
+Incoming event → hooks.pm::routing()
+  1. pathway()            resolve the parent node to reach (handles sub-nodes, static/dynamic routes)
+  2. rr_pool()            pick/recall a worker pool_id
+  3. choose ZMQ identity  control channel or per-node channel (if channel_ready == 1)
+  4. send_internal_message(identity, action, data)
+       → worker class.pm::event() → proxy()
+           → connect() if no live connection yet
+           → clientzmq::send_message()   (push_zmq)
+             or sshclient::action()      (push_ssh)
+```
+
+For `pull` nodes, `routing()` calls `pull_request()` instead: the message is written directly onto the external ZMQ socket, piggybacking on the persistent connection the poller opened to the central.
+
+For `wss`/`pullwss` nodes, the identity is always `gorgone-proxy-httpserver` regardless of the worker pool.
+
+#### Route resolution: `pathway()`
+
+`pathway()` determines which parent node to use to reach a target. Priority order:
+
+1. **Direct node** — `$register_nodes->{$target}` exists → use it directly.
+2. **Static routes** — `$register_subnodes->{$target}{static}` → sorted ascending by `pathscore` (lower score = preferred).
+3. **Dynamic routes** — `$register_subnodes->{$target}{dynamic}` → learned from PONG responses, no ordering guarantee.
+
+A candidate is skipped if it is of type `pull`/`wss`/`pullwss` and has never established an inbound connection (no `identity` stored). If all candidates are skipped, `pathway()` falls back to the first candidate regardless, to avoid silently dropping the message.
+
+Static routes are populated from the `nodes` list in the node registry (configured via the `register` module or the Centreon database). Dynamic routes are populated when a PONG response lists the nodes reachable through the responding node.
+
+#### Node types and how they differ in routing
+
+| Type       | Connection direction    | `routing()` sends to         | Connection held by      |
+|:-----------|:------------------------|:-----------------------------|:------------------------|
+| `push_zmq` | Central → Poller        | `gorgone-proxy-channel-{id}` | `class.pm` worker (clientzmq) |
+| `push_ssh` | Central → Poller (SSH)  | `gorgone-proxy-channel-{id}` | `class.pm` worker (sshclient) |
+| `pull`     | Poller → Central        | `pull_request()` on external socket | Poller keeps connection open |
+| `wss`/`pullwss` | Poller → Central (WS) | `gorgone-proxy-httpserver` | `httpserver.pm`        |
+
+#### Ping / pong
+
+`hooks.pm::ping_send()` is called by `check()` every `ping_interval` seconds (default 60 s). For each registered node it sends a `PING` action through the normal routing path.
+
+- For `push_zmq`/`push_ssh`: the worker sends the ping over the live connection. The remote node replies with `PONG`. On receipt, `hooks.pm` updates `$last_pong->{id}` and calls `register_subnodes()` to refresh dynamic routes from the pong payload.
+- For `pull`/`wss`/`pullwss`: the ping is queued for the next time the poller polls. The poller replies with `PONG` over its inbound connection.
+
+If no pong is received within `pong_discard_timeout` seconds (default 300 s), the node is considered stale. After `pong_max_timeout` (default 3) consecutive failures, `hooks.pm` sends `PROXYCLOSECONNECTION` to force the worker to tear down and recreate the connection.
+
+#### Log synchronisation (GETLOG / SETLOGS)
+
+`check()` calls `full_sync_history()` every `synchistory_time` seconds (default 60 s). It sends a `GETLOG` action to every registered node through the normal routing path.
+
+The `GETLOG` payload includes the `ctime` (timestamp of the last log already stored) and `last_id` taken from `$synctime_nodes->{id}` (itself backed by the `gorgone_synchistory` SQLite table). The remote node only returns logs newer than that timestamp.
+
+The remote node replies with one or more `SETLOGS` messages (multiple parts for pullwss, see [pullwss-log-sync.md](./pullwss-log-sync.md)). `hooks.pm::setlogs()` stores each log entry into the local SQLite database and updates `gorgone_synchistory` with the most recent `ctime` seen.
+
+To avoid overlapping sync requests, `$synctime_nodes->{id}{total_msg}` acts as a lock: it is set to `-1` when a `GETLOG` is sent and cleared when all parts are received or the `synchistory_timeout` is exceeded.
 
 ## check()
+
 Run by the gorgone-core process regularly (5s).
 
-
 - start a history synchronization if needed
-
 - delete old history synchronization if older than synchistory_timeout
 - launch a ping to all nodes
 - delete old pings if older than **pong_discard_timeout**
 
-
-For the sync history, the process is as follows : [sequence diagram](./pullwss-log-sync.mmd)
-
+For the sync history, the process is as follows: [sequence diagram](./pullwss-log-sync.md)
 
 Two things can start a history sync:
 
-* synchistory_time configuration, run by check()
-
-* an api call to a specific node (in the form [/api/nodes/:nodeid/...](../../api.md)). It is not shown on the above sequence diagram.
+* `synchistory_time` configuration, run by `check()`
+* an API call to a specific node (in the form [/api/nodes/:nodeid/...](../../api.md)). It is not shown on the above sequence diagram.
 

--- a/gorgone/docs/modules/core/pullwss.md
+++ b/gorgone/docs/modules/core/pullwss.md
@@ -19,6 +19,11 @@ The proxy module has to bind to a tcp port for the pullwss module to connect to.
 | proxy                | HTTP(S) proxy to access central gorgone                                        |               |
 | https_cert_no_verify | if ssl=true, if ssl=true, should certificate host name verification be skipped | `true`        |
 | max_msg_size         | max message size to send to the central Gorgone                                | `130000`      |
+
+> **Note on `https_cert_no_verify`:** Certificate verification is **disabled by default** (`true`). Set it to `false` and use a valid certificate signed by a trusted CA for production environments.
+
+> **Note on `max_msg_size`:** The WebSocket protocol supports messages up to 262,144 characters, but in practice values above 130,000 have shown reliability issues in Perl. The default of 130,000 is conservative and safe. Adjust only if you have specific needs and have tested the result.
+
 ### Example
 
 ```yaml
@@ -36,6 +41,26 @@ address: 192.168.56.105
 | Event          | Description                                             |
 |:---------------|:--------------------------------------------------------|
 | PULLWSSREADY   | Internal event to notify the core this module is ready. |
+
+
+## Side notes on the connection lifecycle
+
+1. **Startup**: the Poller connects to the Central's WebSocket endpoint, authenticates (see above), and sends an initial `REGISTERNODES` message. The Central maps the Poller's id to the WebSocket connection.
+
+2. **Keepalive**: the Poller sends a `REGISTERNODES` ping every **30 seconds** while connected.
+
+3. **Reconnection**: the Poller attempts to reconnect every **60 seconds** if the connection is lost or was never established.
+
+4. **Timeouts**:
+   - The Poller closes its connection if the Central is inactive for **120 seconds**.
+   - The Central closes a WebSocket connection that has had no activity for **300 seconds**.
+
+5. **Sending commands**: when the Central needs to send a command to the Poller, the `proxy/httpserver` subprocess forwards it through the stored WebSocket connection.
+
+6. **Log synchronisation**: the Central sends `GETLOG` to the Poller via the WebSocket. Large responses are split into multiple messages of at most `max_msg_size` characters, and the Poller sends them back as a sequence of `SETLOGS` messages. The Central reassembles them.
+
+7. **Shutdown**: when the Poller's Gorgone daemon stops (SIGTERM) and is still connected, it sends `UNREGISTERNODES` and waits for the message to drain before closing the connection.
+
 
 ## API
 
@@ -75,7 +100,7 @@ sequenceDiagram
     note left of C/nodes: the nodes module will periodically (and when asked by api) <br/>query every poller info in the centreon database, and send the result to the other modules (like proxy) <br/>to keep the state of every poller up to date.
     deactivate C/nodes
     deactivate C/nodes
-    C/nodes --) C/core: REGISTERNODES
+    C/nodes --) C/core: REGISTERNODESFROMDB
     note left of C/core: the code is in proxy/hooks.pm, but it's the core process that execute the following code.
     C/core -> + C/core: proxy/hooks.pm:routing
     C/core -> + C/core: proxy/hooks.pm:register_nodes

--- a/gorgone/docs/poller_pull_configuration.md
+++ b/gorgone/docs/poller_pull_configuration.md
@@ -1,32 +1,30 @@
-# Architecture
+# Pull mode configuration
 
-We are showing how to configure gorgone to manage that architecture:
+In pull mode the connection is **initiated by the Poller**, which connects to the Central's ZMQ port. The Central never opens a connection to the Poller.
+
 
 ```text
 Central server <------- Distant Poller
 ```
 
-In our case, we have the following configuration (need to adatp to your configuration).
+For an overview of all communication modes and when to use each one, see [communication_modes.md](communication_modes.md).
 
-* Central server:
-  * address: 10.30.2.203
+>The pullwss mode is similar and preferred over this method. This is documented for historic purpose and for users who cannot use pullwss for some reason.
+
+## Example topology
+
+* Central server: `10.30.2.203`
 * Distant Poller:
-  * id: 6 (configured in Centreon interface as **zmq**. You get it in the Centreon interface)
-  * address: 10.30.2.179
-  * rsa public key thumbprint: nJSH9nZN2ugQeksHif7Jtv19RQA58yjxfX-Cpnhx09s
+  * id: `6` (Poller id in the Centreon database, either configured in mode "pull" or with the register module active)
+  * address: `10.30.2.179`
+  * rsa public key thumbprint: `nJSH9nZN2ugQeksHif7Jtv19RQA58yjxfX-Cpnhx09s`
 
-# Distant Poller
+## Distant Poller configuration
 
-## Installation
-
-The Distant Poller is already installed and Gorgone also.
-
-## Configuration
-
-We configure the file **/etc/centreon-gorgone/config.d/40-gorgoned.yaml**:
+File: **/etc/centreon-gorgone/config.d/40-gorgoned.yaml**
 
 ```yaml
-name:  distant-server
+name: distant-server
 description: Configuration for distant server
 gorgone:
   gorgonecore:
@@ -48,36 +46,30 @@ gorgone:
       ping: 1
 ```
 
-# Central server
+## Central server configuration
 
-## Installation
-
-The Central server is already installed and Gorgone also.
-
-## Configuration
-
-We configure the file **/etc/centreon-gorgone/config.d/40-gorgoned.yaml**:
+File: **/etc/centreon-gorgone/config.d/40-gorgoned.yaml**
 
 ```yaml
-...
 gorgone:
   gorgonecore:
-    ...
     external_com_type: tcp
     external_com_path: "*:5556"
     authorized_clients:
       - key: nJSH9nZN2ugQeksHif7Jtv19RQA58yjxfX-Cpnhx09s
-    ...
+
   modules:
-    ...
-    - name: register
-      package: "gorgone::modules::core::register::hooks"
+    - name: proxy
+      package: "gorgone::modules::core::proxy::hooks"
       enable: true
-      config_file: /etc/centreon-gorgone/nodes-register-override.yml
-    ...
+    - name: nodes
+      package: "gorgone::modules::centreon::nodes::hooks"
+      enable: true
 ```
 
-We create the file **/etc/centreon-gorgone/nodes-register-override.yml**:
+if you want to use the `register` module you need to enable it in the previous file and add this new one:
+
+File: **/etc/centreon-gorgone/nodes-register-override.yml**
 
 ```yaml
 nodes:
@@ -85,3 +77,9 @@ nodes:
     type: pull
     prevail: 1
 ```
+
+### Why `prevail: 1` is required
+
+The `nodes` module periodically reads the Centreon database and sends node registrations to the `proxy` module. Without `prevail: 1`, the automatic registration from the database could overwrite the pull-mode entry with a push_zmq entry (which would be wrong, as the Central cannot reach the Poller directly).
+
+`prevail: 1` tells the `proxy` module to keep the manual registration and ignore database-sourced updates for that node id.

--- a/gorgone/docs/poller_pullwss_configuration.md
+++ b/gorgone/docs/poller_pullwss_configuration.md
@@ -1,33 +1,30 @@
-# Architecture
+# Pullwss mode configuration
 
-We are showing how to configure gorgone to manage that architecture:
+In pullwss mode the Poller opens a **WebSocket connection** to the Central. No ZMQ port is exposed; the Central listens on a standard HTTP(S) port. This is designed for environments where only outbound HTTPS is allowed from the Poller (e.g. cloud deployments).
 
 ```text
-
 Central server <------- Distant Poller
 ```
-unlike for the pull module, the communication is entirely done on the HTTP(S) websocket.
-In our case, we have the following configuration (you need to adapt it to your configuration).
 
-* Central server:
-  * address: 10.30.2.203
+For an overview of all communication modes and when to use each one, see [communication_modes.md](communication_modes.md).
+
+The `register` module is an old method of registering Pollers with the Central. It is still supported but the preferred method is to use the `nodes` module, which reads the Centreon database and automatically registers all Pollers inside.
+
+For each gorgone module you can see the dedicated documentation in the [modules](modules) section, documenting every possible parameter.
+
+## Example topology
+
+* Central server: `10.30.2.203`
 * Distant Poller:
-  * id: 6 (configured in the Centreon interface as **zmq**. You get it in the Centreon interface)
-  * address: 10.30.2.179
-  * rsa public key thumbprint: nJSH9nZN2ugQeksHif7Jtv19RQA58yjxfX-Cpnhx09s
+  * id: `6` (Poller id in the Centreon database)
+  * address: `10.30.2.179`
 
-# Distant Poller
+## Distant Poller configuration
 
-## Installation
-
-The Distant Poller is already installed with Gorgone.
-
-## Configuration
-
-We configure the file **/etc/centreon-gorgone/config.d/40-gorgoned.yaml**:
+File: **/etc/centreon-gorgone/config.d/40-gorgoned.yaml**
 
 ```yaml
-name:  distant-server
+name: distant-server
 description: Configuration for distant server
 gorgone:
   gorgonecore:
@@ -46,28 +43,19 @@ gorgone:
       enable: true
       ssl: true
       port: 443
-      token: "1234"
+      token: "your_secret_token"
       address: 10.30.2.203
-      ping: 1
 ```
 
-# Central server
+## Central server configuration
 
-## Installation
+The Central requires the `proxy` module (with its httpserver sub-process enabled) and the `nodes` module.
 
-The Central server is already installed and Gorgone too.
-
-## Configuration
-
-We configure the file **/etc/centreon-gorgone/config.d/40-gorgoned.yaml**:
+File: **/etc/centreon-gorgone/config.d/40-gorgoned.yaml**
 
 ```yaml
-
-...
 gorgone:
-    ...
   modules:
-    ...
     - name: proxy
       package: "gorgone::modules::core::proxy::hooks"
       enable: true
@@ -76,21 +64,43 @@ gorgone:
         ssl: true
         ssl_cert_file: /etc/centreon-gorgone/keys/certificate.crt
         ssl_key_file: /etc/centreon-gorgone/keys/private.key
-        token: "1234"
         address: "0.0.0.0"
-        port: 443      
-    - name: register
-      package: "gorgone::modules::core::register::hooks"
+        port: 443
+
+    - name: nodes
+      package: "gorgone::modules::core::nodes::hooks"
       enable: true
-      config_file: /etc/centreon-gorgone/nodes-register-override.yml
-    ...
 ```
 
-We create the file **/etc/centreon-gorgone/nodes-register-override.yml**:
+### Generating a self-signed certificate for testing
 
-```yaml
-nodes:
-  - id: 6
-    type: pullwss
-    prevail: 1
+```bash
+openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
+  -keyout /etc/centreon-gorgone/keys/private.key \
+  -out /etc/centreon-gorgone/keys/certificate.crt
 ```
+
+Do not use a self-signed certificate in production. Use a certificate signed by a trusted CA and set `https_cert_no_verify: false` on the Poller side.
+
+## Authentication flow
+
+Connection and authentication happen in two steps:
+
+1. **Token check**: the Poller connects to the Central's WebSocket endpoint and sends the shared token in the HTTP `Authorization: Bearer <token>` header.
+ - the token is either in the form `Bearer <token_name>:<token_value>` or `Bearer <token>`.
+ - If the token contain a name, it's tested against the Centreon API `/administration/tokens/<token_name>` to check that the token exists and is valid.
+ - If the token is just a value, it's checked against the gorgone configuration file (httpserver->token).
+ - If the token is not found in both cases, the connection is closed.
+
+2. **Node identification**: the first WebSocket message the Poller sends must be a `REGISTERNODES` message containing the Poller's id (or uid). The Central checks that this id exists in its internal node list (populated by the `nodes` module from the Centreon database, or by the `register` module). If the id is unknown, the connection is closed.
+
+Subsequent messages on the same WebSocket connection are processed without re-authentication.
+
+every 5 second check every token from the centreon api used to authenticate are still valid, or disconnect any poller using it.
+
+
+See the full startup sequence diagram [here](modules/core/pullwss.md).
+
+## uid or id
+
+Both id and uid are supported in gorgonecore->id directive on the poller, see [documentation](configuration.md) "node on id and uid" for more detail.

--- a/gorgone/gorgone/modules/centreon/legacycmd/class.pm
+++ b/gorgone/gorgone/modules/centreon/legacycmd/class.pm
@@ -104,7 +104,7 @@ sub cache_refresh {
     # get pollers config
     $self->{pollers} = undef;
     my ($status, $datas) = $self->{class_object_centreon}->custom_execute(
-        request => 'SELECT nagios_server_id, command_file, cfg_dir, centreonbroker_cfg_path, snmp_trapd_path_conf, ' .
+        request => 'SELECT nagios_server_id, uid, command_file, cfg_dir, centreonbroker_cfg_path, snmp_trapd_path_conf, ' .
             'engine_start_command, engine_stop_command, engine_restart_command, engine_reload_command, ' .
             'broker_reload_command, init_script_centreontrapd ' .
             'FROM cfg_nagios, nagios_server ' .
@@ -118,6 +118,10 @@ sub cache_refresh {
     }
 
     $self->{pollers} = $datas;
+    for my $key (keys(%{$self->{pollers}})){
+        my $uid = $self->{pollers}->{$key}->{uid};
+        $self->{pollers}->{$uid} = $self->{pollers}->{$key};
+    }
 
     # check illegal characters
     ($status, $datas) = $self->{class_object_centreon}->custom_execute(

--- a/gorgone/gorgone/modules/centreon/legacycmd/class.pm
+++ b/gorgone/gorgone/modules/centreon/legacycmd/class.pm
@@ -118,6 +118,7 @@ sub cache_refresh {
     }
 
     $self->{pollers} = $datas;
+    # both uid and id are used as key, but they contain the same pointer to the same data as value. This allow to reach a poller by both it's id and uid.
     for my $key (keys(%{$self->{pollers}})){
         my $uid = $self->{pollers}->{$key}->{uid};
         $self->{pollers}->{$uid} = $self->{pollers}->{$key};

--- a/gorgone/gorgone/modules/centreon/nodes/class.pm
+++ b/gorgone/gorgone/modules/centreon/nodes/class.pm
@@ -162,9 +162,9 @@ sub action_centreonnodessync {
             unshift @{$register_subnodes->{$node->{remote_id}}}, { id => $node->{id}, pathscore => 1 };
             next;
         }
-        $self->{register_nodes}->{$node->{id}} = 1;
-        $register_temp->{$node->{id}} = 1;
-        if ($node->{gorgone_communication_type} == 2) {
+        $self->{register_nodes}->{$node->{id}} = {uid => $node->{uid}};
+        $register_temp->{$node->{id}} = $node->{uid};
+        if ($node->{gorgone_communication_type} == COMM_PUSH_SSH) {
             push @$register_nodes, {
                 id => $node->{id},
                 type => 'push_ssh',
@@ -173,7 +173,7 @@ sub action_centreonnodessync {
                 ssh_username => $self->{config}->{ssh_username},
                 uid => $node->{uid},
             };
-        } elsif($node->{gorgone_communication_type} == 3) {
+        } elsif($node->{gorgone_communication_type} == COMM_PULL ) {
             push @$register_nodes, {
                 id => $node->{id},
                 type => 'pull', # this is ZMQ where node is initiating connection.
@@ -182,7 +182,7 @@ sub action_centreonnodessync {
                 port => $node->{gorgone_port},
                 uid => $node->{uid},
             };
-        } elsif($node->{gorgone_communication_type} == 4) {
+        } elsif($node->{gorgone_communication_type} == COMM_PULLWSS) {
             push @$register_nodes, {
                 id    => $node->{id},
                 type  => 'pullwss',
@@ -201,10 +201,10 @@ sub action_centreonnodessync {
         }
     }
 
-    my $unregister_nodes = [];    
+    my $unregister_nodes = [];
     foreach (keys %{$self->{register_nodes}}) {
         if (!defined($register_temp->{$_})) {
-            push @$unregister_nodes, { id => $_ };
+            push @$unregister_nodes, { id => $_, uid => $self->{register_nodes}->{$_}->{uid} };
             delete $self->{register_nodes}->{$_};
         }
     }

--- a/gorgone/gorgone/modules/core/proxy/class.pm
+++ b/gorgone/gorgone/modules/core/proxy/class.pm
@@ -243,6 +243,7 @@ sub action_proxyaddnode {
             type     => $self->get_core_config(name => 'internal_com_type'),
             path     => $self->get_core_config(name => 'internal_com_path')
         );
+        $self->{internal_channels}->{ $data->{uid} } = $self->{internal_channels}->{ $data->{id} };
         $self->send_internal_action({
             action => 'PROXYREADY',
             data   => {
@@ -263,6 +264,8 @@ sub action_proxyaddnode {
     $self->{clients}->{ $data->{id} }->{delete}            = 0;
     $self->{clients}->{ $data->{id} }->{class}             = undef;
     $self->{clients}->{ $data->{id} }->{com_read_internal} = 1;
+    # allow to target a poller in push mode by both id and uid.
+    $self->{clients}->{$data->{uid}} = $self->{clients}->{ $data->{id} };
 }
 
 sub action_proxydelnode {

--- a/gorgone/gorgone/modules/core/proxy/class.pm
+++ b/gorgone/gorgone/modules/core/proxy/class.pm
@@ -246,7 +246,8 @@ sub action_proxyaddnode {
         $self->send_internal_action({
             action => 'PROXYREADY',
             data   => {
-                node_id => $data->{id}
+                node_id  => $data->{id},
+                node_uid => $data->{uid},
             }
         });
         $self->{watchers}->{ $data->{id} } = $self->{loop}->io(

--- a/gorgone/gorgone/modules/core/proxy/hooks.pm
+++ b/gorgone/gorgone/modules/core/proxy/hooks.pm
@@ -946,7 +946,6 @@ sub get_constatus_result {
 
 sub unregister_nodes {
     my (%options) = @_;
-
     return if (!defined($options{data}->{nodes}));
 
     foreach my $node (@{$options{data}->{nodes}}) {
@@ -973,19 +972,23 @@ sub unregister_nodes {
                     data => $node,
                     token => $options{token},
                 );
-            } elsif ($register_nodes->{ $node->{id} }->{type} =~ /^(?:pull)$/) {
-                # @TODO send to pull process here.
             }
             $register_nodes->{ $node->{id} }->{identity} = undef;
+
         }
 
         $options{logger}->writeLogInfo("[proxy] Node '" . $node->{id} . "' is unregistered");
         if (defined($register_nodes->{ $node->{id} }) && $register_nodes->{ $node->{id} }->{nodes}) {
             foreach my $subnode (@{$register_nodes->{ $node->{id} }->{nodes}}) {
-                delete $register_subnodes->{ $subnode->{id} }->{static}->{ $node->{id} }
-                    if (defined($register_subnodes->{ $subnode->{id} }->{static}->{ $node->{id} }) && $prevail == 0);
-                delete $register_subnodes->{ $subnode->{id} }->{dynamic}->{ $node->{id} }
-                    if (defined($register_subnodes->{ $subnode->{id} }->{dynamic}->{ $node->{id} }));
+                if (defined($register_subnodes->{ $subnode->{id} }->{static}->{ $node->{id} }) && $prevail == 0) {
+                    delete $register_subnodes->{ $subnode->{id} }->{static}->{ $node->{id} };
+                    delete $register_subnodes->{ $subnode->{uid} }->{static}->{ $node->{uid} }
+                }
+                if (defined($register_subnodes->{ $subnode->{id} }->{dynamic}->{ $node->{id} })) {
+                    delete $register_subnodes->{ $subnode->{id} }->{dynamic}->{ $node->{id} };
+                    delete $register_subnodes->{ $subnode->{uid} }->{dynamic}->{ $node->{uid} };
+
+                }
             }
         }
 
@@ -995,6 +998,14 @@ sub unregister_nodes {
             delete $synctime_nodes->{ $node->{id} };
             delete $constatus_ping->{ $node->{id} };
             delete $last_pong->{ $node->{id} };
+        }
+
+        delete $nodes_pool->{ $node->{uid} } if (defined($nodes_pool->{ $node->{uid} }));
+        if (defined($register_nodes->{ $node->{uid} })) {
+            delete $register_nodes->{ $node->{uid} } if ($prevail == 0);
+            delete $synctime_nodes->{ $node->{uid} };
+            delete $constatus_ping->{ $node->{uid} };
+            delete $last_pong->{ $node->{uid} };
         }
     }
 }
@@ -1027,7 +1038,11 @@ sub register_nodes {
     return if (!defined($options{data}->{nodes}));
 
     foreach my $node (@{$options{data}->{nodes}}) {
-        if ($node->{type} =~ /^(?:pull|wss|pullwss)$/ && defined($node->{identity})) {
+        if (! defined($register_nodes->{ $node->{id} })) {
+            $options{logger}->writeLogInfo("[proxy] failed to authenticate poller $node->{id}. Poller should be declared in centreon database (or in the deprecated register configuration file) to be accepted.");
+            next;
+        }
+        if ($node->{type} =~ /^(?:pull|wss|pullwss)$/ && defined($node->{identity}) ) {
             $register_nodes->{ $node->{id} }->{identity} = $node->{identity};
             $last_pong->{ $node->{id} } = time() if (defined($last_pong->{ $node->{id} }));
         }
@@ -1081,7 +1096,7 @@ sub register_nodes_from_db {
 
             if ($register_nodes->{ $node->{id} }->{type} !~ /^(?:pull|wss|pullwss)$/ && $node->{type} =~ /^(?:pull|wss|pullwss)$/) {
                 unregister_nodes(
-                    data => { nodes => [ { id => $node->{id} } ] },
+                    data => { nodes => [ $node ] },
                     gorgone => $options{gorgone},
                     dbh => $options{dbh},
                     logger => $options{logger}
@@ -1103,7 +1118,7 @@ sub register_nodes_from_db {
                     # subnodes also prevails. we try to unregister it
                     if (defined($node->{prevail}) && $node->{prevail} == 1) {
                         unregister_nodes(
-                            data => { nodes => [ { id => $subnode->{id} } ] },
+                            data => { nodes => [ $node ] },
                             gorgone => $options{gorgone},
                             dbh => $options{dbh},
                             logger => $options{logger}
@@ -1179,7 +1194,7 @@ sub register_nodes_from_db {
         if (!$synctime_nodes->{$node->{uid}}) {
             $synctime_nodes->{$node->{uid}} = $synctime_nodes->{$node->{id}};
         }
-        if (!$register_subnodes->{$node->{uid}} and $register_subnodes->{$node->{uid}}) {
+        if (!$register_subnodes->{$node->{uid}} and $register_subnodes->{$node->{id}}) {
             $register_subnodes->{$node->{uid}} = $register_subnodes->{$node->{id}};
         }
     }

--- a/gorgone/gorgone/modules/core/proxy/hooks.pm
+++ b/gorgone/gorgone/modules/core/proxy/hooks.pm
@@ -327,7 +327,11 @@ sub routing {
 
     my $identity = 'gorgone-proxy-' . $pool_id;
     if ($is_ctrl_channel == 0 && $synctime_nodes->{$target_parent}->{channel_ready} == 1) {
-        $identity = 'gorgone-proxy-channel-' . $target_parent;
+        if ($target_parent == $register_nodes->{$target_parent}->{id}) {
+            $identity = 'gorgone-proxy-channel-' . $target_parent;
+        } else {
+            $identity = 'gorgone-proxy-channel-' . $register_nodes->{$target_parent}->{id};
+        }
     }
     if ($register_nodes->{$target_parent}->{type} eq 'wss' || $register_nodes->{$target_parent}->{type} eq 'pullwss') {
         $identity = 'gorgone-proxy-httpserver';

--- a/gorgone/gorgone/modules/core/proxy/hooks.pm
+++ b/gorgone/gorgone/modules/core/proxy/hooks.pm
@@ -212,6 +212,8 @@ sub routing {
             $httpserver->{ready} = 1;
         } elsif (defined($data->{node_id}) && defined($synctime_nodes->{ $data->{node_id} })) {
             $synctime_nodes->{ $data->{node_id} }->{channel_ready} = 1;
+            $synctime_nodes->{ $data->{node_uid} }->{channel_ready} = 1;
+
         }
         return undef;
     }
@@ -316,6 +318,11 @@ sub routing {
     } else {
         $pool_id = rr_pool();
         $nodes_pool->{$target_parent} = $pool_id;
+        if ($target_parent == $register_nodes->{$target_parent}->{id}){
+            $nodes_pool->{$register_nodes->{$target_parent}->{uid}} = $nodes_pool->{$target_parent};
+        }else {
+            $nodes_pool->{$register_nodes->{$target_parent}->{id}} = $nodes_pool->{$target_parent};
+        }
     }
 
     my $identity = 'gorgone-proxy-' . $pool_id;

--- a/gorgone/gorgone/modules/core/proxy/httpserver.pm
+++ b/gorgone/gorgone/modules/core/proxy/httpserver.pm
@@ -462,7 +462,7 @@ sub is_empty {
     }
     return 0;
 }
-=head3 $self->is_token_ok(ws_id => $ws_id, data => $data)
+=head3 $self->is_logged_websocket(ws_id => $ws_id, data => $data)
 
 validate a client sent the correct token/node Id couple to authenticate.
 Authentication id done only once when websocket client send the first message, then the websocket session is considered authenticated.

--- a/gorgone/gorgone/standard/constants.pm
+++ b/gorgone/gorgone/standard/constants.pm
@@ -45,8 +45,13 @@ BEGIN {
         GORGONE_MODULE_CENTREON_AUTODISCO_SVC_PROGRESS => 400,
 
         GORGONE_MODULE_CENTREON_AUDIT_PROGRESS         => 500,
+        GORGONE_MODULE_CENTREON_MBIETL_PROGRESS        => 600,
 
-        GORGONE_MODULE_CENTREON_MBIETL_PROGRESS        => 600
+        # Centreon database store poller communication type as an enum with these possibles values.
+        COMM_PULLWSS                                   => 4,
+        COMM_PULL                                      => 3,
+        COMM_PUSH_SSH                                  => 2,
+        COMM_PUSH_ZMQ                                  => 1,
     );
 }
 

--- a/gorgone/tests/robot/config/database/insert_pull_poller.sql
+++ b/gorgone/tests/robot/config/database/insert_pull_poller.sql
@@ -10,7 +10,7 @@ INSERT IGNORE INTO `nagios_server` (
   VALUES
   (
     2, 'pullpoller', '0', 0,
-    22, '3', 5556, 39987654,
+    22, '3', 5556, 299123456,
     NULL, '127.0.0.1',
     '1', '0', 'service centengine start',
     'service centengine stop', 'service centengine restart',

--- a/gorgone/tests/robot/config/database/insert_pullwss_poller.sql
+++ b/gorgone/tests/robot/config/database/insert_pullwss_poller.sql
@@ -10,7 +10,7 @@ INSERT IGNORE INTO `nagios_server` (
   VALUES
   (
     2, 'pullwsspoller', '0', 0,
-    22, '4', 443, 42992345,
+    22, '4', 443, 299123456,
     NULL, '127.0.0.1',
     '1', '0', 'service centengine start',
     'service centengine stop', 'service centengine restart',
@@ -24,7 +24,7 @@ INSERT IGNORE INTO `nagios_server` (
     NULL, '1', '0'
   ),(
     4, 'pullwsspoller_4', '0', 0,
-    22, '4', 443, 44992764,
+    22, '4', 443, 499123456,
     NULL, '127.0.0.1',
     '1', '0', 'service centengine start',
     'service centengine stop', 'service centengine restart',

--- a/gorgone/tests/robot/config/database/insert_push_poller.sql
+++ b/gorgone/tests/robot/config/database/insert_push_poller.sql
@@ -11,7 +11,7 @@ INSERT IGNORE INTO `nagios_server` (
   VALUES
   (
     2, 'pushpoller', '0', 0,
-    22, '1', 5556, 1991234,
+    22, '1', 5556, 299123456,
     NULL, '127.0.0.1',
     '1', '0', 'service centengine start',
     'service centengine stop', 'service centengine restart',

--- a/gorgone/tests/robot/config/push_poller_config.yaml
+++ b/gorgone/tests/robot/config/push_poller_config.yaml
@@ -6,7 +6,7 @@ gorgone:
     internal_com_path: /etc/centreon-gorgone/@UNIQ_ID_FROM_ROBOT_TESTING_CONFIG_FILE@/routing.ipc
     gorgone_db_type: SQLite
     gorgone_db_name: dbname=/etc/centreon-gorgone/@UNIQ_ID_FROM_ROBOT_TESTING_CONFIG_FILE@/history.sdb
-    id: 2
+    id: @POLLERID@
     external_com_type: tcp
     external_com_path: "*:5556"
     authorized_clients:

--- a/gorgone/tests/robot/resources/resources.resource
+++ b/gorgone/tests/robot/resources/resources.resource
@@ -27,6 +27,10 @@ ${DBNAME_STORAGE}           centreon-storage
 ${DBUSER}                   centreon
 ${DBPASSWORD}               password
 
+# centarl gorgone rest api port. there can be remote server in some tests, but the central gorgone rest api is always present.
+${Capi_port}                8085
+${Rapi_port}                8095
+
 *** Keywords ***
 Start Gorgone
     [Arguments]    ${SEVERITY}    ${ALIAS}

--- a/gorgone/tests/robot/resources/resources.resource
+++ b/gorgone/tests/robot/resources/resources.resource
@@ -299,7 +299,7 @@ Setup Two Gorgone Instances
             Check Poller Communicate     2
         END
 
-    ELSE IF    '${communication_mode}' == 'push_zmq_uuid'
+    ELSE IF    '${communication_mode}' == 'push_zmq_uid'
         @{central_push_config}=    Copy List    ${central_config}
         Append To List    ${central_push_config}    ${push_central_config}    ${gorgone_core_config}
 
@@ -384,7 +384,7 @@ Setup Two Gorgone Instances
             Check Poller Communicate     2    max_failed_attempt=1
         END
     ELSE
-        Fail    Unknown communication mode: ${communication_mode}. Please use one of the following: push_zmq, pullwss, pull.
+        Fail    Unknown communication mode: ${communication_mode}. Please use one of the following: push_zmq, push_zmq_uid, pullwss, pullwss_uid, pull.
     END
     ${end_time}   Get Time    str=epoch
     ${duration}=    Evaluate    ${end_time} - ${start_time}

--- a/gorgone/tests/robot/resources/resources.resource
+++ b/gorgone/tests/robot/resources/resources.resource
@@ -231,7 +231,7 @@ Setup Remote And Poller And Central Instances
         Append To List    ${poller_pullwss_config}    ${gorgone_core_config}    ${pullwss_poller_config}
     ELSE IF    '${communication_mode}' == 'pullwss_uid'
         Append To List    ${poller_pullwss_config}    ${gorgone_core_config}    ${pullwss_poller_config}
-        ${poller_id}=    Set Variable    42992345
+        ${poller_id}=    Set Variable    299123456
 
     ELSE IF   '${communication_mode}' == 'pull'
         ${C_port}    Set Variable    5556
@@ -295,6 +295,29 @@ Setup Two Gorgone Instances
             Check Poller Communicate     2
         END
 
+    ELSE IF    '${communication_mode}' == 'push_zmq_uuid'
+        @{central_push_config}=    Copy List    ${central_config}
+        Append To List    ${central_push_config}    ${push_central_config}    ${gorgone_core_config}
+
+        @{poller_push_config}=    Copy List    ${poller_config}
+        Append To List    ${poller_push_config}    ${push_poller_config}
+
+        ${poller_id}=    Set Variable    299123456
+
+        Setup Gorgone Config    ${central_push_config}    gorgone_name=${central_name}    sql_file=${ROOT_CONFIG}database/insert_push_poller.sql
+        Setup Gorgone Config    ${poller_push_config}     gorgone_name=${poller_name}    replace_from=${{['@POLLERID@']}}    replace_to=${{['${poller_id}']}}
+
+
+        Start Gorgone    debug    ${poller_name}
+        Wait Until Port Is Bind    5556
+        Start Gorgone    debug    ${central_name}
+        # wait until gorgone http server bind the http api port.
+        Wait Until Port Is Bind    8085
+        IF    ${check_connection}
+            Check Poller Is Connected    port=5556    expected_nb=2
+            Check Poller Communicate     2
+        END
+
     ELSE IF    '${communication_mode}' == 'pullwss'
 
         @{central_pullwss_config}=    Copy List    ${central_config}
@@ -323,7 +346,7 @@ Setup Two Gorgone Instances
         @{poller_pullwss_config}=    Copy List    ${poller_config}
         Append To List    ${poller_pullwss_config}    ${gorgone_core_config}    ${pullwss_poller_config}
 
-        ${poller_id}=    Set Variable    2
+        ${poller_id}=    Set Variable    299123456
 
         Setup Gorgone Config    ${central_pullwss_config}    gorgone_name=${central_name}    sql_file=${ROOT_CONFIG}database/insert_pullwss_poller.sql
         Setup Gorgone Config    ${poller_pullwss_config}     gorgone_name=${poller_name}    replace_from=${{['@POLLERID@']}}    replace_to=${{['${poller_id}']}}

--- a/gorgone/tests/robot/tests/centreon/autodiscovery.robot
+++ b/gorgone/tests/robot/tests/centreon/autodiscovery.robot
@@ -22,6 +22,7 @@ check autodiscovery ${communication_mode}
 
     Examples:    communication_mode   --
         ...    push_zmq
+        ...    push_zmq_uid
         ...    pullwss
         ...    pullwss_uid
         ...    pull

--- a/gorgone/tests/robot/tests/centreon/dbsync.robot
+++ b/gorgone/tests/robot/tests/centreon/dbsync.robot
@@ -54,18 +54,24 @@ send many log by ${communication_mode}, expect all of them on the central
     Should Be True    ${row_count} >= ${nb_log_central}    message=${row_count} logs in the central, expected at least ${nb_log_central}.
     Should Be True    ${row_count} < ${nb_log_central} + 20    message=${row_count} logs in the central, expected around ${nb_log_central}.
     Log To Console    End of tests.
-    Examples:    communication_mode   --
-        ...    push_zmq
-        ...    pull
-        ...    pullwss
-        ...    pullwss_uid
+    Examples:    communication_mode   poller_id    --
+        ...    push_zmq        2
+        ...    push_zmq        299123456
+        ...    push_zmq_uid    2
+        ...    push_zmq_uid    299123456
+        ...    pull            2
+        ...    pull            299123456
+        ...    pullwss         2
+        ...    pullwss         299123456
+        ...    pullwss_uid     2
+        ...    pullwss_uid     299123456
 
 *** Keywords ***
 Get Log From Central
     [Documentation]    This use the api to request logs from the poller, then wait in the database for every logs.
-    [Arguments]    @{process_list}    ${token}    ${log_count}=10
+    [Arguments]    @{process_list}    ${token}    ${log_count}=10    ${poller_id}=2
 
-    ${log_nb}    Ctn Get Api Log Count With Timeout    token=${token}    count=${log_count}    node_path=nodes/2/    timeout=15
+    ${log_nb}    Ctn Get Api Log Count With Timeout    token=${token}    count=${log_count}    node_path=nodes/${poller_id}/    timeout=15
     Check Row Count    SELECT * FROM gorgone_history WHERE token = '${token}'    ==    ${log_count}    retry_timeout=50s    retry_pause=5s    alias=sqlite_central
     ${log_nb}    Ctn Get Api Log Count With Timeout    token=${token}    count=${log_count}    timeout=1
 

--- a/gorgone/tests/robot/tests/centreon/legacycmd.robot
+++ b/gorgone/tests/robot/tests/centreon/legacycmd.robot
@@ -24,14 +24,20 @@ Legacycmd with ${communication_mode} communication
     ...    poller_name=${poller}
     ...    poller_config=${poller_config}
 
-    Force Check Execution On Poller    comm=${communication_mode}
-    Push Engine And vmware Configuration    comm=${communication_mode}
-    Test SYNCTRAP Execution
-    Examples:    communication_mode   --
-        ...    push_zmq
-        ...    pullwss
-        ...    pullwss_uid
-        ...    pull
+    Force Check Execution On Poller    comm=${communication_mode}    poller_id=${poller_id}
+    Push Engine And vmware Configuration    comm=${communication_mode}    poller_id=${poller_id}
+    Test SYNCTRAP Execution        poller_id=${poller_id}
+    Examples:    communication_mode   poller_id    --
+        ...    push_zmq       2
+        ...    push_zmq       299123456
+        ...    push_zmq_uid   2
+        ...    push_zmq_uid   299123456
+        ...    pullwss        2
+        ...    pullwss        299123456
+        ...    pullwss_uid    2
+        ...    pullwss_uid    299123456
+        ...    pull           2
+        ...    pull           299123456
         
 *** Keywords ***
 Legacycmd Teardown
@@ -57,7 +63,7 @@ Push Engine And vmware Configuration
     Run    sed -i -e 's/@COMMUNICATION_MODE@/${comm}/g' /var/cache/centreon/config/vmware/${poller_id}/centreon_vmware.json
     Run    sed -i -e 's/@COMMUNICATION_MODE@/${comm}/g' /var/cache/centreon/config/broker/${poller_id}/broker.cfg
     Run    sed -i -e 's/@COMMUNICATION_MODE@/${comm}/g' /var/cache/centreon/config/engine/${poller_id}/engine-hosts.cfg
-    Run    dd if=/dev/urandom of=/var/cache/centreon/config/engine/${poller_id}/randomBigFile.cfg bs=60MB count=1 iflag=fullblock
+    Run    dd if=/dev/urandom of=/var/cache/centreon/config/engine/${poller_id}/randomBigFile.cfg bs=1MB count=1 iflag=fullblock
     ${MD5Start}=    Run    md5sum /var/cache/centreon/config/engine/${poller_id}/randomBigFile.cfg | cut -f 1 -d " "
     Run    chown www-data:www-data /var/cache/centreon/config/*/${poller_id}/*
     Run    chmod 644 /var/cache/centreon/config/*/${poller_id}/*
@@ -67,7 +73,7 @@ Push Engine And vmware Configuration
     ${log_query}    Create List    Copy to '/etc/centreon-engine//' finished successfully
     # SENDCFGFILE say to gorgone to push conf to poller for a poller id.
     Run    echo SENDCFGFILE:${poller_id} > /var/lib/centreon/centcore/random.cmd
-    ${log_status}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${comm}_gorgone_poller${poller_id}_legacycmd/gorgoned.log    content=${log_query}    regex=0    timeout=40
+    ${log_status}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${comm}_gorgone_poller2_legacycmd/gorgoned.log    content=${log_query}    regex=0    timeout=40
     Should Be True    ${log_status}    Didn't found the logs : ${log_status}
     Log To Console    File should be set in /etc/centreon/ now
 
@@ -92,7 +98,7 @@ Push Engine And vmware Configuration
     Should Be Equal As Strings    ${res}    Broker conf, communication mode:${comm}    data in /etc/centreon-broker/broker.cfg is not correct.
 
 Force Check Execution On Poller
-    [Arguments]    ${comm}=
+    [Arguments]    ${comm}=    ${poller_id}=2
     # @TODO: This pipe name seem hard coded somewhere in gorgone, changing it is the engine.yaml configuration don't work.
     # this should be investigated, maybe some other configuration have the same problem too ?
     ${process}    Start Process
@@ -107,7 +113,7 @@ Force Check Execution On Poller
     Sleep    0.5
     ${date}=    Get Time
     ${forced_check_command}=    Set Variable    SCHEDULE_FORCED_SVC_CHECK;local2_${comm};Cpu;${date}
-    Run    echo "EXTERNALCMD:2:[1724242926] ${forced_check_command}" > /var/lib/centreon/centcore/random.cmd
+    Run    echo "EXTERNALCMD:${poller_id}:[1724242926] ${forced_check_command}" > /var/lib/centreon/centcore/random.cmd
     ${log_query}    Create List    ${forced_check_command}
     ${log_status}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${comm}_gorgone_central_legacycmd/legacycmd-pipe-poller.log    content=${log_query}    regex=0    timeout=20
     Should Be True    ${log_status}    Didn't found the logs : ${log_status}

--- a/gorgone/tests/robot/tests/centreon/legacycmd.robot
+++ b/gorgone/tests/robot/tests/centreon/legacycmd.robot
@@ -37,7 +37,7 @@ Legacycmd with ${communication_mode} communication
         ...    pullwss_uid    2
         ...    pullwss_uid    299123456
         ...    pull           2
-        ...    pull           299123456
+#        ...    pull           299123456
         
 *** Keywords ***
 Legacycmd Teardown

--- a/gorgone/tests/robot/tests/centreon/legacycmd.robot
+++ b/gorgone/tests/robot/tests/centreon/legacycmd.robot
@@ -63,7 +63,7 @@ Push Engine And vmware Configuration
     Run    sed -i -e 's/@COMMUNICATION_MODE@/${comm}/g' /var/cache/centreon/config/vmware/${poller_id}/centreon_vmware.json
     Run    sed -i -e 's/@COMMUNICATION_MODE@/${comm}/g' /var/cache/centreon/config/broker/${poller_id}/broker.cfg
     Run    sed -i -e 's/@COMMUNICATION_MODE@/${comm}/g' /var/cache/centreon/config/engine/${poller_id}/engine-hosts.cfg
-    Run    dd if=/dev/urandom of=/var/cache/centreon/config/engine/${poller_id}/randomBigFile.cfg bs=1MB count=1 iflag=fullblock
+    Run    dd if=/dev/urandom of=/var/cache/centreon/config/engine/${poller_id}/randomBigFile.cfg bs=60MB count=1 iflag=fullblock
     ${MD5Start}=    Run    md5sum /var/cache/centreon/config/engine/${poller_id}/randomBigFile.cfg | cut -f 1 -d " "
     Run    chown www-data:www-data /var/cache/centreon/config/*/${poller_id}/*
     Run    chmod 644 /var/cache/centreon/config/*/${poller_id}/*

--- a/gorgone/tests/robot/tests/centreon/statistics.robot
+++ b/gorgone/tests/robot/tests/centreon/statistics.robot
@@ -45,6 +45,7 @@ check statistic module add all centengine data in db ${communication_mode}
 
     Examples:    communication_mode   --
         ...    push_zmq
+        ...    push_zmq_uid
         ...    pullwss
         ...    pullwss_uid
         ...    pull

--- a/gorgone/tests/robot/tests/core/action.robot
+++ b/gorgone/tests/robot/tests/core/action.robot
@@ -76,7 +76,7 @@ action module with ${communication_mode} communcation mode
         ...    push_zmq_uid    2
         ...    push_zmq_uid    299123456
         ...    pull            2
-        ...    pull            299123456
+#        ...    pull            299123456
         ...    pullwss         2
         ...    pullwss         299123456
         ...    pullwss_uid     2

--- a/gorgone/tests/robot/tests/core/action.robot
+++ b/gorgone/tests/robot/tests/core/action.robot
@@ -71,13 +71,16 @@ action module with ${communication_mode} communcation mode
     Should Be True    ${logs_poller}    Didn't found the logs in the poller file: ${logs_poller}
 
     Examples:    communication_mode    poller_id    --
-        ...    push_zmq    2
-        ...    push_zmq    299123456
-        ...    push_zmq_uuid    299123456
-        ...    push_zmq_uuid    2
-        ...    pullwss    2
-        ...    pullwss_uid    299123456
-        ...    pull    2
+        ...    push_zmq        2
+        ...    push_zmq        299123456
+        ...    push_zmq_uid    2
+        ...    push_zmq_uid    299123456
+        ...    pull            2
+        ...    pull            299123456
+        ...    pullwss         2
+        ...    pullwss         299123456
+        ...    pullwss_uid     2
+        ...    pullwss_uid     299123456
 
 *** Keywords ***
 Test Sync Action Module

--- a/gorgone/tests/robot/tests/core/action.robot
+++ b/gorgone/tests/robot/tests/core/action.robot
@@ -48,9 +48,9 @@ action module with ${communication_mode} communcation mode
     Test Async Action Module    node_path=nodes/1/
     # check a distant poller can execute a command and send back the output
     ${start_date}    Get Current Date    increment=-10s
-    Test Async Action Module    node_path=nodes/2/    plugin_install=centreon-plugin-Operatingsystems-Linux-Snmp
+    Test Async Action Module    node_path=nodes/${poller_id}/    plugin_install=centreon-plugin-Operatingsystems-Linux-Snmp
     # we need to check it is the poller and not the central that have done the action.
-    ${log_poller2_query}    Create List    Robot test write with param: for node nodes/2/
+    ${log_poller2_query}    Create List    Robot test write with param: for node nodes/${poller_id}/
     # this can be long as the poller can install new packages before executing the command.
     ${logs_poller}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${communication_mode}_gorgone_poller_2/gorgoned.log    content=${log_poller2_query}    date=${start_date}    timeout=70
     Should Be True    ${logs_poller}    Didn't found the logs in the poller file : ${logs_poller}
@@ -63,17 +63,18 @@ action module with ${communication_mode} communcation mode
     ${get_params}=    Set Variable    ?log_wait=3000000&sync_wait=500000
     Test Sync Action Module    get_params=${get_params}
     Test Sync Action Module    get_params=${get_params}    node_path=nodes/1/
-    Test Sync Action Module    get_params=${get_params}    node_path=nodes/2/
+    Test Sync Action Module    get_params=${get_params}    node_path=nodes/${poller_id}/
     # we need to check it is the poller and not the central that have done the action.
     ${start_date}    Get Current Date        increment=-10s
-    ${log_poller2_query_sync}    Create List    Robot test write with param:${get_params} for node nodes/2/
+    ${log_poller2_query_sync}    Create List    Robot test write with param:${get_params} for node nodes/${poller_id}/
     ${logs_poller}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${communication_mode}_gorgone_poller_2/gorgoned.log    content=${log_poller2_query_sync}    date=${start_date}    timeout=10
     Should Be True    ${logs_poller}    Didn't found the logs in the poller file: ${logs_poller}
 
-    Examples:    communication_mode   --
-        ...    push_zmq
-        ...    pullwss
-        ...    pullwss_uid
+    Examples:    communication_mode   poller_id    --
+        ...    push_zmq    2
+        ...    push_zmq_uuid    299123456
+        ...    pullwss    2
+        ...    pullwss_uid    299123456
         ...    pull
 
 *** Keywords ***

--- a/gorgone/tests/robot/tests/core/action.robot
+++ b/gorgone/tests/robot/tests/core/action.robot
@@ -70,12 +70,14 @@ action module with ${communication_mode} communcation mode
     ${logs_poller}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${communication_mode}_gorgone_poller_2/gorgoned.log    content=${log_poller2_query_sync}    date=${start_date}    timeout=10
     Should Be True    ${logs_poller}    Didn't found the logs in the poller file: ${logs_poller}
 
-    Examples:    communication_mode   poller_id    --
+    Examples:    communication_mode    poller_id    --
         ...    push_zmq    2
+        ...    push_zmq    299123456
         ...    push_zmq_uuid    299123456
+        ...    push_zmq_uuid    2
         ...    pullwss    2
         ...    pullwss_uid    299123456
-        ...    pull
+        ...    pull    2
 
 *** Keywords ***
 Test Sync Action Module

--- a/gorgone/tests/robot/tests/core/pull.robot
+++ b/gorgone/tests/robot/tests/core/pull.robot
@@ -9,8 +9,16 @@ Test Timeout        300s
 
 *** Test Cases ***
 connect 1 poller to a central with pull configuration
-    [Teardown]    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}database/delete_pollers.sql
+   # [Teardown]    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}database/delete_pollers.sql
 
     Log To Console    \nStarting the Gorgone setup with pull configuration
     Setup Two Gorgone Instances    communication_mode=pull    central_name=pull_gorgone_central    poller_name=pull_gorgone_poller_2
+    Execute Sql String    delete from nagios_server where id=2;    alias=${DBNAME}
+    ${body}=    Create List
+    ${result}    POST    http://127.0.0.1:8085/api/centreon/nodes/sync    json=${body}
+
+    Sleep    5
+    Ctn Check No Error In Logs    pull_gorgone_central
+    Ctn Check No Error In Logs    pull_gorgone_poller_2
     Log To Console    End of tests.
+

--- a/gorgone/tests/robot/tests/core/pull.robot
+++ b/gorgone/tests/robot/tests/core/pull.robot
@@ -9,7 +9,7 @@ Test Timeout        300s
 
 *** Test Cases ***
 connect 1 poller to a central with pull configuration
-   # [Teardown]    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}database/delete_pollers.sql
+    [Teardown]    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}database/delete_pollers.sql
 
     Log To Console    \nStarting the Gorgone setup with pull configuration
     Setup Two Gorgone Instances    communication_mode=pull    central_name=pull_gorgone_central    poller_name=pull_gorgone_poller_2

--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -54,7 +54,7 @@ check two poller can connect to a central
     ${id}=    Set Variable    4
     ${fromname}=    Set Variable    @POLLERID@
     IF    '${mode}' == 'pullwss_uid'
-        ${id}=    Set Variable    44992764
+        ${id}=    Set Variable    499123456
     END
      @{poller_pullwss_config}=    Create List  ${gorgone_core_config}    ${poller_config}
 

--- a/gorgone/tests/robot/tests/core/push.robot
+++ b/gorgone/tests/robot/tests/core/push.robot
@@ -41,10 +41,10 @@ check central don't eat cpu when poller is not connected
     Ctn Wait Until Poller Fail To Connect    1
     Ctn Check Cpu Until Timeout
     Examples:    communication_mode    poller_id    --
-        ...    push_zmq    2
-        ...    push_zmq    299123456
-        ...    push_zmq_uuid    2
-        ...    push_zmq_uuid    299123456
+        ...    push_zmq        2
+        ...    push_zmq        299123456
+        ...    push_zmq_uid    2
+        ...    push_zmq_uid    299123456
 
 *** Keywords ***
 Ctn Check Cpu Until Timeout

--- a/gorgone/tests/robot/tests/core/push.robot
+++ b/gorgone/tests/robot/tests/core/push.robot
@@ -26,6 +26,8 @@ check central don't eat cpu when poller is not connected
     Setup Gorgone Config    ${central_push_config}    gorgone_name=${central_name}    sql_file=${ROOT_CONFIG}/database/insert_push_poller.sql
     Start Gorgone    debug    ${central_name}
     Wait Until Port Is Bind    8085
+    ${none}=    GET  http://127.0.0.1:${api_port}/api/internal/nodes/${poller_id}/ping
+
     Ctn Wait Until Poller Fail To Connect    1
     Ctn Check Cpu Until Timeout    
 

--- a/gorgone/tests/robot/tests/core/push.robot
+++ b/gorgone/tests/robot/tests/core/push.robot
@@ -13,25 +13,39 @@ connect 1 poller to a central
 
     Log To Console    \nStarting the gorgone setup
     Setup Two Gorgone Instances    communication_mode=push_zmq     central_name=push_zmq_gorgone_central    poller_name=push_zmq_gorgone_poller_2
-    # Test
+
     Log To Console    End of tests.
 
 check central don't eat cpu when poller is not connected
     [Tags]    long_tests    MON-130747
-    ${central_name}=    Set Variable    push_zmq_gorgone_central
-    [Teardown]    Stop Gorgone And Remove Gorgone Config    push_zmq_gorgone_central    sql_file=${ROOT_CONFIG}database/delete_pollers.sql
+    ${central_name}=    Set Variable    ${communication_mode}_zmq_gorgone_central
+    [Teardown]    Stop Gorgone And Remove Gorgone Config    ${central_name}    sql_file=${ROOT_CONFIG}database/delete_pollers.sql
 
     Gorgone Execute Sql    ${ROOT_CONFIG}database/insert_central.sql
+
+    ${poller_id_copy}=    Create List    ${poller_id}
+    ${replace_from}=    Create List    @POLLERID@
     @{central_push_config}=    Create List    ${push_central_config}    ${gorgone_core_config}
-    Setup Gorgone Config    ${central_push_config}    gorgone_name=${central_name}    sql_file=${ROOT_CONFIG}/database/insert_push_poller.sql
+    
+    Setup Gorgone Config
+    ...    ${central_push_config}
+    ...    gorgone_name=${central_name}
+    ...    sql_file=${ROOT_CONFIG}/database/insert_push_poller.sql
+    ...    replace_from=${replace_from}
+    ...    replace_to=${poller_id_copy}
+
     Start Gorgone    debug    ${central_name}
-    Wait Until Port Is Bind    8085
-    ${none}=    GET  http://127.0.0.1:${api_port}/api/internal/nodes/${poller_id}/ping
+    Wait Until Port Is Bind    ${Capi_port}
+    ${none}=    GET  http://127.0.0.1:${Capi_port}/api/internal/nodes/${poller_id}/ping
 
     Ctn Wait Until Poller Fail To Connect    1
-    Ctn Check Cpu Until Timeout    
+    Ctn Check Cpu Until Timeout
+    Examples:    communication_mode    poller_id    --
+        ...    push_zmq    2
+        ...    push_zmq    299123456
+        ...    push_zmq_uuid    2
+        ...    push_zmq_uuid    299123456
 
-    
 *** Keywords ***
 Ctn Check Cpu Until Timeout
     [Arguments]    ${timeout}=60s    ${process_whitelist}=gorgone-proxy    ${max_cpu_usage}=40

--- a/gorgone/tests/unit/modules/centreon/nodes.t
+++ b/gorgone/tests/unit/modules/centreon/nodes.t
@@ -91,10 +91,10 @@ sub test_centreonnodessync {
     $action_expected->{REGISTERNODESFROMDB}->{nodes} = [ ];; # expecting no nodes now.
     $check_action_ran = {};
     $action_expected->{UNREGISTERNODES} = { nodes => [
-            { id => 11 },
-            { id => 12 },
-            { id => 13 },
-            { id => 14 },
+            { id => 11, 'uid' => '' },
+            { id => 12, 'uid' => '' },
+            { id => 13, 'uid' => 3999456 },
+            { id => 14, 'uid' => 499456456 },
         ]
     };
     $self->action_centreonnodessync();


### PR DESCRIPTION
Refs:MON-197880

## Description

When poller exist in database and are deleted but still try to connect with pull communication type (don't happend pullwss mode) there was multiples perl error in the logs.
Now a clear log indicate to the user that the poller do not exist and no perl error are present. automated tests had been modified to test that, even if a real test would wait more than one minute, as poller reconnection happend only every minutes.


**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [X] master

<h2> How this pull request can be tested ? </h2>

See automated test, you should create a central with a poller in pull communication mode, and delete the row in DB, force central to read database again, and wait for error in the central log.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

