### PR TITLE
fix(ci): force base-10 arithmetic when computing NEXT_MAJOR_VERSION

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -94,7 +94,7 @@ runs:
           BUMP_MAJOR_RIGHT="01"
         else
           BUMP_MAJOR_LEFT=$MAJOR_LEFT
-          BUMP_MAJOR_RIGHT=$(( $MAJOR_RIGHT + 1 ))
+          BUMP_MAJOR_RIGHT=$(( 10#$MAJOR_RIGHT + 1 ))
         fi
 
         export NEXT_MAJOR_VERSION="$BUMP_MAJOR_LEFT.$BUMP_MAJOR_RIGHT"


### PR DESCRIPTION
## Description

Since `MAJOR_VERSION` moved to `26.09`, the `package` action fails to compute `NEXT_MAJOR_VERSION`:

```
line 17: 09: value too great for base (error token is "09")
```

Bash parses numbers with a leading zero as octal, and `09` is not a valid octal number (`26.09` is the first version to trigger this — only `08` and `09` are invalid). The step keeps going, so packaging jobs stay green, but `BUMP_MAJOR_RIGHT` is left empty and `NEXT_MAJOR_VERSION` becomes `26.` instead of `26.10`. Every dependency constraint `< ${NEXT_MAJOR_VERSION}` then becomes `< 26.`, which no `26.09.x` package can satisfy, breaking the `dockerize` jobs (see [this gorgone run](https://github.com/centreon/centreon-collect/actions/runs/28790786185)).

The fix forces base-10 arithmetic: `$(( 10#$MAJOR_RIGHT + 1 ))`. Behavior is unchanged for all previously working versions (`26.05` → `26.6`, `26.12` → `27.01`), and `26.09` now correctly yields `26.10`.

The same fix is applied to the `package-nfpm` action of the centreon and centreon-modules repositories.

**Fixes**: [MON-204491](https://centreon.atlassian.net/browse/MON-204491)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Run a packaging workflow (e.g. `gorgone`) on this branch and check the `package` jobs:

1. The log must not contain `value too great for base`.
2. The generated packages must carry dependency constraints `< 26.10` instead of `< 26.` (`rpm -qpR` on a produced package).
3. The `dockerize` jobs must be able to resolve and install the packages again.

Shell simulation of the bump logic:

```
26.09 -> 26.10 (was: error + "26.")
26.05 -> 26.6  (unchanged)
26.12 -> 27.01 (unchanged)
```

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-204491]: https://centreon.atlassian.net/browse/MON-204491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