### PR TITLE
chore(ci): deliver centreon-collect packages to Artifactory and Pulp in parallel

### DIFF
--- a/.github/actions/package-delivery-pulp/action.yml
+++ b/.github/actions/package-delivery-pulp/action.yml
@@ -1,0 +1,154 @@
+name: "package-delivery"
+description: "Deliver rpm and deb packages to pulp"
+inputs:
+  module_name:
+    description: "The package module name"
+    required: true
+  distrib:
+    description: "The distribution used for packaging"
+    required: true
+  version:
+    description: "Centreon packaged major version"
+    required: true
+  cache_key:
+    description: "The cached package key"
+    required: true
+  stability:
+    description: "The package stability (stable, testing, unstable)"
+    required: true
+  release_type:
+    description: "Type of release (hotfix, release)"
+    required: false
+    default: ""
+  is_cloud:
+    description: "Release context (cloud or not cloud)"
+    required: true
+  delivery_type:
+    description: "Delivery to feature or standard repository"
+    required: false
+    default: "standard"
+  verify:
+    description: "Verify the delivered packages afterwards (presence, metadata resolution, fetchability)"
+    required: false
+    default: "true"
+  pulp_url:
+    description: "The pulp server api url"
+    required: false
+    default: "https://pulp-api.apps.centreon.com"
+  pulp_content_url:
+    description: "The pulp server content url"
+    required: false
+    default: "https://packages.apps.centreon.com"
+  audience:
+    description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
+    required: false
+    default: "https://pulp.dev.centreon.io"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        STABILITY: ${{ inputs.stability }}
+        DELIVERY_TYPE: ${{ inputs.delivery_type }}
+      run: |
+        set -euo pipefail
+
+        if [[ "$DELIVERY_TYPE" != "feature" && "$STABILITY" != "testing" && "$STABILITY" != "unstable" ]]; then
+          echo "::error::stability must be one of: testing, unstable (got '$STABILITY')"
+          exit 1
+        fi
+
+    - name: Compute pulp repository properties
+      id: pulp-properties
+      uses: ./.github/actions/pulp-repository-properties
+      with:
+        module_name: ${{ inputs.module_name }}
+        distrib: ${{ inputs.distrib }}
+        version: ${{ inputs.version }}
+        stability: ${{ inputs.stability }}
+        release_type: ${{ inputs.release_type }}
+        is_cloud: ${{ inputs.is_cloud }}
+        delivery_type: ${{ inputs.delivery_type }}
+
+    - name: Restore packages from cache
+      if: steps.pulp-properties.outputs.skip_delivery == 'false'
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ./*.${{ steps.pulp-properties.outputs.package_extension }}
+        key: ${{ inputs.cache_key }}
+        fail-on-cache-miss: true
+
+    - name: Setup pulp-cli
+      if: steps.pulp-properties.outputs.skip_delivery == 'false'
+      uses: ./.github/actions/setup-pulp-cli
+      with:
+        pulp_url: ${{ inputs.pulp_url }}
+        audience: ${{ inputs.audience }}
+
+    - name: Deliver RPM packages
+      id: deliver-rpm
+      if: steps.pulp-properties.outputs.package_extension == 'rpm' && steps.pulp-properties.outputs.skip_delivery == 'false'
+      shell: bash
+      env:
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
+        REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.repository_prefix }}
+        STABLE_REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.stable_repository_prefix }}
+        BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.base_path_prefix }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+      run: ${{ github.action_path }}/deliver-rpm.sh
+
+    - name: Deliver DEB packages
+      id: deliver-deb
+      if: steps.pulp-properties.outputs.package_extension == 'deb' && steps.pulp-properties.outputs.skip_delivery == 'false'
+      shell: bash
+      env:
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
+        REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.repository_name }}
+        BASE_PATH: ${{ steps.pulp-properties.outputs.base_path }}
+        SUITE: ${{ steps.pulp-properties.outputs.suite }}
+        STABLE_SUITE: ${{ steps.pulp-properties.outputs.stable_suite }}
+        POOL_PATH: ${{ steps.pulp-properties.outputs.pool_path }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+      run: ${{ github.action_path }}/deliver-deb.sh
+
+    - name: Verify RPM delivery
+      if: inputs.verify == 'true' && steps.pulp-properties.outputs.package_extension == 'rpm' && steps.pulp-properties.outputs.skip_delivery == 'false'
+      shell: bash
+      env:
+        MANIFEST: ${{ steps.deliver-rpm.outputs.manifest }}
+        CHECK_MODE: delivery
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+      run: |
+        ${{ github.action_path }}/../../scripts/pulp/check-rpm.sh ||
+          echo "::warning::Pulp delivery verification failed for ${MODULE_NAME} on ${DISTRIB} (non-blocking during the Artifactory-to-Pulp migration, see the run summary table)"
+
+    - name: Verify DEB delivery
+      if: inputs.verify == 'true' && steps.pulp-properties.outputs.package_extension == 'deb' && steps.pulp-properties.outputs.skip_delivery == 'false'
+      shell: bash
+      env:
+        MANIFEST: ${{ steps.deliver-deb.outputs.manifest }}
+        CHECK_MODE: delivery
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+      run: |
+        ${{ github.action_path }}/../../scripts/pulp/check-deb.sh ||
+          echo "::warning::Pulp delivery verification failed for ${MODULE_NAME} on ${DISTRIB} (non-blocking during the Artifactory-to-Pulp migration, see the run summary table)"

--- a/.github/actions/package-delivery-pulp/deliver-deb.sh
+++ b/.github/actions/package-delivery-pulp/deliver-deb.sh
@@ -70,15 +70,26 @@ if [[ ${#FILES[@]} -eq 0 ]]; then
   exit 1
 fi
 
-if ! pulp deb repository show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
-  echo "[INFO] Creating deb repository $REPOSITORY_NAME"
-  pulp deb repository create --name "$REPOSITORY_NAME" >/dev/null
-fi
+# the deb repository/distribution ($REPOSITORY_NAME, e.g. ubuntu-standard-internal)
+# is shared by every distrib of the same family (jammy+noble, bullseye+bookworm+
+# trixie), which run as parallel matrix jobs. get-or-create is not atomic: they all
+# see "not found" and race to create it, and the losers hit a uniqueness error. so
+# tolerate the race — if create fails because a concurrent job won, re-check and
+# proceed; only fail if the resource is genuinely still absent.
+ensure_deb_resource() {
+  local kind=$1 label=$2; shift 2
+  pulp deb "$kind" show --name "$REPOSITORY_NAME" >/dev/null 2>&1 && return 0
+  echo "[INFO] Creating deb $kind $label"
+  pulp deb "$kind" create "$@" >/dev/null 2>&1 && return 0
+  # a concurrent job may have created it between our show and create
+  pulp deb "$kind" show --name "$REPOSITORY_NAME" >/dev/null 2>&1 && return 0
+  echo "::error::Failed to create deb $kind $REPOSITORY_NAME"
+  return 1
+}
 
-if ! pulp deb distribution show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
-  echo "[INFO] Creating deb distribution $REPOSITORY_NAME served at $BASE_PATH"
-  pulp deb distribution create --name "$REPOSITORY_NAME" --base-path "$BASE_PATH" --repository "$REPOSITORY_NAME" >/dev/null
-fi
+ensure_deb_resource repository "$REPOSITORY_NAME" --name "$REPOSITORY_NAME"
+ensure_deb_resource distribution "$REPOSITORY_NAME served at $BASE_PATH" \
+  --name "$REPOSITORY_NAME" --base-path "$BASE_PATH" --repository "$REPOSITORY_NAME"
 
 REPOSITORY_HREF=$(pulp deb repository show --name "$REPOSITORY_NAME" | jq -r '.pulp_href')
 

--- a/.github/actions/package-delivery-pulp/deliver-deb.sh
+++ b/.github/actions/package-delivery-pulp/deliver-deb.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s nullglob
+
+# shellcheck source=.github/scripts/pulp/manifest.sh
+source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
+# shellcheck source=.github/scripts/pulp/api.sh
+source "$(dirname "$0")/../../scripts/pulp/api.sh"
+
+# use the org-variable values, falling back to the defaults when passed empty
+# (an unset org variable is forwarded as an empty string, overriding the default)
+PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
+
+# refuse delivering a package that is already published in the stable suite.
+# rebuilding a testing/unstable version with a different content is fine, but a
+# version that already reached stable must never be re-delivered: pulp
+# deduplicates packages by (package, version, architecture) repository wide, so
+# the new content would silently evict the stable one. bump the version instead.
+assert_not_in_stable() {
+  local file=$1 name version arch packages http_code pkg_file
+  name=$(dpkg-deb -f "$file" Package)
+  version=$(dpkg-deb -f "$file" Version)
+  arch=$(dpkg-deb -f "$file" Architecture)
+
+  # the published stable suite is the source of truth for what reached stable.
+  # the release_components api is not listable by the OIDC ci-user (403, and no
+  # grantable permission exists for it), so check the served Packages index
+  # instead: no api access needed and it reflects exactly what stable publishes.
+  # distinguish "not published yet" (404 -> not in stable) from a fetch failure
+  # (network / 5xx -> unknown): fail closed on the latter, so a transient content
+  # endpoint error cannot let an already-stable version slip through and evict it
+  # (the rpm guardrail is likewise fail-closed).
+  pkg_file=$(mktemp)
+  http_code=$(curl -sSL -o "$pkg_file" -w '%{http_code}' \
+    "$PULP_CONTENT_URL/$BASE_PATH/dists/$STABLE_SUITE/main/binary-$arch/Packages" 2>/dev/null || echo 000)
+  case "$http_code" in
+    404) rm -f "$pkg_file"; return 0 ;;
+    200) packages=$(cat "$pkg_file"); rm -f "$pkg_file" ;;
+    *)
+      rm -f "$pkg_file"
+      echo "::error::Cannot verify the stable suite $STABLE_SUITE (HTTP $http_code) to guard $name $version ($arch); refusing to deliver. Retry once the content endpoint is reachable."
+      return 1
+      ;;
+  esac
+  # empty index -> nothing in stable
+  [[ -z "$packages" ]] && return 0
+
+  # a package is in stable if a Packages stanza matches both name and version
+  if printf '%s\n' "$packages" | awk -v n="$name" -v v="$version" '
+       BEGIN { RS = ""; FS = "\n" }
+       {
+         has_name = 0; has_version = 0
+         for (i = 1; i <= NF; i++) {
+           if ($i == "Package: " n) has_name = 1
+           if ($i == "Version: " v) has_version = 1
+         }
+         if (has_name && has_version) found = 1
+       }
+       END { exit found ? 0 : 1 }
+     '; then
+    echo "::error::$name $version ($arch) is already published in the stable suite $STABLE_SUITE; refusing to deliver it to $SUITE. Bump the package version for a new build."
+    return 1
+  fi
+}
+
+FILES=(*.deb)
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "::error::No deb package found to deliver"
+  exit 1
+fi
+
+if ! pulp deb repository show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
+  echo "[INFO] Creating deb repository $REPOSITORY_NAME"
+  pulp deb repository create --name "$REPOSITORY_NAME" >/dev/null
+fi
+
+if ! pulp deb distribution show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
+  echo "[INFO] Creating deb distribution $REPOSITORY_NAME served at $BASE_PATH"
+  pulp deb distribution create --name "$REPOSITORY_NAME" --base-path "$BASE_PATH" --repository "$REPOSITORY_NAME" >/dev/null
+fi
+
+REPOSITORY_HREF=$(pulp deb repository show --name "$REPOSITORY_NAME" | jq -r '.pulp_href')
+
+PULP_LABELS=$(jq -cn \
+  --arg mod        "$MODULE_NAME" \
+  --arg git_commit "${GITHUB_SHA:-}" \
+  --arg git_ref    "${GITHUB_REF:-}" \
+  --arg run_id     "${GITHUB_RUN_ID:-}" \
+  --arg actor      "${GITHUB_ACTOR:-}" \
+  --arg workflow   "${GITHUB_WORKFLOW:-}" \
+  '{"module": $mod, "git_commit": $git_commit, "git_ref": $git_ref, "github_run_id": $run_id, "github_actor": $actor, "github_workflow": $workflow}')
+
+for FILE in "${FILES[@]}"; do
+  assert_not_in_stable "$FILE"
+  echo "[INFO] Uploading $FILE to $POOL_PATH/ ($SUITE/main, module $MODULE_NAME)"
+  # packages are labeled with their module so that promote-to-stable can identify
+  # which packages belong to this module, pulp-cli does not allow to set labels nor
+  # the relative path of deb packages so the api is used directly
+  TASK_HREF=$(
+    pulp_upload \
+      -F "file=@\"$FILE\"" \
+      -F "relative_path=$POOL_PATH/$FILE" \
+      -F "distribution=$SUITE" \
+      -F "component=main" \
+      -F "repository=$REPOSITORY_HREF" \
+      -F "pulp_labels=$PULP_LABELS" \
+      "$PULP_URL/api/v3/content/deb/packages/"
+  )
+  wait_task "$TASK_HREF"
+
+  # record the uploaded package in the manifest for the verification step
+  name=$(dpkg-deb -f "$FILE" Package)
+  version=$(dpkg-deb -f "$FILE" Version)
+  arch=$(dpkg-deb -f "$FILE" Architecture)
+  sha256=$(sha256sum "$FILE" | cut -d' ' -f1)
+  manifest_add "$(jq -cn \
+    --arg filename "$FILE" --arg name "$name" --arg version "$version" \
+    --arg arch "$arch" --arg sha256 "$sha256" --arg repository "$REPOSITORY_NAME" \
+    --arg base_path "$BASE_PATH" --arg suite "$SUITE" --arg relative_path "$POOL_PATH/$FILE" \
+    '{filename:$filename,name:$name,version:$version,arch:$arch,sha256:$sha256,repository:$repository,base_path:$base_path,suite:$suite,relative_path:$relative_path}')"
+done
+
+echo "[INFO] Publishing repository $REPOSITORY_NAME"
+pulp deb publication create --repository "$REPOSITORY_NAME" --structured >/dev/null
+
+echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/$BASE_PATH/ $SUITE main"
+
+manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "${STABILITY:-}" "delivery" "$PULP_CONTENT_URL"

--- a/.github/actions/package-delivery-pulp/deliver-deb.sh
+++ b/.github/actions/package-delivery-pulp/deliver-deb.sh
@@ -70,26 +70,15 @@ if [[ ${#FILES[@]} -eq 0 ]]; then
   exit 1
 fi
 
-# the deb repository/distribution ($REPOSITORY_NAME, e.g. ubuntu-standard-internal)
-# is shared by every distrib of the same family (jammy+noble, bullseye+bookworm+
-# trixie), which run as parallel matrix jobs. get-or-create is not atomic: they all
-# see "not found" and race to create it, and the losers hit a uniqueness error. so
-# tolerate the race — if create fails because a concurrent job won, re-check and
-# proceed; only fail if the resource is genuinely still absent.
-ensure_deb_resource() {
-  local kind=$1 label=$2; shift 2
-  pulp deb "$kind" show --name "$REPOSITORY_NAME" >/dev/null 2>&1 && return 0
-  echo "[INFO] Creating deb $kind $label"
-  pulp deb "$kind" create "$@" >/dev/null 2>&1 && return 0
-  # a concurrent job may have created it between our show and create
-  pulp deb "$kind" show --name "$REPOSITORY_NAME" >/dev/null 2>&1 && return 0
-  echo "::error::Failed to create deb $kind $REPOSITORY_NAME"
-  return 1
-}
+if ! pulp deb repository show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
+  echo "::error::deb repository $REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before delivering."
+  exit 1
+fi
 
-ensure_deb_resource repository "$REPOSITORY_NAME" --name "$REPOSITORY_NAME"
-ensure_deb_resource distribution "$REPOSITORY_NAME served at $BASE_PATH" \
-  --name "$REPOSITORY_NAME" --base-path "$BASE_PATH" --repository "$REPOSITORY_NAME"
+if ! pulp deb distribution show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
+  echo "::error::deb distribution $REPOSITORY_NAME does not exist. Pulp distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before delivering. Refusing to create it here to avoid an unguarded distribution."
+  exit 1
+fi
 
 REPOSITORY_HREF=$(pulp deb repository show --name "$REPOSITORY_NAME" | jq -r '.pulp_href')
 

--- a/.github/actions/package-delivery-pulp/deliver-rpm.sh
+++ b/.github/actions/package-delivery-pulp/deliver-rpm.sh
@@ -84,13 +84,13 @@ for ARCH in noarch x86_64; do
   BASE_PATH="$BASE_PATH_PREFIX/$ARCH"
 
   if ! pulp rpm repository show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
-    echo "[INFO] Creating rpm repository $REPOSITORY_NAME"
-    pulp rpm repository create --name "$REPOSITORY_NAME" --retain-package-versions 1 >/dev/null
+    echo "::error::rpm repository $REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before delivering."
+    exit 1
   fi
 
   if ! pulp rpm distribution show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
-    echo "[INFO] Creating rpm distribution $REPOSITORY_NAME served at $BASE_PATH"
-    pulp rpm distribution create --name "$REPOSITORY_NAME" --base-path "$BASE_PATH" --repository "$REPOSITORY_NAME" >/dev/null
+    echo "::error::rpm distribution $REPOSITORY_NAME does not exist. Pulp distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before delivering. Refusing to create it here to avoid an unguarded distribution."
+    exit 1
   fi
 
   REPOSITORY_HREF=$(pulp rpm repository show --name "$REPOSITORY_NAME" | jq -r '.pulp_href')

--- a/.github/actions/package-delivery-pulp/deliver-rpm.sh
+++ b/.github/actions/package-delivery-pulp/deliver-rpm.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s nullglob
+
+# shellcheck source=.github/scripts/pulp/manifest.sh
+source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
+# shellcheck source=.github/scripts/pulp/api.sh
+source "$(dirname "$0")/../../scripts/pulp/api.sh"
+
+# use the org-variable values, falling back to the defaults when passed empty
+# (an unset org variable is forwarded as an empty string, overriding the default)
+PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
+
+# refuse delivering a package that is already published in the stable repository.
+# rebuilding a testing/unstable version with a different content is fine, but a
+# version that already reached stable must never be re-delivered. rpm uses a
+# dedicated repository per stability, so this is a policy check (deliveries to
+# testing/unstable cannot evict stable, unlike a shared repository).
+assert_not_in_stable() {
+  local file=$1 arch=$2 base name version release stable_repository repository_version count
+  base=$(basename "$file" .rpm)
+  base=${base%.$arch}
+  release=${base##*-}
+  base=${base%-*}
+  version=${base##*-}
+  name=${base%-*}
+
+  stable_repository="$STABLE_REPOSITORY_PREFIX-$arch"
+  # no stable repository yet => nothing can be in stable
+  if ! pulp rpm repository show --name "$stable_repository" >/dev/null 2>&1; then
+    return 0
+  fi
+  repository_version=$(pulp rpm repository show --name "$stable_repository" | jq -r '.latest_version_href')
+
+  count=$(
+    curl -fsSL -H "Authorization: Github $PULP_TOKEN" -G \
+      --data-urlencode "repository_version=$repository_version" \
+      --data-urlencode "name=$name" \
+      --data-urlencode "version=$version" \
+      --data-urlencode "release=$release" \
+      --data-urlencode "arch=$arch" \
+      --data-urlencode "limit=1" \
+      "$PULP_URL/api/v3/content/rpm/packages/" | jq -r '.count'
+  )
+  if [[ "$count" -gt 0 ]]; then
+    echo "::error::$name $version-$release ($arch) is already published in the stable repository $stable_repository; refusing to deliver it to $REPOSITORY_NAME. Bump the package version for a new build."
+    return 1
+  fi
+}
+
+FILES=(*.rpm)
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "::error::No rpm package found to deliver"
+  exit 1
+fi
+
+mkdir -p noarch x86_64
+for FILE in "${FILES[@]}"; do
+  ARCH=$(echo "$FILE" | grep -oP '(x86_64|noarch)' | head -1 || true)
+  if [[ -z "$ARCH" ]]; then
+    echo "::error::Cannot find the architecture of package $FILE"
+    exit 1
+  fi
+  mv "$FILE" "$ARCH"
+done
+
+PULP_LABELS=$(jq -cn \
+  --arg mod        "$MODULE_NAME" \
+  --arg git_commit "${GITHUB_SHA:-}" \
+  --arg git_ref    "${GITHUB_REF:-}" \
+  --arg run_id     "${GITHUB_RUN_ID:-}" \
+  --arg actor      "${GITHUB_ACTOR:-}" \
+  --arg workflow   "${GITHUB_WORKFLOW:-}" \
+  '{"module": $mod, "git_commit": $git_commit, "git_ref": $git_ref, "github_run_id": $run_id, "github_actor": $actor, "github_workflow": $workflow}')
+
+for ARCH in noarch x86_64; do
+  ARCH_FILES=("$ARCH"/*.rpm)
+  if [[ ${#ARCH_FILES[@]} -eq 0 ]]; then
+    continue
+  fi
+
+  REPOSITORY_NAME="$REPOSITORY_PREFIX-$ARCH"
+  BASE_PATH="$BASE_PATH_PREFIX/$ARCH"
+
+  if ! pulp rpm repository show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
+    echo "[INFO] Creating rpm repository $REPOSITORY_NAME"
+    pulp rpm repository create --name "$REPOSITORY_NAME" --retain-package-versions 1 >/dev/null
+  fi
+
+  if ! pulp rpm distribution show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
+    echo "[INFO] Creating rpm distribution $REPOSITORY_NAME served at $BASE_PATH"
+    pulp rpm distribution create --name "$REPOSITORY_NAME" --base-path "$BASE_PATH" --repository "$REPOSITORY_NAME" >/dev/null
+  fi
+
+  REPOSITORY_HREF=$(pulp rpm repository show --name "$REPOSITORY_NAME" | jq -r '.pulp_href')
+
+  # Packages are uploaded straight into the repository: pulpcore requires
+  # non-admin accounts to provide the destination repository on content upload,
+  # so the upload cannot be decoupled from the repository association. Packages
+  # are labeled with their module so that promote-to-stable can identify them;
+  # pulp-cli does not allow to set labels on upload so the api is used directly.
+  for FILE in "${ARCH_FILES[@]}"; do
+    assert_not_in_stable "$FILE" "$ARCH"
+    echo "[INFO] Uploading $(basename "$FILE") to $REPOSITORY_NAME (module $MODULE_NAME)"
+    TASK_HREF=$(
+      pulp_upload \
+        -F "file=@\"$FILE\"" \
+        -F "repository=$REPOSITORY_HREF" \
+        -F "pulp_labels=$PULP_LABELS" \
+        "$PULP_URL/api/v3/content/rpm/packages/"
+    )
+    wait_task "$TASK_HREF"
+
+    # record the uploaded package in the manifest (name-version-release parsed
+    # the same way as assert_not_in_stable) for the verification step
+    FILENAME=$(basename "$FILE")
+    base=${FILENAME%.rpm}
+    base=${base%."$ARCH"}
+    release=${base##*-}
+    base=${base%-*}
+    version=${base##*-}
+    name=${base%-*}
+    sha256=$(sha256sum "$FILE" | cut -d' ' -f1)
+    manifest_add "$(jq -cn \
+      --arg filename "$FILENAME" --arg name "$name" --arg version "$version" \
+      --arg release "$release" --arg arch "$ARCH" --arg sha256 "$sha256" \
+      --arg repository "$REPOSITORY_NAME" --arg base_path "$BASE_PATH" \
+      '{filename:$filename,name:$name,version:$version,release:$release,arch:$arch,sha256:$sha256,repository:$repository,base_path:$base_path}')"
+  done
+
+  echo "[INFO] Publishing repository $REPOSITORY_NAME"
+  pulp rpm publication create --repository "$REPOSITORY_NAME" >/dev/null
+
+  echo "::notice::Packages are available at $PULP_CONTENT_URL/$BASE_PATH/"
+done
+
+manifest_write "$MODULE_NAME" "${DISTRIB:-}" "rpm" "${STABILITY:-}" "delivery" "$PULP_CONTENT_URL"

--- a/.github/actions/promote-to-stable-pulp/action.yml
+++ b/.github/actions/promote-to-stable-pulp/action.yml
@@ -1,0 +1,140 @@
+name: "promote testing to stable"
+description: "Promote testing packages to stable."
+inputs:
+  module_name:
+    description: "Module name"
+    required: true
+  distrib:
+    description: "The distribution used for packaging"
+    required: true
+  major_version:
+    description: "Centreon packaged major version"
+    required: true
+  stability:
+    description: "The package stability (stable, testing, unstable)"
+    required: true
+  release_type:
+    description: "Type of release (hotfix, release)"
+    required: true
+  is_cloud:
+    description: "Release context (cloud or not cloud)"
+    required: true
+  verify:
+    description: "Verify the promoted packages afterwards (presence, metadata resolution, fetchability)"
+    required: false
+    default: "true"
+  pulp_url:
+    description: "The pulp server api url"
+    required: false
+    default: "https://pulp-api.apps.centreon.com"
+  pulp_content_url:
+    description: "The pulp server content url"
+    required: false
+    default: "https://packages.apps.centreon.com"
+  audience:
+    description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
+    required: false
+    default: "https://pulp.dev.centreon.io"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        RELEASE_TYPE: ${{ inputs.release_type }}
+      run: |
+        set -euo pipefail
+
+        if [[ "$RELEASE_TYPE" != "release" && "$RELEASE_TYPE" != "hotfix" ]]; then
+          echo "::error::release_type input must be defined (release or hotfix)"
+          exit 1
+        fi
+
+    - name: Compute pulp repository properties
+      id: pulp-properties
+      uses: ./.github/actions/pulp-repository-properties
+      with:
+        module_name: ${{ inputs.module_name }}
+        distrib: ${{ inputs.distrib }}
+        version: ${{ inputs.major_version }}
+        stability: ${{ inputs.stability }}
+        release_type: ${{ inputs.release_type }}
+        is_cloud: ${{ inputs.is_cloud }}
+
+    - name: Setup pulp-cli
+      uses: ./.github/actions/setup-pulp-cli
+      with:
+        pulp_url: ${{ inputs.pulp_url }}
+        audience: ${{ inputs.audience }}
+
+    - name: Promote RPM packages to stable
+      id: promote-rpm
+      if: steps.pulp-properties.outputs.package_extension == 'rpm'
+      shell: bash
+      env:
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        TESTING_REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.testing_repository_prefix }}
+        STABLE_REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.stable_repository_prefix }}
+        STABLE_BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.stable_base_path_prefix }}
+        STABILITY: ${{ inputs.stability }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+      run: ${{ github.action_path }}/promote-rpm.sh
+
+    - name: Promote DEB packages to stable
+      id: promote-deb
+      if: steps.pulp-properties.outputs.package_extension == 'deb'
+      shell: bash
+      env:
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.repository_name }}
+        BASE_PATH: ${{ steps.pulp-properties.outputs.base_path }}
+        TESTING_POOL_PATH: ${{ steps.pulp-properties.outputs.testing_pool_path }}
+        TESTING_SUITE: ${{ steps.pulp-properties.outputs.testing_suite }}
+        STABLE_SUITE: ${{ steps.pulp-properties.outputs.stable_suite }}
+        PACKAGE_DISTRIB_NAME: ${{ steps.pulp-properties.outputs.package_distrib_name }}
+        STABILITY: ${{ inputs.stability }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+      run: ${{ github.action_path }}/promote-deb.sh
+
+    - name: Verify RPM promotion
+      # skipped on dry runs (stability != stable): the promote script exits
+      # before promoting anything, so there is no manifest to verify
+      if: inputs.verify == 'true' && inputs.stability == 'stable' && steps.pulp-properties.outputs.package_extension == 'rpm'
+      shell: bash
+      env:
+        MANIFEST: ${{ steps.promote-rpm.outputs.manifest }}
+        CHECK_MODE: promote
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+      run: |
+        ${{ github.action_path }}/../../scripts/pulp/check-rpm.sh ||
+          echo "::warning::Pulp promotion verification failed for ${MODULE_NAME} on ${DISTRIB} (non-blocking during the Artifactory-to-Pulp migration, see the run summary table)"
+
+    - name: Verify DEB promotion
+      # skipped on dry runs (stability != stable): the promote script exits
+      # before promoting anything, so there is no manifest to verify
+      if: inputs.verify == 'true' && inputs.stability == 'stable' && steps.pulp-properties.outputs.package_extension == 'deb'
+      shell: bash
+      env:
+        MANIFEST: ${{ steps.promote-deb.outputs.manifest }}
+        CHECK_MODE: promote
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
+        PULP_URL: ${{ inputs.pulp_url }}
+        PULP_TOKEN: ${{ env.PULP_TOKEN }}
+        PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+      run: |
+        ${{ github.action_path }}/../../scripts/pulp/check-deb.sh ||
+          echo "::warning::Pulp promotion verification failed for ${MODULE_NAME} on ${DISTRIB} (non-blocking during the Artifactory-to-Pulp migration, see the run summary table)"

--- a/.github/actions/promote-to-stable-pulp/promote-deb.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-deb.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=.github/scripts/pulp/manifest.sh
+source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
+# shellcheck source=.github/scripts/pulp/api.sh
+source "$(dirname "$0")/../../scripts/pulp/api.sh"
+
+# use the org-variable values, falling back to the defaults when passed empty
+# (an unset org variable is forwarded as an empty string, overriding the default)
+PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
+
+if ! pulp deb repository show --name "$REPOSITORY_NAME" >/dev/null 2>&1; then
+  echo "::error::Nothing to promote, repository $REPOSITORY_NAME does not exist"
+  exit 1
+fi
+
+VERSION_HREF=$(pulp deb repository show --name "$REPOSITORY_NAME" | jq -r '.latest_version_href')
+
+# packages of the module are identified by the label set at delivery time,
+# the testing pool path scopes the stability and the package distrib name
+# scopes the distribution as the apt repository holds all the suites
+RESPONSE=$(
+  curl -fsSL -H "Authorization: Github $PULP_TOKEN" -G \
+    --data-urlencode "repository_version=$VERSION_HREF" \
+    --data-urlencode "pulp_label_select=module=$MODULE_NAME" \
+    --data-urlencode "limit=1000" \
+    "$PULP_URL/api/v3/content/deb/packages/"
+)
+
+# fail on a truncated page (checked before the pool-path filtering): silently
+# promoting a subset of the module's packages would publish an incomplete
+# stable suite
+if [[ $(echo "$RESPONSE" | jq '.count > (.results | length)') == "true" ]]; then
+  echo "::error::Package query on $REPOSITORY_NAME is truncated ($(echo "$RESPONSE" | jq -r '.results | length')/$(echo "$RESPONSE" | jq -r '.count') results); pagination is required"
+  exit 1
+fi
+
+PACKAGES=$(
+  echo "$RESPONSE" | \
+    jq --arg testing_path "$TESTING_POOL_PATH/" --arg distrib_name "$PACKAGE_DISTRIB_NAME" \
+      '[.results[] | select((.relative_path | startswith($testing_path)) and (.relative_path | contains($distrib_name)))]'
+)
+PACKAGES_COUNT=$(echo "$PACKAGES" | jq 'length')
+
+if [[ "$PACKAGES_COUNT" -eq 0 ]]; then
+  echo "::error::Nothing to promote, no package of module $MODULE_NAME found in $REPOSITORY_NAME ($TESTING_POOL_PATH/)"
+  exit 1
+fi
+
+echo "[INFO] $PACKAGES_COUNT packages of module $MODULE_NAME found in $REPOSITORY_NAME ($TESTING_POOL_PATH/)"
+
+if [[ "$STABILITY" != "stable" ]]; then
+  echo "[INFO] Dry run, $PACKAGES_COUNT packages would be promoted to $STABLE_SUITE/main"
+  exit 0
+fi
+
+REPOSITORY_HREF=$(pulp deb repository show --name "$REPOSITORY_NAME" | jq -r '.pulp_href')
+
+mkdir -p promoted-packages
+
+# module label, built with jq (safe escaping) — consistent with the delivery scripts
+PULP_LABELS=$(jq -cn --arg mod "$MODULE_NAME" '{"module": $mod}')
+
+while read -r PACKAGE; do
+  RELATIVE_PATH=$(echo "$PACKAGE" | jq -r '.relative_path')
+  SHA256=$(echo "$PACKAGE" | jq -r '.sha256')
+  ARCH=$(echo "$PACKAGE" | jq -r '.architecture')
+  FILE_NAME=$(basename "$RELATIVE_PATH")
+  FILE="promoted-packages/$FILE_NAME"
+
+  # the structured publication serves packages under the canonical debian pool
+  # layout, not their upload relative_path, so resolve the published location
+  # from the testing suite Packages indexed by checksum to download the file
+  FILENAME=$(
+    curl -fsSL "$PULP_CONTENT_URL/$BASE_PATH/dists/$TESTING_SUITE/main/binary-$ARCH/Packages" |
+      awk -v sha="$SHA256" 'BEGIN { RS = ""; FS = "\n" } index($0, "SHA256: " sha) { for (i = 1; i <= NF; i++) if ($i ~ /^Filename: /) { sub(/^Filename: /, "", $i); print $i } }'
+  )
+  if [[ -z "$FILENAME" ]]; then
+    echo "::error::Cannot locate the published file of $FILE_NAME (sha256 $SHA256) in $TESTING_SUITE"
+    exit 1
+  fi
+
+  echo "[INFO] Downloading $PULP_CONTENT_URL/$BASE_PATH/$FILENAME"
+  curl -fsSL -o "$FILE" "$PULP_CONTENT_URL/$BASE_PATH/$FILENAME"
+
+  # re-upload the same bytes with the SAME relative_path: pulp reuses the
+  # existing content unit (a different relative_path would create a second unit
+  # that evicts the first, as pulp deduplicates by name+version+architecture
+  # repository wide) and only adds the stable suite association. an upload is
+  # required because pulp_deb rejects direct PackageReleaseComponent creation.
+  echo "[INFO] Promoting $FILE_NAME to $STABLE_SUITE/main"
+  TASK_HREF=$(
+    pulp_upload \
+      -F "file=@\"$FILE\"" \
+      -F "relative_path=$RELATIVE_PATH" \
+      -F "distribution=$STABLE_SUITE" \
+      -F "component=main" \
+      -F "repository=$REPOSITORY_HREF" \
+      -F "pulp_labels=$PULP_LABELS" \
+      "$PULP_URL/api/v3/content/deb/packages/"
+  )
+  wait_task "$TASK_HREF"
+
+  # record the promoted package (with its stable suite coordinates) so the
+  # verification step verifies exactly this set against the stable suite
+  NAME=$(echo "$PACKAGE" | jq -r '.package')
+  VERSION=$(echo "$PACKAGE" | jq -r '.version')
+  manifest_add "$(jq -cn \
+    --arg filename "$FILE_NAME" --arg name "$NAME" --arg version "$VERSION" \
+    --arg arch "$ARCH" --arg sha256 "$SHA256" --arg repository "$REPOSITORY_NAME" \
+    --arg base_path "$BASE_PATH" --arg suite "$STABLE_SUITE" --arg relative_path "$RELATIVE_PATH" \
+    '{filename:$filename,name:$name,version:$version,arch:$arch,sha256:$sha256,repository:$repository,base_path:$base_path,suite:$suite,relative_path:$relative_path}')"
+done < <(echo "$PACKAGES" | jq -c '.[]')
+
+echo "[INFO] Publishing repository $REPOSITORY_NAME"
+pulp deb publication create --repository "$REPOSITORY_NAME" --structured >/dev/null
+
+echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/$BASE_PATH/ $STABLE_SUITE main"
+
+manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "$STABILITY" "promote" "$PULP_CONTENT_URL"

--- a/.github/actions/promote-to-stable-pulp/promote-rpm.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-rpm.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=.github/scripts/pulp/manifest.sh
+source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
+# shellcheck source=.github/scripts/pulp/api.sh
+source "$(dirname "$0")/../../scripts/pulp/api.sh"
+
+# use the org-variable values, falling back to the defaults when passed empty
+# (an unset org variable is forwarded as an empty string, overriding the default)
+PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
+
+declare -A ARCH_CONTENT
+declare -A ARCH_RESULTS
+TOTAL_PACKAGES_COUNT=0
+
+for ARCH in noarch x86_64; do
+  TESTING_REPOSITORY_NAME="$TESTING_REPOSITORY_PREFIX-$ARCH"
+
+  if ! pulp rpm repository show --name "$TESTING_REPOSITORY_NAME" >/dev/null 2>&1; then
+    echo "[INFO] Testing repository $TESTING_REPOSITORY_NAME does not exist"
+    continue
+  fi
+
+  VERSION_HREF=$(pulp rpm repository show --name "$TESTING_REPOSITORY_NAME" | jq -r '.latest_version_href')
+
+  # packages of the module are identified by the label set at delivery time;
+  # keep both the href list (for the content modify call) and the package
+  # identity (name/version/release/arch/filename) to feed the promotion manifest
+  RESPONSE=$(
+    curl -fsSL -H "Authorization: Github $PULP_TOKEN" -G \
+      --data-urlencode "repository_version=$VERSION_HREF" \
+      --data-urlencode "pulp_label_select=module=$MODULE_NAME" \
+      --data-urlencode "limit=1000" \
+      "$PULP_URL/api/v3/content/rpm/packages/"
+  )
+
+  # fail on a truncated page: silently promoting a subset of the module's
+  # packages would publish an incomplete stable repository
+  if [[ $(echo "$RESPONSE" | jq '.count > (.results | length)') == "true" ]]; then
+    echo "::error::Package query on $TESTING_REPOSITORY_NAME is truncated ($(echo "$RESPONSE" | jq -r '.results | length')/$(echo "$RESPONSE" | jq -r '.count') results); pagination is required"
+    exit 1
+  fi
+
+  RESULTS=$(echo "$RESPONSE" | jq '[.results[] | {pulp_href, name, version, release, arch, location_href, sha256}]')
+  CONTENT=$(echo "$RESULTS" | jq '[.[].pulp_href]')
+  ARCH_PACKAGES_COUNT=$(echo "$CONTENT" | jq 'length')
+
+  echo "[INFO] $ARCH_PACKAGES_COUNT $ARCH packages of module $MODULE_NAME found in $TESTING_REPOSITORY_NAME"
+  ARCH_CONTENT[$ARCH]="$CONTENT"
+  ARCH_RESULTS[$ARCH]="$RESULTS"
+  TOTAL_PACKAGES_COUNT=$((TOTAL_PACKAGES_COUNT + ARCH_PACKAGES_COUNT))
+done
+
+if [[ "$TOTAL_PACKAGES_COUNT" -eq 0 ]]; then
+  echo "::error::Nothing to promote, no package of module $MODULE_NAME found in $TESTING_REPOSITORY_PREFIX repositories"
+  exit 1
+fi
+
+if [[ "$STABILITY" != "stable" ]]; then
+  echo "[INFO] Dry run, $TOTAL_PACKAGES_COUNT packages would be promoted to $STABLE_REPOSITORY_PREFIX repositories"
+  exit 0
+fi
+
+for ARCH in noarch x86_64; do
+  CONTENT="${ARCH_CONTENT[$ARCH]:-[]}"
+  ARCH_PACKAGES_COUNT=$(echo "$CONTENT" | jq 'length')
+
+  if [[ "$ARCH_PACKAGES_COUNT" -eq 0 ]]; then
+    echo "[INFO] No $ARCH package to promote"
+    continue
+  fi
+
+  STABLE_REPOSITORY_NAME="$STABLE_REPOSITORY_PREFIX-$ARCH"
+  STABLE_BASE_PATH="$STABLE_BASE_PATH_PREFIX/$ARCH"
+
+  if ! pulp rpm repository show --name "$STABLE_REPOSITORY_NAME" >/dev/null 2>&1; then
+    echo "[INFO] Creating rpm repository $STABLE_REPOSITORY_NAME"
+    # no --retain-package-versions on stable: it keeps the full version history
+    # (unlike testing/unstable which retain only the latest), matching
+    # create-rpm-repos.sh. normally create-repos pre-creates it, this is a fallback.
+    pulp rpm repository create --name "$STABLE_REPOSITORY_NAME" >/dev/null
+  fi
+
+  if ! pulp rpm distribution show --name "$STABLE_REPOSITORY_NAME" >/dev/null 2>&1; then
+    echo "[INFO] Creating rpm distribution $STABLE_REPOSITORY_NAME served at $STABLE_BASE_PATH"
+    pulp rpm distribution create --name "$STABLE_REPOSITORY_NAME" --base-path "$STABLE_BASE_PATH" --repository "$STABLE_REPOSITORY_NAME" >/dev/null
+  fi
+
+  STABLE_REPOSITORY_HREF=$(pulp rpm repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.pulp_href')
+
+  echo "[INFO] Promoting $ARCH_PACKAGES_COUNT packages to $STABLE_REPOSITORY_NAME"
+  # pulp-cli repository content modify does not resolve content by pulp_href, use the api directly
+  TASK_HREF=$(
+    curl -fsSL -H "Authorization: Github $PULP_TOKEN" \
+      -X POST -H "Content-Type: application/json" \
+      -d "{\"add_content_units\": $CONTENT}" \
+      "$PULP_URL${STABLE_REPOSITORY_HREF}modify/" | jq -r '.task'
+  )
+  wait_task "$TASK_HREF"
+
+  echo "[INFO] Publishing repository $STABLE_REPOSITORY_NAME"
+  pulp rpm publication create --repository "$STABLE_REPOSITORY_NAME" >/dev/null
+
+  # record the promoted packages (with their stable target coordinates) so the
+  # verification step verifies exactly this set against the stable repo
+  while read -r PKG; do
+    manifest_add "$(echo "$PKG" | jq -c \
+      --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "$STABLE_BASE_PATH" \
+      '{filename: (.location_href | sub(".*/"; "")), name, version, release, arch, sha256, repository: $repository, base_path: $base_path}')"
+  done < <(echo "${ARCH_RESULTS[$ARCH]}" | jq -c '.[]')
+
+  echo "::notice::Packages are available at $PULP_CONTENT_URL/$STABLE_BASE_PATH/"
+done
+
+manifest_write "$MODULE_NAME" "${DISTRIB:-}" "rpm" "$STABILITY" "promote" "$PULP_CONTENT_URL"

