### PR TITLE
fix(gorgone): fix log duplication for pullwss mode

### DIFF
--- a/gorgone/gorgone/modules/core/proxy/hooks.pm
+++ b/gorgone/gorgone/modules/core/proxy/hooks.pm
@@ -774,6 +774,7 @@ sub full_sync_history {
     my (%options) = @_;
     
     foreach my $id (keys %{$register_nodes}) {
+        next if ($id ne $register_nodes->{$id}->{id}); # register_node container one key per id and one per uid for each poller.
         if ($register_nodes->{$id}->{type} eq 'push_zmq') {
             routing(action => 'GETLOG', target => $id, frame => gorgone::class::frame->new(data => {}), gorgone => $options{gorgone}, dbh => $options{dbh}, logger => $options{logger});
         } elsif ($register_nodes->{$id}->{type} =~ /^(?:pull|wss|pullwss)$/) {

--- a/gorgone/gorgone/modules/core/proxy/hooks.pm
+++ b/gorgone/gorgone/modules/core/proxy/hooks.pm
@@ -450,6 +450,8 @@ sub check {
 
     # We check synclog/ping/ping request timeout 
     foreach (keys %$synctime_nodes) {
+        next if $_ ne $synctime_nodes->{$_}->{id};
+
         if ($register_nodes->{$_}->{type} =~ /^(?:pull|wss|pullwss)$/ && $constatus_ping->{$_}->{in_progress_ping} == 1) {
             my $ping_timeout = defined($register_nodes->{$_}->{ping_timeout}) ? $register_nodes->{$_}->{ping_timeout} : 30;
             if ((time() - $constatus_ping->{$_}->{in_progress_ping_pull}) > $ping_timeout) {
@@ -744,7 +746,7 @@ sub ping_send {
     $nodes_id = [$options{node_id}] if (defined($options{node_id}));
     my $current_time = time();
     foreach my $id (@$nodes_id) {
-        next if $id eq $register_nodes->{$id}->{id};
+        next if $id ne $register_nodes->{$id}->{id};
 
         next if ($constatus_ping->{$id}->{in_progress_ping} == 1 || $current_time < $constatus_ping->{$id}->{next_ping});
 
@@ -775,7 +777,7 @@ sub full_sync_history {
     my (%options) = @_;
     
     foreach my $id (keys %{$register_nodes}) {
-        next if ($id ne $register_nodes->{$id}->{id}); # register_node container one key per id and one per uid for each poller.
+        next if ($id ne $register_nodes->{$id}->{id}); # register_node contain one key per id and one per uid for each poller.
         if ($register_nodes->{$id}->{type} eq 'push_zmq') {
             routing(action => 'GETLOG', target => $id, frame => gorgone::class::frame->new(data => {}), gorgone => $options{gorgone}, dbh => $options{dbh}, logger => $options{logger});
         } elsif ($register_nodes->{$id}->{type} =~ /^(?:pull|wss|pullwss)$/) {

--- a/gorgone/gorgone/modules/core/proxy/hooks.pm
+++ b/gorgone/gorgone/modules/core/proxy/hooks.pm
@@ -744,6 +744,7 @@ sub ping_send {
     $nodes_id = [$options{node_id}] if (defined($options{node_id}));
     my $current_time = time();
     foreach my $id (@$nodes_id) {
+        next if $id eq $register_nodes->{$id}->{id};
 
         next if ($constatus_ping->{$id}->{in_progress_ping} == 1 || $current_time < $constatus_ping->{$id}->{next_ping});
 


### PR DESCRIPTION
## Description

fix log duplication in pullwss mode

The new uid/id enhancement had duplicated the keys in $register_nodes, so now looping on this hashmap need to make a next statement to avoid sending two message.


**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

