### PR TITLE
fix(docker): add missing protobuf shared libs in centreon-engine image

### DIFF
--- a/.github/docker/centreon-engine/trixie/Dockerfile
+++ b/.github/docker/centreon-engine/trixie/Dockerfile
@@ -200,10 +200,9 @@ COPY --from=extractor --link --chmod=755 /extracted/usr/sbin/centengine /usr/sbi
 # Core library
 COPY --from=extractor --link --chmod=755 /extracted/usr/lib*/libcentreon_clib.so /usr/lib/libcentreon_clib.so
 
-# Protobuf shared libraries (centreon-protobuf-lib package, added in MON-197778)
-RUN --mount=type=bind,from=extractor,source=/extracted,target=/ext \
-    find /ext/usr/lib* -maxdepth 1 \( -name 'libcentreon_engine_conf.so' -o -name 'libcentreon_pb_bbdo.so' \) \
-    -exec cp -v {} /usr/lib/ \; 2>/dev/null; true
+# Protobuf shared libraries (centreon-protobuf-lib package)
+COPY --from=extractor --link --chmod=755 /extracted/usr/lib*/libcentreon_engine_conf.so /usr/lib/libcentreon_engine_conf.so
+COPY --from=extractor --link --chmod=755 /extracted/usr/lib*/libcentreon_pb_bbdo.so /usr/lib/libcentreon_pb_bbdo.so
 
 # Broker module (cbmod.so) - engine loads this
 COPY --from=extractor --link --chmod=755 /extracted/usr/lib*/cbmod.so /usr/lib/cbmod.so
@@ -231,8 +230,8 @@ COPY --chmod=600 ./.github/docker/centreon-engine/sudoersCentreon /etc/sudoers.d
 RUN echo "=== Verification ===" && \
     ls -lah /usr/sbin/centengine && \
     ls -lah /usr/lib/libcentreon_clib.so && \
-    ls -lah /usr/lib/libcentreon_engine_conf.so 2>/dev/null || echo "libcentreon_engine_conf.so not present (pre-MON-197778 packages)" && \
-    ls -lah /usr/lib/libcentreon_pb_bbdo.so 2>/dev/null || echo "libcentreon_pb_bbdo.so not present (pre-MON-197778 packages)" && \
+    ls -lah /usr/lib/libcentreon_engine_conf.so && \
+    ls -lah /usr/lib/libcentreon_pb_bbdo.so && \
     ls -lah /usr/lib/cbmod.so && \
     ls -lah /usr/lib64/centreon-engine/*.so && \
     ls -lah /usr/lib64/centreon-connector/ && \

--- a/.github/docker/centreon-engine/trixie/Dockerfile
+++ b/.github/docker/centreon-engine/trixie/Dockerfile
@@ -200,9 +200,10 @@ COPY --from=extractor --link --chmod=755 /extracted/usr/sbin/centengine /usr/sbi
 # Core library
 COPY --from=extractor --link --chmod=755 /extracted/usr/lib*/libcentreon_clib.so /usr/lib/libcentreon_clib.so
 
-# Protobuf shared libraries (centreon-protobuf-lib package)
-COPY --from=extractor --link --chmod=755 /extracted/usr/lib*/libcentreon_engine_conf.so /usr/lib/libcentreon_engine_conf.so
-COPY --from=extractor --link --chmod=755 /extracted/usr/lib*/libcentreon_pb_bbdo.so /usr/lib/libcentreon_pb_bbdo.so
+# Protobuf shared libraries (centreon-protobuf-lib package, added in MON-197778)
+RUN --mount=type=bind,from=extractor,source=/extracted,target=/ext \
+    find /ext/usr/lib* -maxdepth 1 \( -name 'libcentreon_engine_conf.so' -o -name 'libcentreon_pb_bbdo.so' \) \
+    -exec cp -v {} /usr/lib/ \; 2>/dev/null; true
 
 # Broker module (cbmod.so) - engine loads this
 COPY --from=extractor --link --chmod=755 /extracted/usr/lib*/cbmod.so /usr/lib/cbmod.so
@@ -230,8 +231,8 @@ COPY --chmod=600 ./.github/docker/centreon-engine/sudoersCentreon /etc/sudoers.d
 RUN echo "=== Verification ===" && \
     ls -lah /usr/sbin/centengine && \
     ls -lah /usr/lib/libcentreon_clib.so && \
