### PR TITLE
fix(engine): do not clear acknowledgement when a downtime starts (#3475)

### DIFF
--- a/engine/src/broker.cc
+++ b/engine/src/broker.cc
@@ -2714,7 +2714,9 @@ static void forward_pb_host_status(const host* hst,
     }
 
     // Acknowledgement event.
-    handle_acknowledgement(state, host);
+    // Only process it when the acknowledgement actually changed.
+    if (attributes & engine::host::STATUS_ACKNOWLEDGEMENT)
+      handle_acknowledgement(state, host);
   } else {
     auto h{std::make_shared<neb::pb_host_status>()};
     com::centreon::broker::HostStatus& hscr = h.get()->mut_obj();
@@ -4711,7 +4713,9 @@ static void forward_pb_service_status(const engine::service* svc,
     }
 
     // Acknowledgement event.
-    handle_acknowledgement(state, asscr);
+    // Only process it when the acknowledgement actually changed.
+    if (attributes & engine::service::STATUS_ACKNOWLEDGEMENT)
+      handle_acknowledgement(state, asscr);
   } else {
     auto s{std::make_shared<neb::pb_service_status>()};
     ServiceStatus& sscr = s.get()->mut_obj();

--- a/tests/broker-engine/acknowledgement.robot
+++ b/tests/broker-engine/acknowledgement.robot
@@ -387,6 +387,64 @@ BEACK8
     ${content}    Create List    Still 0 running acknowledgements
     Ctn Find In Log With Timeout    ${engineLog0}    ${d}    ${content}    30
 
+BEACK_DT
+    [Documentation]    Scenario: a downtime must not remove an acknowledgement
+    ...    Given a configuration with BBDO3 and a critical service that is acknowledged
+    ...    When a downtime is scheduled on this service and starts
+    ...    Then the acknowledgement must not be deleted
+    ...    And the acknowledgements, services and resources tables must stay consistent.
+    [Tags]    broker    engine    services    extcmd    downtime    MON-197301
+    Ctn Config Engine    ${1}    ${50}    ${20}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module    ${1}
+    Ctn Config BBDO3    ${1}
+    Ctn Broker Config Log    module0    neb    debug
+    Ctn Broker Config Log    central    sql    debug
+
+    ${start}    Get Current Date
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+
+    # The service command is set to CRITICAL to also control active checks
+    ${cmd_id}    Ctn Get Service Command Id    ${1}
+    Ctn Set Command Status    ${cmd_id}    ${2}
+
+    # Time to set the service to CRITICAL HARD.
+    Ctn Process Service Result Hard    host_1    service_1    ${2}    (1;1) is critical
+    ${result}    Ctn Check Service Resource Status With Timeout    host_1    service_1    ${2}    60    HARD
+    Should Be True    ${result}    Service (1;1) should be critical HARD
+
+    # The service is acknowledged (sticky).
+    ${d}    Get Current Date    result_format=epoch    exclude_millis=True
+    Ctn Acknowledge Service Problem    host_1    service_1    STICKY
+    ${ack_id}    Ctn Check Acknowledgement With Timeout    host_1    service_1    ${d}    2    60    HARD
+    Should Be True    ${ack_id} > 0    No acknowledgement on service (1, 1).
+
+    # Both services and resources tables report the acknowledgement.
+    ${result}    Ctn Check Service Resource Acknowledged With Timeout    host_1    service_1    ${1}    30
+    Should Be True    ${result}    Service (1;1) should be acknowledged in services and resources tables.
+
+    # A fixed downtime is scheduled and starts now.
+    ${start_dt}    Ctn Get Round Current Date
+    Ctn Schedule Service Fixed Downtime    host_1    service_1    ${3600}
+    ${result}    Ctn Check Number Of Downtimes    ${1}    ${start_dt}    ${60}
+    Should Be True    ${result}    We should have 1 downtime enabled.
+
+    # The downtime has started on the service.
+    ${result}    Ctn Check Service Downtime With Timeout    host_1    service_1    ${1}    60
+    Should Be True    ${result}    The downtime should be active on service (1;1).
+
+    # the downtime must NOT terminate the acknowledgement, which would
+    # set acknowledgements.deletion_time while services/resources stay acknowledged.
+    ${result}    Ctn Check Acknowledgement Inconsistency With Timeout    host_1    service_1    60
+    Should Not Be True    ${result}    A downtime must not terminate the acknowledgement on service (1;1).
+
+    # And the service must stay acknowledged in both services and resources tables.
+    ${result}    Ctn Check Service Resource Acknowledged With Timeout    host_1    service_1    ${1}    15
+    Should Be True    ${result}    Service (1;1) must stay acknowledged in services and resources tables.
+
 
 *** Keywords ***
 Ctn Clear Acknowledgements

--- a/tests/resources/Common.py
+++ b/tests/resources/Common.py
@@ -827,6 +827,89 @@ def ctn_check_acknowledgement_is_deleted_with_timeout(ack_id: int, timeout: int,
     return False
 
 
+def ctn_check_service_resource_acknowledged_with_timeout(hostname: str, service_desc: str, acknowledged: int, timeout: int):
+    """
+    Check that the acknowledged column of a service is set to the given value in
+    both the centreon_storage.services and centreon_storage.resources tables
+    within the given timeout.
+
+    Args:
+        hostname (str): The host name of the service.
+        service_desc (str): The description of the service.
+        acknowledged (int): The expected value (0 or 1) of the acknowledged columns.
+        timeout (int): The timeout in seconds.
+
+    Returns:
+        True if both services.acknowledged and resources.acknowledged equal the
+        expected value, False otherwise.
+    """
+    limit = time.time() + timeout
+    while time.time() < limit:
+        connection = pymysql.connect(host=DB_HOST,
+                                     user=DB_USER,
+                                     password=DB_PASS,
+                                     autocommit=True,
+                                     database=DB_NAME_STORAGE,
+                                     charset='utf8mb4',
+                                     cursorclass=pymysql.cursors.DictCursor)
+
+        with connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"SELECT s.acknowledged AS svc_ack, r.acknowledged AS res_ack FROM services s JOIN hosts h ON s.host_id=h.host_id JOIN resources r ON r.id=s.service_id AND r.parent_id=s.host_id WHERE h.name='{hostname}' AND s.description='{service_desc}'")
+                result = cursor.fetchall()
+                if len(result) > 0 and result[0]['svc_ack'] is not None and result[0]['res_ack'] is not None:
+                    logger.console(
+                        f"services.acknowledged={result[0]['svc_ack']}, resources.acknowledged={result[0]['res_ack']}")
+                    if int(result[0]['svc_ack']) == acknowledged and int(result[0]['res_ack']) == acknowledged:
+                        return True
+        time.sleep(1)
+    return False
+
+
+def ctn_check_acknowledgement_inconsistency_with_timeout(hostname: str, service_desc: str, timeout: int):
+    """
+    Detect inconsistency for a service acknowledgement: the
+    acknowledgement has been terminated (centreon_storage.acknowledgements.deletion_time
+    is set) while the service is still flagged as acknowledged in the services
+    and/or resources tables (services.acknowledged=1 or resources.acknowledged=1).
+
+    The three tables must always agree. This keyword polls and returns True as
+    soon as such an inconsistency is observed within the timeout, False otherwise.
+
+    Args:
+        hostname (str): The host name of the service.
+        service_desc (str): The description of the service.
+        timeout (int): The timeout in seconds.
+
+    Returns:
+        True if the inconsistency is observed within timeout, False otherwise.
+    """
+    limit = time.time() + timeout
+    while time.time() < limit:
+        connection = pymysql.connect(host=DB_HOST,
+                                     user=DB_USER,
+                                     password=DB_PASS,
+                                     autocommit=True,
+                                     database=DB_NAME_STORAGE,
+                                     charset='utf8mb4',
+                                     cursorclass=pymysql.cursors.DictCursor)
+
+        with connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"SELECT a.deletion_time AS ack_del, s.acknowledged AS svc_ack, r.acknowledged AS res_ack FROM acknowledgements a JOIN hosts h ON a.host_id=h.host_id JOIN services s ON s.host_id=a.host_id AND s.service_id=a.service_id JOIN resources r ON r.parent_id=a.host_id AND r.id=a.service_id WHERE h.name='{hostname}' AND s.description='{service_desc}' ORDER BY a.entry_time DESC LIMIT 1")
+                result = cursor.fetchall()
+                if len(result) > 0:
+                    row = result[0]
+                    logger.console(
+                        f"acknowledgements.deletion_time={row['ack_del']}, services.acknowledged={row['svc_ack']}, resources.acknowledged={row['res_ack']}")
+                    if row['ack_del'] is not None and (int(row['svc_ack']) == 1 or int(row['res_ack']) == 1):
+                        return True
+        time.sleep(1)
+    return False
+
+
 def ctn_check_service_status_with_timeout(hostname: str, service_desc: str, status: int, timeout: int, state_type: str = "SOFT"):
     limit = time.time() + timeout
     while time.time() < limit:


### PR DESCRIPTION
fix(engine): do not clear acknowledgement when a downtime starts
REFS: MON-201851
