### PR TITLE
fix(ci): restore centreon-common runner for deliver-sources jobs

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -455,7 +455,7 @@ jobs:
       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
 
   deliver-sources:
-    runs-on: ubuntu-24.04
+    runs-on: centreon-common
     needs: [get-environment, package]
     if: |
       github.event_name != 'workflow_dispatch' &&

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -425,7 +425,7 @@ jobs:
       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
 
   deliver-sources:
-    runs-on: ubuntu-24.04
+    runs-on: centreon-common
     needs: [get-environment, package]
     if: |
       github.event_name != 'workflow_dispatch' &&


### PR DESCRIPTION
## Summary

- Restore `centreon-common` runner for `deliver-sources` jobs (previously replaced by `ubuntu-24.04`)
- Affects all workflows: `collect.yml`, `gorgone.yml`

## Jira

[MON-201759](https://centreon.atlassian.net/browse/MON-201759)

## Type of change

- [x] CI/CD change (GitHub Actions)

[MON-201759]: https://centreon.atlassian.net/browse/MON-201759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