--- a/.github/actions/promote-to-stable-pulp/promote-rpm.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-rpm.sh
@@ -76,16 +76,13 @@ for ARCH in noarch x86_64; do
   STABLE_BASE_PATH="$STABLE_BASE_PATH_PREFIX/$ARCH"
 
   if ! pulp rpm repository show --name "$STABLE_REPOSITORY_NAME" >/dev/null 2>&1; then
-    echo "[INFO] Creating rpm repository $STABLE_REPOSITORY_NAME"
-    # no --retain-package-versions on stable: it keeps the full version history
-    # (unlike testing/unstable which retain only the latest), matching
-    # create-rpm-repos.sh. normally create-repos pre-creates it, this is a fallback.
-    pulp rpm repository create --name "$STABLE_REPOSITORY_NAME" >/dev/null
+    echo "::error::stable rpm repository $STABLE_REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before promoting."
+    exit 1
   fi
 
   if ! pulp rpm distribution show --name "$STABLE_REPOSITORY_NAME" >/dev/null 2>&1; then
-    echo "[INFO] Creating rpm distribution $STABLE_REPOSITORY_NAME served at $STABLE_BASE_PATH"
-    pulp rpm distribution create --name "$STABLE_REPOSITORY_NAME" --base-path "$STABLE_BASE_PATH" --repository "$STABLE_REPOSITORY_NAME" >/dev/null
+    echo "::error::stable rpm distribution $STABLE_REPOSITORY_NAME does not exist. Pulp distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before promoting. Refusing to create it here to avoid an unguarded distribution."
+    exit 1
   fi
 
   STABLE_REPOSITORY_HREF=$(pulp rpm repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.pulp_href')

--- a/.github/actions/pulp-repository-properties/action.yml
+++ b/.github/actions/pulp-repository-properties/action.yml
@@ -1,0 +1,102 @@
+name: "pulp-repository-properties"
+description: "Compute pulp repository names, base paths and suites of a package delivery"
+inputs:
+  module_name:
+    description: "The package module name"
+    required: true
+  distrib:
+    description: "The distribution used for packaging"
+    required: true
+  version:
+    description: "Centreon packaged major version"
+    required: true
+  stability:
+    description: "The package stability (stable, testing, unstable)"
+    required: true
+  release_type:
+    description: "Type of release (hotfix, release)"
+    required: false
+    default: ""
+  is_cloud:
+    description: "Release context (cloud or not cloud)"
+    required: true
+  delivery_type:
+    description: "Delivery to feature or standard repository"
+    required: false
+    default: "standard"
+outputs:
+  package_extension:
+    description: "Package extension according to the distribution"
+    value: ${{ steps.parse-distrib.outputs.package_extension }}
+  distrib_family:
+    description: "Distrib family (el, debian, ubuntu)"
+    value: ${{ steps.parse-distrib.outputs.distrib_family }}
+  package_distrib_name:
+    description: "Distribution suffix in package name"
+    value: ${{ steps.parse-distrib.outputs.package_distrib_name }}
+  skip_delivery:
+    description: "Whether the delivery must be skipped"
+    value: ${{ steps.properties.outputs.skip_delivery }}
+  repository_prefix:
+    description: "Repository name prefix of rpm repositories (one repository per architecture)"
+    value: ${{ steps.properties.outputs.repository_prefix }}
+  base_path_prefix:
+    description: "Base path prefix of rpm distributions (one distribution per architecture)"
+    value: ${{ steps.properties.outputs.base_path_prefix }}
+  repository_name:
+    description: "Repository name of the deb repository"
+    value: ${{ steps.properties.outputs.repository_name }}
+  base_path:
+    description: "Base path of the deb distribution"
+    value: ${{ steps.properties.outputs.base_path }}
+  suite:
+    description: "Apt suite of the deb delivery"
+    value: ${{ steps.properties.outputs.suite }}
+  testing_repository_prefix:
+    description: "Repository name prefix of testing rpm repositories, used as promotion source"
+    value: ${{ steps.properties.outputs.testing_repository_prefix }}
+  stable_repository_prefix:
+    description: "Repository name prefix of stable rpm repositories"
+    value: ${{ steps.properties.outputs.stable_repository_prefix }}
+  stable_base_path_prefix:
+    description: "Base path prefix of stable rpm distributions"
+    value: ${{ steps.properties.outputs.stable_base_path_prefix }}
+  testing_suite:
+    description: "Apt suite of testing deb packages"
+    value: ${{ steps.properties.outputs.testing_suite }}
+  stable_suite:
+    description: "Apt suite of stable deb packages"
+    value: ${{ steps.properties.outputs.stable_suite }}
+  pool_path:
+    description: "Module scoped pool path of the deb delivery"
+    value: ${{ steps.properties.outputs.pool_path }}
+  testing_pool_path:
+    description: "Module scoped pool path of testing deb packages, used as promotion source"
+    value: ${{ steps.properties.outputs.testing_pool_path }}
+  stable_pool_path:
+    description: "Module scoped pool path of stable deb packages"
+    value: ${{ steps.properties.outputs.stable_pool_path }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Parse distrib name
+      id: parse-distrib
+      uses: ./.github/actions/parse-distrib
+      with:
+        distrib: ${{ inputs.distrib }}
+
+    - name: Compute pulp repository properties
+      id: properties
+      shell: bash
+      env:
+        MODULE_NAME: ${{ inputs.module_name }}
+        DISTRIB: ${{ inputs.distrib }}
+        DISTRIB_FAMILY: ${{ steps.parse-distrib.outputs.distrib_family }}
+        VERSION: ${{ inputs.version }}
+        STABILITY: ${{ inputs.stability }}
+        RELEASE_TYPE: ${{ inputs.release_type }}
+        IS_CLOUD: ${{ inputs.is_cloud }}
+        DELIVERY_TYPE: ${{ inputs.delivery_type }}
+        GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
+      run: ${{ github.action_path }}/properties.sh

--- a/.github/actions/pulp-repository-properties/properties.sh
+++ b/.github/actions/pulp-repository-properties/properties.sh
@@ -6,8 +6,14 @@ if [[ -z "$MODULE_NAME" || -z "$DISTRIB" || -z "$VERSION" || -z "$STABILITY" || 
   exit 1
 fi
 
+# parse-distrib emits the el family either generically ("el") or per version
+# ("el7"/"el8"/"el9"/"el10" on centreon-collect); normalize it to "el" so the
+# family checks below are portable across both conventions.
 case "$DISTRIB_FAMILY" in
-  el) ROOT_REPO="rpm-standard" ;;
+  el | el[0-9]*)
+    ROOT_REPO="rpm-standard"
+    DISTRIB_FAMILY="el"
+    ;;
   debian) ROOT_REPO="apt-standard" ;;
   ubuntu) ROOT_REPO="ubuntu-standard" ;;
   *)

