### PR TITLE
fix(gorgone): remove CPAN build fallback for arm64 in Docker image

### DIFF
--- a/.github/docker/centreon-gorgone/trixie/Dockerfile
+++ b/.github/docker/centreon-gorgone/trixie/Dockerfile
@@ -120,43 +120,23 @@ APT::Install-Recommends "false";
 APT::Install-Suggests "false";
 EOF
 
-# Add Centreon plugins-stable repository (amd64 only — arm64 packages not published there)
+# Add Centreon plugins-stable repository (provides pre-built Perl modules for amd64 and arm64)
+# and install those packages plus runtime dependencies
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    bash -e <<EOF
+    bash -e <<'EOF'
 apt-get update
 apt-get install -y --no-install-recommends gnupg wget ca-certificates
-echo "deb [arch=amd64] https://packages.centreon.com/apt-plugins-stable/ trixie main" \
+echo "deb [arch=amd64,arm64] https://packages.centreon.com/apt-plugins-stable/ trixie main" \
     > /etc/apt/sources.list.d/centreon-plugins.list
 wget -O- https://apt-key.centreon.com | gpg --dearmor \
     | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
-EOF
-
-# amd64: install pre-built Centreon Perl packages.
-# arm64: build from CPAN (no arm64 packages in Centreon repo).
-# Install ONLY runtime dependencies (merged with arch-specific Perl install)
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    --mount=type=cache,target=/root/.cpanm \
-    bash -e <<'EOF'
 apt-get update
-ARCH=$(dpkg --print-architecture)
-if [ "$ARCH" = "amd64" ]; then
-    apt-get install -y --no-install-recommends \
-        libnet-curl-perl \
-        libcrypt-openssl-aes-perl \
-        libssh-session-perl \
-        libmojo-ioloop-signal-perl
-else
-    apt-get install -y --no-install-recommends \
-        cpanminus build-essential \
-        libcurl4-openssl-dev libssl-dev libssh-dev
-    cpanm --notest Net::Curl Crypt::OpenSSL::AES Libssh::Session Mojo::IOLoop::Signal
-    apt-get remove -y --purge cpanminus build-essential \
-        libcurl4-openssl-dev libssl-dev libssh-dev
-    apt-get autoremove -y
-fi
 apt-get install -y --no-install-recommends \
+    libnet-curl-perl \
+    libcrypt-openssl-aes-perl \
+    libssh-session-perl \
+    libmojo-ioloop-signal-perl \
     perl \
     libdbi-perl \
     libdbd-mysql-perl \


### PR DESCRIPTION
## Summary
- The `apt-plugins-stable` repo now publishes arm64 `.deb` packages for `libnet-curl-perl`, `libcrypt-openssl-aes-perl`, `libssh-session-perl` and `libmojo-ioloop-signal-perl` (previously only available for amd64).
- Removes the CPAN compilation fallback (`cpanminus`, `build-essential`, dev headers) used on arm64 in `.github/docker/centreon-gorgone/trixie/Dockerfile`, and installs the same pre-built packages on both architectures via apt.
- Unifies amd64/arm64 behavior, reduces build time and attack surface (no compiler toolchain in the image).

Jira: [MON-202484](https://centreon.atlassian.net/browse/MON-202484)

## Test plan
- [x] `docker-gorgone` CI workflow builds successfully for both `linux/amd64` and `linux/arm64`
- [x] Verification step in the Dockerfile (`perl -c /usr/bin/gorgoned`) passes on both architectures
- [x] Resulting image starts and gorgoned runs correctly on an arm64 host

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MON-202484]: https://centreon.atlassian.net/browse/MON-202484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