### PR TITLE
feat(gorgone): use /administation/tokens endpoint to validate POLLER_TOKEN on Central

### DIFF
--- a/gorgone/gorgone/class/tpapi/centreonv2.pm
+++ b/gorgone/gorgone/class/tpapi/centreonv2.pm
@@ -288,6 +288,17 @@ sub get_scheduling_jobs {
     return (0,$response);
 }
 
+sub get_api_token {
+    my ($self, %options) = @_;
+
+    my $endpoint = '/administration/tokens/' . $options{token_name};
+
+    return $self->request(
+        method => 'GET',
+        endpoint => $endpoint
+    );
+}
+
 sub DESTROY {
     my ($self) = @_;
 

--- a/gorgone/gorgone/class/tpapi/centreonv2.pm
+++ b/gorgone/gorgone/class/tpapi/centreonv2.pm
@@ -24,6 +24,7 @@ use strict;
 use warnings;
 use gorgone::class::http::http;
 use JSON::XS;
+use URI::Escape;
 
 sub new {
     my ($class, %options) = @_;
@@ -291,7 +292,7 @@ sub get_scheduling_jobs {
 sub get_api_token {
     my ($self, %options) = @_;
 
-    my $endpoint = '/administration/tokens/' . $options{token_name};
+    my $endpoint = '/administration/tokens/' . uri_escape($options{token_name});
 
     return $self->request(
         method => 'GET',

--- a/gorgone/gorgone/modules/core/proxy/httpserver.pm
+++ b/gorgone/gorgone/modules/core/proxy/httpserver.pm
@@ -470,6 +470,7 @@ sub is_logged_websocket {
             if ($results->{token} ne $token_value
                 || $results->{type} ne "poller"
                 || $results->{is_revoked}) {
+                $self->{logger}->writeLogDebug('[proxy-httpserver] invalid token - ' . $token_name);
                 $self->close_websocket(
                     code    => 500,
                     message => 'token authorization unallowed',
@@ -478,7 +479,7 @@ sub is_logged_websocket {
                 return 0;
             }
         } else {
-            $self->{logger}->writeLogInfo('[proxy-httpserver] cannot get token - ' . $self->{tpapi_centreonv2}->error());
+            $self->{logger}->writeLogInfo('[proxy-httpserver] cannot get token ' . $token_name . ' - ' . $self->{tpapi_centreonv2}->error());
         }
     }
 

--- a/gorgone/gorgone/modules/core/proxy/httpserver.pm
+++ b/gorgone/gorgone/modules/core/proxy/httpserver.pm
@@ -27,6 +27,7 @@ use warnings;
 use gorgone::standard::library;
 use gorgone::standard::constants qw(:all);
 use gorgone::standard::misc;
+use gorgone::class::tpapi::centreonv2;
 use Mojolicious::Lite;
 use Mojo::Server::Daemon;
 use IO::Socket::SSL;
@@ -123,6 +124,19 @@ sub run {
     my ($self, %options) = @_;
 
     my $listen = 'reuse=1';
+
+    # Initialize Centreon API connection
+    $connector->{tpapi_centreonv2_name} = defined($options{config}->{tpapi_centreonv2}) && $options{config}->{tpapi_centreonv2} ne '' ?
+        $options{config}->{tpapi_centreonv2} : 'centreonv2';
+    $self->{tpapi_centreonv2} = gorgone::class::tpapi::centreonv2->new();
+    my ($status) = $self->{tpapi_centreonv2}->set_configuration(
+        config => $self->{tpapi}->get_configuration(name => $self->{tpapi_centreonv2_name}),
+        logger => $self->{logger}
+    );
+    if ($status) {
+        $self->{logger}->writeLogError('[PROXY] -is_logged_websocket - configure api centreonv2 - ' . $self->{tpapi_centreonv2}->error());
+    }
+
     if ($self->{config}->{httpserver}->{ssl} eq 'true') {
         if (!defined($self->{config}->{httpserver}->{ssl_cert_file}) || $self->{config}->{httpserver}->{ssl_cert_file} eq '' ||
             ! -r "$self->{config}->{httpserver}->{ssl_cert_file}") {
@@ -440,8 +454,30 @@ sub is_logged_websocket {
 
     return 1 if ($self->{ws_clients}->{ $options{ws_id} }->{logged} == 1);
 
-    if (!defined($self->{ws_clients}->{ $options{ws_id} }->{authorization}) ||
-        $self->{ws_clients}->{ $options{ws_id} }->{authorization} !~ /^\s*Bearer\s+$self->{config}->{httpserver}->{token}\s*$/) {
+    my $token = $self->{ws_clients}->{ $options{ws_id} }->{authorization};
+    if ($token =~ /^\s*Bearer\s+(\S*)\s*$/) {
+        $token = $1;
+    }
+    $self->{logger}->writeLogDebug("[PROXY] is_logged_websocket: TOKEN = " . $token);
+
+    my $check_conf_token = 1;
+    my ($token_name, $token_value) = split(/:/, $token, 2);
+    if (defined $token_name && defined $token_value) {
+        my ($status, $results) = $self->{tpapi_centreonv2}->get_api_token(
+            token_name => $token
+        );
+        if ($status != 0) {
+            $self->{logger}->writeLogError('[proxy-httpserver] cannot get token - ' . $self->{tpapi_centreonv2}->error());
+            return 0;
+        }
+        if ($results->{token} =~ $token_value) {
+            my $check_conf_token = 0;
+        }
+    }
+
+    if ($check_conf_token &&
+        !defined($self->{ws_clients}->{ $options{ws_id} }->{authorization}) ||
+        $self->{ws_clients}->{ $options{ws_id} }->{authorization} eq $token) {
         $self->close_websocket(
             code    => 500,
             message => 'token authorization unallowed',

--- a/gorgone/gorgone/modules/core/proxy/httpserver.pm
+++ b/gorgone/gorgone/modules/core/proxy/httpserver.pm
@@ -199,6 +199,32 @@ sub run {
     #});
     #Mojo::IOLoop->singleton->reactor->watch($socket, 1, 0);
 
+    Mojo::IOLoop->singleton->recurring(5 => sub {
+        $connector->{logger}->writeLogDebug('[proxy-httpserver] recurring token revocation check');
+        foreach my $ws_id (keys %{$connector->{ws_clients}}) {
+            if (defined($connector->{ws_clients}->{$ws_id}->{token_name})
+                && $connector->{ws_clients}->{$ws_id}->{logged} == 1) {
+                my $token_name = $connector->{ws_clients}->{$ws_id}->{token_name};
+                my ($status, $results) = $self->{tpapi_centreonv2}->get_api_token(
+                    token_name => $token_name
+                );
+                if ($status == 0 && defined($results->{token})) {
+                    if ($results->{is_revoked}) {
+                        $self->{logger}->writeLogDebug('[proxy-httpserver] token revoked: ' . $token_name);
+                        $connector->{ws_clients}->{$ws_id}->{logged} = 0;
+                        $self->close_websocket(
+                            code    => 500,
+                            message => 'token authorization unallowed',
+                            ws_id   => $options{ws_id}
+                        );
+                    }
+                } else {
+                    $self->{logger}->writeLogDebug('[proxy-httpserver] cannot get token ' . $token_name . ' - ' . $self->{tpapi_centreonv2}->error());
+                }
+            }
+        }
+    });
+
     Mojo::IOLoop->singleton->recurring(60 => sub {
         $connector->{logger}->writeLogDebug('[proxy-httpserver] recurring timeout loop');
         my $ctime = time();
@@ -532,6 +558,7 @@ sub is_logged_websocket {
     $self->{identities}->{ $poller_id } = $options{ws_id};
     $self->{identities}->{ $poller_uid } = $options{ws_id};
     $self->{ws_clients}->{ $options{ws_id} }->{logged} = 1;
+    $self->{ws_clients}->{ $options{ws_id} }->{token_name} = $token_name if (defined $token_name && defined $token_value);
     return 2;
 }
 

--- a/gorgone/gorgone/modules/core/proxy/httpserver.pm
+++ b/gorgone/gorgone/modules/core/proxy/httpserver.pm
@@ -36,6 +36,7 @@ use JSON::XS;
 use IO::Poll qw(POLLIN POLLPRI);
 use EV;
 use HTML::Entities;
+use Date::Parse;
 
 my %handlers = (TERM => {}, HUP => {});
 my ($connector);
@@ -209,8 +210,9 @@ sub run {
                     token_name => $token_name
                 );
                 if ($status == 0 && defined($results->{token})) {
-                    if ($results->{is_revoked}) {
-                        $self->{logger}->writeLogDebug('[proxy-httpserver] token revoked: ' . $token_name);
+                    if ($results->{is_revoked}
+                        || str2time($results->{expiration_date}) < time()) {
+                        $self->{logger}->writeLogDebug('[proxy-httpserver] invalid token: ' . $token_name);
                         $connector->{ws_clients}->{$ws_id}->{logged} = 0;
                         $self->close_websocket(
                             code    => 500,
@@ -493,9 +495,11 @@ sub is_logged_websocket {
         );
         if ($status == 0 && defined($results->{token})) {
             $check_conf_token = 0;
+            $self->{ws_clients}->{ $options{ws_id} }->{token_name} = $token_name;
             if ($results->{token} ne $token_value
                 || $results->{type} ne "poller"
-                || $results->{is_revoked}) {
+                || $results->{is_revoked} == 1
+                || str2time($results->{expiration_date}) < time()) {
                 $self->{logger}->writeLogDebug('[proxy-httpserver] invalid token - ' . $token_name);
                 $self->close_websocket(
                     code    => 500,
@@ -558,7 +562,6 @@ sub is_logged_websocket {
     $self->{identities}->{ $poller_id } = $options{ws_id};
     $self->{identities}->{ $poller_uid } = $options{ws_id};
     $self->{ws_clients}->{ $options{ws_id} }->{logged} = 1;
-    $self->{ws_clients}->{ $options{ws_id} }->{token_name} = $token_name if (defined $token_name && defined $token_value);
     return 2;
 }
 

--- a/gorgone/gorgone/modules/core/proxy/httpserver.pm
+++ b/gorgone/gorgone/modules/core/proxy/httpserver.pm
@@ -209,9 +209,10 @@ sub run {
                 my ($status, $results) = $self->{tpapi_centreonv2}->get_api_token(
                     token_name => $token_name
                 );
-                if ($status == 0 && defined($results->{token})) {
-                    if ($results->{is_revoked}
-                        || str2time($results->{expiration_date}) < time()) {
+                if ($status != 0
+                    || !defined($results->{token})
+                    || $results->{is_revoked}
+                    || str2time($results->{expiration_date}) < time()) {
                         $self->{logger}->writeLogDebug('[proxy-httpserver] invalid token: ' . $token_name);
                         $connector->{ws_clients}->{$ws_id}->{logged} = 0;
                         $self->close_websocket(
@@ -219,9 +220,6 @@ sub run {
                             message => 'invalid token',
                             ws_id   => $ws_id
                         );
-                    }
-                } else {
-                    $self->{logger}->writeLogDebug('[proxy-httpserver] cannot get token ' . $token_name . ' - ' . $self->{tpapi_centreonv2}->error());
                 }
             }
         }
@@ -503,7 +501,7 @@ sub is_logged_websocket {
                 $self->{logger}->writeLogDebug('[proxy-httpserver] invalid token - ' . $token_name);
                 $self->close_websocket(
                     code    => 500,
-                    message => 'token authorization unallowed',
+                    message => 'invalid token',
                     ws_id   => $options{ws_id}
                 );
                 return 0;
@@ -518,7 +516,7 @@ sub is_logged_websocket {
         || $self->{config}->{httpserver}->{token} ne $token)) {
         $self->close_websocket(
             code    => 500,
-            message => 'token authorization unallowed',
+            message => 'invalid token',
             ws_id   => $options{ws_id}
         );
         return 0;

--- a/gorgone/gorgone/modules/core/proxy/httpserver.pm
+++ b/gorgone/gorgone/modules/core/proxy/httpserver.pm
@@ -465,14 +465,11 @@ sub is_logged_websocket {
         my ($status, $results) = $self->{tpapi_centreonv2}->get_api_token(
             token_name => $token_name
         );
-        if ($status != 0) {
-            $self->{logger}->writeLogError('[proxy-httpserver] cannot get token - ' . $self->{tpapi_centreonv2}->error());
-            return 0;
-        } else {
+        if ($status == 0 && defined($results->{token})) {
             $check_conf_token = 0;
-            if ($results->{token} !~ $token_value ||
-                $results->{type} ne "poller" ||
-                $results->{is_revoked}) {
+            if ($results->{token} ne $token_value
+                || $results->{type} ne "poller"
+                || $results->{is_revoked}) {
                 $self->close_websocket(
                     code    => 500,
                     message => 'token authorization unallowed',
@@ -480,12 +477,14 @@ sub is_logged_websocket {
                 );
                 return 0;
             }
+        } else {
+            $self->{logger}->writeLogInfo('[proxy-httpserver] cannot get token - ' . $self->{tpapi_centreonv2}->error());
         }
     }
 
-    if ($check_conf_token == 1 &&
-        (!defined($self->{ws_clients}->{ $options{ws_id} }->{authorization}) ||
-        $self->{ws_clients}->{ $options{ws_id} }->{authorization} eq $token)) {
+    if ($check_conf_token == 1
+        && ($self->{config}->{httpserver}->{token} eq ""
+        || $self->{config}->{httpserver}->{token} ne $token)) {
         $self->close_websocket(
             code    => 500,
             message => 'token authorization unallowed',
@@ -515,7 +514,7 @@ sub is_logged_websocket {
         );
         return 0;
     }
-    if (!defined($content->{nodes}->[0]->{id}) or !defined($self->{nodes}->{$content->{nodes}->[0]->{id}})){
+    if (!defined($content->{nodes}->[0]->{id}) || !defined($self->{nodes}->{$content->{nodes}->[0]->{id}})){
         $self->{logger}->writeLogDebug("[proxy-httpserver] client connection for unknown poller id/uid : " . $content->{nodes}->[0]->{id});
        $self->close_websocket(
             code    => 500,

--- a/gorgone/gorgone/modules/core/proxy/httpserver.pm
+++ b/gorgone/gorgone/modules/core/proxy/httpserver.pm
@@ -127,7 +127,7 @@ sub run {
     my $listen = 'reuse=1';
 
     # Initialize Centreon API connection
-    $connector->{tpapi_centreonv2_name} = defined($options{config}->{tpapi_centreonv2}) && $options{config}->{tpapi_centreonv2} ne '' ?
+    $self->{tpapi_centreonv2_name} = defined($options{config}->{tpapi_centreonv2}) && $options{config}->{tpapi_centreonv2} ne '' ?
         $options{config}->{tpapi_centreonv2} : 'centreonv2';
     $self->{tpapi_centreonv2} = gorgone::class::tpapi::centreonv2->new();
     my ($status) = $self->{tpapi_centreonv2}->set_configuration(
@@ -141,12 +141,12 @@ sub run {
     if ($self->{config}->{httpserver}->{ssl} eq 'true') {
         if (!defined($self->{config}->{httpserver}->{ssl_cert_file}) || $self->{config}->{httpserver}->{ssl_cert_file} eq '' ||
             ! -r "$self->{config}->{httpserver}->{ssl_cert_file}") {
-            $connector->{logger}->writeLogError("[proxy-httpserver] cannot read/find ssl-cert-file");
+            $self->{logger}->writeLogError("[proxy-httpserver] cannot read/find ssl-cert-file");
             exit(1);
         }
         if (!defined($self->{config}->{httpserver}->{ssl_key_file}) || $self->{config}->{httpserver}->{ssl_key_file} eq '' ||
             ! -r "$self->{config}->{httpserver}->{ssl_key_file}") {
-            $connector->{logger}->writeLogError("[proxy-httpserver] cannot read/find ssl-key-file");
+            $self->{logger}->writeLogError("[proxy-httpserver] cannot read/find ssl-key-file");
             exit(1);
         }
         $listen .= '&cert=' . $self->{config}->{httpserver}->{ssl_cert_file} . '&key=' . $self->{config}->{httpserver}->{ssl_key_file};
@@ -216,8 +216,8 @@ sub run {
                         $connector->{ws_clients}->{$ws_id}->{logged} = 0;
                         $self->close_websocket(
                             code    => 500,
-                            message => 'token authorization unallowed',
-                            ws_id   => $options{ws_id}
+                            message => 'invalid token',
+                            ws_id   => $ws_id
                         );
                     }
                 } else {

--- a/gorgone/gorgone/modules/core/proxy/httpserver.pm
+++ b/gorgone/gorgone/modules/core/proxy/httpserver.pm
@@ -458,26 +458,34 @@ sub is_logged_websocket {
     if ($token =~ /^\s*Bearer\s+(\S*)\s*$/) {
         $token = $1;
     }
-    $self->{logger}->writeLogDebug("[PROXY] is_logged_websocket: TOKEN = " . $token);
 
     my $check_conf_token = 1;
     my ($token_name, $token_value) = split(/:/, $token, 2);
     if (defined $token_name && defined $token_value) {
         my ($status, $results) = $self->{tpapi_centreonv2}->get_api_token(
-            token_name => $token
+            token_name => $token_name
         );
         if ($status != 0) {
             $self->{logger}->writeLogError('[proxy-httpserver] cannot get token - ' . $self->{tpapi_centreonv2}->error());
             return 0;
-        }
-        if ($results->{token} =~ $token_value) {
-            my $check_conf_token = 0;
+        } else {
+            $check_conf_token = 0;
+            if ($results->{token} !~ $token_value ||
+                $results->{type} ne "poller" ||
+                $results->{is_revoked}) {
+                $self->close_websocket(
+                    code    => 500,
+                    message => 'token authorization unallowed',
+                    ws_id   => $options{ws_id}
+                );
+                return 0;
+            }
         }
     }
 
-    if ($check_conf_token &&
-        !defined($self->{ws_clients}->{ $options{ws_id} }->{authorization}) ||
-        $self->{ws_clients}->{ $options{ws_id} }->{authorization} eq $token) {
+    if ($check_conf_token == 1 &&
+        (!defined($self->{ws_clients}->{ $options{ws_id} }->{authorization}) ||
+        $self->{ws_clients}->{ $options{ws_id} }->{authorization} eq $token)) {
         $self->close_websocket(
             code    => 500,
             message => 'token authorization unallowed',

--- a/gorgone/tests/robot/config/pullwss_central_config.yaml
+++ b/gorgone/tests/robot/config/pullwss_central_config.yaml
@@ -1,6 +1,14 @@
 gorgone:
   gorgonecore:
     id: 1
+  tpapi:
+    - name: centreonv2
+      base_url: "http://127.0.0.1/centreon/api/latest/"
+      username: "centreon-gorgone"
+      password: "webapiPassword!"
+    - name: clapi
+      username: "centreon-gorgone"
+      password: "webapiPassword!"
   modules:
     - name: proxy
       package: "gorgone::modules::core::proxy::hooks"

--- a/gorgone/tests/robot/resources/resources.resource
+++ b/gorgone/tests/robot/resources/resources.resource
@@ -265,9 +265,8 @@ Setup Remote And Poller And Central Instances
     Log To Console    poller was started and seem connected to ${R_port}...
 
 Setup Two Gorgone Instances
-    [Arguments]    ${central_config}=@{EMPTY}    ${poller_config}=@{EMPTY}    ${communication_mode}=push_zmq    ${central_name}=gorgone_central    ${poller_name}=gorgone_poller_2
+    [Arguments]    ${central_config}=@{EMPTY}    ${poller_config}=@{EMPTY}    ${communication_mode}=push_zmq    ${central_name}=gorgone_central    ${poller_name}=gorgone_poller_2    ${check_connection}=True
     ${start_time}   Get Time    str=epoch
-
 
     Ctn Init Tests
     # This change to the schema should be integrated by php team, for now we will check everything work with a temporary fix
@@ -291,8 +290,10 @@ Setup Two Gorgone Instances
         Start Gorgone    debug    ${central_name}
         # wait until gorgone http server bind the http api port.
         Wait Until Port Is Bind    8085
-        Check Poller Is Connected    port=5556    expected_nb=2
-        Check Poller Communicate     2
+        IF    ${check_connection}
+            Check Poller Is Connected    port=5556    expected_nb=2
+            Check Poller Communicate     2
+        END
 
     ELSE IF    '${communication_mode}' == 'pullwss'
 
@@ -310,8 +311,10 @@ Setup Two Gorgone Instances
         Start Gorgone    debug    ${poller_name}
         # wait until gorgone http server bind the http api port.
         Wait Until Port Is Bind    8085
-        Check Poller Is Connected    port=8086    expected_nb=2
-        Check Poller Communicate     2
+        IF    ${check_connection}
+            Check Poller Is Connected    port=8086    expected_nb=2
+            Check Poller Communicate     2
+        END
     ELSE IF    '${communication_mode}' == 'pullwss_uid'
 
         @{central_pullwss_config}=    Copy List    ${central_config}
@@ -330,8 +333,10 @@ Setup Two Gorgone Instances
         Start Gorgone    debug    ${poller_name}
         # wait until gorgone http server bind the http api port.
         Wait Until Port Is Bind    8085
-        Check Poller Is Connected    port=8086    expected_nb=2
-        Check Poller Communicate     2
+        IF    ${check_connection}
+            Check Poller Is Connected    port=8086    expected_nb=2
+            Check Poller Communicate     2
+        END
     ELSE IF    '${communication_mode}' == 'pull'
         @{central_pull_config}=    Copy List    ${central_config}
         Append To List    ${central_pull_config}    ${pull_central_config}    ${gorgone_core_config}
@@ -347,8 +352,10 @@ Setup Two Gorgone Instances
         Start Gorgone    debug    ${poller_name}
         # wait until gorgone http server bind the http api port.
         Wait Until Port Is Bind    8085
-        Check Poller Is Connected    port=5556    expected_nb=2
-        Check Poller Communicate     2    max_failed_attempt=1
+        IF    ${check_connection}
+            Check Poller Is Connected    port=5556    expected_nb=2
+            Check Poller Communicate     2    max_failed_attempt=1
+        END
     ELSE
         Fail    Unknown communication mode: ${communication_mode}. Please use one of the following: push_zmq, pullwss, pull.
     END

--- a/gorgone/tests/robot/resources/web-api-mockoon.json
+++ b/gorgone/tests/robot/resources/web-api-mockoon.json
@@ -233,14 +233,14 @@
       "type": "http",
       "documentation": "",
       "method": "get",
-      "endpoint": "centreon/api/latest/administration/tokens/:token_name",
+      "endpoint": "centreon/api/latest/administration/tokens/:tokenName",
       "responses": [
         {
           "uuid": "63de4aa2-3cc2-4939-8043-cd4ad5d49c95",
           "body": "{\n  \"name\": \"poller-1\",\n  \"creation_date\": \"{{faker 'date.recent'}}\",\n  \"expiration_date\": null,\n  \"type\": \"poller\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
           "latency": 0,
           "statusCode": 200,
-          "label": "",
+          "label": "poller-1",
           "headers": [],
           "bodyType": "INLINE",
           "filePath": "",
@@ -248,8 +248,8 @@
           "sendFileAsBody": false,
           "rules": [
             {
-              "target": "query",
-              "modifier": "token_name",
+              "target": "params",
+              "modifier": "tokenName",
               "value": "poller-1",
               "invert": false,
               "operator": "equals"
@@ -263,11 +263,11 @@
           "callbacks": []
         },
         {
-          "uuid": "e6040a74-02a4-4f7d-be61-61621c67724e",
-          "body": "{\n  \"name\": \"Central-1\",\n  \"creation_date\": \"2026-06-08T11:54:13+02:00\",\n  \"expiration_date\": null,\n  \"type\": \"cma\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"centralCMAtoken\"\n}",
+          "uuid": "47ad8f64-2726-4988-b211-4237cacb390d",
+          "body": "{\n  \"name\": \"poller-2\",\n  \"creation_date\": \"{{faker 'date.recent'}}\",\n  \"expiration_date\": null,\n  \"type\": \"poller\",\n  \"is_revoked\": true,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
           "latency": 0,
           "statusCode": 200,
-          "label": "",
+          "label": "poller-2",
           "headers": [],
           "bodyType": "INLINE",
           "filePath": "",
@@ -275,8 +275,35 @@
           "sendFileAsBody": false,
           "rules": [
             {
-              "target": "query",
-              "modifier": "token_name",
+              "target": "params",
+              "modifier": "tokenName",
+              "value": "poller-2",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
+          "uuid": "e6040a74-02a4-4f7d-be61-61621c67724e",
+          "body": "{\n  \"name\": \"Central-1\",\n  \"creation_date\": \"2026-06-08T11:54:13+02:00\",\n  \"expiration_date\": null,\n  \"type\": \"cma\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"centralCMAtoken\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "Central-1",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "params",
+              "modifier": "tokenName",
               "value": "Central-1",
               "invert": false,
               "operator": "equals"
@@ -293,8 +320,8 @@
           "uuid": "0fa0168d-5d20-4755-a136-1de4d28b58b9",
           "body": "{\n  \"code\": 404,\n  \"message\": \"Token not found\"\n}",
           "latency": 0,
-          "statusCode": 200,
-          "label": "",
+          "statusCode": 404,
+          "label": "token not found",
           "headers": [],
           "bodyType": "INLINE",
           "filePath": "",
@@ -302,16 +329,23 @@
           "sendFileAsBody": false,
           "rules": [
             {
-              "target": "query",
-              "modifier": "token_name",
+              "target": "params",
+              "modifier": "tokenName",
               "value": "poller-1",
               "invert": true,
               "operator": "equals"
             },
             {
-              "target": "query",
-              "modifier": "token_name",
+              "target": "params",
+              "modifier": "tokenName",
               "value": "Central-1",
+              "invert": true,
+              "operator": "equals"
+            },
+            {
+              "target": "params",
+              "modifier": "tokenName",
+              "value": "poller-2",
               "invert": true,
               "operator": "equals"
             }

--- a/gorgone/tests/robot/resources/web-api-mockoon.json
+++ b/gorgone/tests/robot/resources/web-api-mockoon.json
@@ -237,7 +237,7 @@
       "responses": [
         {
           "uuid": "63de4aa2-3cc2-4939-8043-cd4ad5d49c95",
-          "body": "{\n  \"name\": \"poller-1\",\n  \"creation_date\": \"{{faker 'date.recent'}}\",\n  \"expiration_date\": null,\n  \"type\": \"poller\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
+          "body": "{\n  \"name\": \"poller-1\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": \"{{faker 'date.future'}}\",\n  \"type\": \"poller\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "poller-1",
@@ -264,7 +264,7 @@
         },
         {
           "uuid": "47ad8f64-2726-4988-b211-4237cacb390d",
-          "body": "{\n  \"name\": \"poller-2\",\n  \"creation_date\": \"{{faker 'date.recent'}}\",\n  \"expiration_date\": null,\n  \"type\": \"poller\",\n  \"is_revoked\": true,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
+          "body": "{\n  \"name\": \"poller-2\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": \"{{faker 'date.future'}}\",\n  \"type\": \"poller\",\n  \"is_revoked\": true,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "poller-2",
@@ -290,8 +290,8 @@
           "callbacks": []
         },
         {
-          "uuid": "a878a73d-33b2-4818-8f8b-93c822f3ab57",
-          "body": "{\n  \"name\": \"poller-3\",\n  \"creation_date\": \"{{faker 'date.recent'}}\",\n  \"expiration_date\": null,\n  \"type\": \"poller\",\n  \"is_revoked\": {{getGlobalVar 'revoked'}},\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
+          "uuid": "f5b5c6ca-166c-491d-8d49-5434e26590c8",
+          "body": "{\n  \"name\": \"poller-4\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": \"{{faker 'date.recent'}}\",\n  \"type\": \"poller\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "poller-3",
@@ -317,8 +317,35 @@
           "callbacks": []
         },
         {
+          "uuid": "a878a73d-33b2-4818-8f8b-93c822f3ab57",
+          "body": "{\n  \"name\": \"poller-4\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": \"{{getGlobalVar 'expired'}}\",\n  \"type\": \"poller\",\n  \"is_revoked\": {{getGlobalVar 'revoked'}},\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "poller-4",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "params",
+              "modifier": "tokenName",
+              "value": "poller-4",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
           "uuid": "e6040a74-02a4-4f7d-be61-61621c67724e",
-          "body": "{\n  \"name\": \"Central-1\",\n  \"creation_date\": \"2026-06-08T11:54:13+02:00\",\n  \"expiration_date\": null,\n  \"type\": \"cma\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"centralCMAtoken\"\n}",
+          "body": "{\n  \"name\": \"Central-1\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": \"{{faker 'date.future'}}\",\n  \"type\": \"cma\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"centralCMAtoken\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "Central-1",
@@ -379,6 +406,13 @@
             {
               "target": "params",
               "modifier": "tokenName",
+              "value": "poller-4",
+              "invert": true,
+              "operator": "equals"
+            },
+            {
+              "target": "params",
+              "modifier": "tokenName",
               "value": "Central-1",
               "invert": true,
               "operator": "equals"
@@ -401,11 +435,42 @@
       "type": "http",
       "documentation": "",
       "method": "put",
-      "endpoint": "set-poller-3-is-revoked/:revoked",
+      "endpoint": "set-poller-4-is-revoked/:revoked",
       "responses": [
         {
           "uuid": "2c070a93-177c-42b7-9bfd-c8694bd2b168",
           "body": "{{setGlobalVar 'revoked' (urlParam 'revoked')}}\n{\n  \"is_revoked\": \"{{getGlobalVar 'revoked'}}\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "adaab563-b466-418a-a5e9-5c9842e67273",
+      "type": "http",
+      "documentation": "",
+      "method": "put",
+      "endpoint": "set-poller-4-is-expired/:expired",
+      "responses": [
+        {
+          "uuid": "6b3bc02d-ad54-4154-87ff-bf87e7aee8e5",
+          "body": "{{#if (eq (urlParam 'expired') 'true')}}\n  {{setGlobalVar 'expired' (faker 'date.recent')}}\n{{else}}\n  {{setGlobalVar 'expired' (faker 'date.future')}}\n{{/if}}\n{\n  \"expired\": \"{{getGlobalVar 'expired'}}\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "",
@@ -460,6 +525,10 @@
     {
       "type": "route",
       "uuid": "d22f9a5c-5390-4870-9f3d-7bf7004aafc4"
+    },
+    {
+      "type": "route",
+      "uuid": "adaab563-b466-418a-a5e9-5c9842e67273"
     }
   ],
   "proxyMode": false,

--- a/gorgone/tests/robot/resources/web-api-mockoon.json
+++ b/gorgone/tests/robot/resources/web-api-mockoon.json
@@ -290,6 +290,33 @@
           "callbacks": []
         },
         {
+          "uuid": "a878a73d-33b2-4818-8f8b-93c822f3ab57",
+          "body": "{\n  \"name\": \"poller-3\",\n  \"creation_date\": \"{{faker 'date.recent'}}\",\n  \"expiration_date\": null,\n  \"type\": \"poller\",\n  \"is_revoked\": {{getGlobalVar 'revoked'}},\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "poller-3",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "params",
+              "modifier": "tokenName",
+              "value": "poller-3",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
           "uuid": "e6040a74-02a4-4f7d-be61-61621c67724e",
           "body": "{\n  \"name\": \"Central-1\",\n  \"creation_date\": \"2026-06-08T11:54:13+02:00\",\n  \"expiration_date\": null,\n  \"type\": \"cma\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"centralCMAtoken\"\n}",
           "latency": 0,
@@ -327,33 +354,42 @@
           "filePath": "",
           "databucketID": "",
           "sendFileAsBody": false,
-          "rules": [
-            {
-              "target": "params",
-              "modifier": "tokenName",
-              "value": "poller-1",
-              "invert": true,
-              "operator": "equals"
-            },
-            {
-              "target": "params",
-              "modifier": "tokenName",
-              "value": "Central-1",
-              "invert": true,
-              "operator": "equals"
-            },
-            {
-              "target": "params",
-              "modifier": "tokenName",
-              "value": "poller-2",
-              "invert": true,
-              "operator": "equals"
-            }
-          ],
+          "rules": [],
           "rulesOperator": "AND",
           "disableTemplating": false,
           "fallbackTo404": false,
           "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "d22f9a5c-5390-4870-9f3d-7bf7004aafc4",
+      "type": "http",
+      "documentation": "",
+      "method": "put",
+      "endpoint": "set-poller-3-is-revoked/:revoked",
+      "responses": [
+        {
+          "uuid": "2c070a93-177c-42b7-9bfd-c8694bd2b168",
+          "body": "{{setGlobalVar 'revoked' (urlParam 'revoked')}}\n{\n  \"is_revoked\": \"{{getGlobalVar 'revoked'}}\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
           "crudKey": "id",
           "callbacks": []
         }
@@ -391,6 +427,10 @@
     {
       "type": "route",
       "uuid": "1f01381d-3bec-4b5e-b88a-b04cff57e023"
+    },
+    {
+      "type": "route",
+      "uuid": "d22f9a5c-5390-4870-9f3d-7bf7004aafc4"
     }
   ],
   "proxyMode": false,

--- a/gorgone/tests/robot/resources/web-api-mockoon.json
+++ b/gorgone/tests/robot/resources/web-api-mockoon.json
@@ -354,7 +354,36 @@
           "filePath": "",
           "databucketID": "",
           "sendFileAsBody": false,
-          "rules": [],
+          "rules": [
+            {
+              "target": "params",
+              "modifier": "tokenName",
+              "value": "poller-1",
+              "invert": true,
+              "operator": "equals"
+            },
+            {
+              "target": "params",
+              "modifier": "tokenName",
+              "value": "poller-2",
+              "invert": true,
+              "operator": "equals"
+            },
+            {
+              "target": "params",
+              "modifier": "tokenName",
+              "value": "poller-3",
+              "invert": true,
+              "operator": "equals"
+            },
+            {
+              "target": "params",
+              "modifier": "tokenName",
+              "value": "Central-1",
+              "invert": true,
+              "operator": "equals"
+            }
+          ],
           "rulesOperator": "AND",
           "disableTemplating": false,
           "fallbackTo404": false,

--- a/gorgone/tests/robot/resources/web-api-mockoon.json
+++ b/gorgone/tests/robot/resources/web-api-mockoon.json
@@ -227,6 +227,106 @@
       "responseMode": null,
       "streamingMode": null,
       "streamingInterval": 0
+    },
+    {
+      "uuid": "1f01381d-3bec-4b5e-b88a-b04cff57e023",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "centreon/api/latest/administration/tokens/:token_name",
+      "responses": [
+        {
+          "uuid": "63de4aa2-3cc2-4939-8043-cd4ad5d49c95",
+          "body": "{\n  \"name\": \"poller-1\",\n  \"creation_date\": \"{{faker 'date.recent'}}\",\n  \"expiration_date\": null,\n  \"type\": \"poller\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "query",
+              "modifier": "token_name",
+              "value": "poller-1",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
+          "uuid": "e6040a74-02a4-4f7d-be61-61621c67724e",
+          "body": "{\n  \"name\": \"Central-1\",\n  \"creation_date\": \"2026-06-08T11:54:13+02:00\",\n  \"expiration_date\": null,\n  \"type\": \"cma\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"centralCMAtoken\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "query",
+              "modifier": "token_name",
+              "value": "Central-1",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
+          "uuid": "0fa0168d-5d20-4755-a136-1de4d28b58b9",
+          "body": "{\n  \"code\": 404,\n  \"message\": \"Token not found\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "query",
+              "modifier": "token_name",
+              "value": "poller-1",
+              "invert": true,
+              "operator": "equals"
+            },
+            {
+              "target": "query",
+              "modifier": "token_name",
+              "value": "Central-1",
+              "invert": true,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "AND",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
     }
   ],
   "rootChildren": [
@@ -253,6 +353,10 @@
     {
       "type": "route",
       "uuid": "18c69e8b-3ed3-423b-8aa1-09108774c004"
+    },
+    {
+      "type": "route",
+      "uuid": "1f01381d-3bec-4b5e-b88a-b04cff57e023"
     }
   ],
   "proxyMode": false,

--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -25,8 +25,6 @@ check one poller can connect to a central and gorgone central stop first
         ...    pullwss
         ...    pullwss_uid
 
-
-
 check a remote server can hold a poller connection
     [Tags]    remote
     [Teardown]    Stop Gorgone And Remove Gorgone Config
@@ -81,16 +79,19 @@ check two poller can connect to a central
         ...    pullwss_uid
         ...    pullwss
 
-check one poller can connect to a central with env var
+check one poller can connect to a central with env var ${id}
     [Teardown]    Stop Gorgone And Remove Gorgone Config
     ...    @{process_list}
     ...   sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
 
     @{process_list}    Set Variable    ${mode}_gorgone_central_simple    ${mode}_gorgone_poller_2_simple
     Log To Console    \nStarting the gorgone setup
-    Set Environment Variable    GORGONE_TOKEN    poller-1:myPollerToken
+    Set Environment Variable    GORGONE_TOKEN    ${env_token}
     Setup Two Gorgone Instances    communication_mode=${mode}    central_name=${mode}_gorgone_central_simple    poller_name=${mode}_gorgone_poller_2_simple
     Ctn Check No Error In Logs    ${mode}_gorgone_poller_2_simple
-    Examples:    mode   --
-        ...    pullwss
-        ...    pullwss_uid
+    Examples:    id    mode         env_token    --
+        ...    1    pullwss        poller-1:myPollerToken
+        ...    2    pullwss_uid    poller-1:myPollerToken
+        ...    3    pullwss        Central-1:centralCMAtoken
+        ...    4    pullwss        poller-2:myPollerToken
+        ...    5    pullwss        poller-3:myPollerToken

--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -2,6 +2,10 @@
 Documentation       Start and stop gorgone in pullwss mode
 
 Resource            ${CURDIR}${/}..${/}..${/}resources${/}import.resource
+
+Suite Setup         Start Mockoon    ${ROOT_CONFIG}..${/}resources/web-api-mockoon.json
+Suite Teardown      Stop Mockoon
+
 Test Timeout        220s
 
 *** Variables ***
@@ -76,3 +80,17 @@ check two poller can connect to a central
     Examples:    mode   --
         ...    pullwss_uid
         ...    pullwss
+
+check one poller can connect to a central with env var
+    [Teardown]    Stop Gorgone And Remove Gorgone Config
+    ...    @{process_list}
+    ...   sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
+
+    @{process_list}    Set Variable    ${mode}_gorgone_central_simple    ${mode}_gorgone_poller_2_simple
+    Log To Console    \nStarting the gorgone setup
+    Set Environment Variable    GORGONE_TOKEN    poller-1:myPollerToken
+    Setup Two Gorgone Instances    communication_mode=${mode}    central_name=${mode}_gorgone_central_simple    poller_name=${mode}_gorgone_poller_2_simple
+    Ctn Check No Error In Logs    ${mode}_gorgone_poller_2_simple
+    Examples:    mode   --
+        ...    pullwss
+        ...    pullwss_uid

--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -80,9 +80,10 @@ check two poller can connect to a central
         ...    pullwss
 
 check one poller can connect to a central with env var ${id}
-    [Teardown]    Stop Gorgone And Remove Gorgone Config
-    ...    @{process_list}
-    ...   sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
+    [Teardown]    Run Keywords
+    ...    Remove Environment Variable    GORGONE_TOKEN
+    ...    AND
+    ...    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
 
     @{process_list}    Set Variable    ${mode}_gorgone_central_simple    ${mode}_gorgone_poller_2_simple
     Log To Console    \nStarting the gorgone setup
@@ -94,9 +95,10 @@ check one poller can connect to a central with env var ${id}
         ...    2    pullwss_uid    poller-1:myPollerToken
 
 check one poller cannot connect to a central with env var ${id}
-    [Teardown]    Stop Gorgone And Remove Gorgone Config
-    ...    @{process_list}
-    ...   sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
+    [Teardown]    Run Keywords
+    ...    Remove Environment Variable    GORGONE_TOKEN
+    ...    AND
+    ...    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
 
     ${start_date}    Get Current Date    increment=-10s
     @{process_list}    Set Variable    ${mode}_gorgone_central_simple    ${mode}_gorgone_poller_2_simple
@@ -117,9 +119,10 @@ check one poller cannot connect to a central with env var ${id}
         ...    4    pullwss    do_not_exists:myPollerToken    [proxy-httpserver] cannot get token
 
 check poller token revocation
-    [Teardown]    Stop Gorgone And Remove Gorgone Config
-    ...    @{process_list}
-    ...   sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
+    [Teardown]    Run Keywords
+    ...    Remove Environment Variable    GORGONE_TOKEN
+    ...    AND
+    ...    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
 
     ${start_date}    Get Current Date
     @{process_list}    Set Variable    pullwss_gorgone_central_simple    pullwss_gorgone_poller_2_simple

--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -6,7 +6,7 @@ Resource            ${CURDIR}${/}..${/}..${/}resources${/}import.resource
 Suite Setup         Start Mockoon    ${ROOT_CONFIG}..${/}resources/web-api-mockoon.json
 Suite Teardown      Stop Mockoon
 
-Test Timeout        220s
+Test Timeout        250s
 
 *** Variables ***
 @{process_list}    pullwss_gorgone_poller_2_simple    pullwss_gorgone_central_simple

--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -113,7 +113,8 @@ check one poller cannot connect to a central with env var ${id}
     Examples:    id    mode    env_token    message    --
         ...    1    pullwss    Central-1:centralCMAtoken      [proxy-httpserver] invalid token -
         ...    2    pullwss    poller-2:myPollerToken         [proxy-httpserver] invalid token -
-        ...    3    pullwss    do_not_exists:myPollerToken    [proxy-httpserver] cannot get token
+        ...    3    pullwss    poller-3:myPollerToken         [proxy-httpserver] invalid token -
+        ...    4    pullwss    do_not_exists:myPollerToken    [proxy-httpserver] cannot get token
 
 check poller token revocation
     [Teardown]    Stop Gorgone And Remove Gorgone Config
@@ -123,13 +124,14 @@ check poller token revocation
     ${start_date}    Get Current Date
     @{process_list}    Set Variable    pullwss_gorgone_central_simple    pullwss_gorgone_poller_2_simple
     Log To Console    \nStarting the gorgone setup
-    Set Environment Variable    GORGONE_TOKEN    poller-3:myPollerToken
-    ${response}=    PUT    http://127.0.0.1:80/set-poller-3-is-revoked/false
+    Set Environment Variable    GORGONE_TOKEN    poller-4:myPollerToken
+    ${response}=    PUT    http://127.0.0.1:80/set-poller-4-is-revoked/false
+    ${response}=    PUT    http://127.0.0.1:80/set-poller-4-is-expired/false
     Setup Two Gorgone Instances    communication_mode=pullwss    central_name=pullwss_gorgone_central_simple    poller_name=pullwss_gorgone_poller_2_simple
-    Check Poller Is Connected    port=8086    expected_nb=2
     Ctn Check No Error In Logs    pullwss_gorgone_poller_2_simple
-    ${log_central_query}    Create List    [proxy-httpserver] token revoked
+    ${log_central_query}    Create List    [proxy-httpserver] invalid token
     # The poller is connected
+    Check Poller Is Connected    port=8086    expected_nb=2
     ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
     Should Not Be True    ${logs_central}    Did find the logs in the poller file : ${logs_central}
     Sleep    6
@@ -138,7 +140,21 @@ check poller token revocation
     ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
     Should Not Be True    ${logs_central}    Did find the logs in the poller file : ${logs_central}
     # Token revoked
-    ${response}=    PUT    http://127.0.0.1:80/set-poller-3-is-revoked/true
+    ${response}=    PUT    http://127.0.0.1:80/set-poller-4-is-revoked/true
+    Sleep    6
+    # The poller is disconnected
+    Check Poller Is Connected    port=8086    expected_nb=0
+    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
+    Should Be True    ${logs_central}    Didn't find the logs in the poller file : ${logs_central}
+    # Token revoked
+    ${response}=    PUT    http://127.0.0.1:80/set-poller-4-is-revoked/false
+    Sleep    6
+    # The poller is connected
+    Check Poller Is Connected    port=8086    expected_nb=0
+    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
+    Should Be True    ${logs_central}    Didn't find the logs in the poller file : ${logs_central}
+    # Token revoked
+    ${response}=    PUT    http://127.0.0.1:80/set-poller-4-is-expired/true
     Sleep    6
     # The poller is disconnected
     Check Poller Is Connected    port=8086    expected_nb=0

--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -100,7 +100,7 @@ check one poller cannot connect to a central with env var ${id}
     ...    AND
     ...    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
 
-    ${start_date}    Get Current Date    increment=-10s
+    ${start_date}    Get Current Date
     @{process_list}    Set Variable    ${mode}_gorgone_central_simple    ${mode}_gorgone_poller_2_simple
     Log To Console    \nStarting the gorgone setup
     Set Environment Variable    GORGONE_TOKEN    ${env_token}
@@ -108,14 +108,19 @@ check one poller cannot connect to a central with env var ${id}
     Check Poller Is Connected    port=8086    expected_nb=0
     Ctn Check No Error In Logs    ${mode}_gorgone_poller_2_simple
     # we need to find the message that explains the connection refusal
-    ${log_central_query}    Create List    ${message}
-    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${mode}_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}    timeout=70
-    Should Be True    ${logs_central}    Didn't find the logs in the poller file : ${logs_central}
+    ${log_central_query}    Create List    ${message_central}
+    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${mode}_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
+    Should Be True    ${logs_central}    Didn't find the logs in the central file : ${logs_central}
+    ${log_poller_query}    Create List
+    ...    [pullwss] websocket message: {"code":500,"message":"invalid token"}
+    ...    [pullwss] websocket closed with status 1005
+    ${logs_poller}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${mode}_gorgone_poller_2_simple/gorgoned.log    content=${log_poller_query}    date=${start_date}
+    Should Be True    ${logs_poller}    Didn't find the logs in the poller file : ${logs_poller}
 
-    Examples:    id    mode    env_token    message    --
-        ...    1    pullwss    Central-1:centralCMAtoken      [proxy-httpserver] invalid token -
-        ...    2    pullwss    poller-2:myPollerToken         [proxy-httpserver] invalid token -
-        ...    3    pullwss    poller-3:myPollerToken         [proxy-httpserver] invalid token -
+    Examples:    id    mode    env_token    message_central    --
+        ...    1    pullwss    Central-1:centralCMAtoken      [proxy-httpserver] invalid token
+        ...    2    pullwss    poller-2:myPollerToken         [proxy-httpserver] invalid token
+        ...    3    pullwss    poller-3:myPollerToken         [proxy-httpserver] invalid token
         ...    4    pullwss    do_not_exists:myPollerToken    [proxy-httpserver] cannot get token
 
 check poller token revocation
@@ -124,42 +129,67 @@ check poller token revocation
     ...    AND
     ...    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
 
+    Set Local Variable    ${revoked_url}    http://127.0.0.1:80/set-poller-4-is-revoked
+    Set Local Variable    ${expired_url}    http://127.0.0.1:80/set-poller-4-is-expired
+    Set Local Variable    ${port}    8086
+    Set Local Variable    ${timeout}    11
+    Set Local Variable    ${sleep}    6
+    Set Local Variable    ${central_log_file}    /var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log
+    Set Local Variable    ${poller_log_file}    /var/log/centreon-gorgone/pullwss_gorgone_poller_2_simple/gorgoned.log
+    ${log_poller_query}    Create List
+    ...    [pullwss] websocket message: {"code":500,"message":"invalid token"}
+    ...    [pullwss] websocket closed with status 1005
+
     ${start_date}    Get Current Date
     @{process_list}    Set Variable    pullwss_gorgone_central_simple    pullwss_gorgone_poller_2_simple
     Log To Console    \nStarting the gorgone setup
     Set Environment Variable    GORGONE_TOKEN    poller-4:myPollerToken
-    ${response}=    PUT    http://127.0.0.1:80/set-poller-4-is-revoked/false
-    ${response}=    PUT    http://127.0.0.1:80/set-poller-4-is-expired/false
+    ${response}    PUT    ${revoked_url}/false
+    ${response}    PUT    ${expired_url}/false
     Setup Two Gorgone Instances    communication_mode=pullwss    central_name=pullwss_gorgone_central_simple    poller_name=pullwss_gorgone_poller_2_simple
     Ctn Check No Error In Logs    pullwss_gorgone_poller_2_simple
     ${log_central_query}    Create List    [proxy-httpserver] invalid token
     # The poller is connected
-    Check Poller Is Connected    port=8086    expected_nb=2
-    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
-    Should Not Be True    ${logs_central}    Did find the logs in the poller file : ${logs_central}
-    Sleep    6
+    Check Poller Is Connected    port=${port}    expected_nb=2
+    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout}
+    Should Not Be True    ${logs_central}    Did find the logs in the central file : ${logs_central}
+    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout}
+    Should Not Be True    ${logs_poller}    Did find the logs in the poller file : ${logs_poller}
+    ${start_date}    Get Current Date
+    Sleep    ${sleep}
     # Still connected
-    Check Poller Is Connected    port=8086    expected_nb=2
-    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
-    Should Not Be True    ${logs_central}    Did find the logs in the poller file : ${logs_central}
+    Check Poller Is Connected    port=${port}    expected_nb=2
+    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout}
+    Should Not Be True    ${logs_central}    Did find the logs in the central file : ${logs_central}
+    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout}
+    Should Not Be True    ${logs_poller}    Did find the logs in the poller file : ${logs_poller}
     # Token revoked
-    ${response}=    PUT    http://127.0.0.1:80/set-poller-4-is-revoked/true
-    Sleep    6
+    ${response}    PUT    ${revoked_url}/true
+    ${start_date}    Get Current Date
+    Sleep    ${sleep}
     # The poller is disconnected
-    Check Poller Is Connected    port=8086    expected_nb=0
-    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
-    Should Be True    ${logs_central}    Didn't find the logs in the poller file : ${logs_central}
+    Check Poller Is Connected    port=${port}    expected_nb=0
+    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout}
+    Should Be True    ${logs_central}    Didn't find the logs in the central file : ${logs_central}
+    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout}
+    Should Be True    ${logs_poller}    Didn't find the logs in the poller file : ${logs_poller}
     # Token revoked
-    ${response}=    PUT    http://127.0.0.1:80/set-poller-4-is-revoked/false
-    Sleep    6
+    ${response}    PUT    ${revoked_url}/false
+    ${start_date}    Get Current Date
+    Sleep    ${sleep}
     # The poller is connected
-    Check Poller Is Connected    port=8086    expected_nb=0
-    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
-    Should Be True    ${logs_central}    Didn't find the logs in the poller file : ${logs_central}
+    Check Poller Is Connected    port=${port}    expected_nb=2
+    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout}
+    Should Not Be True    ${logs_central}    Did find the logs in the central file : ${logs_central}
+    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout}
+    Should Not Be True    ${logs_poller}    Did find the logs in the poller file : ${logs_poller}
     # Token revoked
-    ${response}=    PUT    http://127.0.0.1:80/set-poller-4-is-expired/true
-    Sleep    6
+    ${response}    PUT    ${expired_url}/true
+    ${start_date}    Get Current Date
+    Sleep    ${sleep}
     # The poller is disconnected
-    Check Poller Is Connected    port=8086    expected_nb=0
-    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
-    Should Be True    ${logs_central}    Didn't find the logs in the poller file : ${logs_central}
+    Check Poller Is Connected    port=${port}    expected_nb=0
+    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout}
+    Should Be True    ${logs_central}    Didn't find the logs in the central file : ${logs_central}
+    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout}
+    Should Be True    ${logs_poller}    Didn't find the logs in the poller file : ${logs_poller}

--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -108,33 +108,39 @@ check one poller cannot connect to a central with env var ${id}
     # we need to find the message that explains the connection refusal
     ${log_central_query}    Create List    ${message}
     ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${mode}_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}    timeout=70
-    Should Be True    ${logs_central}    Didn't found the logs in the poller file : ${logs_central}
+    Should Be True    ${logs_central}    Didn't find the logs in the poller file : ${logs_central}
 
     Examples:    id    mode    env_token    message    --
         ...    1    pullwss    Central-1:centralCMAtoken      [proxy-httpserver] invalid token -
         ...    2    pullwss    poller-2:myPollerToken         [proxy-httpserver] invalid token -
         ...    3    pullwss    do_not_exists:myPollerToken    [proxy-httpserver] cannot get token
 
-check poller token revocation ${id}
+check poller token revocation
     [Teardown]    Stop Gorgone And Remove Gorgone Config
     ...    @{process_list}
     ...   sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
 
-    ${start_date}    Get Current Date    increment=-10s
-    @{process_list}    Set Variable    ${mode}_gorgone_central_simple    ${mode}_gorgone_poller_2_simple
+    ${start_date}    Get Current Date
+    @{process_list}    Set Variable    pullwss_gorgone_central_simple    pullwss_gorgone_poller_2_simple
     Log To Console    \nStarting the gorgone setup
-    Set Environment Variable    GORGONE_TOKEN    ${env_token}
+    Set Environment Variable    GORGONE_TOKEN    poller-3:myPollerToken
     ${response}=    PUT    http://127.0.0.1:80/set-poller-3-is-revoked/false
-    Setup Two Gorgone Instances    communication_mode=${mode}    central_name=${mode}_gorgone_central_simple    poller_name=${mode}_gorgone_poller_2_simple
+    Setup Two Gorgone Instances    communication_mode=pullwss    central_name=pullwss_gorgone_central_simple    poller_name=pullwss_gorgone_poller_2_simple
     Check Poller Is Connected    port=8086    expected_nb=2
-    Ctn Check No Error In Logs    ${mode}_gorgone_poller_2_simple
-    ${log_central_query}    Create List    ${message}
-    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${mode}_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
-    Should Not Be True    ${logs_central}    Didn't found the logs in the poller file : ${logs_central}
+    Ctn Check No Error In Logs    pullwss_gorgone_poller_2_simple
+    ${log_central_query}    Create List    [proxy-httpserver] token revoked
+    # The poller is connected
+    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
+    Should Not Be True    ${logs_central}    Did find the logs in the poller file : ${logs_central}
+    Sleep    6
+    # Still connected
+    Check Poller Is Connected    port=8086    expected_nb=2
+    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
+    Should Not Be True    ${logs_central}    Did find the logs in the poller file : ${logs_central}
+    # Token revoked
     ${response}=    PUT    http://127.0.0.1:80/set-poller-3-is-revoked/true
     Sleep    6
-    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${mode}_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
-    Should Be True    ${logs_central}    Didn't found the logs in the poller file : ${logs_central}
-
-    Examples:    id    mode         env_token    message    --
-        ...    1    pullwss    poller-3:myPollerToken    [proxy-httpserver] token revoked
+    # The poller is disconnected
+    Check Poller Is Connected    port=8086    expected_nb=0
+    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
+    Should Be True    ${logs_central}    Didn't find the logs in the poller file : ${logs_central}

--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -114,3 +114,27 @@ check one poller cannot connect to a central with env var ${id}
         ...    1    pullwss    Central-1:centralCMAtoken      [proxy-httpserver] invalid token -
         ...    2    pullwss    poller-2:myPollerToken         [proxy-httpserver] invalid token -
         ...    3    pullwss    do_not_exists:myPollerToken    [proxy-httpserver] cannot get token
+
+check poller token revocation ${id}
+    [Teardown]    Stop Gorgone And Remove Gorgone Config
+    ...    @{process_list}
+    ...   sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
+
+    ${start_date}    Get Current Date    increment=-10s
+    @{process_list}    Set Variable    ${mode}_gorgone_central_simple    ${mode}_gorgone_poller_2_simple
+    Log To Console    \nStarting the gorgone setup
+    Set Environment Variable    GORGONE_TOKEN    ${env_token}
+    ${response}=    PUT    http://127.0.0.1:80/set-poller-3-is-revoked/false
+    Setup Two Gorgone Instances    communication_mode=${mode}    central_name=${mode}_gorgone_central_simple    poller_name=${mode}_gorgone_poller_2_simple
+    Check Poller Is Connected    port=8086    expected_nb=2
+    Ctn Check No Error In Logs    ${mode}_gorgone_poller_2_simple
+    ${log_central_query}    Create List    ${message}
+    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${mode}_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
+    Should Not Be True    ${logs_central}    Didn't found the logs in the poller file : ${logs_central}
+    ${response}=    PUT    http://127.0.0.1:80/set-poller-3-is-revoked/true
+    Sleep    6
+    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${mode}_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}
+    Should Be True    ${logs_central}    Didn't found the logs in the poller file : ${logs_central}
+
+    Examples:    id    mode         env_token    message    --
+        ...    1    pullwss    poller-3:myPollerToken    [proxy-httpserver] token revoked

--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -92,6 +92,36 @@ check one poller can connect to a central with env var ${id}
     Examples:    id    mode         env_token    --
         ...    1    pullwss        poller-1:myPollerToken
         ...    2    pullwss_uid    poller-1:myPollerToken
-        ...    3    pullwss        Central-1:centralCMAtoken
-        ...    4    pullwss        poller-2:myPollerToken
-        ...    5    pullwss        poller-3:myPollerToken
+
+check one poller cannot connect to a central with env var ${id}
+    [Teardown]    Stop Gorgone And Remove Gorgone Config
+    ...    @{process_list}
+    ...   sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
+
+    @{process_list}    Set Variable    ${mode}_gorgone_central_simple    ${mode}_gorgone_poller_2_simple
+    Log To Console    \nStarting the gorgone setup
+    Set Environment Variable    GORGONE_TOKEN    ${env_token}
+
+    Ctn Init Tests
+    Gorgone Fix Schema
+    Gorgone Execute Sql    ${ROOT_CONFIG}database/insert_central.sql
+
+    @{central_pullwss_config}=    Create List    ${pullwss_central_config}    ${gorgone_core_config}
+    @{poller_pullwss_config}=    Create List    ${gorgone_core_config}    ${pullwss_poller_config}
+    Setup Gorgone Config
+    ...    ${central_pullwss_config}
+    ...    gorgone_name=${mode}_gorgone_central_simple
+    Setup Gorgone Config
+    ...    ${poller_pullwss_config}
+    ...    gorgone_name=${mode}_gorgone_poller_2_simple
+    Start Gorgone    debug    ${mode}_gorgone_central_simple
+    Wait Until Port Is Bind    8086
+    Start Gorgone    debug    ${mode}_gorgone_poller_2_simple
+    # wait until gorgone http server bind the http api port.
+    Wait Until Port Is Bind    8085
+    Check Poller Is Connected    port=8086    expected_nb=0
+
+    Examples:    id    mode         env_token    --
+        ...    1    pullwss        Central-1:centralCMAtoken
+        ...    2    pullwss        poller-2:myPollerToken
+        ...    3    pullwss        do_not_exists:myPollerToken

--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -98,30 +98,19 @@ check one poller cannot connect to a central with env var ${id}
     ...    @{process_list}
     ...   sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
 
+    ${start_date}    Get Current Date    increment=-10s
     @{process_list}    Set Variable    ${mode}_gorgone_central_simple    ${mode}_gorgone_poller_2_simple
     Log To Console    \nStarting the gorgone setup
     Set Environment Variable    GORGONE_TOKEN    ${env_token}
-
-    Ctn Init Tests
-    Gorgone Fix Schema
-    Gorgone Execute Sql    ${ROOT_CONFIG}database/insert_central.sql
-
-    @{central_pullwss_config}=    Create List    ${pullwss_central_config}    ${gorgone_core_config}
-    @{poller_pullwss_config}=    Create List    ${gorgone_core_config}    ${pullwss_poller_config}
-    Setup Gorgone Config
-    ...    ${central_pullwss_config}
-    ...    gorgone_name=${mode}_gorgone_central_simple
-    Setup Gorgone Config
-    ...    ${poller_pullwss_config}
-    ...    gorgone_name=${mode}_gorgone_poller_2_simple
-    Start Gorgone    debug    ${mode}_gorgone_central_simple
-    Wait Until Port Is Bind    8086
-    Start Gorgone    debug    ${mode}_gorgone_poller_2_simple
-    # wait until gorgone http server bind the http api port.
-    Wait Until Port Is Bind    8085
+    Setup Two Gorgone Instances    communication_mode=${mode}    central_name=${mode}_gorgone_central_simple    poller_name=${mode}_gorgone_poller_2_simple    check_connection=False
     Check Poller Is Connected    port=8086    expected_nb=0
+    Ctn Check No Error In Logs    ${mode}_gorgone_poller_2_simple
+    # we need to find the message that explains the connection refusal
+    ${log_central_query}    Create List    ${message}
+    ${logs_central}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${mode}_gorgone_central_simple/gorgoned.log    content=${log_central_query}    date=${start_date}    timeout=70
+    Should Be True    ${logs_central}    Didn't found the logs in the poller file : ${logs_central}
 
-    Examples:    id    mode         env_token    --
-        ...    1    pullwss        Central-1:centralCMAtoken
-        ...    2    pullwss        poller-2:myPollerToken
-        ...    3    pullwss        do_not_exists:myPollerToken
+    Examples:    id    mode    env_token    message    --
+        ...    1    pullwss    Central-1:centralCMAtoken      [proxy-httpserver] invalid token -
+        ...    2    pullwss    poller-2:myPollerToken         [proxy-httpserver] invalid token -
+        ...    3    pullwss    do_not_exists:myPollerToken    [proxy-httpserver] cannot get token


### PR DESCRIPTION
## Description

Use /administration/tokens/<token name> Centreon API endpoint to validate pollers token.
Token from the conf file is used if the token isn't found with the API, so the "old way" is still working.
The token is invalid if it's revoked or expired, and we check that they're all still valid every 5 seconds.

**Fixes** MON-198541

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

See automated test: 
- create a poller token in Centreon administration,
- add a pullwss poller,
- set an environment variable "GORGONE_TOKEN" with the value "tokenName:tokenValue" on the poller and remove the token in the gorgone configuration => the poller should be able to communicate with the central,
- revoke the token, or wait until it is expired => the poller should be deconnected and cannot communicate with the central.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

