### PR TITLE
fix(gorgone): pullwss token authent fail if token is set to never expire

### DIFF
--- a/gorgone/gorgone/modules/core/proxy/httpserver.pm
+++ b/gorgone/gorgone/modules/core/proxy/httpserver.pm
@@ -212,7 +212,9 @@ sub run {
                 if ($status != 0
                     || !defined($results->{token})
                     || $results->{is_revoked}
-                    || str2time($results->{expiration_date}) < time()) {
+                    || (defined($results->{expiration_date})
+                    && $results->{expiration_date} ne ''
+                    && str2time($results->{expiration_date}) < time())) {
                         $self->{logger}->writeLogDebug('[proxy-httpserver] invalid token: ' . $token_name);
                         $connector->{ws_clients}->{$ws_id}->{logged} = 0;
                         $self->close_websocket(
@@ -497,7 +499,9 @@ sub is_logged_websocket {
             if ($results->{token} ne $token_value
                 || $results->{type} ne "poller"
                 || $results->{is_revoked} == 1
-                || str2time($results->{expiration_date}) < time()) {
+                || (defined($results->{expiration_date})
+                && $results->{expiration_date} ne ''
+                && str2time($results->{expiration_date}) < time())) {
                 $self->{logger}->writeLogDebug('[proxy-httpserver] invalid token - ' . $token_name);
                 $self->close_websocket(
                     code    => 500,

--- a/gorgone/tests/robot/resources/web-api-mockoon.json
+++ b/gorgone/tests/robot/resources/web-api-mockoon.json
@@ -237,10 +237,10 @@
       "responses": [
         {
           "uuid": "63de4aa2-3cc2-4939-8043-cd4ad5d49c95",
-          "body": "{\n  \"name\": \"poller-1\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": \"{{faker 'date.future'}}\",\n  \"type\": \"poller\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
+          "body": "{\n  \"name\": \"poller-ok-expdate\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": \"{{faker 'date.future'}}\",\n  \"type\": \"poller\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
           "latency": 0,
           "statusCode": 200,
-          "label": "poller-1",
+          "label": "poller-ok-expdate",
           "headers": [],
           "bodyType": "INLINE",
           "filePath": "",
@@ -250,7 +250,7 @@
             {
               "target": "params",
               "modifier": "tokenName",
-              "value": "poller-1",
+              "value": "poller-ok-expdate",
               "invert": false,
               "operator": "equals"
             }
@@ -263,11 +263,11 @@
           "callbacks": []
         },
         {
-          "uuid": "47ad8f64-2726-4988-b211-4237cacb390d",
-          "body": "{\n  \"name\": \"poller-2\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": \"{{faker 'date.future'}}\",\n  \"type\": \"poller\",\n  \"is_revoked\": true,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
+          "uuid": "1c9fe405-8cdc-44bb-8f8f-dd35664392c9",
+          "body": "{\n  \"name\": \"poller-ok-noexpdate\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": null,\n  \"type\": \"poller\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
           "latency": 0,
           "statusCode": 200,
-          "label": "poller-2",
+          "label": "poller-ok-noexpdate",
           "headers": [],
           "bodyType": "INLINE",
           "filePath": "",
@@ -277,7 +277,61 @@
             {
               "target": "params",
               "modifier": "tokenName",
-              "value": "poller-2",
+              "value": "poller-ok-noexpdate",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
+          "uuid": "47ad8f64-2726-4988-b211-4237cacb390d",
+          "body": "{\n  \"name\": \"poller-revoked-expdate\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": \"{{faker 'date.future'}}\",\n  \"type\": \"poller\",\n  \"is_revoked\": true,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "poller-revoked-expdate",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "params",
+              "modifier": "tokenName",
+              "value": "poller-revoked-expdate",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
+          "uuid": "d9edc4f2-760f-401b-b523-ee46fe137372",
+          "body": "{\n  \"name\": \"poller-revoked-noexpdate\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": null,\n  \"type\": \"poller\",\n  \"is_revoked\": true,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "poller-revoked-noexpdate",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "params",
+              "modifier": "tokenName",
+              "value": "poller-revoked-noexpdate",
               "invert": false,
               "operator": "equals"
             }
@@ -291,10 +345,10 @@
         },
         {
           "uuid": "f5b5c6ca-166c-491d-8d49-5434e26590c8",
-          "body": "{\n  \"name\": \"poller-4\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": \"{{faker 'date.recent'}}\",\n  \"type\": \"poller\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
+          "body": "{\n  \"name\": \"poller-expired\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": \"{{faker 'date.recent'}}\",\n  \"type\": \"poller\",\n  \"is_revoked\": false,\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
           "latency": 0,
           "statusCode": 200,
-          "label": "poller-3",
+          "label": "poller-expired",
           "headers": [],
           "bodyType": "INLINE",
           "filePath": "",
@@ -304,7 +358,7 @@
             {
               "target": "params",
               "modifier": "tokenName",
-              "value": "poller-3",
+              "value": "poller-expired",
               "invert": false,
               "operator": "equals"
             }
@@ -318,10 +372,10 @@
         },
         {
           "uuid": "a878a73d-33b2-4818-8f8b-93c822f3ab57",
-          "body": "{\n  \"name\": \"poller-4\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": \"{{getGlobalVar 'expired'}}\",\n  \"type\": \"poller\",\n  \"is_revoked\": {{getGlobalVar 'revoked'}},\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
+          "body": "{\n  \"name\": \"poller-config\",\n  \"creation_date\": \"{{faker 'date.past'}}\",\n  \"expiration_date\": \"{{getGlobalVar 'expired'}}\",\n  \"type\": \"poller\",\n  \"is_revoked\": {{getGlobalVar 'revoked'}},\n  \"creator\": {\n    \"id\": 1,\n    \"name\": \"admin\"\n  },\n  \"token\": \"myPollerToken\"\n}",
           "latency": 0,
           "statusCode": 200,
-          "label": "poller-4",
+          "label": "poller-config",
           "headers": [],
           "bodyType": "INLINE",
           "filePath": "",
@@ -331,7 +385,7 @@
             {
               "target": "params",
               "modifier": "tokenName",
-              "value": "poller-4",
+              "value": "poller-config",
               "invert": false,
               "operator": "equals"
             }
@@ -385,28 +439,42 @@
             {
               "target": "params",
               "modifier": "tokenName",
-              "value": "poller-1",
+              "value": "poller-ok-expdate",
               "invert": true,
               "operator": "equals"
             },
             {
               "target": "params",
               "modifier": "tokenName",
-              "value": "poller-2",
+              "value": "poller-ok-noexpdate",
               "invert": true,
               "operator": "equals"
             },
             {
               "target": "params",
               "modifier": "tokenName",
-              "value": "poller-3",
+              "value": "poller-revoked-expdate",
               "invert": true,
               "operator": "equals"
             },
             {
               "target": "params",
               "modifier": "tokenName",
-              "value": "poller-4",
+              "value": "poller-revoked-noexpdate",
+              "invert": true,
+              "operator": "equals"
+            },
+            {
+              "target": "params",
+              "modifier": "tokenName",
+              "value": "poller-expired",
+              "invert": true,
+              "operator": "equals"
+            },
+            {
+              "target": "params",
+              "modifier": "tokenName",
+              "value": "poller-config",
               "invert": true,
               "operator": "equals"
             },
@@ -435,7 +503,7 @@
       "type": "http",
       "documentation": "",
       "method": "put",
-      "endpoint": "set-poller-4-is-revoked/:revoked",
+      "endpoint": "set-poller-config-is-revoked/:revoked",
       "responses": [
         {
           "uuid": "2c070a93-177c-42b7-9bfd-c8694bd2b168",
@@ -466,11 +534,11 @@
       "type": "http",
       "documentation": "",
       "method": "put",
-      "endpoint": "set-poller-4-is-expired/:expired",
+      "endpoint": "set-poller-config-is-expired/:expired",
       "responses": [
         {
           "uuid": "6b3bc02d-ad54-4154-87ff-bf87e7aee8e5",
-          "body": "{{#if (eq (urlParam 'expired') 'true')}}\n  {{setGlobalVar 'expired' (faker 'date.recent')}}\n{{else}}\n  {{setGlobalVar 'expired' (faker 'date.future')}}\n{{/if}}\n{\n  \"expired\": \"{{getGlobalVar 'expired'}}\"\n}",
+          "body": "{{#if (eq (urlParam 'expired') 'true')}}\n  {{setGlobalVar 'expired' (faker 'date.recent')}}\n{{else if (eq (urlParam 'expired') 'false')}}\n  {{setGlobalVar 'expired' (faker 'date.future')}}\n{{else}}\n  {{setGlobalVar 'expired' null}}\n{{/if}}\n{\n  \"expired\": \"{{getGlobalVar 'expired'}}\"\n}",
           "latency": 0,
           "statusCode": 200,
           "label": "",

--- a/gorgone/tests/robot/tests/core/pullwss.robot
+++ b/gorgone/tests/robot/tests/core/pullwss.robot
@@ -91,8 +91,10 @@ check one poller can connect to a central with env var ${id}
     Setup Two Gorgone Instances    communication_mode=${mode}    central_name=${mode}_gorgone_central_simple    poller_name=${mode}_gorgone_poller_2_simple
     Ctn Check No Error In Logs    ${mode}_gorgone_poller_2_simple
     Examples:    id    mode         env_token    --
-        ...    1    pullwss        poller-1:myPollerToken
-        ...    2    pullwss_uid    poller-1:myPollerToken
+        ...    1    pullwss        poller-ok-expdate:myPollerToken
+        ...    2    pullwss_uid    poller-ok-expdate:myPollerToken
+        ...    3    pullwss        poller-ok-noexpdate:myPollerToken
+        ...    4    pullwss_uid    poller-ok-noexpdate:myPollerToken
 
 check one poller cannot connect to a central with env var ${id}
     [Teardown]    Run Keywords
@@ -117,11 +119,12 @@ check one poller cannot connect to a central with env var ${id}
     ${logs_poller}    Ctn Find In Log With Timeout    log=/var/log/centreon-gorgone/${mode}_gorgone_poller_2_simple/gorgoned.log    content=${log_poller_query}    date=${start_date}
     Should Be True    ${logs_poller}    Didn't find the logs in the poller file : ${logs_poller}
 
-    Examples:    id    mode    env_token    message_central    --
-        ...    1    pullwss    Central-1:centralCMAtoken      [proxy-httpserver] invalid token
-        ...    2    pullwss    poller-2:myPollerToken         [proxy-httpserver] invalid token
-        ...    3    pullwss    poller-3:myPollerToken         [proxy-httpserver] invalid token
-        ...    4    pullwss    do_not_exists:myPollerToken    [proxy-httpserver] cannot get token
+    Examples:    id    mode       env_token                                 message_central    --
+        ...      1     pullwss    Central-1:centralCMAtoken                 [proxy-httpserver] invalid token
+        ...      2     pullwss    poller-revoked-expdate:myPollerToken      [proxy-httpserver] invalid token
+        ...      3     pullwss    poller-revoked-noexpdate:myPollerToken    [proxy-httpserver] invalid token
+        ...      4     pullwss    poller-expired:myPollerToken              [proxy-httpserver] invalid token
+        ...      5     pullwss    do_not_exists:myPollerToken               [proxy-httpserver] cannot get token
 
 check poller token revocation
     [Teardown]    Run Keywords
@@ -129,8 +132,8 @@ check poller token revocation
     ...    AND
     ...    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}database${/}delete_pollers.sql
 
-    Set Local Variable    ${revoked_url}    http://127.0.0.1:80/set-poller-4-is-revoked
-    Set Local Variable    ${expired_url}    http://127.0.0.1:80/set-poller-4-is-expired
+    Set Local Variable    ${revoked_url}    http://127.0.0.1:80/set-poller-config-is-revoked
+    Set Local Variable    ${expired_url}    http://127.0.0.1:80/set-poller-config-is-expired
     Set Local Variable    ${port}    8086
     Set Local Variable    ${timeout}    11
     Set Local Variable    ${sleep}    6
@@ -143,7 +146,7 @@ check poller token revocation
     ${start_date}    Get Current Date
     @{process_list}    Set Variable    pullwss_gorgone_central_simple    pullwss_gorgone_poller_2_simple
     Log To Console    \nStarting the gorgone setup
-    Set Environment Variable    GORGONE_TOKEN    poller-4:myPollerToken
+    Set Environment Variable    GORGONE_TOKEN    poller-config:myPollerToken
     ${response}    PUT    ${revoked_url}/false
     ${response}    PUT    ${expired_url}/false
     Setup Two Gorgone Instances    communication_mode=pullwss    central_name=pullwss_gorgone_central_simple    poller_name=pullwss_gorgone_poller_2_simple
@@ -176,6 +179,7 @@ check poller token revocation
     # Token revoked
     ${start_date}    Get Current Date    increment=-1s
     ${response}    PUT    ${revoked_url}/false
+    ${response}    PUT    ${expired_url}/null
     Sleep    ${sleep}
     # The poller is connected
     Check Poller Is Connected    port=${port}    expected_nb=2


### PR DESCRIPTION
## Description

Fix authentification fails for pullwss if the token is set to never expire.
Add new tests for this case.

**Fixes** MON-205722

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Generate a poller token without expiration date, and check the pullwss connection using this token.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

