### PR TITLE
feat(ci): rework CMA asset delivery as a standalone bash script

### DIFF
--- a/.github/actions/deliver-github-asset/action.yml
+++ b/.github/actions/deliver-github-asset/action.yml
@@ -1,144 +1,48 @@
 name: "deliver-github-asset"
-description: "Deliver asset to github release"
+description: "Deliver CMA asset to GitHub release and register on download.centreon.com"
 inputs:
   file_pattern:
-    description: "The path to the file to upload"
-    required: true
+    description: "Glob pattern matching local asset files (required in local mode)"
+    required: false
   github_release:
-    description: "The github release name"
+    description: "Target GitHub release tag (e.g. centreon-monitoring-agent-27.08.3)"
     required: true
   token_download_centreon_com:
-    description: "The token to call download.centreon.com api"
+    description: "Token for download.centreon.com registration"
     required: false
+  mode:
+    description: "Delivery mode: local (default) or action (fetches from Artifactory)"
+    required: false
+    default: "local"
+  version:
+    description: "CMA version to fetch from Artifactory — e.g. 27.08.3 (required in action mode)"
+    required: false
+  distrib:
+    description: "Comma-separated distros to fetch in action mode (default: all)"
+    required: false
+  artifactory_token:
+    description: "JFrog Artifactory token (required in action mode)"
+    required: false
+  dry_run:
+    description: "Dry run — log actions without executing"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
   steps:
-    - name: Deliver asset to github release
-      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+    - name: Deliver CMA assets
+      shell: bash
       env:
-        FILE_PATTERN: ${{ inputs.file_pattern }}
-        GITHUB_RELEASE: ${{ inputs.github_release }}
+        GITHUB_TOKEN: ${{ github.token }}
         TOKEN_DOWNLOAD_CENTREON_COM: ${{ inputs.token_download_centreon_com }}