-    ls -lah /usr/lib/libcentreon_engine_conf.so && \
-    ls -lah /usr/lib/libcentreon_pb_bbdo.so && \
+    ls -lah /usr/lib/libcentreon_engine_conf.so 2>/dev/null || echo "libcentreon_engine_conf.so not present (pre-MON-197778 packages)" && \
+    ls -lah /usr/lib/libcentreon_pb_bbdo.so 2>/dev/null || echo "libcentreon_pb_bbdo.so not present (pre-MON-197778 packages)" && \
     ls -lah /usr/lib/cbmod.so && \
     ls -lah /usr/lib64/centreon-engine/*.so && \
     ls -lah /usr/lib64/centreon-connector/ && \

--- a/.github/docker/centreon-engine/trixie/Dockerfile
+++ b/.github/docker/centreon-engine/trixie/Dockerfile
@@ -200,6 +200,10 @@ COPY --from=extractor --link --chmod=755 /extracted/usr/sbin/centengine /usr/sbi
 # Core library
 COPY --from=extractor --link --chmod=755 /extracted/usr/lib*/libcentreon_clib.so /usr/lib/libcentreon_clib.so
 
+# Protobuf shared libraries (centreon-protobuf-lib package)
+COPY --from=extractor --link --chmod=755 /extracted/usr/lib*/libcentreon_engine_conf.so /usr/lib/libcentreon_engine_conf.so
+COPY --from=extractor --link --chmod=755 /extracted/usr/lib*/libcentreon_pb_bbdo.so /usr/lib/libcentreon_pb_bbdo.so
+
 # Broker module (cbmod.so) - engine loads this
 COPY --from=extractor --link --chmod=755 /extracted/usr/lib*/cbmod.so /usr/lib/cbmod.so
 
@@ -226,6 +230,8 @@ COPY --chmod=600 ./.github/docker/centreon-engine/sudoersCentreon /etc/sudoers.d
 RUN echo "=== Verification ===" && \
     ls -lah /usr/sbin/centengine && \
     ls -lah /usr/lib/libcentreon_clib.so && \
+    ls -lah /usr/lib/libcentreon_engine_conf.so && \
+    ls -lah /usr/lib/libcentreon_pb_bbdo.so && \
     ls -lah /usr/lib/cbmod.so && \
     ls -lah /usr/lib64/centreon-engine/*.so && \
     ls -lah /usr/lib64/centreon-connector/ && \

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -403,7 +403,7 @@ jobs:
         run: |
           ls -lh *.rpm
           mkdir packages-centreon
-          mv centreon-{clib,engine,engine-daemon,engine-opentelemetry,broker,broker-core}-"${MAJOR_VERSION}"*.rpm packages-centreon/
+          mv centreon-{clib,protobuf-lib,engine,engine-daemon,engine-opentelemetry,broker,broker-core}-"${MAJOR_VERSION}"*.rpm packages-centreon/
           ls -lh packages-centreon/
         shell: bash
 
@@ -491,7 +491,7 @@ jobs:
       - name: Prepare packages directory
         run: |
           mkdir -p packages-centreon/amd64 packages-centreon/arm64
-          for deb in centreon-{clib,engine,engine-daemon,engine-opentelemetry,broker,broker-core,broker-cbd,connector-perl,connector-ssh}_${{ needs.get-environment.outputs.major_version }}*.deb; do
+          for deb in centreon-{clib,protobuf-lib,engine,engine-daemon,engine-opentelemetry,broker,broker-core,broker-cbd,connector-perl,connector-ssh}_${{ needs.get-environment.outputs.major_version }}*.deb; do
             [[ ! -f "$deb" ]] && continue
             if [[ "$deb" == *_amd64.deb ]]; then
               mv "$deb" packages-centreon/amd64/


### PR DESCRIPTION
## Summary

Fixes centengine startup failure after merging `MON-197778-vcpkg-upgrade` into `develop`.

- `libcentreon_engine_conf.so` and `libcentreon_pb_bbdo.so` are now system shared libraries installed to `/usr/lib/` by the `centreon-protobuf-lib` package
- The Dockerfile runtime stage extracts all `centreon*.deb` packages but only selectively copies files; these two libs were not included
- Adds explicit `COPY` instructions for both libs + adds them to the build-time verification step

**Root cause:** `engine_conf` switched from STATIC to SHARED in MON-197778, creating `libcentreon_engine_conf.so`. The Dockerfile was not updated to copy it into the final image.

**Error observed:**
```
/usr/sbin/centengine: error while loading shared libraries: libcentreon_engine_conf.so: cannot open shared object file: No such file or directory
```

## Test plan

- [ ] Build the Docker image with packages from `develop` and verify centengine starts without the shared library error
- [ ] Confirm `/usr/lib/libcentreon_engine_conf.so` and `/usr/lib/libcentreon_pb_bbdo.so` are present in the final image
- [ ] Run the docker-compose poller stack and verify `Centreon Engine is ready`

Jira: [MON-202254](https://centreon.atlassian.net/browse/MON-202254)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MON-202254]: https://centreon.atlassian.net/browse/MON-202254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