### PR TITLE
fix(ci): install centreon-engine-daemon explicitly in gorgone test images

### DIFF
--- a/.github/docker/gorgone/alma10/Dockerfile.testing-dependencies
+++ b/.github/docker/gorgone/alma10/Dockerfile.testing-dependencies
@@ -59,6 +59,13 @@ dnf install -y \
   "perl(XML::Simple)" \
   "perl(ZMQ::FFI)"
 
+# centreon-engine-daemon (ships /usr/sbin/centenginestats, needed by
+# centreon/statistics.robot) used to be pulled in transitively via
+# centreon-gorgone-centreon-config -> centreon-common -> centreon-engine-daemon.
+# That link was removed to fix a packaging layer inversion (centreon-common no
+# longer depends on centreon-engine-daemon), so it must be installed explicitly here.
+dnf install -y centreon-engine-daemon
+
 dnf clean all
 
 EOF

--- a/.github/docker/gorgone/alma9/Dockerfile.testing-dependencies
+++ b/.github/docker/gorgone/alma9/Dockerfile.testing-dependencies
@@ -57,6 +57,13 @@ dnf install -y \
   "perl(XML::Simple)" \
   "perl(ZMQ::FFI)"
 
+# centreon-engine-daemon (ships /usr/sbin/centenginestats, needed by
+# centreon/statistics.robot) used to be pulled in transitively via
+# centreon-gorgone-centreon-config -> centreon-common -> centreon-engine-daemon.
+# That link was removed to fix a packaging layer inversion (centreon-common no
+# longer depends on centreon-engine-daemon), so it must be installed explicitly here.
+dnf install -y centreon-engine-daemon
+
 dnf clean all
 
 EOF

--- a/.github/docker/gorgone/trixie/Dockerfile.testing-dependencies
+++ b/.github/docker/gorgone/trixie/Dockerfile.testing-dependencies
@@ -89,6 +89,13 @@ apt-get install -y \
   libxml-simple-perl \
   libzmq-ffi-perl
 
+# centreon-engine-daemon (ships /usr/sbin/centenginestats, needed by
+# centreon/statistics.robot) used to be pulled in transitively via
+# centreon-gorgone-centreon-config -> centreon-common -> centreon-engine-daemon.
+# That link was removed to fix a packaging layer inversion (centreon-common no
+# longer depends on centreon-engine-daemon), so it must be installed explicitly here.
+apt-get install -y centreon-engine-daemon
+
 echo -e '[mysqld]\nskip_ssl\n[client]\nssl=false' > /etc/mysql/mariadb.conf.d/99-disable-ssl.cnf
 
 apt-get clean


### PR DESCRIPTION
## Summary

- `centreon/statistics.robot` needs `/usr/sbin/centenginestats`, shipped by `centreon-engine-daemon`
- It used to arrive transitively via `centreon-gorgone-centreon-config -> centreon-common -> centreon-engine-daemon`
- #3437 removed `centreon-common`'s dependency on `centreon-engine-daemon` (fixing a packaging layer inversion — `centreon-common` is a foundational package and shouldn't depend upward on engine), which broke this accidental path
- Result: `centreon/statistics.robot` now fails on `develop` (alma9, trixie) with `Source file '/usr/sbin/centenginestats' does not exist.`

Fix: install `centreon-engine-daemon` explicitly in each OS's `Dockerfile.testing-dependencies`, instead of relying on incidental transitive resolution.

Root-caused from: https://github.com/centreon/centreon-collect/actions/runs/29827971825/job/88630576467

## Test plan

- [ ] CI robot-test `centreon/statistics.robot` passes on alma9, alma10, trixie

🤖 Generated with [Claude Code](https://claude.com/claude-code)