-      with:
-        script: |
-          const path = require('path');
-          const fs = require('fs');
-
-          const githubRelease = process.env.GITHUB_RELEASE;
-          const filePattern = process.env.FILE_PATTERN;
-
-          const delay = ms => new Promise(res => setTimeout(res, ms));
-
-          let releaseId = null;
-
-          for (let i = 0; i < 10; i++) {
-            const { data: releases } = await github.rest.repos.listReleases({
-              ...context.repo,
-              per_page: 100,
-              page: 1,
-            });
-
-            for (const release of releases) {
-              if (release.tag_name === githubRelease) {
-                releaseId = release.id;
-                break;
-              }
-            }
-
-            if (releaseId !== null) {
-              break;
-            }
-
-            console.log(`Release ${githubRelease} not found, retrying...`);
-
-            await delay(30000);
-          }
-
-          if (releaseId === null) {
-            core.warning(`Release ${githubRelease} does not exist`);
-            return;
-          }
-
-          const globber = await glob.create(filePattern);
-          for await (const file of globber.globGenerator()) {
-            const fileName = path.basename(file);
-
-            core.info(`Uploading asset ${fileName} to release ${githubRelease}`);
-
-            github.rest.repos.uploadReleaseAsset({
-              ...context.repo,
-              release_id: releaseId,
-              name: fileName,
-              data: fs.readFileSync(file),
-            });
-
-            core.info(`Asset ${fileName} uploaded to release ${githubRelease}`);
-
-            if (process.env.TOKEN_DOWNLOAD_CENTREON_COM) {
-              const matches = fileName.match(/^([\w-]+)(?:-|_)(\d+\.\d+)\.(\d+).*\.(\w+)$/);
-              if (matches) {
-                const product = matches[1];
-                const majorVersion = matches[2];
-                const minorVersion = matches[3];
-                const extension = matches[4];
-
-                console.log("Product:", product);
-                console.log("Major Version:", majorVersion);
-                console.log("Minor Version:", minorVersion);
-                console.log("Extension:", extension);
-
-                const fileHash = require('crypto').createHash('md5').update(fs.readFileSync(file)).digest('hex');
-                const fileSize = fs.statSync(file).size;
-
-                let distribSuffix = '';
-                const distribMatches = fileName.match(/(el|deb|ubuntu|exe)\.?(\d+(?:\.\d+)?)?/);
-                if (distribMatches) {
-                  switch (distribMatches[1]) {
-                    case 'el':
-                      distribSuffix = `-${distribMatches[1]}${distribMatches[2]}`;
-                      break;
-                    case 'deb':
-                      distribSuffix = `-debian-${distribMatches[2]}`;
-                      break;
-                    case 'ubuntu':
-                      distribSuffix = `-${distribMatches[1]}-${distribMatches[2]}`;
-                      break;
-                    case 'exe':
-                      distribSuffix = '-windows';
-                      break;
-                  }
-                }
-
-                let archSuffix = '';
-                if (fileName.includes('amd64') || fileName.includes('x86_64')) {
-                  archSuffix = '-amd64';
-                } else if (fileName.includes('arm64') || fileName.includes('aarch64')) {
-                  archSuffix = '-arm64';
-                }
-
-                const downloadUrl = new URL('https://download.centreon.com/api/');
-                const downloadParams = {
-                  token: process.env.TOKEN_DOWNLOAD_CENTREON_COM,
-                  product: product,
-                  release: majorVersion,
-                  version: `${majorVersion}.${minorVersion}${distribSuffix}${archSuffix}`,
-                  extension: extension,
-                  md5: fileHash,
-                  size: fileSize,
-                  ddos: 0,
-                  dryrun: 0,
-                  release_url: `https://github.com/centreon/centreon-collect/releases/download/${githubRelease}/${fileName}`,
-                };
-                downloadUrl.search = new URLSearchParams(downloadParams).toString();
-
-                core.info(`Publishing asset ${fileName} to download.centreon.com`);
-
-                console.log(await fetch(downloadUrl));
-
-                core.info(`Asset ${fileName} published on download.centreon.com`);
-              } else {
-                core.warning(`Asset ${fileName} cannot be parsed to extract product and version information, skipping download.centreon.com upload`);
-              }
-            }
-          }
+        ARTIFACTORY_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
+        DELIVER_MODE: ${{ inputs.mode }}
+        DELIVER_FILE_PATTERN: ${{ inputs.file_pattern }}
+        DELIVER_GITHUB_RELEASE: ${{ inputs.github_release }}
+        DELIVER_VERSION: ${{ inputs.version }}
+        DELIVER_DISTRIB: ${{ inputs.distrib }}
+        DELIVER_REPO: ${{ github.repository }}
+        DELIVER_DRY_RUN: ${{ inputs.dry_run }}
+      run: |
+        bash "${GITHUB_ACTION_PATH}/../../scripts/deliver-cma-assets.sh"

--- a/.github/scripts/deliver-cma-assets.sh
+++ b/.github/scripts/deliver-cma-assets.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# Delivers CMA assets to a GitHub release and registers them on download.centreon.com.
+#
+# Modes
+#   local  (default): deliver local files matching --file-pattern
+#   action:           fetch from Artifactory stable paths (fallback: re-process existing release assets)
+#
+# Usage (local):
+#   ./deliver-cma-assets.sh \
+#     --github-release centreon-monitoring-agent-27.08.3 \
+#     --file-pattern "/tmp/packages/centreon-monitoring-agent-27.08*.rpm"
+#
+# Usage (action — re-run a failed delivery):
+#   ./deliver-cma-assets.sh \
+#     --mode action \
+#     --github-release centreon-monitoring-agent-27.08.3 \
+#     --version 27.08.3 \
+#     [--distrib el8,el9,el10,windows]
+#
+# Tokens (--flag or env var):
+#   GITHUB_TOKEN                  GitHub token with write:contents scope
+#   ARTIFACTORY_ACCESS_TOKEN      JFrog token (action mode only)
+#   TOKEN_DOWNLOAD_CENTREON_COM   download.centreon.com registration token
+#
+# Flags:
+#   --dry-run        Log what would happen without executing uploads/registrations
+#   --force-reupload Re-upload to GitHub release even if the asset is already there
+
+set -euo pipefail
+
+# ─── Colours ──────────────────────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+  BOLD='\033[1m' RESET='\033[0m' GREEN='\033[32m' YELLOW='\033[33m'
+  BLUE='\033[34m' CYAN='\033[36m' RED='\033[31m' DIM='\033[2m'
+else
+  BOLD='' RESET='' GREEN='' YELLOW='' BLUE='' CYAN='' RED='' DIM=''
+fi
+
+log_header() { echo -e "\n${BOLD}${BLUE}◆ $*${RESET}"; }
+log_info()   { echo -e "  ${DIM}ℹ${RESET}  $*"; }
+log_ok()     { echo -e "  ${GREEN}✓${RESET}  $*"; }
+log_skip()   { echo -e "  ${DIM}→${RESET}  $*"; }
+log_upload() { echo -e "  ${CYAN}↑${RESET}  $*"; }
+log_warn()   { echo -e "  ${YELLOW}⚠${RESET}  $*"; }
+log_error()  { echo -e "  ${RED}✗${RESET}  $*" >&2; }
+log_file()   { echo -e "\n  ${BOLD}$*${RESET}"; }
+
+# ─── Config ───────────────────────────────────────────────────────────────────
+MODE="${DELIVER_MODE:-local}"
+FILE_PATTERN="${DELIVER_FILE_PATTERN:-}"
+GITHUB_RELEASE="${DELIVER_GITHUB_RELEASE:-}"
+VERSION="${DELIVER_VERSION:-}"
+DISTRIBS="${DELIVER_DISTRIB:-}"
+DRY_RUN="${DELIVER_DRY_RUN:-false}"
+FORCE_REUPLOAD="false"
+REPO="${DELIVER_REPO:-${GITHUB_REPOSITORY:-centreon/centreon-collect}}"
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+ARTIFACTORY_TOKEN="${ARTIFACTORY_ACCESS_TOKEN:-}"
+DOWNLOAD_TOKEN="${TOKEN_DOWNLOAD_CENTREON_COM:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)              MODE="$2";               shift 2 ;;
+    --file-pattern)      FILE_PATTERN="$2";       shift 2 ;;
+    --github-release)    GITHUB_RELEASE="$2";     shift 2 ;;
+    --version)           VERSION="$2";            shift 2 ;;
+    --distrib)           DISTRIBS="$2";           shift 2 ;;
+    --repo)              REPO="$2";               shift 2 ;;
+    --github-token)      GITHUB_TOKEN="$2";       shift 2 ;;
+    --artifactory-token) ARTIFACTORY_TOKEN="$2";  shift 2 ;;
+    --download-token)    DOWNLOAD_TOKEN="$2";     shift 2 ;;
+    --dry-run)           DRY_RUN="true";          shift   ;;
+    --force-reupload)    FORCE_REUPLOAD="true";   shift   ;;
+    *) log_error "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+REPO_OWNER="${REPO%%/*}"
+REPO_NAME="${REPO##*/}"
+
+# ─── Validation ───────────────────────────────────────────────────────────────
+[[ -z "$GITHUB_RELEASE" ]] && { log_error "--github-release is required"; exit 1; }
+[[ -z "$GITHUB_TOKEN"   ]] && { log_error "GITHUB_TOKEN or --github-token is required"; exit 1; }
+
+# ─── GitHub API ───────────────────────────────────────────────────────────────
+gh_api() {
+  local method="$1" endpoint="$2"
+  curl --fail --silent --show-error --max-time 30 \
+    -X "$method" \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "${@:3}" \
+    "https://api.github.com${endpoint}"
+}
+
+get_release() {
+  gh_api GET "/repos/${REPO_OWNER}/${REPO_NAME}/releases/tags/${GITHUB_RELEASE}"
+}
+
+list_asset_names() {
+  local release_id="$1" page=1
+  while true; do
+    local batch
+    batch=$(gh_api GET "/repos/${REPO_OWNER}/${REPO_NAME}/releases/${release_id}/assets?per_page=100&page=${page}" | jq -r '.[].name')
+    echo "$batch"
+    [[ $(echo "$batch" | wc -l) -lt 100 ]] && break
+    (( page++ ))
+  done
+}
+
+upload_asset() {
+  local release_id="$1" file="$2" filename
+  filename=$(basename "$file")
+  curl --fail --silent \
+    -X POST \
+    -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+    -H "Content-Type: application/octet-stream" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    --data-binary "@${file}" \
+    "https://uploads.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/${release_id}/assets?name=${filename}" \
+    | jq -r '.browser_download_url'
+}
+
+# ─── Artifactory ──────────────────────────────────────────────────────────────
+search_artifactory() {
+  local version="$1"
+  local aql
+  aql=$(printf \
+    'items.find({"$or":[{"repo":"rpm-standard"},{"repo":"apt-standard"},{"repo":"ubuntu-standard"},{"repo":"installers"}],"name":{"$match":"centreon-monitoring-agent*%s*"},"path":{"$match":"*/stable*"}}).include("name","repo","path")' \
+    "$version")
+  curl --fail --silent \
+    -X POST \
+    -H "Authorization: Bearer ${ARTIFACTORY_TOKEN}" \
+    -H "Content-Type: text/plain" \
+    --data "$aql" \
+    "https://packages.centreon.com/artifactory/api/search/aql"
+}
+
+download_from_artifactory() {
+  local repo="$1" art_path="$2" name="$3" dest_dir="$4"
+  curl --fail --silent \
+    -H "Authorization: Bearer ${ARTIFACTORY_TOKEN}" \
+    "https://packages.centreon.com/artifactory/${repo}/${art_path}/${name}" \
+    -o "${dest_dir}/${name}"
+  echo "${dest_dir}/${name}"
+}
+
+# ─── download.centreon.com ────────────────────────────────────────────────────
+file_size() { stat -c '%s' "$1" 2>/dev/null || wc -c < "$1"; }
+
+register_download() {
+  local file="$1" download_url="$2"
+  local filename; filename=$(basename "$file")
+
+  # Parse: product-MAJOR.MINOR.PATCH[...].ext
+  local product major_ver minor_ver extension
+  if [[ "$filename" =~ ^([a-zA-Z0-9-]+)[-_]([0-9]+\.[0-9]+)\.([0-9]+).*\.([a-z]+)$ ]]; then
+    product="${BASH_REMATCH[1]}"
+    major_ver="${BASH_REMATCH[2]}"
+    minor_ver="${BASH_REMATCH[3]}"
+    extension="${BASH_REMATCH[4]}"
+  else
+    log_warn "Cannot parse metadata from ${filename} — skipping download.centreon.com"
+    return 0
+  fi
+
+  # Distrib suffix
+  local distrib_suffix=""
+  if [[ "$filename" =~ \.el([0-9]+)\. ]]; then
+    distrib_suffix="-el${BASH_REMATCH[1]}"
+  elif [[ "$filename" =~ ~deb([0-9]+) ]]; then
+    distrib_suffix="-debian-${BASH_REMATCH[1]}"
+  elif [[ "$filename" =~ ubuntu[._]([0-9]+\.[0-9]+) ]]; then
+    distrib_suffix="-ubuntu-${BASH_REMATCH[1]}"
+  elif [[ "$filename" =~ \.exe$ ]]; then
+    distrib_suffix="-windows"
+  fi
+
+  # Arch suffix
+  local arch_suffix=""
+  if [[ "$filename" =~ (amd64|x86_64) ]]; then
+    arch_suffix="-amd64"
+  elif [[ "$filename" =~ (arm64|aarch64) ]]; then
+    arch_suffix="-arm64"
+  fi
+
+  local file_hash file_sz version_str
+  file_hash=$(md5sum "$file" | cut -d' ' -f1)
+  file_sz=$(file_size "$file")
+  version_str="${major_ver}.${minor_ver}${distrib_suffix}${arch_suffix}"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    log_skip "[dry-run] Would register: ${product} ${version_str}"
+    return 0
+  fi
+
+  local response
+  response=$(curl --get --fail --silent \
+    "https://download.centreon.com/api/" \
+    --data-urlencode "token=${DOWNLOAD_TOKEN}" \
+    --data-urlencode "product=${product}" \
+    --data-urlencode "release=${major_ver}" \
+    --data-urlencode "version=${version_str}" \
+    --data-urlencode "extension=${extension}" \
+    --data-urlencode "md5=${file_hash}" \
+    --data-urlencode "size=${file_sz}" \
+    --data-urlencode "ddos=0" \
+    --data-urlencode "dryrun=0" \
+    --data-urlencode "release_url=${download_url}")
+  log_ok "Registered on download.centreon.com${response:+: ${response}}"
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+echo -e "\n${BOLD}${BLUE}CMA Asset Delivery${RESET}"
+echo -e "  Mode    : ${CYAN}${MODE}${RESET}"
+echo -e "  Release : ${CYAN}${GITHUB_RELEASE}${RESET}"
+echo -e "  Repo    : ${DIM}${REPO}${RESET}"
+[[ "$DRY_RUN" == "true" ]] && echo -e "  ${YELLOW}DRY RUN — no uploads or registrations will be performed${RESET}"
+
+# 1. Find the GitHub release
+log_header "GitHub release"
+log_info "Looking up tag: ${GITHUB_RELEASE}"
+if ! release_json=$(get_release 2>&1); then
+  log_error "Release not found or API error: ${release_json}"
+  exit 1
+fi
+release_id=$(echo "$release_json" | jq -r '.id')
+release_name=$(echo "$release_json" | jq -r '.name')
+log_ok "\"${release_name}\" (id ${release_id})"
+
+# 2. List existing assets (idempotency)
+existing_names=$(list_asset_names "$release_id")
+existing_count=$(echo "$existing_names" | grep -c . || true)
+log_info "${existing_count} asset(s) already on release"
+
+# 3. Collect files
+log_header "Collecting files"
+declare -a FILES=()
+
+if [[ "$MODE" == "local" ]]; then
+  [[ -z "$FILE_PATTERN" ]] && { log_error "--file-pattern is required in local mode"; exit 1; }
+  while IFS= read -r -d '' f; do
+    FILES+=("$f")
+  done < <(find "$(dirname "$FILE_PATTERN")" -maxdepth 1 \
+    -name "$(basename "$FILE_PATTERN")" -print0 2>/dev/null || true)
+  [[ ${#FILES[@]} -eq 0 ]] && { log_warn "No files matched: ${FILE_PATTERN}"; exit 0; }
+  log_info "${#FILES[@]} file(s) matched ${FILE_PATTERN}"
+
+elif [[ "$MODE" == "action" ]]; then
+  [[ -z "$VERSION" ]]           && { log_error "--version is required in action mode"; exit 1; }
+  [[ -z "$ARTIFACTORY_TOKEN" ]] && { log_error "ARTIFACTORY_ACCESS_TOKEN or --artifactory-token is required in action mode"; exit 1; }
+
+  TMP_DIR=$(mktemp -d)
+  trap 'rm -rf "$TMP_DIR"' EXIT
+
+  log_info "Searching Artifactory for CMA ${VERSION} in stable paths…"
+  results_json=""
+  results_json=$(search_artifactory "$VERSION") || log_warn "Artifactory search failed"
+
+  result_count=$(echo "$results_json" | jq '.results | length' 2>/dev/null || echo 0)
+  log_info "${result_count} item(s) found on Artifactory"
+
+  if [[ "$result_count" -eq 0 ]]; then
+    log_info "No Artifactory results — re-downloading ${existing_count} existing release asset(s)"
+    while IFS=$'\t' read -r asset_name download_url; do
+      [[ -z "$asset_name" ]] && continue
+      log_info "Downloading: ${asset_name}"
+      curl --fail --silent \
+        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        "$download_url" -o "${TMP_DIR}/${asset_name}"
+      FILES+=("${TMP_DIR}/${asset_name}")
+    done < <(echo "$release_json" | jq -r '.assets[] | [.name, .browser_download_url] | @tsv' 2>/dev/null || true)
+  else
+    while IFS=$'\t' read -r name repo art_path; do
+      [[ -z "$name" ]] && continue
+      # Filter by --distrib if provided
+      if [[ -n "$DISTRIBS" ]]; then
+        match=false
+        IFS=',' read -ra distrib_list <<< "$DISTRIBS"
+        for d in "${distrib_list[@]}"; do
+          if [[ "$d" == "windows" && "$name" == *.exe ]] || [[ "$name" == *"${d}"* ]]; then
+            match=true; break
+          fi
+        done
+        [[ "$match" == "false" ]] && { log_skip "Filtered: ${name}"; continue; }
+      fi
+      local_path=$(download_from_artifactory "$repo" "$art_path" "$name" "$TMP_DIR") \
+        && FILES+=("$local_path") \
+        || log_error "Failed to download ${name}"
+    done < <(echo "$results_json" | jq -r '.results[] | [.name, .repo, .path] | @tsv')
+  fi
+  log_info "${#FILES[@]} file(s) ready to process"
+
+else
+  log_error "Unknown mode: ${MODE} (expected local or action)"; exit 1
+fi
+
+# 4. Process each file
+log_header "Processing assets"
+uploaded=0; skipped=0; failed=0
+
+for file in "${FILES[@]}"; do
+  filename=$(basename "$file")
+  log_file "$filename"
+
+  on_release=$(echo "$existing_names" | grep -Fx "$filename" || true)
+  download_url=""
+
+  # GitHub release upload
+  if [[ -n "$on_release" && "$FORCE_REUPLOAD" != "true" ]]; then
+    download_url="https://github.com/${REPO}/releases/download/${GITHUB_RELEASE}/${filename}"
+    log_skip "Already on release — skipping upload"
+    (( skipped++ )) || true
+  elif [[ "$DRY_RUN" == "true" ]]; then
+    download_url="https://github.com/${REPO}/releases/download/${GITHUB_RELEASE}/${filename}"
+    log_skip "[dry-run] Would upload to GitHub release"
+    (( uploaded++ )) || true
+  else
+    log_upload "Uploading to GitHub release…"
+    if download_url=$(upload_asset "$release_id" "$file"); then
+      log_ok "Uploaded → ${download_url}"
+      (( uploaded++ )) || true
+    else
+      log_error "Upload failed for ${filename}"
+      (( failed++ )) || true
+      continue
+    fi
+  fi
+
+  # download.centreon.com registration
+  if [[ -n "$DOWNLOAD_TOKEN" ]]; then
+    if register_download "$file" "$download_url"; then
+      : # logged inside the function
+    else
+      log_error "download.centreon.com registration failed for ${filename}"
+      (( failed++ )) || true
+    fi
+  fi
+done
+
+# 5. Summary
+echo -e "\n${BOLD}Summary${RESET}"
+echo -e "  Uploaded : ${GREEN}${uploaded}${RESET}"
+echo -e "  Skipped  : ${DIM}${skipped}${RESET}"
+if [[ "$failed" -gt 0 ]]; then
+  echo -e "  Failed   : ${RED}${failed}${RESET}"
+  exit 1
+else
+  echo -e "  Failed   : ${failed}"
+fi


### PR DESCRIPTION
## Description
Backport of #3479 to `dev-25.10.x`.

Extracts the inline `actions/github-script` logic from `deliver-github-asset/action.yml` into a self-contained bash script (`.github/scripts/deliver-cma-assets.sh`) that maintainers can run manually to re-publish CMA assets when CI delivery fails. Supports `local` mode (glob-matched local files, same behaviour as before) and `action` mode (fetch directly from Artifactory via AQL REST API, with fallback to re-downloading existing GitHub release assets). Also fixes two silent-failure bugs (unawaited upload, unchecked HTTP errors on download.centreon.com), paginates asset listing, and adds a `--dry-run` flag with structured log output.

Ref: MON-201881

**Fixes** MON-201881

## Type of change
- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?
Same testing procedure as #3479.

## Checklist
#### Community contributors & Centreon team
- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).