### PR TITLE
fix(docker): stream centengine.log to stdout for docker logs visibility

### DIFF
--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/00-init.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/00-init.sh
@@ -2,8 +2,8 @@
 
 rm -f /tmp/docker.ready
 
-# log_v2_logger=stdout is set by 05-engine-config.sh, so centengine logs go to
-# Docker stdout directly — no log file used. Clear it anyway for clean restarts.
+# centengine logs to this file (log_v2_logger=file); 10-log-tail_background.sh
+# streams it to stdout. Clear it so tail -F starts clean on restart.
 > /var/log/centreon-engine/centengine.log 2>/dev/null || true
 rm -rf /var/log/centreon-engine/archives/* 2>/dev/null || true
 

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/10-log-tail_background.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/10-log-tail_background.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# centengine logs to a file (log_v2_logger=file in centengine.cfg — Engine has
+# no "stdout" logger, only "file" or "syslog"). Stream that file into the
+# container's stdout so `docker logs` shows checks/notifications/etc.,
+# not just the startup config messages emitted before the file logger takes over.
+CFG="/etc/centreon-engine/centengine.cfg"
+DEFAULT_LOG="/var/log/centreon-engine/centengine.log"
+
+LOG_FILE=$(grep -E '^log_file=' "$CFG" 2>/dev/null | cut -d= -f2-)
+LOG_FILE="${LOG_FILE:-$DEFAULT_LOG}"
+
+# If log_file already points at a stdout-like special path (e.g. /dev/stdout,
+# /proc/1/fd/1), centengine is already writing straight to the container's
+# stdout — tailing it would just be tailing our own output.
+case "$LOG_FILE" in
+    /dev/std*|/proc/*/fd/*)
+        return 0
+        ;;
+esac
+
+touch "$LOG_FILE" 2>/dev/null || true
+exec tail -F "$LOG_FILE" > /proc/1/fd/1 2>&1

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/99-logs.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/99-logs.sh
@@ -3,6 +3,6 @@
 touch /tmp/docker.ready
 echo "Centreon Engine is ready"
 
-# centengine logs directly to stdout (log_v2_logger=stdout set by 05-engine-config.sh)
-# so no tailing or piping needed — docker logs captures everything natively.
+# centengine logs to a file (log_v2_logger=file); 10-log-tail_background.sh
+# streams that file to stdout, so docker logs shows it too.
 exec "$@"


### PR DESCRIPTION
Jira: [MON-203145](https://centreon.atlassian.net/browse/MON-203145)

## Summary
- Centreon Engine has no "stdout" logger — only `log_v2_logger=file` or `syslog`. With the default file config, only the startup `[config]` messages (emitted before the file logger takes over) ever reached `docker logs`; checks/notifications/events all went silently into `/var/log/centreon-engine/centengine.log` inside the container.
- Add `10-log-tail_background.sh`, a container.d startup script that tails the real `centengine.log` into the container's stdout, so `docker logs` shows the full application log stream.
- Skip tailing (via `return 0`, since the script is sourced) when `log_file` already points at a stdout-like special path (`/dev/stdout`, `/proc/1/fd/1`) — centengine would already be writing straight to the container's stdout in that case.
- Fix misleading comments in `00-init.sh` and `99-logs.sh` that incorrectly assumed `log_v2_logger=stdout` was already being set by `05-engine-config.sh` (it never was — that script only patches `rpc_listen_address`).

## Test plan
- [x] Reproduced the original symptom on a local `my-poller-centengine` container with nominal config (`log_v2_logger=file`, real `log_file` path): `docker logs` only showed `[config]` messages, while `/var/log/centreon-engine/centengine.log` contained full `events`/`core`/`process` logs.
- [x] Copied the new script into the running container, restarted it, and confirmed `docker logs` now streams checks/notifications/events, with the container remaining `running`/`healthy` (rest of the entrypoint — plugin install, healthcheck — unaffected).
- [x] CI build of the `centreon-engine` trixie image (not run locally — no local build context for the `.deb` packages).

[MON-203145]: https://centreon.atlassian.net/browse/MON-203145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