### PR TITLE
chore(ci): disable post-packaging jobs on release-29.01-next [TO REVERT]

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -356,813 +356,830 @@ jobs:
       jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
 
-  dockerize:
-    needs: [get-environment, changes, package]
-    if: |
-      needs.changes.outputs.trigger_packaging == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable' &&
-      (
-        needs.get-environment.outputs.is_nightly == 'true' ||
-        contains(needs.get-environment.outputs.labels, 'build-docker-poller')
-      ) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-24.04
-    env:
-      project: centreon-poller
-    strategy:
-      fail-fast: false
-      matrix:
-        distrib: [alma9]
-
-    name: dockerize centreon-poller-${{ matrix.distrib }}
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Parse distrib name
-        id: parse-distrib
-        uses: ./.github/actions/parse-distrib
-        with:
-          distrib: ${{ matrix.distrib }}
-
-      - name: Restore packages
-        id: restore-packages
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ./*.rpm
-          key: ${{ github.run_id }}-${{ github.sha }}-rpm-centreon-collect-${{ steps.parse-distrib.outputs.repo_distrib_name }}-amd64-${{ github.head_ref || github.ref_name }}
-
-      - name: Prepare packages directory
-        if: steps.restore-packages.outputs.cache-hit == 'true'
-        env:
-          MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
-        run: |
-          ls -lh *.rpm
-          mkdir packages-centreon
-          mv centreon-{clib,protobuf-lib,engine,engine-daemon,engine-opentelemetry,broker,broker-core}-"${MAJOR_VERSION}"*.rpm packages-centreon/
-          ls -lh packages-centreon/
-        shell: bash
-
-      - name: Login to registry
-        if: steps.restore-packages.outputs.cache-hit == 'true'
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
-
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-        if: steps.restore-packages.outputs.cache-hit == 'true'
-
-      - name: Build and push web image
-        if: steps.restore-packages.outputs.cache-hit == 'true'
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        env:
-          DOCKER_BUILD_CHECKS_ANNOTATIONS: false
-          DOCKER_BUILD_SUMMARY: false
-          DOCKER_BUILD_RECORD_UPLOAD: false
-        with:
-          file: .github/docker/${{ env.project }}/${{ matrix.distrib }}/Dockerfile
-          context: .
-          build-args: |
-            "VERSION=${{ needs.get-environment.outputs.major_version }}"
-            "IS_CLOUD=${{ needs.get-environment.outputs.is_cloud }}"
-            "STABILITY=${{ needs.get-environment.outputs.stability }}"
-          pull: true
-          push: true
-          load: true
-          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.project }}-${{ matrix.distrib }}:${{ github.head_ref || github.ref_name }}
-          secrets: |
-            "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
-            "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
-
-  dockerize-engine-broker:
-    needs: [get-environment, get-aws-environment, changes, package]
-    if: |
-      needs.changes.outputs.trigger_packaging == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable' &&
-      (
-        needs.get-environment.outputs.is_nightly == 'true' ||
-        contains(needs.get-environment.outputs.labels, 'build-docker-collect') ||
-        needs.get-environment.outputs.stability == 'testing'
-      ) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [centreon-engine, centreon-broker]
-        distrib: [trixie]
-
-    name: dockerize ${{ matrix.image }}-${{ matrix.distrib }}
-
-    # Matrix job outputs come from the last completed matrix leg. Safe here
-    # because compute-tag only depends on the ref/major_version, never on
-    # matrix.image or matrix.distrib, so every leg produces the same tag.
-    outputs:
-      image_tag: ${{ steps.compute-tag.outputs.tag }}
-      additional_tag: ${{ steps.compute-tag.outputs.additional_tag }}
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Restore amd64 packages
-        id: restore-amd64
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ./*.deb
-          key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-collect-${{ matrix.distrib }}-amd64-${{ github.head_ref || github.ref_name }}
-
-      - name: Restore arm64 packages
-        id: restore-arm64
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ./*.deb
-          key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-collect-${{ matrix.distrib }}-arm64-${{ github.head_ref || github.ref_name }}
-
-      - name: Fail if packages cache is missing
-        if: steps.restore-amd64.outputs.cache-hit != 'true' || steps.restore-arm64.outputs.cache-hit != 'true'
-        run: |
-          [[ "${{ steps.restore-amd64.outputs.cache-hit }}" != 'true' ]] && echo "::error::No deb cache for ${{ matrix.distrib }} amd64 — ensure ${{ matrix.distrib }} amd64 is in collect_matrix (get-environment.yml)."
-          [[ "${{ steps.restore-arm64.outputs.cache-hit }}" != 'true' ]] && echo "::error::No deb cache for ${{ matrix.distrib }} arm64 — ensure ${{ matrix.distrib }} arm64 is in collect_matrix (get-environment.yml)."
-          exit 1
-        shell: bash
-
-      - name: Prepare packages directory
-        run: |
-          mkdir -p packages-centreon/amd64 packages-centreon/arm64
-          for deb in centreon-{clib,protobuf-lib,engine,engine-daemon,engine-opentelemetry,broker,broker-core,broker-cbd,connector-perl,connector-ssh}_${{ needs.get-environment.outputs.major_version }}*.deb; do
-            [[ ! -f "$deb" ]] && continue
-            if [[ "$deb" == *_amd64.deb ]]; then
-              mv "$deb" packages-centreon/amd64/
-            elif [[ "$deb" == *_arm64.deb ]]; then
-              mv "$deb" packages-centreon/arm64/
-            fi
-          done
-          ls -lhR packages-centreon/
-        shell: bash
-
-      - name: Login to registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
-
-      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Compute Docker tag
-        id: compute-tag
-        env:
-          RAW_REF: ${{ github.head_ref || github.ref_name }}
-          MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
-        run: |
-          if [[ "$RAW_REF" == "develop" ]]; then
-            echo "tag=develop-${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "additional_tag=develop" >> "$GITHUB_OUTPUT"
-          elif [[ "$RAW_REF" =~ ^dev-[0-9]+\.[0-9]+\.x$ ]]; then
-            echo "tag=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "additional_tag=" >> "$GITHUB_OUTPUT"
-          else
-            docker_tag=$(printf '%s' "$RAW_REF" | sed -E 's#[^[:alnum:]_.-]+#-#g; s#^[.-]+##; s#-+#-#g' | cut -c1-128)
-            if [[ -z "$docker_tag" ]]; then
-              echo "::error::Unable to derive a valid Docker tag from ref '$RAW_REF'"
-              exit 1
-            fi
-            echo "tag=${docker_tag}" >> "$GITHUB_OUTPUT"
-            echo "additional_tag=" >> "$GITHUB_OUTPUT"
-          fi
-        shell: bash
-
-      - name: Build and push image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        env:
-          DOCKER_BUILD_CHECKS_ANNOTATIONS: false
-          DOCKER_BUILD_SUMMARY: false
-          DOCKER_BUILD_RECORD_UPLOAD: false
-        with:
-          file: .github/docker/${{ matrix.image }}/${{ matrix.distrib }}/Dockerfile
-          context: .
-          platforms: linux/amd64,linux/arm64
-          build-args: |
-            "VERSION=${{ needs.get-environment.outputs.major_version }}"
-            "IS_CLOUD=${{ needs.get-environment.outputs.is_cloud }}"
-            "STABILITY=${{ needs.get-environment.outputs.stability }}"
-          pull: true
-          push: true
-          tags: |
-            ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}-${{ matrix.distrib }}:${{ steps.compute-tag.outputs.tag }}
-          secrets: |
-            "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
-            "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
-
-  docker-boot-test:
-    needs: [get-environment, dockerize-engine-broker]
-    if: |
-      ! cancelled() &&
-      needs.get-environment.result == 'success' &&
-      needs.dockerize-engine-broker.result == 'success'
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        distrib: [trixie]
-        platform: [linux/amd64, linux/arm64]
-    name: docker boot test centreon-engine-${{ matrix.distrib }} (${{ matrix.platform }})
-    env:
-      ENGINE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-engine-${{ matrix.distrib }}:${{ needs.dockerize-engine-broker.outputs.image_tag }}
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Login to registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-
-      - name: Set up QEMU
-        if: ${{ matrix.platform == 'linux/arm64' }}
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
-      - name: Replace / with - in the platform name
-        id: platform-name
-        run: echo "dashed=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
-        shell: bash
-
-      - name: Pull image for ${{ matrix.platform }}
-        run: docker pull --platform "${{ matrix.platform }}" "$ENGINE_IMAGE"
-        shell: bash
-
-      - name: Run boot test
-        env:
-          IMAGE: ${{ env.ENGINE_IMAGE }}
-          PLATFORM: ${{ matrix.platform }}
-        run: ./.github/scripts/centreon-engine-docker-boot-test.sh
-        shell: bash
-
-      - name: Upload debug artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: centreon-engine-boot-test-${{ matrix.distrib }}-${{ steps.platform-name.outputs.dashed }}
-          path: /tmp/centreon-engine-boot-test.log
-          retention-days: 1
-
-  docker-config-wiring-test:
-    needs: [get-environment, dockerize-engine-broker]
-    if: |
-      ! cancelled() &&
-      needs.get-environment.result == 'success' &&
-      needs.dockerize-engine-broker.result == 'success'
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        distrib: [trixie]
-    name: docker config/wiring test centreon-engine-${{ matrix.distrib }}
-    env:
-      ENGINE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-engine-${{ matrix.distrib }}:${{ needs.dockerize-engine-broker.outputs.image_tag }}
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Login to registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-
-      - name: Pull image
-        run: docker pull --platform linux/amd64 "$ENGINE_IMAGE"
-        shell: bash
-
-      - name: Run config/wiring test scenarios
-        env:
-          IMAGE: ${{ env.ENGINE_IMAGE }}
-        run: ./.github/scripts/centreon-engine-docker-config-wiring-test.sh
-        shell: bash
-
-      - name: Upload debug artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: centreon-engine-config-wiring-test-${{ matrix.distrib }}
-          path: /tmp/centreon-engine-config-wiring-test.log
-          retention-days: 1
-
-  promote-docker-tag:
-    needs:
-      [
-        get-environment,
-        dockerize-engine-broker,
-        docker-boot-test,
-        docker-config-wiring-test,
-      ]
-    if: |
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      needs.dockerize-engine-broker.outputs.additional_tag != ''
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [centreon-engine, centreon-broker]
-        distrib: [trixie]
-    name: promote ${{ matrix.image }}-${{ matrix.distrib }} floating tag
-    steps:
-      - name: Login to registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
-
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Promote floating tag (manifest retag, no rebuild)
-        run: |
-          docker buildx imagetools create \
-            --tag "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}-${{ matrix.distrib }}:${{ needs.dockerize-engine-broker.outputs.additional_tag }}" \
-            "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}-${{ matrix.distrib }}:${{ needs.dockerize-engine-broker.outputs.image_tag }}"
-        shell: bash
-
-  promote-docker-to-pulp:
-    needs: [get-environment]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability == 'stable' &&
-      github.event_name != 'workflow_dispatch' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-    runs-on: centreon-ubuntu-22.04
-    permissions:
-      contents: read
-      id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        image: [centreon-engine, centreon-broker]
-        distrib: [trixie]
-    name: promote ${{ matrix.image }}-${{ matrix.distrib }} to Pulp stable
-    # HARBOR_TAG reconstructs the release/hotfix branch name (<release_type>-<major_version>-next)
-    # that dockerize-engine-broker tagged the image with while that branch was 'testing'.
-    # release_type comes from the annotated component tag's message ("release ..."/"hotfix ...",
-    # see .github/actions/release-new/action.yml), not from this event's own ref.
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Resolve release bundle tag
-        id: resolve-bundle-tag
-        # release-new (.github/actions/release-new) tags the release bundle
-        # (release-<cloud|onprem>-<YYYYMMDD>-<major>) on the same commit as
-        # this component's stable tag, so it's always among the tags pointing
-        # at HEAD here. Soft failure: no match just means no bundle tag to add.
-        run: |
-          BUNDLE_TAG=$(git tag --points-at HEAD | grep -E '^release-(cloud|onprem)-[0-9]{8}-[0-9]{2}\.[0-9]{2}$' | head -n1) || true
-          echo "tag=$BUNDLE_TAG" >> "$GITHUB_OUTPUT"
-          echo "Resolved release bundle tag: ${BUNDLE_TAG:-<none>}"
-        shell: bash
-
-      - name: Login to Harbor registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Promote Harbor candidate to Pulp stable (best-effort, non-blocking)
-        continue-on-error: true
-        id: promote-pulp
-        env:
-          PULP_URL: https://pulp-api.apps.centreon.com
-          PULP_OIDC_AUDIENCE: https://pulp.dev.centreon.io
-          BASE_PATH: centreon/${{ matrix.image }}-${{ matrix.distrib }}
-          HARBOR_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}-${{ matrix.distrib }}
-          HARBOR_TAG: ${{ needs.get-environment.outputs.release_type }}-${{ needs.get-environment.outputs.major_version }}-next
-          PULP_TAGS: ${{ needs.get-environment.outputs.major_version }}.${{ needs.get-environment.outputs.minor_version }} ${{ needs.get-environment.outputs.major_version }} ${{ steps.resolve-bundle-tag.outputs.tag }}
-          MODULE: ${{ matrix.image }}
-          OS: ${{ matrix.distrib }}
-          STABILITY: ${{ needs.get-environment.outputs.stability }}
-          PLATFORMS: linux/amd64,linux/arm64
-        run: bash .github/scripts/docker-push-to-pulp.sh
-        shell: bash
-
-      - name: Warn if Pulp stable delivery failed
-        if: steps.promote-pulp.outcome == 'failure'
-        run: |
-          echo "::warning::Pulp delivery failed for ${{ matrix.image }}-${{ matrix.distrib }} (Harbor tag ${{ needs.get-environment.outputs.release_type }}-${{ needs.get-environment.outputs.major_version }}-next). This release is available on Harbor but was NOT published to Pulp — investigate before relying on public delivery for this version."
-        shell: bash
-
-  robot-test:
-    needs: [get-environment, get-aws-environment, changes, package]
-    if: |
-      needs.changes.outputs.trigger_e2e_testing == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable' &&
-      ! contains(needs.get-environment.outputs.labels, 'build-docker-collect') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.collect_robot_matrix) }}
-
-    name: robot-test ${{ matrix.operating_system }} ${{ matrix.database_type }} ${{ matrix.arch }} ${{ contains(matrix.tests_params, 'grpc') && 'grpc' || '' }}
-
-    uses: ./.github/workflows/robot-test.yml
-    with:
-      distrib: ${{ matrix.operating_system }}
-      arch: ${{ matrix.arch }}
-      test_img_version: ${{ needs.get-environment.outputs.test_img_version }}
-      database_type: ${{ matrix.database_type }}
-      tests_params: ${{ matrix.tests_params }}
-      is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
-      features_pattern: ${{ inputs.robot_pattern }}
-      aws_role_arn: ${{ needs.get-aws-environment.outputs.aws_role_arn }}
-      aws_web_identity_token_file: ${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}
-    secrets:
-      registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-      registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-      xray_client_id: ${{ secrets.XRAY_CLIENT_ID }}
-      xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
-      jira_base_url: ${{ secrets.JIRA_BASE_URL }}
-      jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
-      jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
-
-  deliver-sources:
-    runs-on: centreon-common
-    needs: [get-environment, package]
-    if: |
-      github.event_name != 'workflow_dispatch' &&
-      needs.get-environment.outputs.stability == 'stable' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect' &&
-      needs.get-environment.outputs.is_cloud == 'false'
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          path: centreon-collect
-
-      - name: Deliver sources
-        uses: ./centreon-collect/.github/actions/release-sources
-        with:
-          bucket_directory: centreon-collect
-          module_directory: centreon-collect
-          module_name: centreon-collect
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
-
-  deliver-rpm:
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    needs: [get-environment, changes, robot-test]
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - distrib: el9
-            arch: amd64
-          - distrib: el10
-            arch: amd64
-
-    name: deliver ${{ matrix.distrib }}
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Publish RPM packages
-        uses: ./.github/actions/rpm-delivery
-        with:
-          module_name: collect
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-centreon-collect-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
-
-  deliver-rpm-pulp:
-    continue-on-error: true
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    needs: [get-environment, changes, robot-test]
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - distrib: el9
-            arch: amd64
-          - distrib: el10
-            arch: amd64
-
-    name: deliver ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_rpm_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: collect
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-centreon-collect-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_rpm_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  deliver-deb:
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect' &&
-      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-
-    needs: [get-environment, changes, robot-test]
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - distrib: trixie
-            arch: amd64
-          - distrib: trixie
-            arch: arm64
-
-    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }}
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Publish DEB packages
-        uses: ./.github/actions/deb-delivery
-        with:
-          module_name: collect
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-collect-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  deliver-deb-pulp:
-    continue-on-error: true
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect' &&
-      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-
-    needs: [get-environment, changes, robot-test]
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - distrib: trixie
-            arch: amd64
-          - distrib: trixie
-            arch: arm64
-
-    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_deb_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: collect
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-collect-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_deb_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  promote:
-    needs: [get-environment, deliver-rpm, deliver-deb]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        distrib: [el9, el10, trixie]
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Promote ${{ matrix.distrib }} to stable
-        uses: ./.github/actions/promote-to-stable
-        with:
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          module_name: collect
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          github_ref_name: ${{ github.ref_name }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  promote-pulp:
-    continue-on-error: true
-    needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        distrib: [el9, el10, trixie]
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Promote ${{ matrix.distrib }} to stable on Pulp
-        id: promote_pulp
-        uses: ./.github/actions/promote-to-stable-pulp
-        continue-on-error: true
-        with:
-          module_name: collect
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp promotion failed
-        if: steps.promote_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
-
-  set-skip-label:
-    needs: [get-environment, deliver-rpm, deliver-deb, promote]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    uses: ./.github/workflows/set-pull-request-skip-label.yml
-
-  clear-branch-cache:
-    runs-on: ubuntu-24.04
-    needs: [get-environment, deliver-rpm, deliver-deb]
-    env:
-      GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-    if: |
-      needs.get-environment.outputs.is_nightly == 'true' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: List and delete cache
-        env:
-          GH_REF_NAME: ${{ github.ref_name }}
-        run: |
-          mapfile -t cache_keys < <(gh cache list --ref "refs/heads/$GH_REF_NAME" --json key -q '.[] | .key')
-          echo $cache_keys
-          while read row; do
-            gh cache delete $row
-            echo "Cache $row was deleted."
-          done <<< "$cache_keys"
-        shell: bash
-
-  create-jira-nightly-ticket:
-    runs-on: ubuntu-24.04
-    needs: [get-environment, deliver-rpm, deliver-deb]
-    if: |
-      needs.get-environment.outputs.is_nightly == 'true' && github.run_attempt == 1 &&
-      startsWith(github.ref_name, 'dev') &&
-      (failure() || cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) &&
-      github.repository == 'centreon/centreon-collect'
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Create Jira ticket based on nightly build failure
-        uses: ./.github/actions/create-jira-ticket
-        with:
-          jira_base_url: ${{ secrets.JIRA_BASE_URL }}
-          jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
-          jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
-          module_name: "centreon-collect"
-          ticket_reason_for_creation: "Nightly"
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (dockerize)
+#   dockerize:
+#     needs: [get-environment, changes, package]
+#     if: |
+#       needs.changes.outputs.trigger_packaging == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.get-environment.outputs.stability != 'stable' &&
+#       (
+#         needs.get-environment.outputs.is_nightly == 'true' ||
+#         contains(needs.get-environment.outputs.labels, 'build-docker-poller')
+#       ) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     runs-on: ubuntu-24.04
+#     env:
+#       project: centreon-poller
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         distrib: [alma9]
+#
+#     name: dockerize centreon-poller-${{ matrix.distrib }}
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Parse distrib name
+#         id: parse-distrib
+#         uses: ./.github/actions/parse-distrib
+#         with:
+#           distrib: ${{ matrix.distrib }}
+#
+#       - name: Restore packages
+#         id: restore-packages
+#         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+#         with:
+#           path: ./*.rpm
+#           key: ${{ github.run_id }}-${{ github.sha }}-rpm-centreon-collect-${{ steps.parse-distrib.outputs.repo_distrib_name }}-amd64-${{ github.head_ref || github.ref_name }}
+#
+#       - name: Prepare packages directory
+#         if: steps.restore-packages.outputs.cache-hit == 'true'
+#         env:
+#           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
+#         run: |
+#           ls -lh *.rpm
+#           mkdir packages-centreon
+#           mv centreon-{clib,protobuf-lib,engine,engine-daemon,engine-opentelemetry,broker,broker-core}-"${MAJOR_VERSION}"*.rpm packages-centreon/
+#           ls -lh packages-centreon/
+#         shell: bash
+#
+#       - name: Login to registry
+#         if: steps.restore-packages.outputs.cache-hit == 'true'
+#         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+#
+#       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+#         if: steps.restore-packages.outputs.cache-hit == 'true'
+#
+#       - name: Build and push web image
+#         if: steps.restore-packages.outputs.cache-hit == 'true'
+#         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+#         env:
+#           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
+#           DOCKER_BUILD_SUMMARY: false
+#           DOCKER_BUILD_RECORD_UPLOAD: false
+#         with:
+#           file: .github/docker/${{ env.project }}/${{ matrix.distrib }}/Dockerfile
+#           context: .
+#           build-args: |
+#             "VERSION=${{ needs.get-environment.outputs.major_version }}"
+#             "IS_CLOUD=${{ needs.get-environment.outputs.is_cloud }}"
+#             "STABILITY=${{ needs.get-environment.outputs.stability }}"
+#           pull: true
+#           push: true
+#           load: true
+#           tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.project }}-${{ matrix.distrib }}:${{ github.head_ref || github.ref_name }}
+#           secrets: |
+#             "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
+#             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (dockerize-engine-broker)
+#   dockerize-engine-broker:
+#     needs: [get-environment, get-aws-environment, changes, package]
+#     if: |
+#       needs.changes.outputs.trigger_packaging == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.get-environment.outputs.stability != 'stable' &&
+#       (
+#         needs.get-environment.outputs.is_nightly == 'true' ||
+#         contains(needs.get-environment.outputs.labels, 'build-docker-collect') ||
+#         needs.get-environment.outputs.stability == 'testing'
+#       ) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         image: [centreon-engine, centreon-broker]
+#         distrib: [trixie]
+#
+#     name: dockerize ${{ matrix.image }}-${{ matrix.distrib }}
+#
+#     # Matrix job outputs come from the last completed matrix leg. Safe here
+#     # because compute-tag only depends on the ref/major_version, never on
+#     # matrix.image or matrix.distrib, so every leg produces the same tag.
+#     outputs:
+#       image_tag: ${{ steps.compute-tag.outputs.tag }}
+#       additional_tag: ${{ steps.compute-tag.outputs.additional_tag }}
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Restore amd64 packages
+#         id: restore-amd64
+#         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+#         with:
+#           path: ./*.deb
+#           key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-collect-${{ matrix.distrib }}-amd64-${{ github.head_ref || github.ref_name }}
+#
+#       - name: Restore arm64 packages
+#         id: restore-arm64
+#         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+#         with:
+#           path: ./*.deb
+#           key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-collect-${{ matrix.distrib }}-arm64-${{ github.head_ref || github.ref_name }}
+#
+#       - name: Fail if packages cache is missing
+#         if: steps.restore-amd64.outputs.cache-hit != 'true' || steps.restore-arm64.outputs.cache-hit != 'true'
+#         run: |
+#           [[ "${{ steps.restore-amd64.outputs.cache-hit }}" != 'true' ]] && echo "::error::No deb cache for ${{ matrix.distrib }} amd64 — ensure ${{ matrix.distrib }} amd64 is in collect_matrix (get-environment.yml)."
+#           [[ "${{ steps.restore-arm64.outputs.cache-hit }}" != 'true' ]] && echo "::error::No deb cache for ${{ matrix.distrib }} arm64 — ensure ${{ matrix.distrib }} arm64 is in collect_matrix (get-environment.yml)."
+#           exit 1
+#         shell: bash
+#
+#       - name: Prepare packages directory
+#         run: |
+#           mkdir -p packages-centreon/amd64 packages-centreon/arm64
+#           for deb in centreon-{clib,protobuf-lib,engine,engine-daemon,engine-opentelemetry,broker,broker-core,broker-cbd,connector-perl,connector-ssh}_${{ needs.get-environment.outputs.major_version }}*.deb; do
+#             [[ ! -f "$deb" ]] && continue
+#             if [[ "$deb" == *_amd64.deb ]]; then
+#               mv "$deb" packages-centreon/amd64/
+#             elif [[ "$deb" == *_arm64.deb ]]; then
+#               mv "$deb" packages-centreon/arm64/
+#             fi
+#           done
+#           ls -lhR packages-centreon/
+#         shell: bash
+#
+#       - name: Login to registry
+#         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+#
+#       - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+#
+#       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+#
+#       - name: Compute Docker tag
+#         id: compute-tag
+#         env:
+#           RAW_REF: ${{ github.head_ref || github.ref_name }}
+#           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
+#         run: |
+#           if [[ "$RAW_REF" == "develop" ]]; then
+#             echo "tag=develop-${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
+#             echo "additional_tag=develop" >> "$GITHUB_OUTPUT"
+#           elif [[ "$RAW_REF" =~ ^dev-[0-9]+\.[0-9]+\.x$ ]]; then
+#             echo "tag=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
+#             echo "additional_tag=" >> "$GITHUB_OUTPUT"
+#           else
+#             docker_tag=$(printf '%s' "$RAW_REF" | sed -E 's#[^[:alnum:]_.-]+#-#g; s#^[.-]+##; s#-+#-#g' | cut -c1-128)
+#             if [[ -z "$docker_tag" ]]; then
+#               echo "::error::Unable to derive a valid Docker tag from ref '$RAW_REF'"
+#               exit 1
+#             fi
+#             echo "tag=${docker_tag}" >> "$GITHUB_OUTPUT"
+#             echo "additional_tag=" >> "$GITHUB_OUTPUT"
+#           fi
+#         shell: bash
+#
+#       - name: Build and push image
+#         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+#         env:
+#           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
+#           DOCKER_BUILD_SUMMARY: false
+#           DOCKER_BUILD_RECORD_UPLOAD: false
+#         with:
+#           file: .github/docker/${{ matrix.image }}/${{ matrix.distrib }}/Dockerfile
+#           context: .
+#           platforms: linux/amd64,linux/arm64
+#           build-args: |
+#             "VERSION=${{ needs.get-environment.outputs.major_version }}"
+#             "IS_CLOUD=${{ needs.get-environment.outputs.is_cloud }}"
+#             "STABILITY=${{ needs.get-environment.outputs.stability }}"
+#           pull: true
+#           push: true
+#           tags: |
+#             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}-${{ matrix.distrib }}:${{ steps.compute-tag.outputs.tag }}
+#           secrets: |
+#             "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
+#             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (docker-boot-test)
+#   docker-boot-test:
+#     needs: [get-environment, dockerize-engine-broker]
+#     if: |
+#       ! cancelled() &&
+#       needs.get-environment.result == 'success' &&
+#       needs.dockerize-engine-broker.result == 'success'
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         distrib: [trixie]
+#         platform: [linux/amd64, linux/arm64]
+#     name: docker boot test centreon-engine-${{ matrix.distrib }} (${{ matrix.platform }})
+#     env:
+#       ENGINE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-engine-${{ matrix.distrib }}:${{ needs.dockerize-engine-broker.outputs.image_tag }}
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Login to registry
+#         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#
+#       - name: Set up QEMU
+#         if: ${{ matrix.platform == 'linux/arm64' }}
+#         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+#
+#       - name: Replace / with - in the platform name
+#         id: platform-name
+#         run: echo "dashed=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+#         shell: bash
+#
+#       - name: Pull image for ${{ matrix.platform }}
+#         run: docker pull --platform "${{ matrix.platform }}" "$ENGINE_IMAGE"
+#         shell: bash
+#
+#       - name: Run boot test
+#         env:
+#           IMAGE: ${{ env.ENGINE_IMAGE }}
+#           PLATFORM: ${{ matrix.platform }}
+#         run: ./.github/scripts/centreon-engine-docker-boot-test.sh
+#         shell: bash
+#
+#       - name: Upload debug artifacts on failure
+#         if: failure()
+#         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+#         with:
+#           name: centreon-engine-boot-test-${{ matrix.distrib }}-${{ steps.platform-name.outputs.dashed }}
+#           path: /tmp/centreon-engine-boot-test.log
+#           retention-days: 1
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (docker-config-wiring-test)
+#   docker-config-wiring-test:
+#     needs: [get-environment, dockerize-engine-broker]
+#     if: |
+#       ! cancelled() &&
+#       needs.get-environment.result == 'success' &&
+#       needs.dockerize-engine-broker.result == 'success'
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         distrib: [trixie]
+#     name: docker config/wiring test centreon-engine-${{ matrix.distrib }}
+#     env:
+#       ENGINE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-engine-${{ matrix.distrib }}:${{ needs.dockerize-engine-broker.outputs.image_tag }}
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Login to registry
+#         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#
+#       - name: Pull image
+#         run: docker pull --platform linux/amd64 "$ENGINE_IMAGE"
+#         shell: bash
+#
+#       - name: Run config/wiring test scenarios
+#         env:
+#           IMAGE: ${{ env.ENGINE_IMAGE }}
+#         run: ./.github/scripts/centreon-engine-docker-config-wiring-test.sh
+#         shell: bash
+#
+#       - name: Upload debug artifacts on failure
+#         if: failure()
+#         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+#         with:
+#           name: centreon-engine-config-wiring-test-${{ matrix.distrib }}
+#           path: /tmp/centreon-engine-config-wiring-test.log
+#           retention-days: 1
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-docker-tag)
+#   promote-docker-tag:
+#     needs:
+#       [
+#         get-environment,
+#         dockerize-engine-broker,
+#         docker-boot-test,
+#         docker-config-wiring-test,
+#       ]
+#     if: |
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       needs.dockerize-engine-broker.outputs.additional_tag != ''
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         image: [centreon-engine, centreon-broker]
+#         distrib: [trixie]
+#     name: promote ${{ matrix.image }}-${{ matrix.distrib }} floating tag
+#     steps:
+#       - name: Login to registry
+#         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+#
+#       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+#
+#       - name: Promote floating tag (manifest retag, no rebuild)
+#         run: |
+#           docker buildx imagetools create \
+#             --tag "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}-${{ matrix.distrib }}:${{ needs.dockerize-engine-broker.outputs.additional_tag }}" \
+#             "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}-${{ matrix.distrib }}:${{ needs.dockerize-engine-broker.outputs.image_tag }}"
+#         shell: bash
+
+  # [release-bump test — TO REVERT] disabled: delivery/promote (promote-docker-to-pulp)
+#   promote-docker-to-pulp:
+#     needs: [get-environment]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.get-environment.outputs.stability == 'stable' &&
+#       github.event_name != 'workflow_dispatch' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#     runs-on: centreon-ubuntu-22.04
+#     permissions:
+#       contents: read
+#       id-token: write
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         image: [centreon-engine, centreon-broker]
+#         distrib: [trixie]
+#     name: promote ${{ matrix.image }}-${{ matrix.distrib }} to Pulp stable
+#     # HARBOR_TAG reconstructs the release/hotfix branch name (<release_type>-<major_version>-next)
+#     # that dockerize-engine-broker tagged the image with while that branch was 'testing'.
+#     # release_type comes from the annotated component tag's message ("release ..."/"hotfix ...",
+#     # see .github/actions/release-new/action.yml), not from this event's own ref.
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#         with:
+#           fetch-depth: 0
+#           fetch-tags: true
+#
+#       - name: Resolve release bundle tag
+#         id: resolve-bundle-tag
+#         # release-new (.github/actions/release-new) tags the release bundle
+#         # (release-<cloud|onprem>-<YYYYMMDD>-<major>) on the same commit as
+#         # this component's stable tag, so it's always among the tags pointing
+#         # at HEAD here. Soft failure: no match just means no bundle tag to add.
+#         run: |
+#           BUNDLE_TAG=$(git tag --points-at HEAD | grep -E '^release-(cloud|onprem)-[0-9]{8}-[0-9]{2}\.[0-9]{2}$' | head -n1) || true
+#           echo "tag=$BUNDLE_TAG" >> "$GITHUB_OUTPUT"
+#           echo "Resolved release bundle tag: ${BUNDLE_TAG:-<none>}"
+#         shell: bash
+#
+#       - name: Login to Harbor registry
+#         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#
+#       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+#
+#       - name: Promote Harbor candidate to Pulp stable (best-effort, non-blocking)
+#         continue-on-error: true
+#         id: promote-pulp
+#         env:
+#           PULP_URL: https://pulp-api.apps.centreon.com
+#           PULP_OIDC_AUDIENCE: https://pulp.dev.centreon.io
+#           BASE_PATH: centreon/${{ matrix.image }}-${{ matrix.distrib }}
+#           HARBOR_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}-${{ matrix.distrib }}
+#           HARBOR_TAG: ${{ needs.get-environment.outputs.release_type }}-${{ needs.get-environment.outputs.major_version }}-next
+#           PULP_TAGS: ${{ needs.get-environment.outputs.major_version }}.${{ needs.get-environment.outputs.minor_version }} ${{ needs.get-environment.outputs.major_version }} ${{ steps.resolve-bundle-tag.outputs.tag }}
+#           MODULE: ${{ matrix.image }}
+#           OS: ${{ matrix.distrib }}
+#           STABILITY: ${{ needs.get-environment.outputs.stability }}
+#           PLATFORMS: linux/amd64,linux/arm64
+#         run: bash .github/scripts/docker-push-to-pulp.sh
+#         shell: bash
+#
+#       - name: Warn if Pulp stable delivery failed
+#         if: steps.promote-pulp.outcome == 'failure'
+#         run: |
+#           echo "::warning::Pulp delivery failed for ${{ matrix.image }}-${{ matrix.distrib }} (Harbor tag ${{ needs.get-environment.outputs.release_type }}-${{ needs.get-environment.outputs.major_version }}-next). This release is available on Harbor but was NOT published to Pulp — investigate before relying on public delivery for this version."
+#         shell: bash
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (robot-test)
+#   robot-test:
+#     needs: [get-environment, get-aws-environment, changes, package]
+#     if: |
+#       needs.changes.outputs.trigger_e2e_testing == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.get-environment.outputs.stability != 'stable' &&
+#       ! contains(needs.get-environment.outputs.labels, 'build-docker-collect') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.collect_robot_matrix) }}
+#
+#     name: robot-test ${{ matrix.operating_system }} ${{ matrix.database_type }} ${{ matrix.arch }} ${{ contains(matrix.tests_params, 'grpc') && 'grpc' || '' }}
+#
+#     uses: ./.github/workflows/robot-test.yml
+#     with:
+#       distrib: ${{ matrix.operating_system }}
+#       arch: ${{ matrix.arch }}
+#       test_img_version: ${{ needs.get-environment.outputs.test_img_version }}
+#       database_type: ${{ matrix.database_type }}
+#       tests_params: ${{ matrix.tests_params }}
+#       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
+#       features_pattern: ${{ inputs.robot_pattern }}
+#       aws_role_arn: ${{ needs.get-aws-environment.outputs.aws_role_arn }}
+#       aws_web_identity_token_file: ${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}
+#     secrets:
+#       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#       xray_client_id: ${{ secrets.XRAY_CLIENT_ID }}
+#       xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
+#       jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+#       jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
+#       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-sources)
+#   deliver-sources:
+#     runs-on: centreon-common
+#     needs: [get-environment, package]
+#     if: |
+#       github.event_name != 'workflow_dispatch' &&
+#       needs.get-environment.outputs.stability == 'stable' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect' &&
+#       needs.get-environment.outputs.is_cloud == 'false'
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#         with:
+#           path: centreon-collect
+#
+#       - name: Deliver sources
+#         uses: ./centreon-collect/.github/actions/release-sources
+#         with:
+#           bucket_directory: centreon-collect
+#           module_directory: centreon-collect
+#           module_name: centreon-collect
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-rpm)
+#   deliver-rpm:
+#     if: |
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     needs: [get-environment, changes, robot-test]
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include:
+#           - distrib: el9
+#             arch: amd64
+#           - distrib: el10
+#             arch: amd64
+#
+#     name: deliver ${{ matrix.distrib }}
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Publish RPM packages
+#         uses: ./.github/actions/rpm-delivery
+#         with:
+#           module_name: collect
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-centreon-collect-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-rpm-pulp)
+#   deliver-rpm-pulp:
+#     continue-on-error: true
+#     if: |
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     needs: [get-environment, changes, robot-test]
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include:
+#           - distrib: el9
+#             arch: amd64
+#           - distrib: el10
+#             arch: amd64
+#
+#     name: deliver ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_rpm_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: collect
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-centreon-collect-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_rpm_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-deb)
+#   deliver-deb:
+#     if: |
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect' &&
+#       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+#
+#     needs: [get-environment, changes, robot-test]
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include:
+#           - distrib: trixie
+#             arch: amd64
+#           - distrib: trixie
+#             arch: arm64
+#
+#     name: deliver ${{ matrix.distrib }} ${{ matrix.arch }}
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Publish DEB packages
+#         uses: ./.github/actions/deb-delivery
+#         with:
+#           module_name: collect
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-collect-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-deb-pulp)
+#   deliver-deb-pulp:
+#     continue-on-error: true
+#     if: |
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect' &&
+#       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+#
+#     needs: [get-environment, changes, robot-test]
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include:
+#           - distrib: trixie
+#             arch: amd64
+#           - distrib: trixie
+#             arch: arm64
+#
+#     name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_deb_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: collect
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-collect-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_deb_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote)
+#   promote:
+#     needs: [get-environment, deliver-rpm, deliver-deb]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         distrib: [el9, el10, trixie]
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Promote ${{ matrix.distrib }} to stable
+#         uses: ./.github/actions/promote-to-stable
+#         with:
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           module_name: collect
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           github_ref_name: ${{ github.ref_name }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-pulp)
+#   promote-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         distrib: [el9, el10, trixie]
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Pulp
+#         id: promote_pulp
+#         uses: ./.github/actions/promote-to-stable-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: collect
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp promotion failed
+#         if: steps.promote_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (set-skip-label)
+#   set-skip-label:
+#     needs: [get-environment, deliver-rpm, deliver-deb, promote]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     uses: ./.github/workflows/set-pull-request-skip-label.yml
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (clear-branch-cache)
+#   clear-branch-cache:
+#     runs-on: ubuntu-24.04
+#     needs: [get-environment, deliver-rpm, deliver-deb]
+#     env:
+#       GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+#     if: |
+#       needs.get-environment.outputs.is_nightly == 'true' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: List and delete cache
+#         env:
+#           GH_REF_NAME: ${{ github.ref_name }}
+#         run: |
+#           mapfile -t cache_keys < <(gh cache list --ref "refs/heads/$GH_REF_NAME" --json key -q '.[] | .key')
+#           echo $cache_keys
+#           while read row; do
+#             gh cache delete $row
+#             echo "Cache $row was deleted."
+#           done <<< "$cache_keys"
+#         shell: bash
+
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (create-jira-nightly-ticket)
+#   create-jira-nightly-ticket:
+#     runs-on: ubuntu-24.04
+#     needs: [get-environment, deliver-rpm, deliver-deb]
+#     if: |
+#       needs.get-environment.outputs.is_nightly == 'true' && github.run_attempt == 1 &&
+#       startsWith(github.ref_name, 'dev') &&
+#       (failure() || cancelled() || contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) &&
+#       github.repository == 'centreon/centreon-collect'
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Create Jira ticket based on nightly build failure
+#         uses: ./.github/actions/create-jira-ticket
+#         with:
+#           jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+#           jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
+#           jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
+#           module_name: "centreon-collect"
+#           ticket_reason_for_creation: "Nightly"

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -114,246 +114,253 @@ jobs:
           stability: ${{ needs.get-environment.outputs.stability }}
           upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
-  deliver-rpm:
-    runs-on: ubuntu-24.04
-    needs: [get-environment, package]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-rpm)
+#   deliver-rpm:
+#     runs-on: ubuntu-24.04
+#     needs: [get-environment, package]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#
+#     strategy:
+#       matrix:
+#         distrib: [el9, el10]
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Delivery
+#         uses: ./.github/actions/rpm-delivery
+#         with:
+#           module_name: common
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
 
-    strategy:
-      matrix:
-        distrib: [el9, el10]
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-rpm-pulp)
+#   deliver-rpm-pulp:
+#     continue-on-error: true
+#     runs-on: centreon-ubuntu-22.04
+#     needs: [get-environment, package]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#
+#     strategy:
+#       matrix:
+#         distrib: [el9, el10]
+#
+#     name: deliver ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_rpm_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: common
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_rpm_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-deb)
+#   deliver-deb:
+#     runs-on: ubuntu-24.04
+#     needs: [get-environment, package]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+#
+#     strategy:
+#       matrix:
+#         distrib: [trixie]
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Delivery
+#         uses: ./.github/actions/deb-delivery
+#         with:
+#           module_name: common
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-      - name: Delivery
-        uses: ./.github/actions/rpm-delivery
-        with:
-          module_name: common
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-deb-pulp)
+#   deliver-deb-pulp:
+#     continue-on-error: true
+#     runs-on: centreon-ubuntu-22.04
+#     needs: [get-environment, package]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+#
+#     strategy:
+#       matrix:
+#         distrib: [trixie]
+#
+#     name: deliver ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_deb_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: common
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_deb_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-  deliver-rpm-pulp:
-    continue-on-error: true
-    runs-on: centreon-ubuntu-22.04
-    needs: [get-environment, package]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote)
+#   promote:
+#     needs: [get-environment, deliver-rpm, deliver-deb]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       matrix:
+#         distrib: [el9, el10, trixie]
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Promote ${{ matrix.distrib }} to stable
+#         uses: ./.github/actions/promote-to-stable
+#         with:
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           module_name: common
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           github_ref_name: ${{ github.ref_name }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-    strategy:
-      matrix:
-        distrib: [el9, el10]
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-pulp)
+#   promote-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       matrix:
+#         distrib: [el9, el10, trixie]
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Pulp
+#         id: promote_pulp
+#         uses: ./.github/actions/promote-to-stable-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: common
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp promotion failed
+#         if: steps.promote_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
-    name: deliver ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_rpm_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: common
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_rpm_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  deliver-deb:
-    runs-on: ubuntu-24.04
-    needs: [get-environment, package]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-
-    strategy:
-      matrix:
-        distrib: [trixie]
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Delivery
-        uses: ./.github/actions/deb-delivery
-        with:
-          module_name: common
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  deliver-deb-pulp:
-    continue-on-error: true
-    runs-on: centreon-ubuntu-22.04
-    needs: [get-environment, package]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-
-    strategy:
-      matrix:
-        distrib: [trixie]
-
-    name: deliver ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_deb_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: common
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_deb_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  promote:
-    needs: [get-environment, deliver-rpm, deliver-deb]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        distrib: [el9, el10, trixie]
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Promote ${{ matrix.distrib }} to stable
-        uses: ./.github/actions/promote-to-stable
-        with:
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          module_name: common
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          github_ref_name: ${{ github.ref_name }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  promote-pulp:
-    continue-on-error: true
-    needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      matrix:
-        distrib: [el9, el10, trixie]
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Promote ${{ matrix.distrib }} to stable on Pulp
-        id: promote_pulp
-        uses: ./.github/actions/promote-to-stable-pulp
-        continue-on-error: true
-        with:
-          module_name: common
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp promotion failed
-        if: steps.promote_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
-
-  set-skip-label:
-    needs: [get-environment, deliver-rpm, deliver-deb, promote]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    uses: ./.github/workflows/set-pull-request-skip-label.yml
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (set-skip-label)
+#   set-skip-label:
+#     needs: [get-environment, deliver-rpm, deliver-deb, promote]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     uses: ./.github/workflows/set-pull-request-skip-label.yml

--- a/.github/workflows/docker-gorgone.yml
+++ b/.github/workflows/docker-gorgone.yml
@@ -96,296 +96,301 @@ jobs:
           stability: ${{ needs.get-environment.outputs.stability }}
           upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
-  dockerize:
-    needs: [get-environment, package]
-    if: needs.get-environment.outputs.stability != 'stable'
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        operating_system: [trixie]
-    name: dockerize centreon-gorgone-${{ matrix.operating_system }}
-    env:
-      project: centreon-gorgone
-    # Matrix job outputs come from the last completed matrix leg; safe only while
-    # operating_system has a single value (trixie). Revisit if this matrix grows.
-    outputs:
-      image_tag: ${{ steps.compute-tag.outputs.tag }}
-      additional_tag: ${{ steps.compute-tag.outputs.additional_tag }}
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (dockerize)
+#   dockerize:
+#     needs: [get-environment, package]
+#     if: needs.get-environment.outputs.stability != 'stable'
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         operating_system: [trixie]
+#     name: dockerize centreon-gorgone-${{ matrix.operating_system }}
+#     env:
+#       project: centreon-gorgone
+#     # Matrix job outputs come from the last completed matrix leg; safe only while
+#     # operating_system has a single value (trixie). Revisit if this matrix grows.
+#     outputs:
+#       image_tag: ${{ steps.compute-tag.outputs.tag }}
+#       additional_tag: ${{ steps.compute-tag.outputs.additional_tag }}
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Login to registry
+#         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+#
+#       - name: Parse distrib name
+#         id: parse-distrib
+#         uses: ./.github/actions/parse-distrib
+#         with:
+#           distrib: ${{ matrix.operating_system }}
+#
+#       - name: get cached gorgone and perl-libs package
+#         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+#         with:
+#           path: ./*.${{ steps.parse-distrib.outputs.package_extension }}
+#           key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.parse-distrib.outputs.package_extension }}-${{ steps.parse-distrib.outputs.package_extension == 'rpm' && steps.parse-distrib.outputs.distrib_family || steps.parse-distrib.outputs.distrib_name }}
+#           fail-on-cache-miss: true
+#
+#       - run: |
+#           mkdir packages-centreon
+#           mv *.${{ steps.parse-distrib.outputs.package_extension }} packages-centreon/
+#         shell: bash
+#
+#       - name: Set up QEMU
+#         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+#
+#       - name: Set up Docker Buildx
+#         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+#
+#       - name: Compute Docker tag
+#         id: compute-tag
+#         env:
+#           RAW_REF: ${{ github.head_ref || github.ref_name }}
+#           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
+#         run: |
+#           if [[ "$RAW_REF" == "develop" ]]; then
+#             echo "tag=develop-${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
+#             echo "additional_tag=develop" >> "$GITHUB_OUTPUT"
+#           elif [[ "$RAW_REF" =~ ^dev-[0-9]+\.[0-9]+\.x$ ]]; then
+#             echo "tag=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
+#             echo "additional_tag=" >> "$GITHUB_OUTPUT"
+#           else
+#             docker_tag=$(printf '%s' "$RAW_REF" | sed -E 's#[^[:alnum:]_.-]+#-#g; s#^[.-]+##; s#-+#-#g' | cut -c1-128)
+#             if [[ -z "$docker_tag" ]]; then
+#               echo "::error::Unable to derive a valid Docker tag from ref '$RAW_REF'"
+#               exit 1
+#             fi
+#             echo "tag=${docker_tag}" >> "$GITHUB_OUTPUT"
+#             echo "additional_tag=" >> "$GITHUB_OUTPUT"
+#           fi
+#         shell: bash
+#
+#       - name: Docker build and push
+#         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+#         env:
+#           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
+#           DOCKER_BUILD_SUMMARY: false
+#           DOCKER_BUILD_RECORD_UPLOAD: false
+#         with:
+#           context: .
+#           file: .github/docker/centreon-gorgone/${{ matrix.operating_system }}/Dockerfile
+#           build-args: |
+#             "VERSION=${{ needs.get-environment.outputs.major_version }}"
+#             "IS_CLOUD=${{ needs.get-environment.outputs.is_cloud }}"
+#             "STABILITY=${{ needs.get-environment.outputs.stability }}"
+#           platforms: linux/amd64,linux/arm64
+#           pull: true
+#           push: true
+#           tags: |
+#             ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ steps.compute-tag.outputs.tag }}
+#           secrets: |
+#             "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
+#             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
 
-      - name: Login to registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (docker-boot-test)
+#   docker-boot-test:
+#     needs: [get-environment, dockerize]
+#     if: |
+#       ! cancelled() &&
+#       needs.get-environment.result == 'success' &&
+#       needs.dockerize.result == 'success'
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         operating_system: [trixie]
+#         platform: [linux/amd64, linux/arm64]
+#     name: docker boot test centreon-gorgone-${{ matrix.operating_system }} (${{ matrix.platform }})
+#     env:
+#       GORGONE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Login to registry
+#         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#
+#       - name: Set up QEMU
+#         if: ${{ matrix.platform == 'linux/arm64' }}
+#         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+#
+#       - name: Replace / with - in the platform name
+#         id: platform-name
+#         run: echo "dashed=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+#         shell: bash
+#
+#       - name: Pull image for ${{ matrix.platform }}
+#         run: docker pull --platform "${{ matrix.platform }}" "$GORGONE_IMAGE"
+#         shell: bash
+#
+#       - name: Run boot test
+#         env:
+#           IMAGE: ${{ env.GORGONE_IMAGE }}
+#           PLATFORM: ${{ matrix.platform }}
+#         run: ./.github/scripts/gorgone-docker-boot-test.sh
+#         shell: bash
+#
+#       - name: Upload debug artifacts on failure
+#         if: failure()
+#         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+#         with:
+#           name: centreon-gorgone-boot-test-${{ matrix.operating_system }}-${{ steps.platform-name.outputs.dashed }}
+#           path: /tmp/gorgone-boot-test.log
+#           retention-days: 1
 
-      - name: Parse distrib name
-        id: parse-distrib
-        uses: ./.github/actions/parse-distrib
-        with:
-          distrib: ${{ matrix.operating_system }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (docker-config-wiring-test)
+#   docker-config-wiring-test:
+#     needs: [get-environment, dockerize]
+#     if: |
+#       ! cancelled() &&
+#       needs.get-environment.result == 'success' &&
+#       needs.dockerize.result == 'success'
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         operating_system: [trixie]
+#     name: docker config/wiring test centreon-gorgone-${{ matrix.operating_system }}
+#     env:
+#       GORGONE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Login to registry
+#         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#
+#       - name: Pull image
+#         run: docker pull --platform linux/amd64 "$GORGONE_IMAGE"
+#         shell: bash
+#
+#       - name: Run config/wiring test scenarios
+#         env:
+#           IMAGE: ${{ env.GORGONE_IMAGE }}
+#         run: ./.github/scripts/gorgone-docker-config-wiring-test.sh
+#         shell: bash
+#
+#       - name: Dump compose logs on failure
+#         if: failure()
+#         run: docker compose -f .github/docker/centreon-gorgone/docker-compose.config-wiring-test.yml -p gorgone-config-wiring-test logs
+#         shell: bash
 
-      - name: get cached gorgone and perl-libs package
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ./*.${{ steps.parse-distrib.outputs.package_extension }}
-          key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.parse-distrib.outputs.package_extension }}-${{ steps.parse-distrib.outputs.package_extension == 'rpm' && steps.parse-distrib.outputs.distrib_family || steps.parse-distrib.outputs.distrib_name }}
-          fail-on-cache-miss: true
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-docker-tag)
+#   promote-docker-tag:
+#     needs: [get-environment, dockerize, docker-boot-test, docker-config-wiring-test]
+#     if: |
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       needs.dockerize.outputs.additional_tag != ''
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         operating_system: [trixie]
+#     name: promote centreon-gorgone-${{ matrix.operating_system }} floating tag
+#     steps:
+#       - name: Login to registry
+#         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+#
+#       - name: Set up Docker Buildx
+#         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+#
+#       - name: Promote floating tag (manifest retag, no rebuild)
+#         run: |
+#           docker buildx imagetools create \
+#             --tag "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.additional_tag }}" \
+#             "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}"
+#         shell: bash
 
-      - run: |
-          mkdir packages-centreon
-          mv *.${{ steps.parse-distrib.outputs.package_extension }} packages-centreon/
-        shell: bash
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Compute Docker tag
-        id: compute-tag
-        env:
-          RAW_REF: ${{ github.head_ref || github.ref_name }}
-          MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
-        run: |
-          if [[ "$RAW_REF" == "develop" ]]; then
-            echo "tag=develop-${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "additional_tag=develop" >> "$GITHUB_OUTPUT"
-          elif [[ "$RAW_REF" =~ ^dev-[0-9]+\.[0-9]+\.x$ ]]; then
-            echo "tag=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
-            echo "additional_tag=" >> "$GITHUB_OUTPUT"
-          else
-            docker_tag=$(printf '%s' "$RAW_REF" | sed -E 's#[^[:alnum:]_.-]+#-#g; s#^[.-]+##; s#-+#-#g' | cut -c1-128)
-            if [[ -z "$docker_tag" ]]; then
-              echo "::error::Unable to derive a valid Docker tag from ref '$RAW_REF'"
-              exit 1
-            fi
-            echo "tag=${docker_tag}" >> "$GITHUB_OUTPUT"
-            echo "additional_tag=" >> "$GITHUB_OUTPUT"
-          fi
-        shell: bash
-
-      - name: Docker build and push
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        env:
-          DOCKER_BUILD_CHECKS_ANNOTATIONS: false
-          DOCKER_BUILD_SUMMARY: false
-          DOCKER_BUILD_RECORD_UPLOAD: false
-        with:
-          context: .
-          file: .github/docker/centreon-gorgone/${{ matrix.operating_system }}/Dockerfile
-          build-args: |
-            "VERSION=${{ needs.get-environment.outputs.major_version }}"
-            "IS_CLOUD=${{ needs.get-environment.outputs.is_cloud }}"
-            "STABILITY=${{ needs.get-environment.outputs.stability }}"
-          platforms: linux/amd64,linux/arm64
-          pull: true
-          push: true
-          tags: |
-            ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ steps.compute-tag.outputs.tag }}
-          secrets: |
-            "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
-            "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
-
-  docker-boot-test:
-    needs: [get-environment, dockerize]
-    if: |
-      ! cancelled() &&
-      needs.get-environment.result == 'success' &&
-      needs.dockerize.result == 'success'
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        operating_system: [trixie]
-        platform: [linux/amd64, linux/arm64]
-    name: docker boot test centreon-gorgone-${{ matrix.operating_system }} (${{ matrix.platform }})
-    env:
-      GORGONE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Login to registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-
-      - name: Set up QEMU
-        if: ${{ matrix.platform == 'linux/arm64' }}
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-
-      - name: Replace / with - in the platform name
-        id: platform-name
-        run: echo "dashed=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
-        shell: bash
-
-      - name: Pull image for ${{ matrix.platform }}
-        run: docker pull --platform "${{ matrix.platform }}" "$GORGONE_IMAGE"
-        shell: bash
-
-      - name: Run boot test
-        env:
-          IMAGE: ${{ env.GORGONE_IMAGE }}
-          PLATFORM: ${{ matrix.platform }}
-        run: ./.github/scripts/gorgone-docker-boot-test.sh
-        shell: bash
-
-      - name: Upload debug artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: centreon-gorgone-boot-test-${{ matrix.operating_system }}-${{ steps.platform-name.outputs.dashed }}
-          path: /tmp/gorgone-boot-test.log
-          retention-days: 1
-
-  docker-config-wiring-test:
-    needs: [get-environment, dockerize]
-    if: |
-      ! cancelled() &&
-      needs.get-environment.result == 'success' &&
-      needs.dockerize.result == 'success'
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        operating_system: [trixie]
-    name: docker config/wiring test centreon-gorgone-${{ matrix.operating_system }}
-    env:
-      GORGONE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Login to registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-
-      - name: Pull image
-        run: docker pull --platform linux/amd64 "$GORGONE_IMAGE"
-        shell: bash
-
-      - name: Run config/wiring test scenarios
-        env:
-          IMAGE: ${{ env.GORGONE_IMAGE }}
-        run: ./.github/scripts/gorgone-docker-config-wiring-test.sh
-        shell: bash
-
-      - name: Dump compose logs on failure
-        if: failure()
-        run: docker compose -f .github/docker/centreon-gorgone/docker-compose.config-wiring-test.yml -p gorgone-config-wiring-test logs
-        shell: bash
-
-  promote-docker-tag:
-    needs: [get-environment, dockerize, docker-boot-test, docker-config-wiring-test]
-    if: |
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      needs.dockerize.outputs.additional_tag != ''
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        operating_system: [trixie]
-    name: promote centreon-gorgone-${{ matrix.operating_system }} floating tag
-    steps:
-      - name: Login to registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Promote floating tag (manifest retag, no rebuild)
-        run: |
-          docker buildx imagetools create \
-            --tag "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.additional_tag }}" \
-            "${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}:${{ needs.dockerize.outputs.image_tag }}"
-        shell: bash
-
-  promote-docker-to-pulp:
-    needs: [get-environment]
-    if: |
-      needs.get-environment.outputs.stability == 'stable' &&
-      github.event_name != 'workflow_dispatch' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    runs-on: centreon-ubuntu-22.04
-    permissions:
-      contents: read
-      id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        operating_system: [trixie]
-    name: promote centreon-gorgone-${{ matrix.operating_system }} to Pulp stable
-    # HARBOR_TAG reconstructs the release/hotfix branch name (<release_type>-<major_version>-next)
-    # that dockerize tagged the image with while that branch was 'testing'. release_type comes
-    # from the annotated component tag's message ("release ..."/"hotfix ...", see
-    # .github/actions/release-new/action.yml), not from this event's own ref.
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Resolve release bundle tag
-        id: resolve-bundle-tag
-        # release-new (.github/actions/release-new) tags the release bundle
-        # (release-<cloud|onprem>-<YYYYMMDD>-<major>) on the same commit as
-        # this component's stable tag, so it's always among the tags pointing
-        # at HEAD here. Soft failure: no match just means no bundle tag to add.
-        run: |
-          BUNDLE_TAG=$(git tag --points-at HEAD | grep -E '^release-(cloud|onprem)-[0-9]{8}-[0-9]{2}\.[0-9]{2}$' | head -n1) || true
-          echo "tag=$BUNDLE_TAG" >> "$GITHUB_OUTPUT"
-          echo "Resolved release bundle tag: ${BUNDLE_TAG:-<none>}"
-        shell: bash
-
-      - name: Login to Harbor registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Promote Harbor candidate to Pulp stable (best-effort, non-blocking)
-        continue-on-error: true
-        id: promote-pulp
-        env:
-          PULP_URL: https://pulp-api.apps.centreon.com
-          PULP_OIDC_AUDIENCE: https://pulp.dev.centreon.io
-          BASE_PATH: centreon/centreon-gorgone-${{ matrix.operating_system }}
-          HARBOR_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}
-          HARBOR_TAG: ${{ needs.get-environment.outputs.release_type }}-${{ needs.get-environment.outputs.major_version }}-next
-          PULP_TAGS: ${{ needs.get-environment.outputs.major_version }}.${{ needs.get-environment.outputs.minor_version }} ${{ needs.get-environment.outputs.major_version }} ${{ steps.resolve-bundle-tag.outputs.tag }}
-          MODULE: centreon-gorgone
-          OS: ${{ matrix.operating_system }}
-          STABILITY: ${{ needs.get-environment.outputs.stability }}
-          PLATFORMS: linux/amd64,linux/arm64
-        run: bash .github/scripts/docker-push-to-pulp.sh
-        shell: bash
-
-      - name: Warn if Pulp stable delivery failed
-        if: steps.promote-pulp.outcome == 'failure'
-        run: |
-          echo "::warning::Pulp delivery failed for centreon-gorgone-${{ matrix.operating_system }} (Harbor tag ${{ needs.get-environment.outputs.release_type }}-${{ needs.get-environment.outputs.major_version }}-next). This release is available on Harbor but was NOT published to Pulp — investigate before relying on public delivery for this version."
-        shell: bash
+  # [release-bump test — TO REVERT] disabled: delivery/promote (promote-docker-to-pulp)
+#   promote-docker-to-pulp:
+#     needs: [get-environment]
+#     if: |
+#       needs.get-environment.outputs.stability == 'stable' &&
+#       github.event_name != 'workflow_dispatch' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     runs-on: centreon-ubuntu-22.04
+#     permissions:
+#       contents: read
+#       id-token: write
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         operating_system: [trixie]
+#     name: promote centreon-gorgone-${{ matrix.operating_system }} to Pulp stable
+#     # HARBOR_TAG reconstructs the release/hotfix branch name (<release_type>-<major_version>-next)
+#     # that dockerize tagged the image with while that branch was 'testing'. release_type comes
+#     # from the annotated component tag's message ("release ..."/"hotfix ...", see
+#     # .github/actions/release-new/action.yml), not from this event's own ref.
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#         with:
+#           fetch-depth: 0
+#           fetch-tags: true
+#
+#       - name: Resolve release bundle tag
+#         id: resolve-bundle-tag
+#         # release-new (.github/actions/release-new) tags the release bundle
+#         # (release-<cloud|onprem>-<YYYYMMDD>-<major>) on the same commit as
+#         # this component's stable tag, so it's always among the tags pointing
+#         # at HEAD here. Soft failure: no match just means no bundle tag to add.
+#         run: |
+#           BUNDLE_TAG=$(git tag --points-at HEAD | grep -E '^release-(cloud|onprem)-[0-9]{8}-[0-9]{2}\.[0-9]{2}$' | head -n1) || true
+#           echo "tag=$BUNDLE_TAG" >> "$GITHUB_OUTPUT"
+#           echo "Resolved release bundle tag: ${BUNDLE_TAG:-<none>}"
+#         shell: bash
+#
+#       - name: Login to Harbor registry
+#         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#
+#       - name: Set up Docker Buildx
+#         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+#
+#       - name: Promote Harbor candidate to Pulp stable (best-effort, non-blocking)
+#         continue-on-error: true
+#         id: promote-pulp
+#         env:
+#           PULP_URL: https://pulp-api.apps.centreon.com
+#           PULP_OIDC_AUDIENCE: https://pulp.dev.centreon.io
+#           BASE_PATH: centreon/centreon-gorgone-${{ matrix.operating_system }}
+#           HARBOR_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-gorgone-${{ matrix.operating_system }}
+#           HARBOR_TAG: ${{ needs.get-environment.outputs.release_type }}-${{ needs.get-environment.outputs.major_version }}-next
+#           PULP_TAGS: ${{ needs.get-environment.outputs.major_version }}.${{ needs.get-environment.outputs.minor_version }} ${{ needs.get-environment.outputs.major_version }} ${{ steps.resolve-bundle-tag.outputs.tag }}
+#           MODULE: centreon-gorgone
+#           OS: ${{ matrix.operating_system }}
+#           STABILITY: ${{ needs.get-environment.outputs.stability }}
+#           PLATFORMS: linux/amd64,linux/arm64
+#         run: bash .github/scripts/docker-push-to-pulp.sh
+#         shell: bash
+#
+#       - name: Warn if Pulp stable delivery failed
+#         if: steps.promote-pulp.outcome == 'failure'
+#         run: |
+#           echo "::warning::Pulp delivery failed for centreon-gorgone-${{ matrix.operating_system }} (Harbor tag ${{ needs.get-environment.outputs.release_type }}-${{ needs.get-environment.outputs.major_version }}-next). This release is available on Harbor but was NOT published to Pulp — investigate before relying on public delivery for this version."
+#         shell: bash

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -255,453 +255,463 @@ jobs:
           stability: ${{ needs.get-environment.outputs.stability }}
           upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
-  dockerize:
-    needs: [get-environment, changes, package]
-    if: |
-      needs.changes.outputs.trigger_packaging == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.os_and_database_matrix).operating_systems }}
-    name: dockerize ${{ matrix.operating_system }}
-    env:
-      project: gorgone-testing
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (dockerize)
+#   dockerize:
+#     needs: [get-environment, changes, package]
+#     if: |
+#       needs.changes.outputs.trigger_packaging == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.get-environment.outputs.stability != 'stable' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.os_and_database_matrix).operating_systems }}
+#     name: dockerize ${{ matrix.operating_system }}
+#     env:
+#       project: gorgone-testing
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Login to registry
+#         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+#         with:
+#           registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
+#           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+#
+#       - name: Parse distrib name
+#         id: parse-distrib
+#         uses: ./.github/actions/parse-distrib
+#         with:
+#           distrib: ${{ matrix.operating_system }}
+#
+#       - name: Get FROM image tag
+#         id: from_image_version
+#         env:
+#           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
+#           OPERATING_SYSTEM: ${{ matrix.operating_system }}
+#           REGISTRY_URL: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
+#           GH_BASE_REF: ${{ github.base_ref || github.ref_name }}
+#           PROJECT: ${{ env.project }}
+#         run: |
+#           FROM_IMAGE_VERSION="$MAJOR_VERSION"
+#           FROM_IMAGE="gorgone-testing-dependencies-$OPERATING_SYSTEM"
+#           IMAGE_TAG_EXISTS=$(docker manifest inspect "$REGISTRY_URL/${FROM_IMAGE}:$GH_HEAD_REF" >/dev/null 2>&1 && echo yes || echo no)
+#           if [[ "$IMAGE_TAG_EXISTS" == "yes" ]]; then
+#             FROM_IMAGE_VERSION="$GH_HEAD_REF"
+#             echo "::notice::FROM image $FROM_IMAGE:$FROM_IMAGE_VERSION will be used to build docker image $PROJECT-$OPERATING_SYSTEM."
+#           else
+#             IMAGE_TAG_EXISTS=$(docker manifest inspect "$REGISTRY_URL/${FROM_IMAGE}:$GH_BASE_REF" >/dev/null 2>&1 && echo yes || echo no)
+#             if [[ "$IMAGE_TAG_EXISTS" == "yes" ]]; then
+#               FROM_IMAGE_VERSION="$GH_BASE_REF"
+#               echo "::notice::FROM image $FROM_IMAGE:$FROM_IMAGE_VERSION will be used to build docker image $PROJECT-$OPERATING_SYSTEM."
+#             fi
+#           fi
+#
+#           echo "from_image_version=$FROM_IMAGE_VERSION" >> $GITHUB_OUTPUT
+#         shell: bash
+#
+#       - name: get cached gorgone and perl-libs package
+#         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+#         with:
+#           path: ./*.${{ steps.parse-distrib.outputs.package_extension }}
+#           key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.parse-distrib.outputs.package_extension }}-${{ steps.parse-distrib.outputs.repo_distrib_name }}
+#           fail-on-cache-miss: true
+#
+#       - env:
+#           PACKAGE_EXTENSION: ${{ steps.parse-distrib.outputs.package_extension }}
+#         run: |
+#           mkdir packages-centreon-gorgone
+#           mv *."$PACKAGE_EXTENSION" packages-centreon-gorgone/
+#         shell: bash
+#
+#       - name: Get linked branch of centreon repository
+#         id: centreon_repo_linked_branch
+#         env:
+#           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
+#           GH_REF: ${{ github.head_ref || github.ref_name }}
+#         run: |
+#           CENTREON_REPO_LINKED_BRANCH=$(git ls-remote -h https://github.com/centreon/centreon.git | grep -E "refs/heads/dev-${MAJOR_VERSION}\.x$" >/dev/null 2>&1 && echo "dev-${MAJOR_VERSION}.x" || echo develop)
+#
+#           GIT_BRANCH_EXISTS=$(git ls-remote -h https://github.com/centreon/centreon.git | grep -E "refs/heads/${GH_REF}$" >/dev/null 2>&1 && echo yes || echo no)
+#           if [[ "$GIT_BRANCH_EXISTS" == "yes" ]]; then
+#             CENTREON_REPO_LINKED_BRANCH="$GH_REF"
+#           fi
+#
+#           echo "linked_branch=$CENTREON_REPO_LINKED_BRANCH" >> $GITHUB_OUTPUT
+#         shell: bash
+#
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#         with:
+#           repository: centreon/centreon
+#           path: centreon
+#           ref: ${{ steps.centreon_repo_linked_branch.outputs.linked_branch }}
+#           sparse-checkout: |
+#             centreon/www/install/createTables.sql
+#             centreon/www/install/createTablesCentstorage.sql
+#
+#       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+#
+#       - name: Docker build and push
+#         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+#         env:
+#           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
+#           DOCKER_BUILD_SUMMARY: false
+#           DOCKER_BUILD_RECORD_UPLOAD: false
+#         with:
+#           context: .
+#           file: .github/docker/gorgone/${{ matrix.operating_system }}/Dockerfile.testing
+#           build-args: |
+#             "REGISTRY_URL=${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}"
+#             "FROM_IMAGE_VERSION=${{ steps.from_image_version.outputs.from_image_version }}"
+#           pull: true
+#           push: true
+#           load: true
+#           tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ matrix.operating_system }}:${{ github.head_ref || github.ref_name }}
+#
+#       - name: Store image in local archive
+#         env:
+#           REGISTRY_URL: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
+#           OPERATING_SYSTEM: ${{ matrix.operating_system }}
+#           GH_REF: ${{ github.head_ref || github.ref_name }}
+#         run: |
+#           docker tag "$REGISTRY_URL/gorgone-testing-$OPERATING_SYSTEM:$GH_REF" "gorgone-testing-$OPERATING_SYSTEM:$GH_REF"
+#           mkdir -p docker-image
+#           docker save --output "./docker-image/gorgone-testing-$OPERATING_SYSTEM.tar" "gorgone-testing-$OPERATING_SYSTEM:$GH_REF"
+#         shell: bash
+#
+#       - name: Clear previous docker image from cache
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#           OPERATING_SYSTEM: ${{ matrix.operating_system }}
+#           GH_REF: ${{ github.head_ref || github.ref_name }}
+#         run: |
+#           curl \
+#             -X DELETE \
+#             -H "Accept: application/vnd.github.v3+json" \
+#             -H "Authorization: token $GITHUB_TOKEN" \
+#             "https://api.github.com/repos/centreon/centreon-collect/actions/caches?key=docker-image-gorgone-testing-$OPERATING_SYSTEM-$GH_REF"
+#         shell: bash
+#
+#       - name: Store docker image in cache
+#         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+#         with:
+#           path: ./docker-image
+#           key: docker-image-gorgone-testing-${{ matrix.operating_system }}-${{ github.head_ref || github.ref_name }}
 
-      - name: Login to registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (robot-test)
+#   robot-test:
+#     needs: [get-environment, changes, dockerize]
+#     if: |
+#       github.repository == 'centreon/centreon-collect' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.get-environment.outputs.stability != 'stable' &&
+#       needs.changes.outputs.trigger_e2e_testing == 'true' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.os_and_database_matrix).operating_systems }}
+#     name: robot-test ${{ matrix.operating_system }}
+#     uses: ./.github/workflows/robot-test-gorgone.yml
+#     with:
+#       distrib: ${{ matrix.operating_system }}
+#     secrets:
+#       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
 
-      - name: Parse distrib name
-        id: parse-distrib
-        uses: ./.github/actions/parse-distrib
-        with:
-          distrib: ${{ matrix.operating_system }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-sources)
+#   deliver-sources:
+#     runs-on: centreon-common
+#     needs: [get-environment, package]
+#     if: |
+#       github.event_name != 'workflow_dispatch' &&
+#       needs.get-environment.outputs.stability == 'stable' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       needs.get-environment.outputs.is_cloud == 'false'
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Deliver sources
+#         uses: ./.github/actions/release-sources
+#         with:
+#           bucket_directory: centreon-gorgone
+#           module_directory: gorgone
+#           module_name: centreon-gorgone
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
 
-      - name: Get FROM image tag
-        id: from_image_version
-        env:
-          MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
-          OPERATING_SYSTEM: ${{ matrix.operating_system }}
-          REGISTRY_URL: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
-          GH_BASE_REF: ${{ github.base_ref || github.ref_name }}
-          PROJECT: ${{ env.project }}
-        run: |
-          FROM_IMAGE_VERSION="$MAJOR_VERSION"
-          FROM_IMAGE="gorgone-testing-dependencies-$OPERATING_SYSTEM"
-          IMAGE_TAG_EXISTS=$(docker manifest inspect "$REGISTRY_URL/${FROM_IMAGE}:$GH_HEAD_REF" >/dev/null 2>&1 && echo yes || echo no)
-          if [[ "$IMAGE_TAG_EXISTS" == "yes" ]]; then
-            FROM_IMAGE_VERSION="$GH_HEAD_REF"
-            echo "::notice::FROM image $FROM_IMAGE:$FROM_IMAGE_VERSION will be used to build docker image $PROJECT-$OPERATING_SYSTEM."
-          else
-            IMAGE_TAG_EXISTS=$(docker manifest inspect "$REGISTRY_URL/${FROM_IMAGE}:$GH_BASE_REF" >/dev/null 2>&1 && echo yes || echo no)
-            if [[ "$IMAGE_TAG_EXISTS" == "yes" ]]; then
-              FROM_IMAGE_VERSION="$GH_BASE_REF"
-              echo "::notice::FROM image $FROM_IMAGE:$FROM_IMAGE_VERSION will be used to build docker image $PROJECT-$OPERATING_SYSTEM."
-            fi
-          fi
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-rpm)
+#   deliver-rpm:
+#     runs-on: ubuntu-24.04
+#     needs: [get-environment, unit-test-perl, robot-test, changes]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         distrib: [el9, el10]
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Delivery
+#         uses: ./.github/actions/rpm-delivery
+#         with:
+#           module_name: gorgone
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
 
-          echo "from_image_version=$FROM_IMAGE_VERSION" >> $GITHUB_OUTPUT
-        shell: bash
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-rpm-pulp)
+#   deliver-rpm-pulp:
+#     continue-on-error: true
+#     runs-on: centreon-ubuntu-22.04
+#     needs: [get-environment, unit-test-perl, robot-test, changes]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         distrib: [el9, el10]
+#
+#     name: deliver ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_rpm_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: gorgone
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_rpm_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-      - name: get cached gorgone and perl-libs package
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ./*.${{ steps.parse-distrib.outputs.package_extension }}
-          key: ${{ github.sha }}-${{ github.run_id }}-${{ steps.parse-distrib.outputs.package_extension }}-${{ steps.parse-distrib.outputs.repo_distrib_name }}
-          fail-on-cache-miss: true
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-deb)
+#   deliver-deb:
+#     runs-on: ubuntu-24.04
+#     needs: [get-environment, unit-test-perl, robot-test, changes]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+#
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         distrib: [trixie]  # No ubuntu in 24.10, 24.11 or later for now
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Delivery
+#         uses: ./.github/actions/deb-delivery
+#         with:
+#           module_name: gorgone
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-      - env:
-          PACKAGE_EXTENSION: ${{ steps.parse-distrib.outputs.package_extension }}
-        run: |
-          mkdir packages-centreon-gorgone
-          mv *."$PACKAGE_EXTENSION" packages-centreon-gorgone/
-        shell: bash
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-deb-pulp)
+#   deliver-deb-pulp:
+#     continue-on-error: true
+#     runs-on: centreon-ubuntu-22.04
+#     needs: [get-environment, unit-test-perl, robot-test, changes]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+#
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         distrib: [trixie]  # No ubuntu in 24.10, 24.11 or later for now
+#
+#     name: deliver ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_deb_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: gorgone
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_deb_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-      - name: Get linked branch of centreon repository
-        id: centreon_repo_linked_branch
-        env:
-          MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
-          GH_REF: ${{ github.head_ref || github.ref_name }}
-        run: |
-          CENTREON_REPO_LINKED_BRANCH=$(git ls-remote -h https://github.com/centreon/centreon.git | grep -E "refs/heads/dev-${MAJOR_VERSION}\.x$" >/dev/null 2>&1 && echo "dev-${MAJOR_VERSION}.x" || echo develop)
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote)
+#   promote:
+#     needs: [get-environment, deliver-rpm, deliver-deb]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         distrib: [el9, el10, trixie]
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Promote ${{ matrix.distrib }} to stable
+#         uses: ./.github/actions/promote-to-stable
+#         with:
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           module_name: gorgone
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           github_ref_name: ${{ github.ref_name }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-          GIT_BRANCH_EXISTS=$(git ls-remote -h https://github.com/centreon/centreon.git | grep -E "refs/heads/${GH_REF}$" >/dev/null 2>&1 && echo yes || echo no)
-          if [[ "$GIT_BRANCH_EXISTS" == "yes" ]]; then
-            CENTREON_REPO_LINKED_BRANCH="$GH_REF"
-          fi
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-pulp)
+#   promote-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         distrib: [el9, el10, trixie]
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Pulp
+#         id: promote_pulp
+#         uses: ./.github/actions/promote-to-stable-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: gorgone
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp promotion failed
+#         if: steps.promote_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
-          echo "linked_branch=$CENTREON_REPO_LINKED_BRANCH" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: centreon/centreon
-          path: centreon
-          ref: ${{ steps.centreon_repo_linked_branch.outputs.linked_branch }}
-          sparse-checkout: |
-            centreon/www/install/createTables.sql
-            centreon/www/install/createTablesCentstorage.sql
-
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Docker build and push
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        env:
-          DOCKER_BUILD_CHECKS_ANNOTATIONS: false
-          DOCKER_BUILD_SUMMARY: false
-          DOCKER_BUILD_RECORD_UPLOAD: false
-        with:
-          context: .
-          file: .github/docker/gorgone/${{ matrix.operating_system }}/Dockerfile.testing
-          build-args: |
-            "REGISTRY_URL=${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}"
-            "FROM_IMAGE_VERSION=${{ steps.from_image_version.outputs.from_image_version }}"
-          pull: true
-          push: true
-          load: true
-          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ matrix.operating_system }}:${{ github.head_ref || github.ref_name }}
-
-      - name: Store image in local archive
-        env:
-          REGISTRY_URL: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          OPERATING_SYSTEM: ${{ matrix.operating_system }}
-          GH_REF: ${{ github.head_ref || github.ref_name }}
-        run: |
-          docker tag "$REGISTRY_URL/gorgone-testing-$OPERATING_SYSTEM:$GH_REF" "gorgone-testing-$OPERATING_SYSTEM:$GH_REF"
-          mkdir -p docker-image
-          docker save --output "./docker-image/gorgone-testing-$OPERATING_SYSTEM.tar" "gorgone-testing-$OPERATING_SYSTEM:$GH_REF"
-        shell: bash
-
-      - name: Clear previous docker image from cache
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPERATING_SYSTEM: ${{ matrix.operating_system }}
-          GH_REF: ${{ github.head_ref || github.ref_name }}
-        run: |
-          curl \
-            -X DELETE \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            "https://api.github.com/repos/centreon/centreon-collect/actions/caches?key=docker-image-gorgone-testing-$OPERATING_SYSTEM-$GH_REF"
-        shell: bash
-
-      - name: Store docker image in cache
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ./docker-image
-          key: docker-image-gorgone-testing-${{ matrix.operating_system }}-${{ github.head_ref || github.ref_name }}
-
-  robot-test:
-    needs: [get-environment, changes, dockerize]
-    if: |
-      github.repository == 'centreon/centreon-collect' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable' &&
-      needs.changes.outputs.trigger_e2e_testing == 'true' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.os_and_database_matrix).operating_systems }}
-    name: robot-test ${{ matrix.operating_system }}
-    uses: ./.github/workflows/robot-test-gorgone.yml
-    with:
-      distrib: ${{ matrix.operating_system }}
-    secrets:
-      registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-      registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-
-  deliver-sources:
-    runs-on: centreon-common
-    needs: [get-environment, package]
-    if: |
-      github.event_name != 'workflow_dispatch' &&
-      needs.get-environment.outputs.stability == 'stable' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      needs.get-environment.outputs.is_cloud == 'false'
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Deliver sources
-        uses: ./.github/actions/release-sources
-        with:
-          bucket_directory: centreon-gorgone
-          module_directory: gorgone
-          module_name: centreon-gorgone
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
-
-  deliver-rpm:
-    runs-on: ubuntu-24.04
-    needs: [get-environment, unit-test-perl, robot-test, changes]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-
-    strategy:
-      fail-fast: false
-      matrix:
-        distrib: [el9, el10]
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Delivery
-        uses: ./.github/actions/rpm-delivery
-        with:
-          module_name: gorgone
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
-
-  deliver-rpm-pulp:
-    continue-on-error: true
-    runs-on: centreon-ubuntu-22.04
-    needs: [get-environment, unit-test-perl, robot-test, changes]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-
-    strategy:
-      fail-fast: false
-      matrix:
-        distrib: [el9, el10]
-
-    name: deliver ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_rpm_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: gorgone
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_rpm_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  deliver-deb:
-    runs-on: ubuntu-24.04
-    needs: [get-environment, unit-test-perl, robot-test, changes]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-
-    strategy:
-      fail-fast: false
-      matrix:
-        distrib: [trixie]  # No ubuntu in 24.10, 24.11 or later for now
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Delivery
-        uses: ./.github/actions/deb-delivery
-        with:
-          module_name: gorgone
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  deliver-deb-pulp:
-    continue-on-error: true
-    runs-on: centreon-ubuntu-22.04
-    needs: [get-environment, unit-test-perl, robot-test, changes]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-
-    strategy:
-      fail-fast: false
-      matrix:
-        distrib: [trixie]  # No ubuntu in 24.10, 24.11 or later for now
-
-    name: deliver ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_deb_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: gorgone
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_deb_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  promote:
-    needs: [get-environment, deliver-rpm, deliver-deb]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        distrib: [el9, el10, trixie]
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Promote ${{ matrix.distrib }} to stable
-        uses: ./.github/actions/promote-to-stable
-        with:
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          module_name: gorgone
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          github_ref_name: ${{ github.ref_name }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  promote-pulp:
-    continue-on-error: true
-    needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        distrib: [el9, el10, trixie]
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Promote ${{ matrix.distrib }} to stable on Pulp
-        id: promote_pulp
-        uses: ./.github/actions/promote-to-stable-pulp
-        continue-on-error: true
-        with:
-          module_name: gorgone
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp promotion failed
-        if: steps.promote_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
-
-  set-skip-label:
-    needs: [get-environment, deliver-rpm, deliver-deb, promote]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    uses: ./.github/workflows/set-pull-request-skip-label.yml
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (set-skip-label)
+#   set-skip-label:
+#     needs: [get-environment, deliver-rpm, deliver-deb, promote]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     uses: ./.github/workflows/set-pull-request-skip-label.yml

--- a/.github/workflows/libzmq.yml
+++ b/.github/workflows/libzmq.yml
@@ -83,56 +83,57 @@ jobs:
           path: ./*.rpm
           key: unsigned-${{ github.run_id }}-${{ github.sha }}-rpm-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
 
-  sign-rpm:
-    needs: [get-environment, package-rpm]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable'
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        include:
-          - image: packaging-alma9
-            distrib: el9
-            arch: amd64
-          - image: packaging-alma10
-            distrib: el10
-            arch: amd64
-    name: sign rpm ${{ matrix.distrib }}
-    container:
-      image: docker.centreon.com/centreon-private/rpm-signing:latest
-      options: -t
-      credentials:
-        username: ${{ secrets.HARBOR_CENTREON_PRIVATE_USERNAME }}
-        password: ${{ secrets.HARBOR_CENTREON_PRIVATE_TOKEN }}
-
-    steps:
-      - run: apt-get install -y zstd
-        shell: bash
-
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ./*.rpm
-          key: unsigned-${{ github.run_id }}-${{ github.sha }}-rpm-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
-
-      - run: echo "HOME=/root" >> $GITHUB_ENV
-        shell: bash
-
-      - run: rpmsign --addsign ./*.rpm
-        shell: bash
-
-      - uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ./*.rpm
-          key: ${{ github.run_id }}-${{ github.sha }}-rpm-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
-
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: packages-${{ matrix.distrib }}
-          path: ./*.rpm
-          retention-days: 1
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (sign-rpm)
+#   sign-rpm:
+#     needs: [get-environment, package-rpm]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.get-environment.outputs.stability != 'stable'
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       matrix:
+#         include:
+#           - image: packaging-alma9
+#             distrib: el9
+#             arch: amd64
+#           - image: packaging-alma10
+#             distrib: el10
+#             arch: amd64
+#     name: sign rpm ${{ matrix.distrib }}
+#     container:
+#       image: docker.centreon.com/centreon-private/rpm-signing:latest
+#       options: -t
+#       credentials:
+#         username: ${{ secrets.HARBOR_CENTREON_PRIVATE_USERNAME }}
+#         password: ${{ secrets.HARBOR_CENTREON_PRIVATE_TOKEN }}
+#
+#     steps:
+#       - run: apt-get install -y zstd
+#         shell: bash
+#
+#       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+#         with:
+#           path: ./*.rpm
+#           key: unsigned-${{ github.run_id }}-${{ github.sha }}-rpm-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
+#
+#       - run: echo "HOME=/root" >> $GITHUB_ENV
+#         shell: bash
+#
+#       - run: rpmsign --addsign ./*.rpm
+#         shell: bash
+#
+#       - uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+#         with:
+#           path: ./*.rpm
+#           key: ${{ github.run_id }}-${{ github.sha }}-rpm-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
+#
+#       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+#         with:
+#           name: packages-${{ matrix.distrib }}
+#           path: ./*.rpm
+#           retention-days: 1
 
   package-deb:
     needs: [get-environment]
@@ -202,256 +203,263 @@ jobs:
           path: ./*.deb
           key: ${{ github.run_id }}-${{ github.sha }}-deb-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
 
-  deliver-rpm:
-    needs: [get-environment, sign-rpm]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        include:
-          - distrib: el9
-            arch: amd64
-          - distrib: el10
-            arch: amd64
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-rpm)
+#   deliver-rpm:
+#     needs: [get-environment, sign-rpm]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       matrix:
+#         include:
+#           - distrib: el9
+#             arch: amd64
+#           - distrib: el10
+#             arch: amd64
+#
+#     name: deliver ${{ matrix.distrib }}
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Publish RPM packages
+#         uses: ./.github/actions/rpm-delivery
+#         with:
+#           module_name: libzmq
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
 
-    name: deliver ${{ matrix.distrib }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-rpm-pulp)
+#   deliver-rpm-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, sign-rpm]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       matrix:
+#         include:
+#           - distrib: el9
+#             arch: amd64
+#           - distrib: el10
+#             arch: amd64
+#
+#     name: deliver ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_rpm_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: libzmq
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_rpm_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-deb)
+#   deliver-deb:
+#     needs: [get-environment, package-deb]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       matrix:
+#         include:
+#           - distrib: trixie
+#             arch: amd64
+#
+#     name: deliver ${{ matrix.distrib }} ${{ matrix.arch }}
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Publish DEB packages
+#         uses: ./.github/actions/deb-delivery
+#         with:
+#           module_name: libzmq
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-      - name: Publish RPM packages
-        uses: ./.github/actions/rpm-delivery
-        with:
-          module_name: libzmq
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-deb-pulp)
+#   deliver-deb-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, package-deb]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       matrix:
+#         include:
+#           - distrib: trixie
+#             arch: amd64
+#
+#     name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_deb_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: libzmq
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_deb_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-  deliver-rpm-pulp:
-    continue-on-error: true
-    needs: [get-environment, sign-rpm]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      matrix:
-        include:
-          - distrib: el9
-            arch: amd64
-          - distrib: el10
-            arch: amd64
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote)
+#   promote:
+#     needs: [get-environment, deliver-rpm, deliver-deb]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       matrix:
+#         distrib: [el9, el10, trixie]
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Promote ${{ matrix.distrib }} to stable
+#         uses: ./.github/actions/promote-to-stable
+#         with:
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           module_name: libzmq
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           github_ref_name: ${{ github.ref_name }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-    name: deliver ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-pulp)
+#   promote-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       matrix:
+#         distrib: [el9, el10, trixie]
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Pulp
+#         id: promote_pulp
+#         uses: ./.github/actions/promote-to-stable-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: libzmq
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp promotion failed
+#         if: steps.promote_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_rpm_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: libzmq
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_rpm_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  deliver-deb:
-    needs: [get-environment, package-deb]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        include:
-          - distrib: trixie
-            arch: amd64
-
-    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }}
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Publish DEB packages
-        uses: ./.github/actions/deb-delivery
-        with:
-          module_name: libzmq
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  deliver-deb-pulp:
-    continue-on-error: true
-    needs: [get-environment, package-deb]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      matrix:
-        include:
-          - distrib: trixie
-            arch: amd64
-
-    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_deb_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: libzmq
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-libzmq-${{ matrix.distrib }}-${{ matrix.arch }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_deb_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  promote:
-    needs: [get-environment, deliver-rpm, deliver-deb]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        distrib: [el9, el10, trixie]
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Promote ${{ matrix.distrib }} to stable
-        uses: ./.github/actions/promote-to-stable
-        with:
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          module_name: libzmq
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          github_ref_name: ${{ github.ref_name }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  promote-pulp:
-    continue-on-error: true
-    needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      matrix:
-        distrib: [el9, el10, trixie]
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Promote ${{ matrix.distrib }} to stable on Pulp
-        id: promote_pulp
-        uses: ./.github/actions/promote-to-stable-pulp
-        continue-on-error: true
-        with:
-          module_name: libzmq
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp promotion failed
-        if: steps.promote_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
-
-  set-skip-label:
-    needs: [get-environment, deliver-rpm, deliver-deb, promote]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    uses: ./.github/workflows/set-pull-request-skip-label.yml
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (set-skip-label)
+#   set-skip-label:
+#     needs: [get-environment, deliver-rpm, deliver-deb, promote]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     uses: ./.github/workflows/set-pull-request-skip-label.yml

--- a/.github/workflows/lua-curl.yml
+++ b/.github/workflows/lua-curl.yml
@@ -143,254 +143,261 @@ jobs:
           stability: ${{ needs.get-environment.outputs.stability }}
           upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
-  deliver-rpm:
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    needs: [get-environment, package]
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        include:
-          - distrib: el9
-            arch: amd64
-          - distrib: el10
-            arch: amd64
-    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-rpm)
+#   deliver-rpm:
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     needs: [get-environment, package]
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       matrix:
+#         include:
+#           - distrib: el9
+#             arch: amd64
+#           - distrib: el10
+#             arch: amd64
+#     name: deliver ${{ matrix.distrib }} ${{ matrix.arch }}
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Publish RPM packages
+#         uses: ./.github/actions/rpm-delivery
+#         with:
+#           module_name: lua-curl
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-lua-curl-${{ matrix.distrib }}-${{ matrix.arch }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
 
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-rpm-pulp)
+#   deliver-rpm-pulp:
+#     continue-on-error: true
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     needs: [get-environment, package]
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       matrix:
+#         include:
+#           - distrib: el9
+#             arch: amd64
+#           - distrib: el10
+#             arch: amd64
+#     name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_rpm_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: lua-curl
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-lua-curl-${{ matrix.distrib }}-${{ matrix.arch }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_rpm_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-      - name: Publish RPM packages
-        uses: ./.github/actions/rpm-delivery
-        with:
-          module_name: lua-curl
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-lua-curl-${{ matrix.distrib }}-${{ matrix.arch }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-deb)
+#   deliver-deb:
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+#     needs: [get-environment, package]
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       matrix:
+#         include:
+#           - distrib: trixie
+#             arch: amd64
+#
+#     name: deliver ${{ matrix.distrib }} ${{ matrix.arch }}
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Publish DEB packages
+#         uses: ./.github/actions/deb-delivery
+#         with:
+#           module_name: lua-curl
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-lua-curl-${{ matrix.distrib }}-${{ matrix.arch }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-  deliver-rpm-pulp:
-    continue-on-error: true
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    needs: [get-environment, package]
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      matrix:
-        include:
-          - distrib: el9
-            arch: amd64
-          - distrib: el10
-            arch: amd64
-    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-deb-pulp)
+#   deliver-deb-pulp:
+#     continue-on-error: true
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+#     needs: [get-environment, package]
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       matrix:
+#         include:
+#           - distrib: trixie
+#             arch: amd64
+#
+#     name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_deb_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: lua-curl
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-lua-curl-${{ matrix.distrib }}-${{ matrix.arch }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_deb_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote)
+#   promote:
+#     needs: [get-environment, deliver-rpm, deliver-deb]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#     runs-on: ubuntu-24.04
+#     strategy:
+#       matrix:
+#         distrib: [el9, el10, trixie]
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Promote ${{ matrix.distrib }} to stable
+#         uses: ./.github/actions/promote-to-stable
+#         with:
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           module_name: lua-curl
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           github_ref_name: ${{ github.ref_name }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-      - name: Deliver packages on Pulp
-        id: deliver_rpm_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: lua-curl
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-lua-curl-${{ matrix.distrib }}-${{ matrix.arch }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-pulp)
+#   promote-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       matrix:
+#         distrib: [el9, el10, trixie]
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Pulp
+#         id: promote_pulp
+#         uses: ./.github/actions/promote-to-stable-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: lua-curl
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp promotion failed
+#         if: steps.promote_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_rpm_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  deliver-deb:
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-    needs: [get-environment, package]
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        include:
-          - distrib: trixie
-            arch: amd64
-
-    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }}
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Publish DEB packages
-        uses: ./.github/actions/deb-delivery
-        with:
-          module_name: lua-curl
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-lua-curl-${{ matrix.distrib }}-${{ matrix.arch }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  deliver-deb-pulp:
-    continue-on-error: true
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-    needs: [get-environment, package]
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      matrix:
-        include:
-          - distrib: trixie
-            arch: amd64
-
-    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_deb_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: lua-curl
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-deb-lua-curl-${{ matrix.distrib }}-${{ matrix.arch }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_deb_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  promote:
-    needs: [get-environment, deliver-rpm, deliver-deb]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        distrib: [el9, el10, trixie]
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Promote ${{ matrix.distrib }} to stable
-        uses: ./.github/actions/promote-to-stable
-        with:
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          module_name: lua-curl
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          github_ref_name: ${{ github.ref_name }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  promote-pulp:
-    continue-on-error: true
-    needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      matrix:
-        distrib: [el9, el10, trixie]
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Promote ${{ matrix.distrib }} to stable on Pulp
-        id: promote_pulp
-        uses: ./.github/actions/promote-to-stable-pulp
-        continue-on-error: true
-        with:
-          module_name: lua-curl
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp promotion failed
-        if: steps.promote_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
-
-  set-skip-label:
-    needs: [get-environment, deliver-rpm, deliver-deb, promote]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    uses: ./.github/workflows/set-pull-request-skip-label.yml
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (set-skip-label)
+#   set-skip-label:
+#     needs: [get-environment, deliver-rpm, deliver-deb, promote]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     uses: ./.github/workflows/set-pull-request-skip-label.yml

--- a/.github/workflows/monitoring-agent.yml
+++ b/.github/workflows/monitoring-agent.yml
@@ -430,486 +430,496 @@ jobs:
       jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
 
-  robot-test:
-    needs: [get-environment, get-aws-environment, changes, package-linux]
-    if: |
-      needs.changes.outputs.trigger_e2e_testing == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (robot-test)
+#   robot-test:
+#     needs: [get-environment, get-aws-environment, changes, package-linux]
+#     if: |
+#       needs.changes.outputs.trigger_e2e_testing == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       needs.get-environment.outputs.stability != 'stable' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include: ${{ fromJson(needs.get-environment.outputs.cma_robot_matrix) }}
+#
+#     name: robot-test ${{ matrix.operating_system }} ${{ matrix.database_type }} ${{ matrix.arch }} ${{ contains(matrix.tests_params, 'grpc') && 'grpc' || '' }}
+#
+#     uses: ./.github/workflows/robot-test.yml
+#     with:
+#       distrib: ${{ matrix.operating_system }}
+#       arch: ${{ matrix.arch }}
+#       test_img_version: ${{ needs.get-environment.outputs.test_img_version }}
+#       database_type: ${{ matrix.database_type }}
+#       tests_params: ${{ matrix.tests_params }}
+#       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
+#       features_pattern: 'cma.*\.robot'
+#       aws_role_arn: ${{ needs.get-aws-environment.outputs.aws_role_arn }}
+#       aws_web_identity_token_file: ${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}
+#       store_docker_image_in_cache: false
+#     secrets:
+#       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+#       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+#       xray_client_id: ${{ secrets.XRAY_CLIENT_ID }}
+#       xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
+#       jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+#       jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
+#       jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
 
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.get-environment.outputs.cma_robot_matrix) }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-rpm)
+#   deliver-rpm:
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     needs: [get-environment, build-and-test-agent-windows, robot-test]
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include:
+#           - distrib: el8
+#             arch: amd64
+#           - distrib: el9
+#             arch: amd64
+#           - distrib: el10
+#             arch: amd64
+#
+#     name: deliver ${{ matrix.distrib }}
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Publish RPM packages
+#         uses: ./.github/actions/rpm-delivery
+#         with:
+#           module_name: monitoring-agent
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-centreon-monitoring-agent-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
 
-    name: robot-test ${{ matrix.operating_system }} ${{ matrix.database_type }} ${{ matrix.arch }} ${{ contains(matrix.tests_params, 'grpc') && 'grpc' || '' }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-rpm-pulp)
+#   deliver-rpm-pulp:
+#     continue-on-error: true
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
+#       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     needs: [get-environment, build-and-test-agent-windows, robot-test]
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include:
+#           - distrib: el8
+#             arch: amd64
+#           - distrib: el9
+#             arch: amd64
+#           - distrib: el10
+#             arch: amd64
+#
+#     name: deliver ${{ matrix.distrib }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_rpm_pulp
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: monitoring-agent
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-centreon-monitoring-agent-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_rpm_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-    uses: ./.github/workflows/robot-test.yml
-    with:
-      distrib: ${{ matrix.operating_system }}
-      arch: ${{ matrix.arch }}
-      test_img_version: ${{ needs.get-environment.outputs.test_img_version }}
-      database_type: ${{ matrix.database_type }}
-      tests_params: ${{ matrix.tests_params }}
-      is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
-      features_pattern: 'cma.*\.robot'
-      aws_role_arn: ${{ needs.get-aws-environment.outputs.aws_role_arn }}
-      aws_web_identity_token_file: ${{ needs.get-aws-environment.outputs.aws_web_identity_token_file }}
-      store_docker_image_in_cache: false
-    secrets:
-      registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-      registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-      xray_client_id: ${{ secrets.XRAY_CLIENT_ID }}
-      xray_client_secret: ${{ secrets.XRAY_CLIENT_SECRET }}
-      jira_base_url: ${{ secrets.JIRA_BASE_URL }}
-      jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
-      jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-deb)
+#   deliver-deb:
+#     if: |
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     needs: [get-environment, changes, build-and-test-agent-windows, robot-test]
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include:
+#           - distrib: bullseye
+#             arch: amd64
+#           - distrib: bullseye
+#             arch: arm64
+#           - distrib: bookworm
+#             arch: amd64
+#           - distrib: bookworm
+#             arch: arm64
+#           - distrib: trixie
+#             arch: amd64
+#           - distrib: trixie
+#             arch: arm64
+#           - distrib: jammy
+#             arch: amd64
+#           - distrib: jammy
+#             arch: arm64
+#           - distrib: noble
+#             arch: amd64
+#           - distrib: noble
+#             arch: arm64
+#
+#     name: deliver ${{ matrix.distrib }} ${{ matrix.arch }}
+#
+#     steps:
+#       - name: Checkout sources
+#         if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Publish DEB packages
+#         if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
+#         uses: ./.github/actions/deb-delivery
+#         with:
+#           module_name: monitoring-agent
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-monitoring-agent-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-  deliver-rpm:
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-deb-pulp)
+#   deliver-deb-pulp:
+#     continue-on-error: true
+#     if: |
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     needs: [get-environment, changes, build-and-test-agent-windows, robot-test]
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         include:
+#           - distrib: bullseye
+#             arch: amd64
+#           - distrib: bullseye
+#             arch: arm64
+#           - distrib: bookworm
+#             arch: amd64
+#           - distrib: bookworm
+#             arch: arm64
+#           - distrib: trixie
+#             arch: amd64
+#           - distrib: trixie
+#             arch: arm64
+#           - distrib: jammy
+#             arch: amd64
+#           - distrib: jammy
+#             arch: arm64
+#           - distrib: noble
+#             arch: amd64
+#           - distrib: noble
+#             arch: arm64
+#
+#     name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Deliver packages on Pulp
+#         id: deliver_deb_pulp
+#         if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
+#         uses: ./.github/actions/package-delivery-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: monitoring-agent
+#           distrib: ${{ matrix.distrib }}
+#           version: ${{ needs.get-environment.outputs.major_version }}
+#           cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-monitoring-agent-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp delivery failed
+#         if: steps.deliver_deb_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
 
-    needs: [get-environment, build-and-test-agent-windows, robot-test]
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - distrib: el8
-            arch: amd64
-          - distrib: el9
-            arch: amd64
-          - distrib: el10
-            arch: amd64
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (deliver-windows)
+#   deliver-windows:
+#     if: |
+#       needs.changes.outputs.trigger_delivery == 'true' &&
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     needs: [get-environment, changes, build-and-test-agent-windows, robot-test]
+#     runs-on: windows-latest
+#
+#     steps:
+#       - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
+#         env:
+#           JF_URL: https://packages.centreon.com
+#           JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#
+#       - name: Restore cache monitoring agent
+#         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+#         with:
+#           path: agent\installer\centreon-monitoring-agent.exe
+#           key: ${{ github.run_id }}-${{ github.sha }}-exe-centreon-monitoring-agent-${{ github.head_ref || github.ref_name }}
+#           fail-on-cache-miss: true
+#
+#       - name: Deliver
+#         env:
+#           CMA_MAJOR_VERSION: ${{ needs.get-environment.outputs.cma_major_version }}
+#           CMA_MINOR_VERSION: ${{ needs.get-environment.outputs.cma_minor_version }}
+#           STABILITY: ${{ needs.get-environment.outputs.stability }}
+#         run: |
+#           Write-Host "[DEBUG] deliver to testing - Major version: $env:CMA_MAJOR_VERSION"
+#           Write-Host "[DEBUG] deliver to testing - Minor version: $env:CMA_MINOR_VERSION"
+#
+#           $VERSION = "$env:CMA_MAJOR_VERSION.$env:CMA_MINOR_VERSION"
+#           $STABILITY = "$env:STABILITY"
+#
+#           $TARGET_PATH = "installers/monitoring-agent/$env:CMA_MAJOR_VERSION/$STABILITY/windows/"
+#
+#           $VERSION_EXE = "centreon-monitoring-agent-${VERSION}.exe"
+#
+#           Copy-Item -Path "agent\installer\centreon-monitoring-agent.exe" -Destination "${VERSION_EXE}"
+#           Write-Host "[DEBUG] deliver testing to - Target path: ${TARGET_PATH}"
+#           jf rt upload $VERSION_EXE "${TARGET_PATH}" --sync-deletes="${TARGET_PATH}"
+#         shell: powershell
 
-    name: deliver ${{ matrix.distrib }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-linux)
+#   promote-linux:
+#     needs: [get-environment, deliver-rpm, deliver-deb]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         distrib: [el8, el9, el10, bullseye, bookworm, trixie, jammy, noble]
+#
+#     steps:
+#       - name: Checkout sources
+#         if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - name: Promote ${{ matrix.distrib }} to stable
+#         if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
+#         uses: ./.github/actions/promote-to-stable
+#         with:
+#           artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#           module_name: monitoring-agent
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           minor_version: ${{ needs.get-environment.outputs.minor_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           github_ref_name: ${{ github.ref_name }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#
+#       - name: Parse distrib name
+#         if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
+#         id: parse-distrib
+#         uses: ./.github/actions/parse-distrib
+#         with:
+#           distrib: ${{ matrix.distrib }}
+#
+#       - name: Deliver monitoring agent to github release
+#         if: ${{ needs.get-environment.outputs.is_cloud == 'false' }}
+#         uses: ./.github/actions/deliver-github-asset
+#         with:
+#           file_pattern: /tmp/promoted-packages/centreon-monitoring-agent${{ steps.parse-distrib.outputs.package_version_separator }}${{ needs.get-environment.outputs.cma_major_version }}.${{ needs.get-environment.outputs.cma_minor_version }}*.${{ steps.parse-distrib.outputs.package_extension }}
+#           github_release: centreon-monitoring-agent-${{ needs.get-environment.outputs.cma_major_version }}.${{ needs.get-environment.outputs.cma_minor_version }}
+#           token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
 
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-linux-pulp)
+#   promote-linux-pulp:
+#     continue-on-error: true
+#     needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     runs-on: centreon-ubuntu-22.04
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         distrib: [el8, el9, el10, bullseye, bookworm, trixie, jammy, noble]
+#     permissions:
+#       contents: read
+#       id-token: write
+#
+#     steps:
+#       - name: Checkout sources
+#         if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
+#         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#
+#       - name: Promote ${{ matrix.distrib }} to stable on Pulp
+#         id: promote_pulp
+#         if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
+#         uses: ./.github/actions/promote-to-stable-pulp
+#         continue-on-error: true
+#         with:
+#           module_name: monitoring-agent
+#           distrib: ${{ matrix.distrib }}
+#           major_version: ${{ needs.get-environment.outputs.major_version }}
+#           stability: ${{ needs.get-environment.outputs.stability }}
+#           release_type: ${{ needs.get-environment.outputs.release_type }}
+#           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
+#           pulp_url: ${{ vars.PULP_API_URL }}
+#           pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
+#           audience: ${{ vars.PULP_OIDC_AUDIENCE }}
+#
+#       - name: Warn if the Pulp promotion failed
+#         if: steps.promote_pulp.outcome == 'failure'
+#         shell: bash
+#         run: |
+#           echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
 
-      - name: Publish RPM packages
-        uses: ./.github/actions/rpm-delivery
-        with:
-          module_name: monitoring-agent
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-centreon-monitoring-agent-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          centreon_technique_pat: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (promote-windows)
+#   promote-windows:
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled') &&
+#       github.repository == 'centreon/centreon-collect'
+#
+#     needs: [get-environment, deliver-windows]
+#     runs-on: windows-latest
+#
+#     steps:
+#       - name: Checkout sources
+#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#
+#       - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
+#         env:
+#           JF_URL: https://packages.centreon.com
+#           JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+#
+#       - name: Promote testing to stable
+#         env:
+#           CMA_MAJOR_VERSION: ${{ needs.get-environment.outputs.cma_major_version }}
+#           CMA_MINOR_VERSION: ${{ needs.get-environment.outputs.cma_minor_version }}
+#           STABILITY: ${{ needs.get-environment.outputs.stability }}
+#           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
+#         run: |
+#           Write-Host "[DEBUG] promote to stable - Major version: $env:CMA_MAJOR_VERSION"
+#           Write-Host "[DEBUG] promote to stable - Minor version: $env:CMA_MINOR_VERSION"
+#
+#           $VERSION= "$env:CMA_MAJOR_VERSION.$env:CMA_MINOR_VERSION"
+#           $MODULE_NAME= "monitoring-agent-$env:CMA_MAJOR_VERSION.$env:CMA_MINOR_VERSION"
+#           $STABILITY= "$env:STABILITY"
+#
+#           $SRC_PATH = "installers/monitoring-agent/$env:MAJOR_VERSION/testing/windows/"
+#           $TARGET_PATH = "installers/monitoring-agent/$env:MAJOR_VERSION/$STABILITY/windows/"
+#
+#           $VERSION_EXE = "centreon-monitoring-agent-${VERSION}.exe"
+#
+#           Write-Host "[DEBUG] promote to stable from: ${SRC_PATH}${VERSION_EXE}"
+#
+#           jf rt download "${SRC_PATH}${VERSION_EXE}" --flat --fail-no-op
+#
+#           Write-Host "[DEBUG] promote to stable ${VERSION_EXE} to path: ${TARGET_PATH}"
+#
+#           jf rt upload $VERSION_EXE "${TARGET_PATH}"
+#         shell: powershell
+#
+#       - name: Deliver monitoring agent to github release
+#         if: ${{ needs.get-environment.outputs.is_cloud == 'false' }}
+#         uses: ./.github/actions/deliver-github-asset
+#         with:
+#           file_pattern: ./centreon-monitoring-agent-${{ needs.get-environment.outputs.cma_major_version }}.${{ needs.get-environment.outputs.cma_minor_version }}*.exe
+#           github_release: centreon-monitoring-agent-${{ needs.get-environment.outputs.cma_major_version }}.${{ needs.get-environment.outputs.cma_minor_version }}
+#           token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
 
-  deliver-rpm-pulp:
-    continue-on-error: true
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
-      contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    needs: [get-environment, build-and-test-agent-windows, robot-test]
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - distrib: el8
-            arch: amd64
-          - distrib: el9
-            arch: amd64
-          - distrib: el10
-            arch: amd64
-
-    name: deliver ${{ matrix.distrib }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_rpm_pulp
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: monitoring-agent
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.run_id }}-${{ github.sha }}-rpm-centreon-monitoring-agent-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          delivery_type: ${{ needs.get-environment.outputs.delivery_type }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_rpm_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  deliver-deb:
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    needs: [get-environment, changes, build-and-test-agent-windows, robot-test]
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - distrib: bullseye
-            arch: amd64
-          - distrib: bullseye
-            arch: arm64
-          - distrib: bookworm
-            arch: amd64
-          - distrib: bookworm
-            arch: arm64
-          - distrib: trixie
-            arch: amd64
-          - distrib: trixie
-            arch: arm64
-          - distrib: jammy
-            arch: amd64
-          - distrib: jammy
-            arch: arm64
-          - distrib: noble
-            arch: amd64
-          - distrib: noble
-            arch: arm64
-
-    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }}
-
-    steps:
-      - name: Checkout sources
-        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Publish DEB packages
-        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
-        uses: ./.github/actions/deb-delivery
-        with:
-          module_name: monitoring-agent
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-monitoring-agent-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-  deliver-deb-pulp:
-    continue-on-error: true
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    needs: [get-environment, changes, build-and-test-agent-windows, robot-test]
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - distrib: bullseye
-            arch: amd64
-          - distrib: bullseye
-            arch: arm64
-          - distrib: bookworm
-            arch: amd64
-          - distrib: bookworm
-            arch: arm64
-          - distrib: trixie
-            arch: amd64
-          - distrib: trixie
-            arch: arm64
-          - distrib: jammy
-            arch: amd64
-          - distrib: jammy
-            arch: arm64
-          - distrib: noble
-            arch: amd64
-          - distrib: noble
-            arch: arm64
-
-    name: deliver ${{ matrix.distrib }} ${{ matrix.arch }} (pulp)
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Deliver packages on Pulp
-        id: deliver_deb_pulp
-        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
-        uses: ./.github/actions/package-delivery-pulp
-        continue-on-error: true
-        with:
-          module_name: monitoring-agent
-          distrib: ${{ matrix.distrib }}
-          version: ${{ needs.get-environment.outputs.major_version }}
-          cache_key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-monitoring-agent-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp delivery failed
-        if: steps.deliver_deb_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp delivery failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory delivery remains authoritative). See the 'Deliver packages on Pulp' step for the guardrail / auth / upload error."
-
-  deliver-windows:
-    if: |
-      needs.changes.outputs.trigger_delivery == 'true' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    needs: [get-environment, changes, build-and-test-agent-windows, robot-test]
-    runs-on: windows-latest
-
-    steps:
-      - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
-        env:
-          JF_URL: https://packages.centreon.com
-          JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-
-      - name: Restore cache monitoring agent
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: agent\installer\centreon-monitoring-agent.exe
-          key: ${{ github.run_id }}-${{ github.sha }}-exe-centreon-monitoring-agent-${{ github.head_ref || github.ref_name }}
-          fail-on-cache-miss: true
-
-      - name: Deliver
-        env:
-          CMA_MAJOR_VERSION: ${{ needs.get-environment.outputs.cma_major_version }}
-          CMA_MINOR_VERSION: ${{ needs.get-environment.outputs.cma_minor_version }}
-          STABILITY: ${{ needs.get-environment.outputs.stability }}
-        run: |
-          Write-Host "[DEBUG] deliver to testing - Major version: $env:CMA_MAJOR_VERSION"
-          Write-Host "[DEBUG] deliver to testing - Minor version: $env:CMA_MINOR_VERSION"
-
-          $VERSION = "$env:CMA_MAJOR_VERSION.$env:CMA_MINOR_VERSION"
-          $STABILITY = "$env:STABILITY"
-
-          $TARGET_PATH = "installers/monitoring-agent/$env:CMA_MAJOR_VERSION/$STABILITY/windows/"
-
-          $VERSION_EXE = "centreon-monitoring-agent-${VERSION}.exe"
-
-          Copy-Item -Path "agent\installer\centreon-monitoring-agent.exe" -Destination "${VERSION_EXE}"
-          Write-Host "[DEBUG] deliver testing to - Target path: ${TARGET_PATH}"
-          jf rt upload $VERSION_EXE "${TARGET_PATH}" --sync-deletes="${TARGET_PATH}"
-        shell: powershell
-
-  promote-linux:
-    needs: [get-environment, deliver-rpm, deliver-deb]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        distrib: [el8, el9, el10, bullseye, bookworm, trixie, jammy, noble]
-
-    steps:
-      - name: Checkout sources
-        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Promote ${{ matrix.distrib }} to stable
-        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
-        uses: ./.github/actions/promote-to-stable
-        with:
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          module_name: monitoring-agent
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          minor_version: ${{ needs.get-environment.outputs.minor_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          github_ref_name: ${{ github.ref_name }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-
-      - name: Parse distrib name
-        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
-        id: parse-distrib
-        uses: ./.github/actions/parse-distrib
-        with:
-          distrib: ${{ matrix.distrib }}
-
-      - name: Deliver monitoring agent to github release
-        if: ${{ needs.get-environment.outputs.is_cloud == 'false' }}
-        uses: ./.github/actions/deliver-github-asset
-        with:
-          file_pattern: /tmp/promoted-packages/centreon-monitoring-agent${{ steps.parse-distrib.outputs.package_version_separator }}${{ needs.get-environment.outputs.cma_major_version }}.${{ needs.get-environment.outputs.cma_minor_version }}*.${{ steps.parse-distrib.outputs.package_extension }}
-          github_release: centreon-monitoring-agent-${{ needs.get-environment.outputs.cma_major_version }}.${{ needs.get-environment.outputs.cma_minor_version }}
-          token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
-
-  promote-linux-pulp:
-    continue-on-error: true
-    needs: [get-environment, deliver-rpm-pulp, deliver-deb-pulp]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    runs-on: centreon-ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        distrib: [el8, el9, el10, bullseye, bookworm, trixie, jammy, noble]
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Checkout sources
-        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Promote ${{ matrix.distrib }} to stable on Pulp
-        id: promote_pulp
-        if: ${{ !(needs.get-environment.outputs.is_cloud == 'true' && matrix.distrib == 'bullseye') }}
-        uses: ./.github/actions/promote-to-stable-pulp
-        continue-on-error: true
-        with:
-          module_name: monitoring-agent
-          distrib: ${{ matrix.distrib }}
-          major_version: ${{ needs.get-environment.outputs.major_version }}
-          stability: ${{ needs.get-environment.outputs.stability }}
-          release_type: ${{ needs.get-environment.outputs.release_type }}
-          is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
-          pulp_url: ${{ vars.PULP_API_URL }}
-          pulp_content_url: ${{ vars.PULP_CONTENT_URL }}
-          audience: ${{ vars.PULP_OIDC_AUDIENCE }}
-
-      - name: Warn if the Pulp promotion failed
-        if: steps.promote_pulp.outcome == 'failure'
-        shell: bash
-        run: |
-          echo "::warning::Pulp promotion failed (non-blocking during the Artifactory-to-Pulp migration; Artifactory promotion remains authoritative). See the 'Promote to stable on Pulp' step."
-
-  promote-windows:
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      (contains(fromJson('["stable"]'), needs.get-environment.outputs.stability) && github.event_name != 'workflow_dispatch') &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
-
-    needs: [get-environment, deliver-windows]
-    runs-on: windows-latest
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
-        env:
-          JF_URL: https://packages.centreon.com
-          JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-
-      - name: Promote testing to stable
-        env:
-          CMA_MAJOR_VERSION: ${{ needs.get-environment.outputs.cma_major_version }}
-          CMA_MINOR_VERSION: ${{ needs.get-environment.outputs.cma_minor_version }}
-          STABILITY: ${{ needs.get-environment.outputs.stability }}
-          MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
-        run: |
-          Write-Host "[DEBUG] promote to stable - Major version: $env:CMA_MAJOR_VERSION"
-          Write-Host "[DEBUG] promote to stable - Minor version: $env:CMA_MINOR_VERSION"
-
-          $VERSION= "$env:CMA_MAJOR_VERSION.$env:CMA_MINOR_VERSION"
-          $MODULE_NAME= "monitoring-agent-$env:CMA_MAJOR_VERSION.$env:CMA_MINOR_VERSION"
-          $STABILITY= "$env:STABILITY"
-
-          $SRC_PATH = "installers/monitoring-agent/$env:MAJOR_VERSION/testing/windows/"
-          $TARGET_PATH = "installers/monitoring-agent/$env:MAJOR_VERSION/$STABILITY/windows/"
-
-          $VERSION_EXE = "centreon-monitoring-agent-${VERSION}.exe"
-
-          Write-Host "[DEBUG] promote to stable from: ${SRC_PATH}${VERSION_EXE}"
-
-          jf rt download "${SRC_PATH}${VERSION_EXE}" --flat --fail-no-op
-
-          Write-Host "[DEBUG] promote to stable ${VERSION_EXE} to path: ${TARGET_PATH}"
-
-          jf rt upload $VERSION_EXE "${TARGET_PATH}"
-        shell: powershell
-
-      - name: Deliver monitoring agent to github release
-        if: ${{ needs.get-environment.outputs.is_cloud == 'false' }}
-        uses: ./.github/actions/deliver-github-asset
-        with:
-          file_pattern: ./centreon-monitoring-agent-${{ needs.get-environment.outputs.cma_major_version }}.${{ needs.get-environment.outputs.cma_minor_version }}*.exe
-          github_release: centreon-monitoring-agent-${{ needs.get-environment.outputs.cma_major_version }}.${{ needs.get-environment.outputs.cma_minor_version }}
-          token_download_centreon_com: ${{ secrets.TOKEN_DOWNLOAD_CENTREON_COM }}
-
-  set-skip-label:
-    needs:
-      [
-        get-environment,
-        deliver-rpm,
-        deliver-deb,
-        deliver-windows,
-        promote-linux,
-        promote-windows,
-      ]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    uses: ./.github/workflows/set-pull-request-skip-label.yml
+  # [release-bump test — TO REVERT] disabled: downstream of packaging (set-skip-label)
+#   set-skip-label:
+#     needs:
+#       [
+#         get-environment,
+#         deliver-rpm,
+#         deliver-deb,
+#         deliver-windows,
+#         promote-linux,
+#         promote-windows,
+#       ]
+#     if: |
+#       needs.get-environment.outputs.skip_workflow == 'false' &&
+#       ! cancelled() &&
+#       ! contains(needs.*.result, 'failure') &&
+#       ! contains(needs.*.result, 'cancelled')
+#     uses: ./.github/workflows/set-pull-request-skip-label.yml


### PR DESCRIPTION
Temporary, revert-marked change for testing the `release-bump-version` workflow.

Comments out every job **downstream of packaging** (dockerize, e2e/robot, API tests, deliver*, promote*, jira) so that **packaging is the terminal job** and nothing is delivered or promoted while we validate version bumps on `release-29.01-next`.

**Revert this PR/commit to restore the full pipeline.**