--- a/.github/actions/pulp-repository-properties/properties.sh
+++ b/.github/actions/pulp-repository-properties/properties.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "$MODULE_NAME" || -z "$DISTRIB" || -z "$VERSION" || -z "$STABILITY" || -z "$IS_CLOUD" ]]; then
+  echo "::error::some mandatory inputs are empty, please check the logs."
+  exit 1
+fi
+
+case "$DISTRIB_FAMILY" in
+  el) ROOT_REPO="rpm-standard" ;;
+  debian) ROOT_REPO="apt-standard" ;;
+  ubuntu) ROOT_REPO="ubuntu-standard" ;;
+  *)
+    echo "::error::Unsupported distribution family: $DISTRIB_FAMILY"
+    exit 1
+    ;;
+esac
+
+TESTING_SEGMENT="testing"
+TESTING_POOL_SEGMENT="testing"
+if [[ "$RELEASE_TYPE" == "release" || "$RELEASE_TYPE" == "hotfix" ]]; then
+  TESTING_SEGMENT="testing-$RELEASE_TYPE"
+  TESTING_POOL_SEGMENT="testing/$RELEASE_TYPE"
+fi
+
+STABILITY_SEGMENT="$STABILITY"
+POOL_SEGMENT="$STABILITY"
+if [[ "$STABILITY" == "testing" ]]; then
+  STABILITY_SEGMENT="$TESTING_SEGMENT"
+  POOL_SEGMENT="$TESTING_POOL_SEGMENT"
+fi
+
+REPOSITORY_PREFIX=""
+BASE_PATH_PREFIX=""
+TESTING_REPOSITORY_PREFIX=""
+STABLE_REPOSITORY_PREFIX=""
+STABLE_BASE_PATH_PREFIX=""
+REPOSITORY_NAME=""
+BASE_PATH=""
+SUITE=""
+TESTING_SUITE=""
+STABLE_SUITE=""
+POOL_PATH=""
+TESTING_POOL_PATH=""
+STABLE_POOL_PATH=""
+
+if [[ "$DELIVERY_TYPE" == "feature" ]]; then
+  if [[ "$DISTRIB_FAMILY" != "el" ]]; then
+    echo "::notice::Feature delivery is not supported for $DISTRIB_FAMILY packages, skipping delivery."
+    echo "skip_delivery=true" >> "$GITHUB_OUTPUT"
+    exit 0
+  fi
+
+  FEATURE_TICKET=$(echo "$GH_HEAD_REF" | grep -oE 'MON-[0-9]+' | head -1 || true)
+  if [[ -z "$FEATURE_TICKET" ]]; then
+    echo "::error::Cannot extract the feature ticket from branch name $GH_HEAD_REF"
+    exit 1
+  fi
+
+  REPOSITORY_PREFIX="$ROOT_REPO-feature-$FEATURE_TICKET-$VERSION-$DISTRIB-$STABILITY"
+  BASE_PATH_PREFIX="$ROOT_REPO-feature/$FEATURE_TICKET/$VERSION/$DISTRIB/$STABILITY"
+else
+  if [[ "$IS_CLOUD" == "true" ]]; then
+    ROOT_REPO="$ROOT_REPO-internal"
+  fi
+
+  if [[ "$DISTRIB_FAMILY" == "el" ]]; then
+    REPOSITORY_PREFIX="$ROOT_REPO-$VERSION-$DISTRIB-$STABILITY_SEGMENT"
+    BASE_PATH_PREFIX="$ROOT_REPO/$VERSION/$DISTRIB/$STABILITY_SEGMENT"
+    TESTING_REPOSITORY_PREFIX="$ROOT_REPO-$VERSION-$DISTRIB-$TESTING_SEGMENT"
+    STABLE_REPOSITORY_PREFIX="$ROOT_REPO-$VERSION-$DISTRIB-stable"
+    STABLE_BASE_PATH_PREFIX="$ROOT_REPO/$VERSION/$DISTRIB/stable"
+  else
+    REPOSITORY_NAME="$ROOT_REPO"
+    BASE_PATH="$ROOT_REPO"
+    SUITE="$DISTRIB-$VERSION-$STABILITY_SEGMENT"
+    TESTING_SUITE="$DISTRIB-$VERSION-$TESTING_SEGMENT"
+    STABLE_SUITE="$DISTRIB-$VERSION-stable"
+    POOL_PATH="pool/$VERSION/$POOL_SEGMENT/$MODULE_NAME"
+    TESTING_POOL_PATH="pool/$VERSION/$TESTING_POOL_SEGMENT/$MODULE_NAME"
+    STABLE_POOL_PATH="pool/$VERSION/stable/$MODULE_NAME"
+  fi
+fi
+
+echo "[DEBUG] - repository_prefix: $REPOSITORY_PREFIX"
+echo "[DEBUG] - base_path_prefix: $BASE_PATH_PREFIX"
+echo "[DEBUG] - testing_repository_prefix: $TESTING_REPOSITORY_PREFIX"
+echo "[DEBUG] - stable_repository_prefix: $STABLE_REPOSITORY_PREFIX"
+echo "[DEBUG] - stable_base_path_prefix: $STABLE_BASE_PATH_PREFIX"
+echo "[DEBUG] - repository_name: $REPOSITORY_NAME"
+echo "[DEBUG] - base_path: $BASE_PATH"
+echo "[DEBUG] - suite: $SUITE"
+echo "[DEBUG] - testing_suite: $TESTING_SUITE"
+echo "[DEBUG] - stable_suite: $STABLE_SUITE"
+echo "[DEBUG] - pool_path: $POOL_PATH"
+echo "[DEBUG] - testing_pool_path: $TESTING_POOL_PATH"
+echo "[DEBUG] - stable_pool_path: $STABLE_POOL_PATH"
+
+{
+  echo "skip_delivery=false"
+  echo "repository_prefix=$REPOSITORY_PREFIX"
+  echo "base_path_prefix=$BASE_PATH_PREFIX"
+  echo "testing_repository_prefix=$TESTING_REPOSITORY_PREFIX"
+  echo "stable_repository_prefix=$STABLE_REPOSITORY_PREFIX"
+  echo "stable_base_path_prefix=$STABLE_BASE_PATH_PREFIX"
+  echo "repository_name=$REPOSITORY_NAME"
+  echo "base_path=$BASE_PATH"
+  echo "suite=$SUITE"
+  echo "testing_suite=$TESTING_SUITE"
+  echo "stable_suite=$STABLE_SUITE"
+  echo "pool_path=$POOL_PATH"
+  echo "testing_pool_path=$TESTING_POOL_PATH"
+  echo "stable_pool_path=$STABLE_POOL_PATH"
+} >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-pulp-cli/action.yml
+++ b/.github/actions/setup-pulp-cli/action.yml
@@ -49,8 +49,12 @@ runs:
           exit 1
         fi
 
