### PR TITLE
feat(agent): per-command timeout for CMA native checks

### DIFF
--- a/agent/inc/com/centreon/agent/check.hh
+++ b/agent/inc/com/centreon/agent/check.hh
@@ -172,6 +172,8 @@ class check : public std::enable_shared_from_this<check> {
 
   asio::system_timer _time_out_timer;
 
+  std::optional<duration> _custom_timeout;
+
   void _start_timeout_timer(const duration& timeout);
 
   bool _running_check = false;
@@ -275,6 +277,13 @@ class check : public std::enable_shared_from_this<check> {
   uint64_t get_service_id() const { return _service.service_id(); }
 
   const engine_to_agent_request_ptr& get_conf() const { return _conf; }
+
+  void set_custom_timeout(const duration& timeout) {
+    _custom_timeout = timeout;
+  }
+  const std::optional<duration>& get_custom_timeout() const {
+    return _custom_timeout;
+  }
 
   const time_point& get_last_start() const { return _last_start; }
 

--- a/agent/native_windows/src/check_counter.cc
+++ b/agent/native_windows/src/check_counter.cc
@@ -454,6 +454,7 @@ void check_counter::start_check(const duration& timeout) {
   if (!_start_check(timeout)) {
     return;
   }
+  const duration effective_timeout = get_custom_timeout().value_or(timeout);
 
   std::string output;
   std::list<common::perfdata> perf;
@@ -472,7 +473,7 @@ void check_counter::start_check(const duration& timeout) {
       // if we need two samples, we need to wait for the second one
       duration wait_duration =
           std::min(get_raw_start_expected().get_step() / 2,
-                   timeout - std::chrono::milliseconds(500));
+                   effective_timeout - std::chrono::milliseconds(500));
 
       _measure_timer.expires_after(wait_duration);
       _measure_timer.async_wait(

--- a/agent/native_windows/src/check_files.cc
+++ b/agent/native_windows/src/check_files.cc
@@ -1117,6 +1117,8 @@ void check_files::start_check(const duration& timeout) {
   if (!check::_start_check(timeout)) {
     return;
   }
+  const duration effective_timeout = get_custom_timeout().value_or(timeout);
+
   if (!_worker_thread_files_check) {
     _worker_files_check =
         std::make_shared<check_files_detail::check_files_thread>(_io_context,
@@ -1126,7 +1128,7 @@ void check_files::start_check(const duration& timeout) {
   }
   unsigned running_check_index = _get_running_check_index();
   _worker_files_check->async_get_files(
-      _filter, std::chrono::system_clock::now() + timeout,
+      _filter, std::chrono::system_clock::now() + effective_timeout,
       [me = shared_from_this(), running_check_index](
           const absl::flat_hash_map<std::string,
                                     std::unique_ptr<file_metadata>>& result,

--- a/agent/src/check.cc
+++ b/agent/src/check.cc
@@ -179,7 +179,7 @@ bool check::_start_check(const duration& timeout) {
     return false;
   }
   _running_check = true;
-  _start_timeout_timer(timeout);
+  _start_timeout_timer(_custom_timeout.value_or(timeout));
   SPDLOG_LOGGER_TRACE(_logger, "start check for service {}",
                       _service.service_description());
 

--- a/agent/src/check_exec.cc
+++ b/agent/src/check_exec.cc
@@ -93,6 +93,7 @@ void check_exec::start_check(const duration& timeout) {
   if (!check::_start_check(timeout)) {
     return;
   }
+  const duration effective_timeout = get_custom_timeout().value_or(timeout);
 
   try {
     auto proc = std::make_shared<com::centreon::common::process<false>>(
@@ -109,7 +110,7 @@ void check_exec::start_check(const duration& timeout) {
             int exit_status, const std::string& std_out, const std::string&) {
           me->on_completion(running_index, exit_code, exit_status, std_out);
         },
-        timeout + std::chrono::milliseconds(100));
+        effective_timeout + std::chrono::milliseconds(100));
     _pid = proc->get_pid();
     if (_credentials_decrypt) {
       _process_args->clear_unencrypted_args();

--- a/agent/src/check_health.cc
+++ b/agent/src/check_health.cc
@@ -107,10 +107,11 @@ void check_health::start_check(const duration& timeout) {
   if (!_start_check(timeout)) {
     return;
   }
+  const duration effective_timeout = get_custom_timeout().value_or(timeout);
 
   duration wait_beforecompute =
       std::min(get_raw_start_expected().get_step() / 2,
-               timeout - std::chrono::milliseconds(100));
+               effective_timeout - std::chrono::milliseconds(100));
   // we wait a little in order to have statistics check_interval/2
   _measure_timer.expires_after(wait_beforecompute);
   _measure_timer.async_wait(

--- a/agent/src/drive_size.cc
+++ b/agent/src/drive_size.cc
@@ -434,6 +434,7 @@ void check_drive_size::start_check(const duration& timeout) {
   if (!check::_start_check(timeout)) {
     return;
   }
+  const duration effective_timeout = get_custom_timeout().value_or(timeout);
 
   if (!_worker_thread) {
     _worker = std::make_shared<check_drive_size_detail::drive_size_thread>(
@@ -444,7 +445,7 @@ void check_drive_size::start_check(const duration& timeout) {
   unsigned running_check_index = _get_running_check_index();
 
   _worker->async_get_fs_stats(
-      _filter, std::chrono::system_clock::now() + timeout,
+      _filter, std::chrono::system_clock::now() + effective_timeout,
       [me = shared_from_this(), running_check_index](
           const std::list<check_drive_size_detail::fs_stat>& result) {
         me->_completion_handler(running_check_index, result);

--- a/agent/src/native_check_cpu_base.cc
+++ b/agent/src/native_check_cpu_base.cc
@@ -254,14 +254,15 @@ void native_check_cpu<nb_metric>::start_check(const duration& timeout) {
   if (!check::_start_check(timeout)) {
     return;
   }
+  const duration effective_timeout = get_custom_timeout().value_or(timeout);
 
   try {
     std::unique_ptr<check_cpu_detail::cpu_time_snapshot<nb_metric>> begin =
         get_cpu_time_snapshot(true);
 
-    // end of measure = min(now+timeout, next check)
+    // end of measure = min(now+effective_timeout, next check)
     time_point now = std::chrono::system_clock::now();
-    time_point end_measure = now + timeout;
+    time_point end_measure = now + effective_timeout;
     time_step next = this->get_raw_start_expected();
     next.increment_to_after_min(now);
     if (next.value() < end_measure) {

--- a/agent/src/scheduler.cc
+++ b/agent/src/scheduler.cc
@@ -938,53 +938,64 @@ std::shared_ptr<check> scheduler::default_check_builder(
         args = &no_arg;
       }
 
+      std::optional<duration> custom_timeout;
+      if (args->IsObject() && args->HasMember("timeout")) {
+        auto timeout_sec = check::get_double(service.command_name(), "timeout",
+                                             (*args)["timeout"], true);
+        if (timeout_sec.has_value() && timeout_sec.value() > 0) {
+          custom_timeout =
+              std::chrono::seconds(static_cast<unsigned>(timeout_sec.value()));
+        }
+      }
+
+      std::shared_ptr<check> result;
       if (check_type == "cpu_percentage"sv) {
-        return std::make_shared<check_cpu>(io_context, logger,
-                                           first_start_expected, service, *args,
-                                           conf, std::move(handler), stat);
+        result = std::make_shared<check_cpu>(
+            io_context, logger, first_start_expected, service, *args, conf,
+            std::move(handler), stat);
       } else if (check_type == "health"sv) {
-        return std::make_shared<check_health>(
+        result = std::make_shared<check_health>(
             io_context, logger, first_start_expected, service, *args, conf,
             std::move(handler), stat);
       } else if (check_type == "custom"sv) {
-        return std::make_shared<check_custom>(
+        result = std::make_shared<check_custom>(
             io_context, logger, first_start_expected, service, *args, conf,
             std::move(handler), stat, credentials_decrypt);
 #ifdef _WIN32
       } else if (check_type == "uptime"sv) {
-        return std::make_shared<check_uptime>(
+        result = std::make_shared<check_uptime>(
             io_context, logger, first_start_expected, service, *args, conf,
             std::move(handler), stat);
       } else if (check_type == "storage"sv) {
-        return std::make_shared<check_drive_size>(
+        result = std::make_shared<check_drive_size>(
             io_context, logger, first_start_expected, service, *args, conf,
             std::move(handler), stat);
       } else if (check_type == "memory"sv) {
-        return std::make_shared<check_memory>(
+        result = std::make_shared<check_memory>(
             io_context, logger, first_start_expected, service, *args, conf,
             std::move(handler), stat);
       } else if (check_type == "service"sv) {
-        return std::make_shared<check_service>(
+        result = std::make_shared<check_service>(
             io_context, logger, first_start_expected, service, *args, conf,
             std::move(handler), stat);
       } else if (check_type == "counter"sv) {
-        return std::make_shared<check_counter>(
+        result = std::make_shared<check_counter>(
             io_context, logger, first_start_expected, service, *args, conf,
             std::move(handler), stat);
       } else if (check_type == "tasksched"sv) {
-        return std::make_shared<check_sched>(
+        result = std::make_shared<check_sched>(
             io_context, logger, first_start_expected, service, *args, conf,
             std::move(handler), stat);
       } else if (check_type == "files"sv) {
-        return std::make_shared<check_files>(
+        result = std::make_shared<check_files>(
             io_context, logger, first_start_expected, service, *args, conf,
             std::move(handler), stat);
       } else if (check_type == "eventlog_nscp"sv) {
-        return check_event_log::load(io_context, logger, first_start_expected,
-                                     service, *args, conf, std::move(handler),
-                                     stat);
+        result = check_event_log::load(io_context, logger, first_start_expected,
+                                       service, *args, conf, std::move(handler),
+                                       stat);
       } else if (check_type == "process_nscp"sv) {
-        return std::make_shared<check_process>(
+        result = std::make_shared<check_process>(
             io_context, logger, first_start_expected, service, *args, conf,
             std::move(handler), stat);
 #endif
@@ -992,6 +1003,11 @@ std::shared_ptr<check> scheduler::default_check_builder(
         throw exceptions::msg_fmt("command {}, unknown native check:{}",
                                   service.command_name(), command_line);
       }
+
+      if (custom_timeout.has_value()) {
+        result->set_custom_timeout(custom_timeout.value());
+      }
+      return result;
     } catch (const std::exception& e) {
       SPDLOG_LOGGER_ERROR(logger, "unexpected error: {}", e.what());
       return check_dummy::load(io_context, logger, first_start_expected,

--- a/agent/test/scheduler_test.cc
+++ b/agent/test/scheduler_test.cc
@@ -804,6 +804,135 @@ TEST_F(scheduler_test, can_decrypt) {
   EXPECT_EQ(check_created->get_process_args()->get_args()[0], "*.*");
 }
 
+/**
+ * @brief build a native check from a json command line by calling
+ * scheduler::default_check_builder directly. The returned check holds a
+ * reference to conf's first service, so conf must outlive the returned check.
+ */
+static std::shared_ptr<check> build_native_check(
+    const std::shared_ptr<com::centreon::agent::MessageToAgent>& conf,
+    const std::string& command_line) {
+  auto cnf = conf->mutable_config();
+  auto serv = cnf->add_services();
+  serv->set_service_description("serv");
+  serv->set_command_name("command");
+  serv->set_command_line(command_line);
+  serv->set_check_interval(10);
+  return scheduler::default_check_builder(
+      g_io_context, spdlog::default_logger(), std::chrono::system_clock::now(),
+      cnf->services(cnf->services_size() - 1), conf,
+      [](const std::shared_ptr<check>&, int,
+         const std::list<com::centreon::common::perfdata>&,
+         const std::list<std::string>&) {},
+      std::make_shared<checks_statistics>(), nullptr);
+}
+
+/**
+ * @brief a numeric "timeout" arg in a native check command is parsed and stored
+ * as the check's per-command custom timeout (here 60s), independent of the
+ * global check_timeout.
+ */
+TEST_F(scheduler_test, custom_timeout_from_args_number) {
+  auto conf = std::make_shared<com::centreon::agent::MessageToAgent>();
+  conf->mutable_config()->set_check_timeout(120);
+  auto chk = build_native_check(
+      conf, R"({"check":"cpu_percentage","args":{"timeout":60}})");
+  ASSERT_TRUE(chk);
+  ASSERT_TRUE(chk->get_custom_timeout().has_value());
+  EXPECT_EQ(*chk->get_custom_timeout(), std::chrono::seconds(60));
+}
+
+/**
+ * @brief the "timeout" arg may be given as a numeric string ("45"), as Centreon
+ * often emits string values; it is parsed to the same 45s custom timeout.
+ */
+TEST_F(scheduler_test, custom_timeout_from_args_string) {
+  auto conf = std::make_shared<com::centreon::agent::MessageToAgent>();
+  conf->mutable_config()->set_check_timeout(120);
+  auto chk = build_native_check(
+      conf, R"({"check":"cpu_percentage","args":{"timeout":"45"}})");
+  ASSERT_TRUE(chk);
+  ASSERT_TRUE(chk->get_custom_timeout().has_value());
+  EXPECT_EQ(*chk->get_custom_timeout(), std::chrono::seconds(45));
+}
+
+/**
+ * @brief when no "timeout" arg is present, the check holds no custom timeout
+ * (get_custom_timeout() == nullopt), so the global check_timeout keeps
+ * applying.
+ */
+TEST_F(scheduler_test, no_custom_timeout_keeps_global) {
+  auto conf = std::make_shared<com::centreon::agent::MessageToAgent>();
+  conf->mutable_config()->set_check_timeout(120);
+  auto chk =
+      build_native_check(conf, R"({"check":"cpu_percentage","args":{}})");
+  ASSERT_TRUE(chk);
+  EXPECT_FALSE(chk->get_custom_timeout().has_value());
+}
+
+/**
+ * @brief a non-numeric "timeout" arg is rejected during parsing: the builder
+ * falls back to a check_dummy carrying the error instead of a real check.
+ */
+TEST_F(scheduler_test, invalid_custom_timeout_yields_dummy) {
+  auto conf = std::make_shared<com::centreon::agent::MessageToAgent>();
+  conf->mutable_config()->set_check_timeout(120);
+  auto chk = build_native_check(
+      conf, R"({"check":"cpu_percentage","args":{"timeout":"not_a_number"}})");
+  auto dummy = std::dynamic_pointer_cast<check_dummy>(chk);
+  ASSERT_TRUE(dummy);
+}
+
+/**
+ * @brief a per-command timeout (1s) must take precedence over a high global
+ * check_timeout (10s): the timeout handler fires at ~1s, before the check would
+ * complete at 3s, yielding an UNKNOWN(3) status.
+ */
+TEST_F(scheduler_test, custom_timeout_overrides_global) {
+  auto conf = create_conf(1, 1, 1, 1, 10 /* global check_timeout */);
+
+  std::mutex m;
+  std::condition_variable cond;
+  bool done = false;
+  int captured_status = -1;
+  std::list<std::string> captured_outputs;
+
+  auto chk = std::make_shared<tempo_check>(
+      g_io_context, spdlog::default_logger(), std::chrono::system_clock::now(),
+      conf->config().services(0), conf, 0, std::chrono::milliseconds(3000),
+      [&](const std::shared_ptr<check>&, int status,
+          const std::list<com::centreon::common::perfdata>&,
+          const std::list<std::string>& outputs) {
+        {
+          std::lock_guard l(m);
+          captured_status = status;
+          captured_outputs = outputs;
+          done = true;
+        }
+        cond.notify_all();
+      },
+      std::make_shared<checks_statistics>());
+
+  chk->set_custom_timeout(std::chrono::seconds(1));
+
+  time_point start = std::chrono::system_clock::now();
+  asio::post(*g_io_context,
+             [chk]() { chk->start_check(std::chrono::seconds(10)); });
+
+  std::unique_lock l(m);
+  ASSERT_TRUE(
+      cond.wait_for(l, std::chrono::seconds(2), [&]() { return done; }));
+  auto elapsed = std::chrono::system_clock::now() - start;
+  EXPECT_EQ(captured_status, 3);  // UNKNOWN
+  EXPECT_LT(elapsed, std::chrono::milliseconds(2000));
+  // the completion must be the timeout path (output set by
+  // check::_timeout_timer_handler), not the normal "Command OK" result.
+  ASSERT_FALSE(captured_outputs.empty());
+  EXPECT_NE(captured_outputs.front().find("Timeout at execution of"),
+            std::string::npos)
+      << "unexpected output: " << captured_outputs.front();
+}
+
 /*
  * struct to store data about a check execution
  * used by scripted_check to store data about each check execution


### PR DESCRIPTION
feat(agent): per-command timeout for CMA native checks.
REFS: MON-199434
