### PR TITLE
test(ci): validate Pulp unstable delivery for gorgone & monitoring-agent [do not merge]

### DIFF
--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -175,10 +175,8 @@ jobs:
 
   package:
     needs: [get-environment, changes, unit-test-perl]
+    # TEMP(test-pulp-unstable): force package to run regardless of changes/stability so deliver-*-pulp has freshly built packages in cache
     if: |
-      needs.changes.outputs.trigger_packaging == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
@@ -455,14 +453,7 @@ jobs:
   deliver-rpm:
     runs-on: ubuntu-24.04
     needs: [get-environment, unit-test-perl, robot-test, changes]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+    if: false # TEMP(test-pulp-unstable): disable Artifactory RPM delivery, validate Pulp only
 
     strategy:
       fail-fast: false
@@ -490,12 +481,10 @@ jobs:
   deliver-rpm-pulp:
     continue-on-error: true
     runs-on: centreon-ubuntu-22.04
-    needs: [get-environment, unit-test-perl, robot-test, changes]
+    # TEMP(test-pulp-unstable): depend on package so the RPM package cache is guaranteed ready
+    needs: [get-environment, package]
+    # TEMP(test-pulp-unstable): run regardless of changes/stability to validate Pulp delivery
     if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
@@ -523,7 +512,7 @@ jobs:
           distrib: ${{ matrix.distrib }}
           version: ${{ needs.get-environment.outputs.major_version }}
           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
+          stability: unstable # TEMP(test-pulp-unstable): force unstable Pulp suite
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
@@ -540,14 +529,7 @@ jobs:
   deliver-deb:
     runs-on: ubuntu-24.04
     needs: [get-environment, unit-test-perl, robot-test, changes]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+    if: false # TEMP(test-pulp-unstable): disable Artifactory DEB delivery, validate Pulp only
 
     strategy:
       fail-fast: false
@@ -573,15 +555,13 @@ jobs:
   deliver-deb-pulp:
     continue-on-error: true
     runs-on: centreon-ubuntu-22.04
-    needs: [get-environment, unit-test-perl, robot-test, changes]
+    # TEMP(test-pulp-unstable): depend on package so the DEB package cache is guaranteed ready
+    needs: [get-environment, package]
+    # TEMP(test-pulp-unstable): run regardless of changes/stability to validate Pulp delivery
     if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+      ! contains(needs.*.result, 'cancelled')
 
     strategy:
       fail-fast: false
@@ -606,7 +586,7 @@ jobs:
           distrib: ${{ matrix.distrib }}
           version: ${{ needs.get-environment.outputs.major_version }}
           cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
+          stability: unstable # TEMP(test-pulp-unstable): force unstable Pulp suite
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
           pulp_url: ${{ vars.PULP_API_URL }}

--- a/.github/workflows/monitoring-agent.yml
+++ b/.github/workflows/monitoring-agent.yml
@@ -392,8 +392,37 @@ jobs:
       ! contains(needs.*.result, 'cancelled')
     strategy:
       fail-fast: false
+      # TEMP(test-pulp-unstable): build every distrib/arch (overriding the dynamic
+      # cma_matrix) so the Pulp delivery test exercises all distribs — this list
+      # matches the deliver-rpm-pulp / deliver-deb-pulp matrices.
       matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.cma_matrix) }}
+        include:
+          - operating_system: el8
+            arch: amd64
+          - operating_system: el9
+            arch: amd64
+          - operating_system: el10
+            arch: amd64
+          - operating_system: bullseye
+            arch: amd64
+          - operating_system: bullseye
+            arch: arm64
+          - operating_system: bookworm
+            arch: amd64
+          - operating_system: bookworm
+            arch: arm64
+          - operating_system: trixie
+            arch: amd64
+          - operating_system: trixie
+            arch: arm64
+          - operating_system: jammy
+            arch: amd64
+          - operating_system: jammy
+            arch: arm64
+          - operating_system: noble
+            arch: amd64
+          - operating_system: noble
+            arch: arm64
 
     name: package ${{ matrix.operating_system }} ${{ matrix.arch }}
 

--- a/.github/workflows/monitoring-agent.yml
+++ b/.github/workflows/monitoring-agent.yml
@@ -385,10 +385,8 @@ jobs:
   package-linux:
     needs:
       [get-environment, get-aws-environment, changes, check-version-consistency]
+    # TEMP(test-pulp-unstable): force Linux package build to run regardless of changes/stability so deliver-*-pulp has freshly built packages in cache
     if: |
-      needs.changes.outputs.trigger_packaging == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
@@ -470,14 +468,7 @@ jobs:
       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
 
   deliver-rpm:
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
+    if: false # TEMP(test-pulp-unstable): disable Artifactory RPM delivery, validate Pulp only
 
     needs: [get-environment, build-and-test-agent-windows, robot-test]
     runs-on: centreon-ubuntu-22.04
@@ -514,16 +505,15 @@ jobs:
 
   deliver-rpm-pulp:
     continue-on-error: true
+    # TEMP(test-pulp-unstable): run regardless of changes/stability to validate Pulp delivery
     if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       github.repository == 'centreon/centreon-collect'
 
-    needs: [get-environment, build-and-test-agent-windows, robot-test]
+    # TEMP(test-pulp-unstable): depend on package-linux so the RPM package cache is guaranteed ready (drop Windows/robot deps)
+    needs: [get-environment, package-linux]
     runs-on: centreon-ubuntu-22.04
     strategy:
       fail-fast: false
@@ -554,7 +544,7 @@ jobs:
           distrib: ${{ matrix.distrib }}
           version: ${{ needs.get-environment.outputs.major_version }}
           cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-centreon-monitoring-agent-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
-          stability: ${{ needs.get-environment.outputs.stability }}
+          stability: unstable # TEMP(test-pulp-unstable): force unstable Pulp suite
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
@@ -569,14 +559,7 @@ jobs:
           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
   deliver-deb:
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
+    if: false # TEMP(test-pulp-unstable): disable Artifactory DEB delivery, validate Pulp only
 
     needs: [get-environment, changes, build-and-test-agent-windows, robot-test]
     runs-on: centreon-ubuntu-22.04
@@ -627,16 +610,15 @@ jobs:
 
   deliver-deb-pulp:
     continue-on-error: true
+    # TEMP(test-pulp-unstable): run regardless of changes/stability to validate Pulp delivery
     if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       github.repository == 'centreon/centreon-collect'
 
-    needs: [get-environment, changes, build-and-test-agent-windows, robot-test]
+    # TEMP(test-pulp-unstable): depend on package-linux so the DEB package cache is guaranteed ready (drop Windows/robot deps)
+    needs: [get-environment, package-linux]
     runs-on: centreon-ubuntu-22.04
     strategy:
       fail-fast: false
@@ -683,7 +665,7 @@ jobs:
           distrib: ${{ matrix.distrib }}
           version: ${{ needs.get-environment.outputs.major_version }}
           cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-monitoring-agent-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
-          stability: ${{ needs.get-environment.outputs.stability }}
+          stability: unstable # TEMP(test-pulp-unstable): force unstable Pulp suite
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
           pulp_url: ${{ vars.PULP_API_URL }}
@@ -697,14 +679,7 @@ jobs:
           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
   deliver-windows:
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
+    if: false # TEMP(test-pulp-unstable): disable Artifactory Windows delivery, validate Pulp only
 
     needs: [get-environment, changes, build-and-test-agent-windows, robot-test]
     runs-on: windows-latest

--- a/.github/workflows/monitoring-agent.yml
+++ b/.github/workflows/monitoring-agent.yml
@@ -394,14 +394,16 @@ jobs:
       fail-fast: false
       # TEMP(test-pulp-unstable): build every distrib/arch (overriding the dynamic
       # cma_matrix) so the Pulp delivery test exercises all distribs — this list
-      # matches the deliver-rpm-pulp / deliver-deb-pulp matrices.
+      # matches the deliver-rpm-pulp / deliver-deb-pulp matrices. RHEL uses the
+      # alma8/9/10 names (the packaging image + parse-distrib input); parse-distrib
+      # maps them to repo_distrib_name el8/9/10, matching the deliver cache_key.
       matrix:
         include:
-          - operating_system: el8
+          - operating_system: alma8
             arch: amd64
-          - operating_system: el9
+          - operating_system: alma9
             arch: amd64
-          - operating_system: el10
+          - operating_system: alma10
             arch: amd64
           - operating_system: bullseye
             arch: amd64


### PR DESCRIPTION
## Purpose — DO NOT MERGE

Throwaway CI-only branch (MON-200796) to **functionally validate the new Pulp delivery** introduced by centreon/centreon-collect PR #3549, end to end, before we rely on it. It forces the `gorgone` and `monitoring-agent` pipelines to deliver their packages to **Pulp in the `unstable` stability only**, with **no Artifactory delivery**, so a maintainer can observe the Pulp upload against a real run.

This branch is based on the `MON-200796-collect-delivery-pulp` feature branch, **not** `develop`, and must never be merged.

## What this changes (test-only, all marked `# TEMP(test-pulp-unstable)`)

Only `.github/workflows/gorgone.yml` and `.github/workflows/monitoring-agent.yml` are touched. The 4 other delivery workflows, the pulp actions, and everything else are untouched.

1. **No Artifactory delivery** — the Artifactory deliver jobs are disabled with `if: false` (kept in place so the diff is obvious and reversible):
   - gorgone: `deliver-rpm`, `deliver-deb`
   - monitoring-agent: `deliver-rpm`, `deliver-deb`, `deliver-windows`
2. **Pulp delivery forced to `unstable`** — `deliver-rpm-pulp` / `deliver-deb-pulp` now pass `stability: unstable` explicitly instead of `${{ needs.get-environment.outputs.stability }}`.
3. **Full pipeline forced to run** — a workflow-only change does not set `trigger_packaging` / `trigger_delivery`, so the build/package/deliver jobs would normally be skipped. To guarantee the pulp deliver jobs get freshly built packages from cache:
   - the package job (`package` for gorgone, `package-linux` for monitoring-agent) is forced to run (dropped the `trigger_packaging` / `skip_workflow` / stability gates, kept only the `!cancelled && !failure && !cancelled` guard);
   - `deliver-rpm-pulp` / `deliver-deb-pulp` now `needs: [get-environment, package]` (gorgone) / `[get-environment, package-linux]` (monitoring-agent), which guarantees ordering and that the `fail-on-cache-miss` package cache is ready, and drops the `changes` gating from their `if`.
   - The Windows build path is intentionally **not** forced; the pulp Linux delivery does not depend on it.
4. The stable-only Pulp promote jobs (`promote-pulp` / `promote-linux-pulp`) are left as-is and will simply not run on an unstable PR.

## After validation

Close this PR and delete the branch. Nothing here should ever land on a shared branch.
