### PR TITLE
feat(docker): support custom plugins and dependencies in centreon-engine container

### DIFF
--- a/.github/docker/centreon-engine/trixie/Dockerfile
+++ b/.github/docker/centreon-engine/trixie/Dockerfile
@@ -166,13 +166,15 @@ mkdir -p /etc/centreon-engine \
          /usr/share/centreon/lib/centreon-broker \
          /usr/lib64/centreon-engine \
          /usr/lib/nagios/plugins \
+         /usr/lib/nagios/plugins/custom \
          /usr/lib64/nagios
 ln -s /usr/lib/nagios/plugins /usr/lib64/nagios/plugins
 chown -R centreon-engine:centreon-engine \
          /etc/centreon-engine \
          /var/lib/centreon-engine \
          /var/log/centreon-engine \
-         /var/lib/centreon/centplugins
+         /var/lib/centreon/centplugins \
+         /usr/lib/nagios/plugins/custom
 chown -R centreon-broker:centreon-broker \
           /etc/centreon-broker
 chmod 775 /etc/centreon-engine \

--- a/.github/docker/centreon-engine/trixie/entrypoint/apt_install.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/apt_install.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Shared helper sourced by the container.d startup/watcher scripts.
+# Single source of truth for "install APT packages safely".
+
+APT_LOCK="/var/lock/centreon-engine-apt.lock"
+
+# apt_install_pkgs <pkg> [pkg...]
+#
+# Serializes against the other concurrent apt callers (40/41/45/46) via flock to
+# avoid dpkg lock conflicts, refreshes the package lists, then batch-installs.
+#
+# Batch install is the fast path and resolves inter-package dependencies in one
+# shot. If it fails — a nonexistent name (e.g. "toto"), a purely virtual package,
+# or an unsatisfiable dependency — apt aborts the WHOLE transaction, so we fall
+# back to installing each package individually. That isolates the bad package and
+# lets every valid one still land. The per-package retry does not break shared
+# dependencies: each install still pulls what it needs from the repo.
+apt_install_pkgs() {
+    [ "$#" -gt 0 ] || return 0
+    (
+        flock -w 120 9 || { echo "apt lock timeout, skipping install" > /proc/1/fd/1; exit 0; }
+        export DEBIAN_FRONTEND=noninteractive
+        sudo apt-get update -qq > /proc/1/fd/1 2>&1 || true
+        if sudo apt-get install -y -- "$@" > /proc/1/fd/1 2>&1; then
+            echo "installed: $*" > /proc/1/fd/1
+        else
+            echo "WARNING: batch install failed, retrying packages individually" > /proc/1/fd/1
+            for p in "$@"; do
+                if sudo apt-get install -y -- "$p" > /proc/1/fd/1 2>&1; then
+                    echo "installed: $p" > /proc/1/fd/1
+                else
+                    echo "WARNING: skipping unavailable package: $p" > /proc/1/fd/1
+                fi
+            done
+        fi
+    ) 9>"${APT_LOCK}"
+}

