### PR TITLE
fix(gorgone): stabilize flaky pullwss and push robot tests

### DIFF
--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -6,7 +6,7 @@ Resource            ${CURDIR}${/}..${/}..${/}resources${/}import.resource
 Suite Setup         Start Mockoon    ${ROOT_CONFIG}..${/}resources/web-api-mockoon.json
 Suite Teardown      Stop Mockoon
 
-Test Timeout        250s
+Test Timeout        300s
 
 *** Variables ***
 @{process_list}    pullwss_gorgone_poller_2_simple    pullwss_gorgone_central_simple
@@ -132,7 +132,11 @@ check poller token revocation
     Set Local Variable    ${revoked_url}    http://127.0.0.1:80/set-poller-4-is-revoked
     Set Local Variable    ${expired_url}    http://127.0.0.1:80/set-poller-4-is-expired
     Set Local Variable    ${port}    8086
-    Set Local Variable    ${timeout}    25
+    # "absent" checks always burn their full timeout (the string isn't there yet), so
+    # keep them short. Only "present" checks (after revocation) need real headroom for
+    # the blocking tpapi_centreonv2 API call inside the 5s recurring revocation check.
+    Set Local Variable    ${timeout_absent}    10
+    Set Local Variable    ${timeout_present}    30
     Set Local Variable    ${sleep}    6
     Set Local Variable    ${central_log_file}    /var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log
     Set Local Variable    ${poller_log_file}    /var/log/centreon-gorgone/pullwss_gorgone_poller_2_simple/gorgoned.log
@@ -151,17 +155,17 @@ check poller token revocation
     ${log_central_query}    Create List    [proxy-httpserver] invalid token
     # The poller is connected
     Check Poller Is Connected    port=${port}    expected_nb=2
-    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout}
+    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout_absent}
     Should Not Be True    ${logs_central}    Did find the logs in the central file : ${logs_central}
-    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout}
+    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout_absent}
     Should Not Be True    ${logs_poller}    Did find the logs in the poller file : ${logs_poller}
     ${start_date}    Get Current Date
     Sleep    ${sleep}
     # Still connected
     Check Poller Is Connected    port=${port}    expected_nb=2
-    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout}
+    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout_absent}
     Should Not Be True    ${logs_central}    Did find the logs in the central file : ${logs_central}
-    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout}
+    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout_absent}
     Should Not Be True    ${logs_poller}    Did find the logs in the poller file : ${logs_poller}
     # Token revoked
     ${response}    PUT    ${revoked_url}/true
@@ -169,9 +173,9 @@ check poller token revocation
     Sleep    ${sleep}
     # The poller is disconnected
     Check Poller Is Connected    port=${port}    expected_nb=0
-    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout}
+    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout_present}
     Should Be True    ${logs_central}    Didn't find the logs in the central file : ${logs_central}
-    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout}
+    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout_present}
     Should Be True    ${logs_poller}    Didn't find the logs in the poller file : ${logs_poller}
     # Token revoked
     ${response}    PUT    ${revoked_url}/false
@@ -179,9 +183,9 @@ check poller token revocation
     Sleep    ${sleep}
     # The poller is connected
     Check Poller Is Connected    port=${port}    expected_nb=2
-    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout}
+    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout_absent}
     Should Not Be True    ${logs_central}    Did find the logs in the central file : ${logs_central}
-    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout}
+    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout_absent}
     Should Not Be True    ${logs_poller}    Did find the logs in the poller file : ${logs_poller}
     # Token revoked
     ${response}    PUT    ${expired_url}/true
@@ -189,7 +193,7 @@ check poller token revocation
     Sleep    ${sleep}
     # The poller is disconnected
     Check Poller Is Connected    port=${port}    expected_nb=0
-    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout}
+    ${logs_central}    Ctn Find In Log With Timeout    log=${central_log_file}    content=${log_central_query}    date=${start_date}    timeout=${timeout_present}
     Should Be True    ${logs_central}    Didn't find the logs in the central file : ${logs_central}
-    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout}
+    ${logs_poller}    Ctn Find In Log With Timeout    log=${poller_log_file}    content=${log_poller_query}    date=${start_date}    timeout=${timeout_present}
     Should Be True    ${logs_poller}    Didn't find the logs in the poller file : ${logs_poller}

--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -132,7 +132,7 @@ check poller token revocation
     Set Local Variable    ${revoked_url}    http://127.0.0.1:80/set-poller-4-is-revoked
     Set Local Variable    ${expired_url}    http://127.0.0.1:80/set-poller-4-is-expired
     Set Local Variable    ${port}    8086
-    Set Local Variable    ${timeout}    11
+    Set Local Variable    ${timeout}    25
     Set Local Variable    ${sleep}    6
     Set Local Variable    ${central_log_file}    /var/log/centreon-gorgone/pullwss_gorgone_central_simple/gorgoned.log
     Set Local Variable    ${poller_log_file}    /var/log/centreon-gorgone/pullwss_gorgone_poller_2_simple/gorgoned.log

--- a/gorgone/tests/robot/tests/core/push.robot
+++ b/gorgone/tests/robot/tests/core/push.robot
@@ -2,7 +2,7 @@
 Documentation       Start and stop gorgone
 
 Resource            ${CURDIR}${/}..${/}..${/}resources${/}import.resource
