### PR TITLE
fix(mbi): keep one monthly availability row per group

### DIFF
--- a/gorgone/gorgone/modules/centreon/mbi/libs/bi/HostAvailability.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/bi/HostAvailability.pm
@@ -142,7 +142,7 @@ sub getHGMonthAvailability {
 	my $db = $self->{"centstorage"};
 	
 	$self->{"logger"}->writeLog("DEBUG","[HOST] Calculating availability for hosts");
-	my $query = "SELECT h.hg_id, h.hc_id, hc.id as cat_id, hg.id as group_id, ha.liveservice_id, avg(available/(available+unavailable+unreachable)) as av_percent,";
+	my $query = "SELECT h.hg_id, h.hc_id, MAX(hc.id) as cat_id, MAX(hg.id) as group_id, ha.liveservice_id, avg(available/(available+unavailable+unreachable)) as av_percent,";
 	$query .= " sum(available) as av_time, sum(unavailable) as unav_time, sum(alert_unavailable_opened) as unav_opened, sum(alert_unavailable_closed) as unav_closed,";
 	$query .= " sum(alert_unreachable_opened) as unr_opened, sum(alert_unreachable_closed) as unr_closed";
 	$query .= " FROM ".$self->{"name"}." ha";
@@ -151,7 +151,7 @@ sub getHGMonthAvailability {
 	$query .= " STRAIGHT_JOIN mod_bi_hostgroups hg ON (h.hg_name=hg.hg_name AND h.hg_id=hg.hg_id)";
 	$query .= " STRAIGHT_JOIN mod_bi_hostcategories hc ON (h.hc_name=hc.hc_name AND h.hc_id=hc.hc_id)";
 	$query .= " WHERE t.year = YEAR('".$start."') AND t.month = MONTH('".$start."') and t.hour=0";
-	$query .= " GROUP BY h.hg_id, h.hc_id,hc.id,hg.id,  ha.liveservice_id";
+	$query .= " GROUP BY h.hg_id, h.hc_id, ha.liveservice_id";
 	my $sth = $db->query({ query => $query });
 	
 	$self->{"logger"}->writeLog("DEBUG","[HOST] Calculating MTBF/MTRS/MTBSI for Host");	

--- a/gorgone/gorgone/modules/centreon/mbi/libs/bi/ServiceAvailability.pm
+++ b/gorgone/gorgone/modules/centreon/mbi/libs/bi/ServiceAvailability.pm
@@ -143,7 +143,7 @@ sub getHGMonthAvailability {
 	my $db = $self->{"centstorage"};
 
 	my $query = "SELECT  s.hg_id, s.hc_id, s.sc_id, sa.liveservice_id,";
-	$query .= "  hc.id as hcat_id, hg.id as group_id, sc.id as scat_id,";
+	$query .= "  MAX(hc.id) as hcat_id, MAX(hg.id) as group_id, MAX(sc.id) as scat_id,";
 	$query .= " avg((available+degraded)/(available+unavailable+degraded)) as av_percent,";
 	$query .= " sum(available) as av_time, sum(unavailable) as unav_time, sum(degraded) as degraded_time,";
 	$query .= "  sum(alert_unavailable_opened) as unav_opened,sum(alert_unavailable_closed) as unav_closed,";
@@ -156,7 +156,7 @@ sub getHGMonthAvailability {
 	$query .= " STRAIGHT_JOIN mod_bi_hostcategories hc ON (s.hc_name=hc.hc_name AND s.hc_id=hc.hc_id)";
 	$query .= " STRAIGHT_JOIN mod_bi_servicecategories sc ON (s.sc_id=sc.sc_id AND s.sc_name=sc.sc_name)";
 	$query .= " WHERE t.year = YEAR('".$start."') AND t.month = MONTH('".$start."') and t.hour=0";
-	$query .= " GROUP BY s.hg_id, s.hc_id, s.sc_id, sa.liveservice_id, hc.id, hg.id, sc.id";
+	$query .= " GROUP BY s.hg_id, s.hc_id, s.sc_id, sa.liveservice_id";
 	my $sth = $db->query({ query => $query });
 
 	my @data = ();
@@ -182,7 +182,7 @@ sub getHGMonthAvailability_optimised {
 	my ($self, $start, $end, $eventObj) = @_;
 	my $db = $self->{"centstorage"};
 	
-	my $query = "SELECT * from  ( SELECT  s.hg_id, s.hc_id, s.sc_id, sa.liveservice_id,   hc.id as hcat_id, hg.id as group_id, sc.id as scat_id,"; 
+	my $query = "SELECT * from  ( SELECT  s.hg_id, s.hc_id, s.sc_id, sa.liveservice_id,   MAX(hc.id) as hcat_id, MAX(hg.id) as group_id, MAX(sc.id) as scat_id,"; 
 	$query .= "avg((available+degraded)/(available+unavailable+degraded)) as av_percent, ";
 	$query .= "sum(available) as av_time, sum(unavailable) as unav_time, sum(degraded) as degraded_time, ";
 	$query .= "sum(alert_unavailable_opened) as unav_opened,sum(alert_unavailable_closed) as unav_closed, ";
@@ -194,7 +194,7 @@ sub getHGMonthAvailability_optimised {
 	$query .= "STRAIGHT_JOIN mod_bi_hostcategories hc ON (s.hc_name=hc.hc_name AND s.hc_id=hc.hc_id) ";
 	$query .= "STRAIGHT_JOIN mod_bi_servicecategories sc ON (s.sc_id=sc.sc_id AND s.sc_name=sc.sc_name)";
 	$query .= " WHERE YEAR(from_unixtime(time_id)) = YEAR('".$start."') AND MONTH(from_unixtime(time_id))  = MONTH('".$start."') and hour(from_unixtime(time_id)) = 0 ";
-	$query .= "GROUP BY s.hg_id, s.hc_id, s.sc_id, sa.liveservice_id, hc.id, sc.id, hg.id ) availability ";
+	$query .= "GROUP BY s.hg_id, s.hc_id, s.sc_id, sa.liveservice_id ) availability ";
 	$query .= "LEFT JOIN (  SELECT s.hg_id,s.hc_id,s.sc_id,e.modbiliveservice_id, ";
 	$query .= "SUM(IF(state=1,1,0)) as warningEvents,   SUM(IF(state=2,1,0)) as criticalEvents, ";
 	$query .= "SUM(IF(state=3,1,0)) as unknownEvents  FROM mod_bi_servicestateevents e ";


### PR DESCRIPTION
## Description

Fixes: [MON-204739](https://centreon.atlassian.net/browse/MON-204739)

The Gorgone MBI ETL monthly hostgroup availability queries
(`getHGMonthAvailability` in `HostAvailability.pm` and
`ServiceAvailability.pm`, plus the `_optimised` variant) grouped by the
surrogate ids of the versioned dimension tables (`hg.id`, `hc.id`,
`sc.id`), added by the ONLY_FULL_GROUP_BY compat fix (#1995,
[MON-156429](https://centreon.atlassian.net/browse/MON-156429)).

Those ids are not functionally dependent on the raw ids: the dimension
tables keep one row per (raw id, name) version, so a hostgroup, host
category or service category rename mid-month splits the monthly
availability row into one row per name version. The event counts —
computed separately, grouped by raw ids only — then attach the
full-month totals to each split row (double-counted alerts), and
MTBF/MTRS combine partial-period numerators with full-month
denominators.

Select `MAX()` of the surrogate ids instead (deterministically the
newest name version, with the original aliases preserved) and restore
the original grouping keys. The queries remain
ONLY_FULL_GROUP_BY-compliant.

Same fix as the centreon-modules legacy ETL one
(centreon/centreon-modules#8770). See MON-204739 for a detailed
walkthrough of the bug mechanism.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## How this pull request can be tested ?

1. On a platform using the Gorgone MBI ETL, rename a hostgroup (or
   host/service category) mid-month.
2. Run the monthly event statistics ETL for that month.
3. Before the fix, `mod_bi_hgmonthavailability` /
   `mod_bi_hgservicemonthavailability` contain two rows for that
   hostgroup/category combination (with doubled alert totals); after
   the fix, exactly one row with full-month sums.

The three queries were re-checked for ONLY_FULL_GROUP_BY compliance:
every non-aggregated SELECT column is in GROUP BY.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-204739]: https://centreon.atlassian.net/browse/MON-204739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-156429]: https://centreon.atlassian.net/browse/MON-156429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