--- a/.github/docker/centreon-engine/trixie/entrypoint/check_custom_deps.py
+++ b/.github/docker/centreon-engine/trixie/entrypoint/check_custom_deps.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+Parse custom-deps.json and print a space-separated list of APT packages to install.
+Package names are validated against Debian naming rules before being emitted.
+
+Usage: check_custom_deps.py <custom_deps_json_path>
+"""
+
+import json
+import re
+import sys
+
+PKG_RE = re.compile(r'^[a-z0-9][a-z0-9+\-.]+$')
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: check_custom_deps.py <custom_deps_json_path>", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with open(sys.argv[1]) as f:
+            deps = json.load(f)
+    except Exception as e:
+        print(f"Failed to read {sys.argv[1]}: {e}", file=sys.stderr)
+        sys.exit(0)
+
+    pkgs = []
+    for pkg in deps.get("apt", []):
+        pkg = str(pkg).lower()
+        if PKG_RE.match(pkg):
+            pkgs.append(pkg)
+        else:
+            print(f"  {pkg}: invalid package name, skipping", file=sys.stderr)
+
+    print(" ".join(pkgs))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/40-engine.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/40-engine.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+# Sourced by container.sh, which already sets `set -e` for the whole entrypoint.
 
 PLUGINS_JSON="/etc/centreon-engine/plugins.json"
 

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/40-engine.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/40-engine.sh
@@ -3,25 +3,19 @@
 set -e
 
 PLUGINS_JSON="/etc/centreon-engine/plugins.json"
-APT_LOCK="/var/lock/centreon-engine-apt.lock"
 
-# flock serializes this against other concurrent apt calls (41-custom-deps,
-# 45-plugin-watcher, 46-custom-deps-watcher) to avoid dpkg lock conflicts.
-(
-    flock -w 120 9 || { echo "apt lock timeout, skipping plugin install"; exit 0; }
-    export DEBIAN_FRONTEND=noninteractive
-    sudo apt-get update -qq
+. /var/lib/centreon-engine/apt_install.sh
 
-    if [ -f "$PLUGINS_JSON" ]; then
-        PKGS=$(python3 /var/lib/centreon-engine/check_plugins.py "$PLUGINS_JSON" 2>/dev/null)
-        if [ -n "$PKGS" ]; then
-            echo "Installing plugins from plugins.json: $PKGS"
-            # shellcheck disable=SC2086
-            sudo apt-get install -y -- $PKGS > /proc/1/fd/1 2>&1 || true
-        else
-            echo "plugins.json is empty or unreadable, skipping plugin install"
-        fi
+if [ -f "$PLUGINS_JSON" ]; then
+    PKGS=$(python3 /var/lib/centreon-engine/check_plugins.py "$PLUGINS_JSON" 2>/dev/null)
+    if [ -n "$PKGS" ]; then
+        echo "Installing plugins from plugins.json: $PKGS"
+        # Run in background so centengine starts without waiting for apt.
+        # shellcheck disable=SC2086
+        apt_install_pkgs $PKGS &
     else
-        echo "No plugins.json found at $PLUGINS_JSON, skipping plugin install"
+        echo "plugins.json is empty or unreadable, skipping plugin install"
     fi
-) 9>"${APT_LOCK}" &
+else
+    echo "No plugins.json found at $PLUGINS_JSON, skipping plugin install"
+fi

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/40-engine.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/40-engine.sh
@@ -3,9 +3,12 @@
 set -e
 
 PLUGINS_JSON="/etc/centreon-engine/plugins.json"
+APT_LOCK="/var/lock/centreon-engine-apt.lock"
 
-# Install plugins listed in plugins.json (targeted, not greedy)
+# flock serializes this against other concurrent apt calls (41-custom-deps,
+# 45-plugin-watcher, 46-custom-deps-watcher) to avoid dpkg lock conflicts.
 (
+    flock -w 120 9 || { echo "apt lock timeout, skipping plugin install"; exit 0; }
     export DEBIAN_FRONTEND=noninteractive
     sudo apt-get update -qq
 
@@ -21,4 +24,4 @@ PLUGINS_JSON="/etc/centreon-engine/plugins.json"
     else
         echo "No plugins.json found at $PLUGINS_JSON, skipping plugin install"
     fi
-) &
+) 9>"${APT_LOCK}" &

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/41-custom-deps.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/41-custom-deps.sh
@@ -3,20 +3,17 @@
 set -e
 
 DEPS_JSON="/etc/centreon-engine/custom-deps.json"
-APT_LOCK="/var/lock/centreon-engine-apt.lock"
 
 [ -f "$DEPS_JSON" ] || exit 0
 
-(
-    flock -w 120 9 || { echo "apt lock timeout, skipping custom deps install"; exit 0; }
-    export DEBIAN_FRONTEND=noninteractive
-    PKGS=$(python3 /var/lib/centreon-engine/check_custom_deps.py "$DEPS_JSON" 2>/dev/null)
-    if [ -n "$PKGS" ]; then
-        echo "Installing custom APT deps: $PKGS"
-        sudo apt-get update -qq > /proc/1/fd/1 2>&1 || true
-        # shellcheck disable=SC2086
-        sudo apt-get install -y -- $PKGS > /proc/1/fd/1 2>&1 || true
-    else
-        echo "custom-deps.json found but no valid APT packages to install"
-    fi
-) 9>"${APT_LOCK}" &
+. /var/lib/centreon-engine/apt_install.sh
+
+PKGS=$(python3 /var/lib/centreon-engine/check_custom_deps.py "$DEPS_JSON" 2>/dev/null)
+if [ -n "$PKGS" ]; then
+    echo "Installing custom APT deps: $PKGS"
+    # Run in background so centengine starts without waiting for apt.
+    # shellcheck disable=SC2086
+    apt_install_pkgs $PKGS &
+else
+    echo "custom-deps.json found but no valid APT packages to install"
+fi

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/41-custom-deps.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/41-custom-deps.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
-set -e
+# This script is sourced by container.sh (see 00-init loop), so it runs in the
+# parent shell: use `return` (not `exit`, which would kill the whole entrypoint
+# before centengine starts) and let container.sh own `set -e`.
 
 DEPS_JSON="/etc/centreon-engine/custom-deps.json"
 
-[ -f "$DEPS_JSON" ] || exit 0
+[ -f "$DEPS_JSON" ] || return 0
 
 . /var/lib/centreon-engine/apt_install.sh
 

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/41-custom-deps.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/41-custom-deps.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+
+DEPS_JSON="/etc/centreon-engine/custom-deps.json"
+
+[ -f "$DEPS_JSON" ] || exit 0
+
+(
+    export DEBIAN_FRONTEND=noninteractive
+    PKGS=$(python3 /var/lib/centreon-engine/check_custom_deps.py "$DEPS_JSON" 2>/dev/null)
+    if [ -n "$PKGS" ]; then
+        echo "Installing custom APT deps: $PKGS"
+        sudo apt-get update -qq > /proc/1/fd/1 2>&1 || true
+        # shellcheck disable=SC2086
+        sudo apt-get install -y -- $PKGS > /proc/1/fd/1 2>&1 || true
+    else
+        echo "custom-deps.json found but no valid APT packages to install"
+    fi
+) &

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/41-custom-deps.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/41-custom-deps.sh
@@ -3,10 +3,12 @@
 set -e
 
 DEPS_JSON="/etc/centreon-engine/custom-deps.json"
+APT_LOCK="/var/lock/centreon-engine-apt.lock"
 
 [ -f "$DEPS_JSON" ] || exit 0
 
 (
+    flock -w 120 9 || { echo "apt lock timeout, skipping custom deps install"; exit 0; }
     export DEBIAN_FRONTEND=noninteractive
     PKGS=$(python3 /var/lib/centreon-engine/check_custom_deps.py "$DEPS_JSON" 2>/dev/null)
     if [ -n "$PKGS" ]; then
@@ -17,4 +19,4 @@ DEPS_JSON="/etc/centreon-engine/custom-deps.json"
     else
         echo "custom-deps.json found but no valid APT packages to install"
     fi
-) &
+) 9>"${APT_LOCK}" &

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/45-plugin-watcher_background.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/45-plugin-watcher_background.sh
@@ -2,18 +2,15 @@
 
 PLUGINS_JSON="/etc/centreon-engine/plugins.json"
 PLUGINS_DIR="/etc/centreon-engine"
-APT_LOCK="/var/lock/centreon-engine-apt.lock"
+
+. /var/lib/centreon-engine/apt_install.sh
 
 install_from_json() {
     PKGS=$(python3 /var/lib/centreon-engine/check_plugins.py "$PLUGINS_JSON")
     if [ -n "$PKGS" ]; then
         echo "plugins.json changed — installing: $PKGS"
-        (
-            flock -w 120 9 || { echo "apt lock timeout, skipping plugin install"; exit 0; }
-            DEBIAN_FRONTEND=noninteractive sudo apt-get update -qq > /proc/1/fd/1 2>&1 || true
-            # shellcheck disable=SC2086
-            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -- $PKGS > /proc/1/fd/1 2>&1 || true
-        ) 9>"${APT_LOCK}"
+        # shellcheck disable=SC2086
+        apt_install_pkgs $PKGS
     else
         echo "plugins.json changed — all plugins already up-to-date, skipping install"
     fi

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/45-plugin-watcher_background.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/45-plugin-watcher_background.sh
@@ -2,14 +2,18 @@
 
 PLUGINS_JSON="/etc/centreon-engine/plugins.json"
 PLUGINS_DIR="/etc/centreon-engine"
+APT_LOCK="/var/lock/centreon-engine-apt.lock"
 
 install_from_json() {
     PKGS=$(python3 /var/lib/centreon-engine/check_plugins.py "$PLUGINS_JSON")
     if [ -n "$PKGS" ]; then
         echo "plugins.json changed — installing: $PKGS"
-        DEBIAN_FRONTEND=noninteractive sudo apt-get update -qq > /proc/1/fd/1 2>&1 || true
-        # shellcheck disable=SC2086
-        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -- $PKGS > /proc/1/fd/1 2>&1 || true
+        (
+            flock -w 120 9 || { echo "apt lock timeout, skipping plugin install"; exit 0; }
+            DEBIAN_FRONTEND=noninteractive sudo apt-get update -qq > /proc/1/fd/1 2>&1 || true
+            # shellcheck disable=SC2086
+            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -- $PKGS > /proc/1/fd/1 2>&1 || true
+        ) 9>"${APT_LOCK}"
     else
         echo "plugins.json changed — all plugins already up-to-date, skipping install"
     fi

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/46-custom-deps-watcher_background.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/46-custom-deps-watcher_background.sh
@@ -2,14 +2,18 @@
 
 DEPS_JSON="/etc/centreon-engine/custom-deps.json"
 DEPS_DIR="/etc/centreon-engine"
+APT_LOCK="/var/lock/centreon-engine-apt.lock"
 
 install_custom_deps() {
     PKGS=$(python3 /var/lib/centreon-engine/check_custom_deps.py "$DEPS_JSON")
     if [ -n "$PKGS" ]; then
         echo "custom-deps.json changed — installing: $PKGS"
-        DEBIAN_FRONTEND=noninteractive sudo apt-get update -qq > /proc/1/fd/1 2>&1 || true
-        # shellcheck disable=SC2086
-        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -- $PKGS > /proc/1/fd/1 2>&1 || true
+        (
+            flock -w 120 9 || { echo "apt lock timeout, skipping custom deps install"; exit 0; }
+            DEBIAN_FRONTEND=noninteractive sudo apt-get update -qq > /proc/1/fd/1 2>&1 || true
+            # shellcheck disable=SC2086
+            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -- $PKGS > /proc/1/fd/1 2>&1 || true
+        ) 9>"${APT_LOCK}"
     else
         echo "custom-deps.json changed — no valid APT packages, skipping install"
     fi

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/46-custom-deps-watcher_background.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/46-custom-deps-watcher_background.sh
@@ -2,18 +2,15 @@
 
 DEPS_JSON="/etc/centreon-engine/custom-deps.json"
 DEPS_DIR="/etc/centreon-engine"
-APT_LOCK="/var/lock/centreon-engine-apt.lock"
+
+. /var/lib/centreon-engine/apt_install.sh
 
 install_custom_deps() {
     PKGS=$(python3 /var/lib/centreon-engine/check_custom_deps.py "$DEPS_JSON")
     if [ -n "$PKGS" ]; then
         echo "custom-deps.json changed — installing: $PKGS"
-        (
-            flock -w 120 9 || { echo "apt lock timeout, skipping custom deps install"; exit 0; }
-            DEBIAN_FRONTEND=noninteractive sudo apt-get update -qq > /proc/1/fd/1 2>&1 || true
-            # shellcheck disable=SC2086
-            DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -- $PKGS > /proc/1/fd/1 2>&1 || true
-        ) 9>"${APT_LOCK}"
+        # shellcheck disable=SC2086
+        apt_install_pkgs $PKGS
     else
         echo "custom-deps.json changed — no valid APT packages, skipping install"
     fi

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/46-custom-deps-watcher_background.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/46-custom-deps-watcher_background.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+DEPS_JSON="/etc/centreon-engine/custom-deps.json"
+DEPS_DIR="/etc/centreon-engine"
+
+install_custom_deps() {
+    PKGS=$(python3 /var/lib/centreon-engine/check_custom_deps.py "$DEPS_JSON")
+    if [ -n "$PKGS" ]; then
+        echo "custom-deps.json changed — installing: $PKGS"
+        DEBIAN_FRONTEND=noninteractive sudo apt-get update -qq > /proc/1/fd/1 2>&1 || true
+        # shellcheck disable=SC2086
+        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y -- $PKGS > /proc/1/fd/1 2>&1 || true
+    else
+        echo "custom-deps.json changed — no valid APT packages, skipping install"
+    fi
+}
+
+# close_write fires when the file is closed after writing (content is complete).
+# moved_to catches atomic replacements (write-then-rename used by config tools).
+# Note: inotify-tools 4.x matches --include against the full event line
+# (e.g. "/etc/centreon-engine/ MOVED_TO custom-deps.json"), so ^ anchor must be omitted.
+inotifywait -m -q \
+    -e close_write -e moved_to \
+    --include 'custom-deps\.json$' \
+    "$DEPS_DIR" |
+while read -r _dir _event _file; do
+    install_custom_deps
+done


### PR DESCRIPTION
## MON-201883

Adds two mechanisms to let users extend the centreon-engine container with their own plugins and dependencies, without modifying the base image.

## Changes

### Custom scripts — volume mount point
A dedicated directory `/usr/lib/nagios/plugins/custom/` is created and owned by `centreon-engine` in the Dockerfile. Users mount their scripts there via docker-compose:
```yaml
volumes:
  - ./my-plugins:/usr/lib/nagios/plugins/custom:ro
```
Scripts must be executable (`chmod +x`).

### Runtime APT dependencies — `custom-deps.json`
New entrypoint script `41-custom-deps.sh` (runs after `40-engine.sh`) reads `/etc/centreon-engine/custom-deps.json` at startup and installs the listed APT packages:
```json
{
  "apt": ["snmp", "python3-requests", "libnet-snmp-perl"]
}
```
Package names are validated against Debian naming rules in `check_custom_deps.py` before being passed to `apt-get`.

Hot-reload is handled by `46-custom-deps-watcher_background.sh`: same inotify pattern as the existing `45-plugin-watcher_background.sh`, re-installs whenever `custom-deps.json` changes.

Mount in docker-compose:
```yaml
volumes:
  - ./custom-deps.json:/etc/centreon-engine/custom-deps.json:ro
```

No sudoers changes required — `apt`/`apt-get` are already allowed.

### Custom image build
For pip3/cpan/compiled dependencies, users extend the published image:
```dockerfile
FROM centreon/centreon-engine:24.10
USER root
RUN apt-get update && apt-get install -y --no-install-recommends \
    python3-boto3 libnet-snmp-perl && \
    rm -rf /var/lib/apt/lists/*
USER centreon-engine
```

## Test plan
- [x] Build with existing `.deb` mount → unchanged behaviour
- [x] Mount a script directory → verify centreon-engine can call `/usr/lib/nagios/plugins/custom/my-script.sh`
- [x] Mount `custom-deps.json` with `"apt": ["snmp"]` → `dpkg -l snmp` shows installed after startup
- [x] Modify `custom-deps.json` while container is running → package installs without restart
- [ ] Invalid package name in `custom-deps.json` → skipped with warning, valid packages still installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)