+        # retry on transient GitHub OIDC token service errors (5xx/timeouts):
+        # the endpoint occasionally returns 503, and a single blip must not break
+        # the whole delivery.
         PULP_TOKEN=$(
-          curl -fsSL -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             -G --data-urlencode "audience=$AUDIENCE" \
             "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value'
         )

--- a/.github/actions/setup-pulp-cli/action.yml
+++ b/.github/actions/setup-pulp-cli/action.yml
@@ -1,0 +1,102 @@
+name: "setup-pulp-cli"
+description: "Install pulp-cli and authenticate to pulp with a GitHub OIDC token"
+inputs:
+  pulp_url:
+    description: "The pulp server api url"
+    required: false
+    default: "https://pulp-api.apps.centreon.com"
+  audience:
+    description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
+    required: false
+    default: "https://pulp.dev.centreon.io"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.12"
+
+    - name: Install pulp-cli
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if ! command -v pulp >/dev/null 2>&1; then
+          echo "[INFO] Installing pulp-cli"
+          pip install --quiet "pulp-cli==0.37.1" "pulp-cli-deb==0.4.3"
+        fi
+
+    - name: Request a GitHub OIDC token for pulp
+      shell: bash
+      env:
+        AUDIENCE: ${{ inputs.audience }}
+      run: |
+        set -euo pipefail
+
+        # an unset org variable is forwarded as "": fail loudly rather than
+        # falling back to a default audience, a token minted for the wrong
+        # audience must never be silently requested against another server
+        if [[ -z "$AUDIENCE" ]]; then
+          echo "::error::audience input is empty (is the PULP_OIDC_AUDIENCE org variable defined?)"
+          exit 1
+        fi
+
+        # the job must grant id-token write permission for these to be set
+        if [[ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" || -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]]; then
+          echo "::error::Missing OIDC token request context, the job needs 'permissions: id-token: write'"
+          exit 1
+        fi
+
+        PULP_TOKEN=$(
+          curl -fsSL -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            -G --data-urlencode "audience=$AUDIENCE" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r '.value'
+        )
+        if [[ -z "$PULP_TOKEN" || "$PULP_TOKEN" == "null" ]]; then
+          echo "::error::Could not obtain a GitHub OIDC token"
+          exit 1
+        fi
+
+        # keep the token out of any log and expose it to the next steps
+        echo "::add-mask::$PULP_TOKEN"
+        echo "PULP_TOKEN=$PULP_TOKEN" >> "$GITHUB_ENV"
+
+    - name: Configure pulp-cli
+      shell: bash
+      env:
+        PULP_URL: ${{ inputs.pulp_url }}
+      run: |
+        set -euo pipefail
+
+        # fall back to the default when the caller passes an empty value (unset
+        # org variable forwarded as "" would otherwise override the default).
+        PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
+
+        # keep the pulp-cli config (which stores the OIDC token) under the per-job
+        # RUNNER_TEMP rather than the runner's persistent ~/.config, and share the
+        # location with the later steps, so a self-hosted runner does not retain
+        # the token in a home reused across jobs.
+        export XDG_CONFIG_HOME="${RUNNER_TEMP:-/tmp}/pulp-cli-config"
+        mkdir -p "$XDG_CONFIG_HOME"
+        echo "XDG_CONFIG_HOME=$XDG_CONFIG_HOME" >> "$GITHUB_ENV"
+
+        # the GitHub OIDC plugin authenticates requests carrying this header,
+        # there is no username/password, the token grants are derived from the
+        # token claims by the pulp server rules
+        # pulp-cli splits --header on the first colon and keeps the value
+        # verbatim, so no space after the colon (it would be rejected as
+        # leading whitespace); the sent header is still "Authorization: Github …"
+        pulp config create --overwrite \
+          --base-url "$PULP_URL" \
+          --api-root "/" \
+          --header "Authorization:Github $PULP_TOKEN" \
+          --timeout 0
+
+        # fail fast on connectivity issues, scripts cannot distinguish
+        # a missing resource from an unreachable server otherwise
+        if ! pulp status >/dev/null; then
+          echo "::error::Pulp server $PULP_URL is not reachable"
+          exit 1
+        fi

--- a/.github/scripts/pulp/api.sh
+++ b/.github/scripts/pulp/api.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Shared pulp api helpers for the delivery/promotion scripts. Source this file
+# like manifest.sh; PULP_URL and PULP_TOKEN must be set by the caller.
+
+# wait for a pulp api task to complete. a failed poll request (network blip,
+# api 5xx) is retried like an unexpected state instead of aborting the caller
+# under set -e; the 200-attempt cap bounds the total wait (~10 min).
+wait_task() {
+  local task_href=$1
+  local state attempt
+  for ((attempt = 0; attempt < 200; attempt++)); do
+    state=$(curl -fsSL -H "Authorization: Github $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null | jq -r '.state' 2>/dev/null) || state=""
+    case "$state" in
+      completed)
+        return 0
+        ;;
+      failed|canceled)
+        echo "::error::Task $task_href $state: $(curl -fsSL -H "Authorization: Github $PULP_TOKEN" "$PULP_URL$task_href" | jq -c '.error')"
+        return 1
+        ;;
+      *)
+        sleep 3
+        ;;
+    esac
+  done
+  echo "::error::Task $task_href did not complete in time (~10 min)"
+  return 1
+}
+
+# upload a package through the pulp api, with retry on transient failures
+# (concurrent deliveries can race on artifact creation), echoes the task href
+pulp_upload() {
+  local attempt response http_code body
+  for attempt in 1 2 3; do
+    response=$(curl -sS -H "Authorization: Github $PULP_TOKEN" -w $'\n%{http_code}' "$@" 2>/dev/null) || response=""
+    http_code=${response##*$'\n'}
+    body=${response%$'\n'*}
+    if [[ "$http_code" == "202" ]]; then
+      echo "$body" | jq -r '.task'
+      return 0
+    fi
+    echo "[WARN] upload attempt $attempt/3 failed (HTTP ${http_code:-network-error}), retrying..." >&2
+    sleep $((attempt * 3))
+  done
+  echo "::error::Upload failed after 3 attempts (HTTP ${http_code:-network-error})" >&2
+  return 1
+}

--- a/.github/scripts/pulp/check-common.sh
+++ b/.github/scripts/pulp/check-common.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Shared helpers for the pulp delivery/promotion verification scripts
+# (check-rpm.sh, check-deb.sh).
+#
+# The check never aborts mid-verification: every expected package is checked, its
+# per-package result is recorded, the full table is rendered to the step summary,
+# and only then is a non-zero status returned if anything failed. Source this
+# file, call load_expected, verify the packages, then call render_summary.
+
+PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
+METADATA_TIMEOUT="${METADATA_TIMEOUT:-300}"
+METADATA_INTERVAL="${METADATA_INTERVAL:-15}"
+
+# accumulated per-package result rows and the aggregate failure flag
+ROWS=()
+PRESENT_OK=0
+META_OK=0
+TOTAL=0
+FAILED=0
+
+# load_expected <package_type> — load the manifest emitted by the delivery or
+# promotion step into PACKAGES_JSON/COUNT; the manifest is required.
+load_expected() {
+  local package_type=$1
+  if [[ -z "${MANIFEST:-}" || ! -s "${MANIFEST:-}" ]]; then
+    echo "::error::pulp verification requires the manifest emitted by the delivery/promote step"
+    exit 1
+  fi
+  echo "[INFO] Reading expected ${package_type} packages from manifest ${MANIFEST}"
+  PACKAGES_JSON=$(jq -c '.packages' "$MANIFEST")
+  COUNT=$(echo "$PACKAGES_JSON" | jq 'length')
+  if [[ "$COUNT" -eq 0 ]]; then
+    echo "::error::No expected ${package_type} package to verify"
+    exit 1
+  fi
+  echo "[INFO] ${COUNT} expected ${package_type} package(s) to verify"
+}
+
+# wait_for_metadata — repeatedly call the sourcing script's resolve_pending (one
+# resolution round over the still-unresolved packages, returning 0 once none
+# remain) until everything resolves or METADATA_TIMEOUT is reached.
+wait_for_metadata() {
+  local deadline=$(( SECONDS + METADATA_TIMEOUT ))
+  until resolve_pending; do
+    if [[ "$SECONDS" -ge "$deadline" ]]; then
+      echo "[WARN] Metadata resolution timed out after ${METADATA_TIMEOUT}s"
+      break
+    fi
+    echo "[INFO] Waiting ${METADATA_INTERVAL}s for metadata to publish..."
+    sleep "$METADATA_INTERVAL"
+  done
+}
+
+# record_row <filename> <arch> <present:bool> <in_metadata:bool> <fetchable:bool>
+record_row() {
+  local filename=$1 arch=$2 present=$3 in_meta=$4 fetchable=$5
+  local p m f
+  TOTAL=$((TOTAL + 1))
+  if [[ "$present" == "true" ]]; then p="✅"; PRESENT_OK=$((PRESENT_OK + 1)); else p="❌"; FAILED=1; fi
+  if [[ "$in_meta" == "true" ]]; then m="✅"; META_OK=$((META_OK + 1)); else m="❌"; FAILED=1; fi
+  if [[ "$fetchable" == "true" ]]; then f="✅"; else f="❌"; FAILED=1; fi
+  ROWS+=("| \`$filename\` | $arch | $p | $m | $f |")
+  echo "[CHECK] $filename ($arch): present=$p metadata=$m fetchable=$f"
+}
+
+# check_fetchable_and_record — HEAD each resolved package on the content url and
+# record every package's result row. Uses the E_FILENAME/E_ARCH/E_BASEPATH,
+# PRESENT_IDX, META_IDX and RESOLVED_IDX arrays filled by the sourcing script.
+check_fetchable_and_record() {
+  local i url code fetchable
+  for i in "${!E_FILENAME[@]}"; do
+    fetchable=false
+    if [[ "${META_IDX[$i]}" == "true" ]]; then
+      url="${PULP_CONTENT_URL}/${E_BASEPATH[$i]}/${RESOLVED_IDX[$i]}"
+      code=$(curl -fsSL -o /dev/null -w '%{http_code}' -I "$url" 2>/dev/null || echo 000)
+      [[ "$code" == "200" ]] && fetchable=true
+    fi
+    record_row "${E_FILENAME[$i]}" "${E_ARCH[$i]}" "${PRESENT_IDX[$i]}" "${META_IDX[$i]}" "$fetchable"
+  done
+}
+
+# render_summary — write the per-OS table to the step summary (and stdout), then
+# return non-zero if any package failed any check. Called once, after all checks.
+render_summary() {
+  local title
+  title="### ${DISTRIB:-?} — ${STABILITY:-?} (${CHECK_MODE:-delivery}, pulp)"
+
+  {
+    echo "$title"
+    echo ""
+    echo "| Package | Arch | On repository | In metadata | Fetchable |"
+    echo "|---|---|---|---|---|"
+    if ((${#ROWS[@]})); then
+      printf '%s\n' "${ROWS[@]}"
+    fi
+    echo ""
+    echo "Result: ${PRESENT_OK}/${TOTAL} present · ${META_OK}/${TOTAL} resolvable"
+    if [[ "$FAILED" -ne 0 ]]; then
+      echo ""
+      echo "> ❌ Some packages are missing on the repository or unresolvable through metadata."
+    fi
+    echo ""
+  } | tee -a "${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+  if [[ "$FAILED" -ne 0 ]]; then
+    echo "::error::pulp verification: ${DISTRIB:-?} verification failed (see the table above)"
+    return 1
+  fi
+  echo "[INFO] All ${TOTAL} package(s) verified on ${DISTRIB:-?}"
+  return 0
+}

--- a/.github/scripts/pulp/check-deb.sh
+++ b/.github/scripts/pulp/check-deb.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Verify that the delivered/promoted DEB packages are (1) physically present as
+# content units in their target pulp repository and (2) resolvable through the
+# published apt metadata (and actually fetchable from the content url).
+#
+# Metadata resolution mirrors promote-deb.sh: the structured publication serves
+# packages under the canonical pool layout, so the published Filename is resolved
+# from the suite's Packages index by sha256. Architecture "all" packages are
+# listed under every binary-<arch>, so they are looked up across the suite's
+# architectures.
+#
+# The expected list is the manifest emitted by the delivery/promote step. The
+# script never exits early — see check-common.sh.
+set -uo pipefail
+
+# shellcheck source=.github/scripts/pulp/check-common.sh
+source "$(dirname "$0")/check-common.sh"
+
+load_expected "DEB"
+
+# --- load expected packages into parallel arrays ---------------------------
+mapfile -t E_FILENAME   < <(echo "$PACKAGES_JSON" | jq -r '.[].filename')
+mapfile -t E_ARCH       < <(echo "$PACKAGES_JSON" | jq -r '.[].arch')
+mapfile -t E_SHA256     < <(echo "$PACKAGES_JSON" | jq -r '.[].sha256')
+mapfile -t E_REPOSITORY < <(echo "$PACKAGES_JSON" | jq -r '.[].repository')
+mapfile -t E_BASEPATH   < <(echo "$PACKAGES_JSON" | jq -r '.[].base_path')
+mapfile -t E_SUITE      < <(echo "$PACKAGES_JSON" | jq -r '.[].suite')
+mapfile -t E_RELPATH    < <(echo "$PACKAGES_JSON" | jq -r '.[].relative_path')
+
+# --- physical presence: content units in the repository's latest version ----
+declare -A PRESENT_BY_REPO
+for repo in $(printf '%s\n' "${E_REPOSITORY[@]}" | sort -u); do
+  version_href=$(pulp deb repository show --name "$repo" 2>/dev/null | jq -r '.latest_version_href // empty')
+  if [[ -z "$version_href" ]]; then
+    echo "[WARN] Repository $repo does not exist or has no version"
+    PRESENT_BY_REPO[$repo]=""
+    continue
+  fi
+  PRESENT_BY_REPO[$repo]=$(
+    curl -fsSL -H "Authorization: Github $PULP_TOKEN" -G \
+      --data-urlencode "repository_version=$version_href" \
+      --data-urlencode "pulp_label_select=module=$MODULE_NAME" \
+      --data-urlencode "limit=1000" \
+      "$PULP_URL/api/v3/content/deb/packages/" 2>/dev/null \
+      | jq -r '.results[].relative_path'
+  )
+done
+
+declare -A PRESENT_IDX
+for i in "${!E_FILENAME[@]}"; do
+  if printf '%s\n' "${PRESENT_BY_REPO[${E_REPOSITORY[$i]}]:-}" | grep -Fxq "${E_RELPATH[$i]}"; then
+    PRESENT_IDX[$i]=true
+  else
+    PRESENT_IDX[$i]=false
+  fi
+done
+
+# --- metadata resolvability + fetchability, with a bounded retry window -----
+# resolve a package's published Filename from a suite Packages index by sha256
+resolve_filename() {
+  local packages=$1 sha=$2
+  printf '%s' "$packages" | awk -v sha="$sha" '
+    BEGIN { RS = ""; FS = "\n" }
+    index($0, "SHA256: " sha) {
+      for (i = 1; i <= NF; i++) if ($i ~ /^Filename: /) { sub(/^Filename: /, "", $i); print $i; exit }
+    }'
+}
+
+declare -A META_IDX      # idx -> true|false
+declare -A RESOLVED_IDX  # idx -> published Filename
+for i in "${!E_FILENAME[@]}"; do META_IDX[$i]=false; done
+
+# one resolution round: fetch each suite's Packages indexes once, then resolve
+# each pending package's published Filename by sha256
+resolve_pending() {
+  local -A pkg_cache=()    # key: base_path|suite|arch -> Packages body
+  local -A arches_cache=() # key: base_path|suite -> space separated arches
+  local all_resolved=true i base_path suite arch search_arches sk ck a filename
+  for i in "${!E_FILENAME[@]}"; do
+    [[ "${META_IDX[$i]}" == "true" ]] && continue
+    base_path=${E_BASEPATH[$i]}; suite=${E_SUITE[$i]}; arch=${E_ARCH[$i]}
+
+    # architectures to search: the package arch, plus every arch of the suite
+    # for "all" packages (which are duplicated across each binary-<arch>)
+    search_arches="$arch"
+    if [[ "$arch" == "all" ]]; then
+      sk="$base_path|$suite"
+      if [[ -z "${arches_cache[$sk]+set}" ]]; then
+        arches_cache[$sk]=$(curl -fsSL "$PULP_CONTENT_URL/$base_path/dists/$suite/Release" 2>/dev/null \
+          | awk -F': ' '/^Architectures:/ { print $2; exit }')
+      fi
+      search_arches="${arches_cache[$sk]:-amd64 arm64 all}"
+    fi
+
+    filename=""
+    for a in $search_arches; do
+      ck="$base_path|$suite|$a"
+      if [[ -z "${pkg_cache[$ck]+set}" ]]; then
+        pkg_cache[$ck]=$(curl -fsSL "$PULP_CONTENT_URL/$base_path/dists/$suite/main/binary-$a/Packages" 2>/dev/null || true)
+      fi
+      filename=$(resolve_filename "${pkg_cache[$ck]}" "${E_SHA256[$i]}")
+      [[ -n "$filename" ]] && break
+    done
+
+    if [[ -n "$filename" ]]; then
+      META_IDX[$i]=true
+      RESOLVED_IDX[$i]=$filename
+    else
+      all_resolved=false
+    fi
+  done
+  [[ "$all_resolved" == "true" ]]
+}
+
+wait_for_metadata
+check_fetchable_and_record
+render_summary

--- a/.github/scripts/pulp/check-rpm.sh
+++ b/.github/scripts/pulp/check-rpm.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Verify that the delivered/promoted RPM packages are (1) physically present as
+# content units in their target pulp repository and (2) resolvable through the
+# published repodata (and actually fetchable from the content url).
+#
+# The expected list is the manifest emitted by the delivery/promote step. The
+# script never exits early — see check-common.sh.
+set -uo pipefail
+
+# shellcheck source=.github/scripts/pulp/check-common.sh
+source "$(dirname "$0")/check-common.sh"
+
+load_expected "RPM"
+
+# --- load expected packages into parallel arrays ---------------------------
+mapfile -t E_FILENAME   < <(echo "$PACKAGES_JSON" | jq -r '.[].filename')
+mapfile -t E_ARCH       < <(echo "$PACKAGES_JSON" | jq -r '.[].arch')
+mapfile -t E_SHA256     < <(echo "$PACKAGES_JSON" | jq -r '.[].sha256')
+mapfile -t E_REPOSITORY < <(echo "$PACKAGES_JSON" | jq -r '.[].repository')
+mapfile -t E_BASEPATH   < <(echo "$PACKAGES_JSON" | jq -r '.[].base_path')
+
+# --- physical presence: content units in each repository's latest version --
+declare -A PRESENT_BY_REPO
+declare -A EXPECTED_COUNT_BY_REPO
+
+for repo in $(printf '%s\n' "${E_REPOSITORY[@]}" | sort -u); do
+  version_href=$(pulp rpm repository show --name "$repo" 2>/dev/null | jq -r '.latest_version_href // empty')
+  if [[ -z "$version_href" ]]; then
+    echo "[WARN] Repository $repo does not exist or has no version"
+    PRESENT_BY_REPO[$repo]=""
+    continue
+  fi
+  PRESENT_BY_REPO[$repo]=$(
+    curl -fsSL -H "Authorization: Github $PULP_TOKEN" -G \
+      --data-urlencode "repository_version=$version_href" \
+      --data-urlencode "pulp_label_select=module=$MODULE_NAME" \
+      --data-urlencode "limit=1000" \
+      "$PULP_URL/api/v3/content/rpm/packages/" 2>/dev/null \
+      | jq -r '.results[].location_href' | awk -F/ '{print $NF}'
+  )
+done
+
+declare -A PRESENT_IDX   # idx -> true|false
+for i in "${!E_FILENAME[@]}"; do
+  repo=${E_REPOSITORY[$i]}
+  EXPECTED_COUNT_BY_REPO[$repo]=$(( ${EXPECTED_COUNT_BY_REPO[$repo]:-0} + 1 ))
+  if printf '%s\n' "${PRESENT_BY_REPO[$repo]:-}" | grep -Fxq "${E_FILENAME[$i]}"; then
+    PRESENT_IDX[$i]=true
+  else
+    PRESENT_IDX[$i]=false
+  fi
+done
+
+# right number (delivery only): flag content-unit filenames present under the
+# module that were not expected (e.g. a stale package left behind). the testing
+# and unstable repositories retain a single version per package, so any extra is
+# suspect; the stable repository legitimately keeps the full version history of
+# previous releases, so this sweep would flag every past release on promotion.
+[[ "${CHECK_MODE:-delivery}" == "delivery" ]] && for repo in "${!EXPECTED_COUNT_BY_REPO[@]}"; do
+  present_count=$(printf '%s\n' "${PRESENT_BY_REPO[$repo]:-}" | grep -c . || true)
+  if [[ "$present_count" -gt "${EXPECTED_COUNT_BY_REPO[$repo]}" ]]; then
+    echo "::warning::Repository $repo holds $present_count module packages but only ${EXPECTED_COUNT_BY_REPO[$repo]} were expected (unexpected extras)"
+    while read -r fn; do
+      [[ -z "$fn" ]] && continue
+      if ! printf '%s\n' "${E_FILENAME[@]}" | grep -Fxq "$fn"; then
+        record_row "$fn" "?" "false" "false" "false"
+      fi
+    done < <(printf '%s\n' "${PRESENT_BY_REPO[$repo]:-}")
+  fi
+done
+
+# --- metadata resolvability + fetchability, with a bounded retry window -----
+declare -A META_IDX      # idx -> true|false
+declare -A RESOLVED_IDX  # idx -> published location href
+for i in "${!E_FILENAME[@]}"; do META_IDX[$i]=false; done
+
+# resolve the published location href of the package whose sha256 checksum
+# matches, from a primary.xml body: matching by checksum (not filename) binds
+# the verification to the exact delivered content, like the DEB by-sha256 match
+resolve_href() {
+  local primary=$1 sha=$2
+  printf '%s' "$primary" | awk -v sha="$sha" '
+    BEGIN { RS = "</package>" }
+    index($0, ">" sha "</checksum>") {
+      if (match($0, /<location[^>]*href="[^"]+"/)) {
+        s = substr($0, RSTART, RLENGTH)
+        sub(/.*href="/, "", s); sub(/"$/, "", s)
+        print s; exit
+      }
+    }'
+}
+
+# one resolution round: fetch each base_path's primary.xml once, then resolve
+# each pending package's published href by sha256
+resolve_pending() {
+  local -A primary_cache=()
+  local all_resolved=true i base_path repomd primary_href href
+  for i in "${!E_FILENAME[@]}"; do
+    [[ "${META_IDX[$i]}" == "true" ]] && continue
+    base_path=${E_BASEPATH[$i]}
+
+    if [[ -z "${primary_cache[$base_path]+set}" ]]; then
+      repomd=$(curl -fsSL "$PULP_CONTENT_URL/$base_path/repodata/repomd.xml" 2>/dev/null || true)
+      primary_href=$(printf '%s' "$repomd" | grep -oP '<location href="\K[^"]+primary\.xml[^"]*' | head -1 || true)
+      if [[ -n "$primary_href" ]]; then
+        primary_cache[$base_path]=$(curl -fsSL "$PULP_CONTENT_URL/$base_path/$primary_href" 2>/dev/null | gunzip -c 2>/dev/null || true)
+      else
+        primary_cache[$base_path]=""
+      fi
+    fi
+
+    href=$(resolve_href "${primary_cache[$base_path]}" "${E_SHA256[$i]}")
+    if [[ -n "$href" ]]; then
+      META_IDX[$i]=true
+      RESOLVED_IDX[$i]=$href
+    else
+      all_resolved=false
+    fi
+  done
+  [[ "$all_resolved" == "true" ]]
+}
+
+wait_for_metadata
+check_fetchable_and_record
+render_summary

--- a/.github/scripts/pulp/manifest.sh
+++ b/.github/scripts/pulp/manifest.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Shared helpers to emit the delivery/promotion manifest consumed by the
+# verification scripts (check-rpm.sh, check-deb.sh). Source this file, append
+# one compact JSON object per package with manifest_add, then finalize the
+# manifest with manifest_write.
+#
+# The manifest is the authoritative "expected packages" list: it is captured at
+# the moment of upload (the packages that were on the runner before/at upload),
+# so the check step verifies exactly this set rather than re-reading the build
+# cache. Each entry carries the package identity (for the content-api presence
+# query), its sha256 (for the by-checksum metadata match) and the pulp target
+# coordinates (so the check re-derives no path).
+
+MANIFEST_ENTRIES=()
+
+# manifest_add <compact-json-object>
+manifest_add() {
+  MANIFEST_ENTRIES+=("$1")
+}
+
+# manifest_write <module> <distrib> <package_type> <stability> <mode> <content_url>
+# writes the manifest json to the workspace and exposes its path as the
+# "manifest" step output when running inside a github action.
+manifest_write() {
+  local module=$1 distrib=$2 package_type=$3 stability=$4 mode=$5 content_url=$6
+  local file="${GITHUB_WORKSPACE:-$PWD}/pulp-delivery-manifest.json"
+  local packages="[]"
+  if ((${#MANIFEST_ENTRIES[@]})); then
+    packages=$(printf '%s\n' "${MANIFEST_ENTRIES[@]}" | jq -s '.')
+  fi
+
+  # NB: the jq variable is named module_name, not module — `module` is a reserved
+  # jq keyword and `$module` fails to parse on stricter jq builds (the CI runner)
+  jq -n \
+    --arg module_name "$module" \
+    --arg distrib "$distrib" \
+    --arg package_type "$package_type" \
+    --arg stability "$stability" \
+    --arg mode "$mode" \
+    --arg content_url "$content_url" \
+    --argjson packages "$packages" \
+    '{
+      "module": $module_name,
+      distrib: $distrib,
+      package_type: $package_type,
+      stability: $stability,
+      mode: $mode,
+      pulp_content_url: $content_url,
+      packages: $packages
+    }' > "$file"
+
+  echo "[INFO] Wrote delivery manifest ($(echo "$packages" | jq 'length') package(s)) to $file"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "manifest=$file" >> "$GITHUB_OUTPUT"
+  fi
+}

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -878,6 +878,61 @@ jobs:
           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
 
+  deliver-rpm-pulp:
+    continue-on-error: true
+    if: |
+      needs.changes.outputs.trigger_delivery == 'true' &&
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+
+    needs: [get-environment, changes, robot-test]
+    runs-on: centreon-ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distrib: el9
+            arch: amd64
+          - distrib: el10
+            arch: amd64
+
+    name: deliver ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Deliver packages on Pulp
+        id: deliver_rpm_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: collect
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-centreon-collect-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_rpm_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   deliver-deb:
     if: |
       needs.changes.outputs.trigger_delivery == 'true' &&
@@ -918,6 +973,60 @@ jobs:
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
+  deliver-deb-pulp:
+    continue-on-error: true
+    if: |
+      needs.changes.outputs.trigger_delivery == 'true' &&
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect' &&
+      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+
+    needs: [get-environment, changes, robot-test]
+    runs-on: centreon-ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distrib: trixie
+            arch: amd64
+          - distrib: trixie
+            arch: arm64
+
+    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Deliver packages on Pulp
+        id: deliver_deb_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: collect
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-collect-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_deb_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   promote:
     needs: [get-environment, deliver-rpm, deliver-deb]
     if: |
@@ -950,6 +1059,51 @@ jobs:
           github_ref_name: ${{ github.ref_name }}
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+
+  promote-pulp:
+    continue-on-error: true
+    needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      (contains(fromJson('["stable", "testing"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+
+    runs-on: centreon-ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        distrib: [el9, el10, trixie]
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Promote ${{ matrix.distrib }} to stable on Pulp
+        id: promote_pulp
+        uses: ./.github/actions/promote-to-stable-pulp
+        continue-on-error: true
+        with:
+          module_name: collect
+          distrib: ${{ matrix.distrib }}
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp promotion failed
+        if: steps.promote_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
   set-skip-label:
     needs: [get-environment, deliver-rpm, deliver-deb, promote]

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -1031,7 +1031,7 @@ jobs:
     needs: [get-environment, deliver-rpm, deliver-deb]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable", "testing"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
@@ -1065,7 +1065,7 @@ jobs:
     needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable", "testing"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -147,6 +147,54 @@ jobs:
           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
 
+  deliver-rpm-pulp:
+    continue-on-error: true
+    runs-on: centreon-ubuntu-22.04
+    needs: [get-environment, package]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled')
+
+    strategy:
+      matrix:
+        distrib: [el9, el10]
+
+    name: deliver ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Deliver packages on Pulp
+        id: deliver_rpm_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: common
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_rpm_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   deliver-deb:
     runs-on: ubuntu-24.04
     needs: [get-environment, package]
@@ -178,11 +226,58 @@ jobs:
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
+  deliver-deb-pulp:
+    continue-on-error: true
+    runs-on: centreon-ubuntu-22.04
+    needs: [get-environment, package]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+
+    strategy:
+      matrix:
+        distrib: [trixie]
+
+    name: deliver ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Deliver packages on Pulp
+        id: deliver_deb_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: common
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_deb_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   promote:
     needs: [get-environment, deliver-rpm, deliver-deb]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable", "testing"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
@@ -209,6 +304,50 @@ jobs:
           github_ref_name: ${{ github.ref_name }}
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+
+  promote-pulp:
+    continue-on-error: true
+    needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+
+    runs-on: centreon-ubuntu-22.04
+    strategy:
+      matrix:
+        distrib: [el9, el10, trixie]
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Promote ${{ matrix.distrib }} to stable on Pulp
+        id: promote_pulp
+        uses: ./.github/actions/promote-to-stable-pulp
+        continue-on-error: true
+        with:
+          module_name: common
+          distrib: ${{ matrix.distrib }}
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp promotion failed
+        if: steps.promote_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
   set-skip-label:
     needs: [get-environment, deliver-rpm, deliver-deb, promote]

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -487,6 +487,56 @@ jobs:
           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
 
+  deliver-rpm-pulp:
+    continue-on-error: true
+    runs-on: centreon-ubuntu-22.04
+    needs: [get-environment, unit-test-perl, robot-test, changes]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      needs.changes.outputs.trigger_delivery == 'true' &&
+      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled')
+
+    strategy:
+      fail-fast: false
+      matrix:
+        distrib: [el9, el10]
+
+    name: deliver ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Deliver packages on Pulp
+        id: deliver_rpm_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: gorgone
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_rpm_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   deliver-deb:
     runs-on: ubuntu-24.04
     needs: [get-environment, unit-test-perl, robot-test, changes]
@@ -520,6 +570,55 @@ jobs:
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
+  deliver-deb-pulp:
+    continue-on-error: true
+    runs-on: centreon-ubuntu-22.04
+    needs: [get-environment, unit-test-perl, robot-test, changes]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      needs.changes.outputs.trigger_delivery == 'true' &&
+      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+
+    strategy:
+      fail-fast: false
+      matrix:
+        distrib: [trixie]  # No ubuntu in 24.10, 24.11 or later for now
+
+    name: deliver ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Deliver packages on Pulp
+        id: deliver_deb_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: gorgone
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_deb_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   promote:
     needs: [get-environment, deliver-rpm, deliver-deb]
     if: |
@@ -552,6 +651,51 @@ jobs:
           github_ref_name: ${{ github.ref_name }}
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+
+  promote-pulp:
+    continue-on-error: true
+    needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      (contains(fromJson('["stable", "testing"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+
+    runs-on: centreon-ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        distrib: [el9, el10, trixie]
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Promote ${{ matrix.distrib }} to stable on Pulp
+        id: promote_pulp
+        uses: ./.github/actions/promote-to-stable-pulp
+        continue-on-error: true
+        with:
+          module_name: gorgone
+          distrib: ${{ matrix.distrib }}
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp promotion failed
+        if: steps.promote_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
   set-skip-label:
     needs: [get-environment, deliver-rpm, deliver-deb, promote]

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -623,7 +623,7 @@ jobs:
     needs: [get-environment, deliver-rpm, deliver-deb]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable", "testing"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
@@ -657,7 +657,7 @@ jobs:
     needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable", "testing"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&

--- a/.github/workflows/libzmq.yml
+++ b/.github/workflows/libzmq.yml
@@ -240,6 +240,57 @@ jobs:
           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
 
+  deliver-rpm-pulp:
+    continue-on-error: true
+    needs: [get-environment, sign-rpm]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled')
+    runs-on: centreon-ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - distrib: el9
+            arch: amd64
+          - distrib: el10
+            arch: amd64
+
+    name: deliver ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Deliver packages on Pulp
+        id: deliver_rpm_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: libzmq
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_rpm_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   deliver-deb:
     needs: [get-environment, package-deb]
     if: |
@@ -274,11 +325,59 @@ jobs:
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
+  deliver-deb-pulp:
+    continue-on-error: true
+    needs: [get-environment, package-deb]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+    runs-on: centreon-ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - distrib: trixie
+            arch: amd64
+
+    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Deliver packages on Pulp
+        id: deliver_deb_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: libzmq
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_deb_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   promote:
     needs: [get-environment, deliver-rpm, deliver-deb]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable", "testing"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
@@ -304,6 +403,49 @@ jobs:
           github_ref_name: ${{ github.ref_name }}
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+
+  promote-pulp:
+    continue-on-error: true
+    needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+    runs-on: centreon-ubuntu-22.04
+    strategy:
+      matrix:
+        distrib: [el9, el10, trixie]
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Promote ${{ matrix.distrib }} to stable on Pulp
+        id: promote_pulp
+        uses: ./.github/actions/promote-to-stable-pulp
+        continue-on-error: true
+        with:
+          module_name: libzmq
+          distrib: ${{ matrix.distrib }}
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp promotion failed
+        if: steps.promote_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
   set-skip-label:
     needs: [get-environment, deliver-rpm, deliver-deb, promote]

--- a/.github/workflows/lua-curl.yml
+++ b/.github/workflows/lua-curl.yml
@@ -180,6 +180,56 @@ jobs:
           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
 
+  deliver-rpm-pulp:
+    continue-on-error: true
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled')
+    needs: [get-environment, package]
+    runs-on: centreon-ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - distrib: el9
+            arch: amd64
+          - distrib: el10
+            arch: amd64
+    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Deliver packages on Pulp
+        id: deliver_rpm_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: lua-curl
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-lua-curl-${{ matrix.distrib }}-${{ matrix.arch }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_rpm_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   deliver-deb:
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
@@ -214,11 +264,59 @@ jobs:
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
+  deliver-deb-pulp:
+    continue-on-error: true
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+    needs: [get-environment, package]
+    runs-on: centreon-ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - distrib: trixie
+            arch: amd64
+
+    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Deliver packages on Pulp
+        id: deliver_deb_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: lua-curl
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-lua-curl-${{ matrix.distrib }}-${{ matrix.arch }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_deb_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   promote:
     needs: [get-environment, deliver-rpm, deliver-deb]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable", "testing"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
@@ -244,6 +342,49 @@ jobs:
           github_ref_name: ${{ github.ref_name }}
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+
+  promote-pulp:
+    continue-on-error: true
+    needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+    runs-on: centreon-ubuntu-22.04
+    strategy:
+      matrix:
+        distrib: [el9, el10, trixie]
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Promote ${{ matrix.distrib }} to stable on Pulp
+        id: promote_pulp
+        uses: ./.github/actions/promote-to-stable-pulp
+        continue-on-error: true
+        with:
+          module_name: lua-curl
+          distrib: ${{ matrix.distrib }}
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp promotion failed
+        if: steps.promote_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
   set-skip-label:
     needs: [get-environment, deliver-rpm, deliver-deb, promote]

--- a/.github/workflows/monitoring-agent.yml
+++ b/.github/workflows/monitoring-agent.yml
@@ -512,6 +512,62 @@ jobs:
           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
 
+  deliver-rpm-pulp:
+    continue-on-error: true
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+
+    needs: [get-environment, build-and-test-agent-windows, robot-test]
+    runs-on: centreon-ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distrib: el8
+            arch: amd64
+          - distrib: el9
+            arch: amd64
+          - distrib: el10
+            arch: amd64
+
+    name: deliver ${{ matrix.distrib }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Deliver packages on Pulp
+        id: deliver_rpm_pulp
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: monitoring-agent
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-centreon-monitoring-agent-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_rpm_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   deliver-deb:
     if: |
       needs.changes.outputs.trigger_delivery == 'true' &&
@@ -569,6 +625,77 @@ jobs:
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
+  deliver-deb-pulp:
+    continue-on-error: true
+    if: |
+      needs.changes.outputs.trigger_delivery == 'true' &&
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+
+    needs: [get-environment, changes, build-and-test-agent-windows, robot-test]
+    runs-on: centreon-ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distrib: bullseye
+            arch: amd64
+          - distrib: bullseye
+            arch: arm64
+          - distrib: bookworm
+            arch: amd64
+          - distrib: bookworm
+            arch: arm64
+          - distrib: trixie
+            arch: amd64
+          - distrib: trixie
+            arch: arm64
+          - distrib: jammy
+            arch: amd64
+          - distrib: jammy
+            arch: arm64
+          - distrib: noble
+            arch: amd64
+          - distrib: noble
+            arch: arm64
+
+    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Deliver packages on Pulp
+        id: deliver_deb_pulp
+        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
+        uses: ./.github/actions/package-delivery-pulp
+        continue-on-error: true
+        with:
+          module_name: monitoring-agent
+          distrib: ${{ matrix.distrib }}
+          version: ${{ needs.get-environment.outputs.major_version }}
+          cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-monitoring-agent-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp delivery failed
+        if: steps.deliver_deb_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
   deliver-windows:
     if: |
       needs.changes.outputs.trigger_delivery == 'true' &&
@@ -620,7 +747,7 @@ jobs:
     needs: [get-environment, deliver-rpm, deliver-deb]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable", "testing"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
@@ -665,6 +792,53 @@ jobs:
           file_pattern: /tmp/promoted-packages/centreon-monitoring-agent${{ steps.parse-distrib.outputs.package_version_separator }}${{ needs.get-environment.outputs.cma_major_version }}.${{ needs.get-environment.outputs.cma_minor_version }}*.${{ steps.parse-distrib.outputs.package_extension }}
           github_release: centreon-monitoring-agent-${{ needs.get-environment.outputs.cma_major_version }}.${{ needs.get-environment.outputs.cma_minor_version }}
           token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
+
+  promote-linux-pulp:
+    continue-on-error: true
+    needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled') &&
+      github.repository == 'centreon/centreon-collect'
+
+    runs-on: centreon-ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        distrib: [el8, el9, el10, bullseye, bookworm, trixie, jammy, noble]
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout sources
+        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Promote ${{ matrix.distrib }} to stable on Pulp
+        id: promote_pulp
+        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
+        uses: ./.github/actions/promote-to-stable-pulp
+        continue-on-error: true
+        with:
+          module_name: monitoring-agent
+          distrib: ${{ matrix.distrib }}
+          major_version: ${{ needs.get-environment.outputs.major_version }}
+          stability: ${{ needs.get-environment.outputs.stability }}
+          release_type: ${{ needs.get-environment.outputs.release_type }}
+          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+          pulp_url: ${{ vars.PULP_API_URL }}
+          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+
+      - name: Warn if the Pulp promotion failed
+        if: steps.promote_pulp.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
   promote-windows:
     if: |


### PR DESCRIPTION
## Description

Port the **parallel Artifactory + Pulp delivery** from centreon (reference implementation, MON-200796) to centreon-collect. During the migration Artifactory stays authoritative and the Pulp path is **non-blocking** (job- and step-level `continue-on-error`), so the switch-over can be rolled out / rolled back safely.

**Functionally validated end to end** (via a temporary test PR, #3550, now closed): RPM (el8/el9/el10) and DEB (bullseye/bookworm/trixie/jammy/noble × amd64/arm64) packages delivered to Pulp successfully — the final run with the fail-closed scripts, against the structure provisioned by delivery-tooling `create-repos`.

## Changes

- **Pulp actions/scripts added verbatim** from the reference: `package-delivery-pulp`, `promote-to-stable-pulp`, `setup-pulp-cli`, `pulp-repository-properties`, and `.github/scripts/pulp/*.sh`. Authentication is **GitHub OIDC** (no username/password). `parse-distrib` already exposed the required outputs, so it was reused unchanged.
- **All six delivery workflows** gain Pulp twin jobs mirroring their Artifactory jobs: `collect.yml` (`collect`), `gorgone.yml` (`gorgone`), `common.yml` (`common`), `libzmq.yml` (`libzmq`), `lua-curl.yml` (`lua-curl`), `monitoring-agent.yml` (`monitoring-agent`).
  - `deliver-rpm-pulp` / `deliver-deb-pulp` — same `needs` / `if` / `matrix` and the **same `cache_key`** as `deliver-rpm` / `deliver-deb`, calling `package-delivery-pulp`.
  - `promote-pulp` — mirrors `promote`, `needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]`, calling `promote-to-stable-pulp`.
  - All: `runs-on: centreon-ubuntu-22.04`, `permissions: {contents: read, id-token: write}`, `continue-on-error` at job **and** step level, `actions/checkout@v7.0.0`, and a `::warning::` step that surfaces a (masked) Pulp failure.
- The Artifactory jobs (`deliver-rpm` / `deliver-deb` / `promote`) and the downstream jobs (`set-skip-label`, `clear-branch-cache`, `create-jira-nightly-ticket`) are **unchanged**.

### Repository/distribution creation is delegated to create-repos (fail-closed)

The delivery and promote scripts **no longer create Pulp repositories or distributions**. Provisioning is centralized in delivery-tooling `create-repos`, which owns the whole structure consistently (naming, `--retain-package-versions`, empty publications, content guards on the internal business distributions). If the target repository or distribution is missing, `deliver-rpm.sh` / `deliver-deb.sh` / `promote-rpm.sh` **fail closed** with an explicit error pointing to create-repos (`promote-deb.sh` already behaved this way). Same change applied to centreon (centreon#11016) and centreon-modules (centreon-modules#8791), so the shared pulp files stay identical across the three repositories.

## Robustness fixes (surfaced during functional validation)

- **`pulp-repository-properties`**: normalize centreon-collect's per-version RHEL family. `parse-distrib` emits `el7`/`el8`/`el9`/`el10` here (centreon emits a generic `el`); the property script now accepts `el[0-9]*` and normalizes to `el`, so RPM delivery works for every EL version.
- **`setup-pulp-cli`**: **retry the GitHub OIDC token request** (`curl --retry 5 --retry-delay 3 --retry-all-errors`). The token endpoint occasionally returns a transient `503`; a single blip no longer aborts the whole delivery.

## Configuration

Pulp endpoints come from the **organization variables** `vars.PULP_API_URL`, `vars.PULP_CONTENT_URL`, `vars.PULP_OIDC_AUDIENCE` (already created for centreon; centreon-collect must be able to read them). Action defaults are kept as a fallback.

## Prerequisites (status)

1. ✅ **OIDC rule** granting `centreon/centreon-collect` rpm/deb write — merged and deployed (delivery-tooling#201).
2. ✅ **Repository structure** — provisioned by delivery-tooling `create-repos` (delivery-tooling#155), already executed for 26.09 (onprem + cloud), covering every distribution the monitoring agent delivers (el8 + apt/ubuntu families).
3. ⚠️ **Operational requirement**: with the fail-closed delegation, `create-repos` must have been run for a major version **before** the first delivery/promotion of that version — otherwise the Pulp jobs fail with an explicit error (non-blocking during the migration).

## Notes

- **Promotion runs on `stable` only.** In every workflow the `promote` and `promote-pulp` (monitoring-agent: `promote-linux-pulp`) jobs — Artifactory and Pulp — are gated on `["stable"]` (narrowed from `["stable", "testing"]`); a real promotion only ever happened on stable.
- **monitoring-agent**: the `deliver-windows` job has **no** Pulp twin (Windows is not handled by the deb/rpm Pulp actions); the promote twin is `promote-linux-pulp`.
- The bundled `manifest.sh` includes the reserved-jq-keyword fix (`$module_name`), consistent with centreon (companion of centreon/centreon#11002).

Refs: MON-200796
