### PR TITLE
fix(ci): promote docker floating tag only after e2e runtime tests pass

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -666,10 +666,8 @@ jobs:
     needs: [get-environment, dockerize-engine-broker, docker-boot-test, docker-config-wiring-test]
     if: |
       ! cancelled() &&
-      needs.get-environment.result == 'success' &&
-      needs.dockerize-engine-broker.result == 'success' &&
-      needs.docker-boot-test.result == 'success' &&
-      needs.docker-config-wiring-test.result == 'success' &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
       needs.dockerize-engine-broker.outputs.additional_tag != ''
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -467,6 +467,7 @@ jobs:
     # matrix.image or matrix.distrib, so every leg produces the same tag.
     outputs:
       image_tag: ${{ steps.compute-tag.outputs.tag }}
+      additional_tag: ${{ steps.compute-tag.outputs.additional_tag }}
 
     steps:
       - name: Checkout sources
@@ -560,7 +561,6 @@ jobs:
           push: true
           tags: |
             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}-${{ matrix.distrib }}:${{ steps.compute-tag.outputs.tag }}
-            ${{ steps.compute-tag.outputs.additional_tag != '' && format('{0}/{1}-{2}:{3}', vars.DOCKER_INTERNAL_REGISTRY_URL, matrix.image, matrix.distrib, steps.compute-tag.outputs.additional_tag) || '' }}
           secrets: |
             "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
@@ -661,6 +661,39 @@ jobs:
           name: centreon-engine-config-wiring-test-${{ matrix.distrib }}
           path: /tmp/centreon-engine-config-wiring-test.log
           retention-days: 1
+
+  promote-docker-tag:
+    needs: [get-environment, dockerize-engine-broker, docker-boot-test, docker-config-wiring-test]
+    if: |
+      ! cancelled() &&
+      needs.get-environment.result == 'success' &&
+      needs.dockerize-engine-broker.result == 'success' &&
+      needs.docker-boot-test.result == 'success' &&
+      needs.docker-config-wiring-test.result == 'success' &&
+      needs.dockerize-engine-broker.outputs.additional_tag != ''
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [centreon-engine, centreon-broker]
+        distrib: [trixie]
+    name: promote ${{ matrix.image }}-${{ matrix.distrib }} floating tag
+    steps:
+      - name: Login to registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Promote floating tag (manifest retag, no rebuild)
+        run: |
+          docker buildx imagetools create \
+            --tag "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}-${{ matrix.distrib }}:${{ needs.dockerize-engine-broker.outputs.additional_tag }}" \
+            "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}-${{ matrix.distrib }}:${{ needs.dockerize-engine-broker.outputs.image_tag }}"
+        shell: bash
 
   robot-test:
     needs: [get-environment, get-aws-environment, changes, package]

--- a/.github/workflows/docker-gorgone.yml
+++ b/.github/workflows/docker-gorgone.yml
@@ -6,6 +6,11 @@ concurrency:
 
 on:
   workflow_dispatch:
+    inputs:
+      simulate_promote_tag:
+        description: 'Test-only: force additional_tag to this value to exercise promote-docker-tag on a throwaway tag. Never use "develop" here.'
+        required: false
+        default: ''
   push:
     branches:
       - develop
@@ -147,10 +152,18 @@ jobs:
         env:
           RAW_REF: ${{ github.head_ref || github.ref_name }}
           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
+          SIMULATE_PROMOTE_TAG: ${{ inputs.simulate_promote_tag }}
         run: |
+          if [[ "$SIMULATE_PROMOTE_TAG" == "develop" ]]; then
+            echo "::error::simulate_promote_tag must not be 'develop' — use a throwaway value to avoid clobbering the real floating tag."
+            exit 1
+          fi
           if [[ "$RAW_REF" == "develop" ]]; then
             echo "tag=develop-${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
             echo "additional_tag=develop" >> "$GITHUB_OUTPUT"
+          elif [[ -n "$SIMULATE_PROMOTE_TAG" ]]; then
+            echo "tag=${MAJOR_VERSION}-promote-test" >> "$GITHUB_OUTPUT"
+            echo "additional_tag=${SIMULATE_PROMOTE_TAG}" >> "$GITHUB_OUTPUT"
           elif [[ "$RAW_REF" =~ ^dev-[0-9]+\.[0-9]+\.x$ ]]; then
             echo "tag=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
             echo "additional_tag=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-gorgone.yml