-Test Timeout        220s
+Test Timeout        450s
 
 *** Variables ***
 @{process_list}    push_zmq_gorgone_central    push_zmq_gorgone_poller_2
@@ -47,8 +47,12 @@ Ctn Check Cpu Until Timeout
 Ctn Wait Until Poller Fail To Connect
     [Arguments]    ${nb_fail}=1    ${poller_id}=2
 
+    # ping_failed is only incremented pong_discard_timeout (default 300s) after a ping is
+    # actually sent, and the first ping itself is scheduled with up to ping_interval
+    # (default 60s) of jitter after registration - so the wait budget needs real headroom,
+    # not just a few retries. 60 * 5s = 300s covers the documented default plus margin.
     ${response}     Set Variable    ${EMPTY}
-    FOR    ${i}    IN RANGE    35
+    FOR    ${i}    IN RANGE    60
         Sleep    5
         ${response}=    GET  http://127.0.0.1:8085/api/internal/constatus
         Log    ${response.json()}
@@ -60,7 +64,7 @@ Ctn Wait Until Poller Fail To Connect
         END
     END
     Log To Console    json response : ${response.json()}
-    Should Be True    ${i} < 34    timeout after ${i} time waiting for poller status in gorgone rest api (/api/internal/constatus)
+    Should Be True    ${i} < 59    timeout after ${i} time waiting for poller status in gorgone rest api (/api/internal/constatus)
     Should Be True    ${nb_fail} == ${response.json()}[data][${poller_id}][ping_failed]    there was failed ping between the central and the poller ${poller_id}
     Should Be True    0 == ${response.json()}[data][${poller_id}][ping_ok]    there was successful ping between the central and the poller ${poller_id}
     Log To Console    ${nb_fail} failed ping between the central and the poller ${poller_id}


### PR DESCRIPTION
## Description

Two flaky Robot Framework tests were blocking every gorgone package delivery to the unstable/testing channel since 2026-07-06.

### 1. `core/pullwss.robot` — `check poller token revocation`

Flaky since #3465 (`tpapi_centreonv2->get_api_token` for POLLER_TOKEN validation): that call is a blocking HTTP request executed inside the proxy httpserver's 5s recurring revocation check, so under CI runner load the detection can occasionally take longer than the test expected (11s).

First attempt bumped the single shared `${timeout}` 11s → 25s, but that backfired: the test's "absent" assertions (`Should Not Be True`) always burn their *full* timeout since the string genuinely isn't there yet — 8 such checks in this test case, so the bump added ~112s of guaranteed overhead and pushed the suite's `Test Timeout` (250s) over budget instead (confirmed on run [29432369140](https://github.com/centreon/centreon-collect/actions/runs/29432369140/job/87411315475?pr=3562) — the individual find-in-log check *did* eventually succeed, but the overall test still timed out).

Fixed by splitting into `${timeout_absent}` (10s, tight since these checks can never return early) and `${timeout_present}` (30s, generous headroom only where actually needed). Also bumped the suite's `Test Timeout` 250s → 300s for margin.

### 2. `core/push.robot` — `check central don't eat cpu when poller is not connected`

Tagged `MON-130747` — that ticket (the original "gorgone eats 100% CPU when a poller doesn't respond" bug) is **released** (24.10); this test is its regression guard, not an open issue.

Root cause of its flakiness: `ping_failed` is only incremented `pong_discard_timeout` (default 300s) after a ping is actually sent, and the first ping itself is scheduled with up to `ping_interval` (default 60s) of jitter after registration. Neither is overridden in this test's config. The test's wait budget (35×5s=175s) didn't reliably cover that, causing `timeout after 34 ...` failures under CI load (same PR run, same underlying "not enough headroom for a slow-but-correct detection" pattern as the pullwss fix above — unrelated to #3465/tpapi).

Fixed by bumping the wait loop to 60×5s=300s and the file's `Test Timeout` 220s → 450s accordingly.

Both fixes validated locally with `robot --dryrun` (no undefined-variable/syntax errors; `push.robot`'s 2 tests parse clean).

**Note**: the underlying issue behind the pullwss flakiness — `get_api_token`'s blocking HTTP call running inside the single-threaded Mojo::IOLoop recurring timer — is a separate, real concern beyond this test: a slow centreon-web response would stall handling of *all* connected poller websockets on the central for that duration, not just this test. Worth a follow-up ticket to make that call non-blocking or bound it with a short client-side timeout.

**Fixes** # (none — found via CI investigation; MON-130747 itself is already released, this only fixes its regression test's flakiness)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] master

## How this pull request can be tested ?

Re-run `gorgone.yml` (workflow_dispatch) on `develop`, or watch this PR's own CI, and confirm `robot-test alma9/alma10/trixie / core/pullwss.robot` and `core/push.robot` pass consistently across several runs, unblocking `deliver-rpm`/`deliver-deb`/`promote`.

## Checklist

- [x] I have followed the coding style guidelines provided by Centreon
- [x] I have commented my code, especially hard-to-understand areas of the PR.
- [x] I have rebased my development branch on the base branch (develop).