+++ b/.github/workflows/docker-gorgone.yml
@@ -109,10 +109,10 @@ jobs:
       additional_tag: ${{ steps.compute-tag.outputs.additional_tag }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
@@ -125,7 +125,7 @@ jobs:
           distrib: ${{ matrix.operating_system }}
 
       - name: get cached gorgone and perl-libs package
-        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ./*.${{ steps.parse-distrib.outputs.package_extension }}
           key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.parse-distrib.outputs.package_extension }}-${{ steps.parse-distrib.outputs.package_extension == 'rpm' && steps.parse-distrib.outputs.distrib_family || steps.parse-distrib.outputs.distrib_name }}
@@ -137,10 +137,10 @@ jobs:
         shell: bash
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Compute Docker tag
         id: compute-tag
@@ -166,7 +166,7 @@ jobs:
         shell: bash
 
       - name: Docker build and push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         env:
           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
           DOCKER_BUILD_SUMMARY: false
@@ -204,10 +204,10 @@ jobs:
       GORGONE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
           username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
@@ -215,7 +215,7 @@ jobs:
 
       - name: Set up QEMU
         if: ${{ matrix.platform == 'linux/arm64' }}
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Replace / with - in the platform name
         id: platform-name
@@ -257,10 +257,10 @@ jobs:
       GORGONE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
           username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
@@ -298,14 +298,14 @@ jobs:
     name: promote centreon-gorgone-${{ matrix.operating_system }} floating tag
     steps:
       - name: Login to registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Promote floating tag (manifest retag, no rebuild)
         run: |

--- a/.github/workflows/docker-gorgone.yml
+++ b/.github/workflows/docker-gorgone.yml
@@ -106,6 +106,7 @@ jobs:
     # operating_system has a single value (trixie). Revisit if this matrix grows.
     outputs:
       image_tag: ${{ steps.compute-tag.outputs.tag }}
+      additional_tag: ${{ steps.compute-tag.outputs.additional_tag }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -182,13 +183,16 @@ jobs:
           push: true
           tags: |
             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ steps.compute-tag.outputs.tag }}
-            ${{ steps.compute-tag.outputs.additional_tag != '' && format('{0}/centreon-gorgone-{1}:{2}', vars.DOCKER_INTERNAL_REGISTRY_URL, matrix.operating_system, steps.compute-tag.outputs.additional_tag) || '' }}
           secrets: |
             "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
 
   docker-boot-test:
     needs: [get-environment, dockerize]
+    if: |
+      ! cancelled() &&
+      needs.get-environment.result == 'success' &&
+      needs.dockerize.result == 'success'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -239,6 +243,10 @@ jobs:
 
   docker-config-wiring-test:
     needs: [get-environment, dockerize]
+    if: |
+      ! cancelled() &&
+      needs.get-environment.result == 'success' &&
+      needs.dockerize.result == 'success'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -271,4 +279,37 @@ jobs:
       - name: Dump compose logs on failure
         if: failure()
         run: docker compose -f .github/docker/centreon-gorgone/docker-compose.config-wiring-test.yml -p gorgone-config-wiring-test logs
+        shell: bash
+
+  promote-docker-tag:
+    needs: [get-environment, dockerize, docker-boot-test, docker-config-wiring-test]
+    if: |
+      ! cancelled() &&
+      needs.get-environment.result == 'success' &&
+      needs.dockerize.result == 'success' &&
+      needs.docker-boot-test.result == 'success' &&
+      needs.docker-config-wiring-test.result == 'success' &&
+      needs.dockerize.outputs.additional_tag != ''
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        operating_system: [trixie]
+    name: promote centreon-gorgone-${{ matrix.operating_system }} floating tag
+    steps:
+      - name: Login to registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Promote floating tag (manifest retag, no rebuild)
+        run: |
+          docker buildx imagetools create \
+            --tag "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.additional_tag }}" \
+            "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}"
         shell: bash

--- a/.github/workflows/docker-gorgone.yml
+++ b/.github/workflows/docker-gorgone.yml
@@ -6,11 +6,6 @@ concurrency:
 
 on:
   workflow_dispatch:
-    inputs:
-      simulate_promote_tag:
-        description: 'Test-only: force additional_tag to this value to exercise promote-docker-tag on a throwaway tag. Never use "develop" here.'
-        required: false
-        default: ''
   push:
     branches:
       - develop
@@ -152,18 +147,10 @@ jobs:
         env:
           RAW_REF: ${{ github.head_ref || github.ref_name }}
           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
-          SIMULATE_PROMOTE_TAG: ${{ inputs.simulate_promote_tag }}
         run: |
-          if [[ "$SIMULATE_PROMOTE_TAG" == "develop" ]]; then
-            echo "::error::simulate_promote_tag must not be 'develop' — use a throwaway value to avoid clobbering the real floating tag."
-            exit 1
-          fi
           if [[ "$RAW_REF" == "develop" ]]; then
             echo "tag=develop-${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
             echo "additional_tag=develop" >> "$GITHUB_OUTPUT"
-          elif [[ -n "$SIMULATE_PROMOTE_TAG" ]]; then
-            echo "tag=${MAJOR_VERSION}-promote-test" >> "$GITHUB_OUTPUT"
-            echo "additional_tag=${SIMULATE_PROMOTE_TAG}" >> "$GITHUB_OUTPUT"
           elif [[ "$RAW_REF" =~ ^dev-[0-9]+\.[0-9]+\.x$ ]]; then
             echo "tag=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
             echo "additional_tag=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-gorgone.yml
+++ b/.github/workflows/docker-gorgone.yml
@@ -191,8 +191,8 @@ jobs:
     needs: [get-environment, dockerize]
     if: |
       ! cancelled() &&
-      needs.get-environment.result == 'success' &&
-      needs.dockerize.result == 'success'
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -245,8 +245,8 @@ jobs:
     needs: [get-environment, dockerize]
     if: |
       ! cancelled() &&
-      needs.get-environment.result == 'success' &&
-      needs.dockerize.result == 'success'
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -285,10 +285,8 @@ jobs:
     needs: [get-environment, dockerize, docker-boot-test, docker-config-wiring-test]
     if: |
       ! cancelled() &&
-      needs.get-environment.result == 'success' &&
-      needs.dockerize.result == 'success' &&
-      needs.docker-boot-test.result == 'success' &&
-      needs.docker-config-wiring-test.result == 'success' &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
       needs.dockerize.outputs.additional_tag != ''
     runs-on: ubuntu-24.04
     strategy:


### PR DESCRIPTION
## Summary

Fixes MON-203216: `dockerize-engine-broker` (`collect.yml`) and `dockerize` (`docker-gorgone.yml`) pushed the floating `develop` tag in the **same** `docker/build-push-action` step as the versioned candidate tag, before `docker-boot-test`/`docker-config-wiring-test` ran. A failed test left `centreon-engine-trixie:develop` (or `centreon-broker-trixie:develop`, `centreon-gorgone-trixie:develop`) pointing at a broken image until the next green nightly.

- Build/push step now pushes **only** the versioned candidate tag (`develop-<major>`).
- New `promote-docker-tag` job runs `docker buildx imagetools create` (manifest retag, no rebuild) to point the floating tag at that same digest — gated on `docker-boot-test` **and** `docker-config-wiring-test` both succeeding, and skipped entirely when there's no floating tag to promote (PRs, `dev-*.x`).
- `centreon-broker` has no e2e tests of its own; its floating-tag promotion is gated on the `centreon-engine` tests (same build, same job) — imperfect but strictly better than the current no-guard-at-all state. Adding broker-specific e2e coverage is left for a follow-up ticket.
- `docker-gorgone.yml`'s `docker-boot-test`/`docker-config-wiring-test` were also missing the explicit `needs.*.result == 'success'` guard that `collect.yml` already carries (worked around a GitHub Actions implicit-`success()` skip bug, see commit `dc7d714ba`). Added it here too since the new promote job now depends on these tests actually running.

**Verification note:** confirmed no in-repo consumer (in `centreon-collect` or `centreon`) references the floating `:develop` tag for these three images — the boot/wiring test jobs already pull the immutable per-run `image_tag`. The floating tag's consumers are external (per the ticket's stated risk), which this fix protects.

## Test plan

- [x] `actionlint` clean on both modified files (no `-ignore` overrides needed beyond the repo's existing set)
- [x] `yamllint` clean with the repo's exact CI rule set
- [x] On this PR: confirm `promote-docker-tag` appears in the Actions graph and is **skipped** (branch name != `develop`, so `additional_tag` is empty) — expected no-op
- [ ] After merge, on the next `develop` push/nightly: confirm `promote-docker-tag` runs after both test jobs go green, and that `centreon-engine-trixie:develop` / `centreon-broker-trixie:develop` / `centreon-gorgone-trixie:develop` end up pointing at the same digest as `...:develop-<major>`