### PR TITLE
fix(ci): handle branch names with non docker tag friendly characters

### DIFF
--- a/.github/actions/compute-docker-tag/action.yml
+++ b/.github/actions/compute-docker-tag/action.yml
@@ -1,0 +1,26 @@
+name: "compute-docker-tag"
+description: "Sanitize a git ref (branch or tag name) into a valid Docker tag."
+inputs:
+  ref:
+    description: "The raw git ref to sanitize (e.g. github.head_ref || github.ref_name)"
+    required: true
+outputs:
+  tag:
+    description: "The sanitized, Docker-tag-friendly value"
+    value: ${{ steps.compute-docker-tag.outputs.tag }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Compute Docker tag
+      id: compute-docker-tag
+      env:
+        RAW_REF: ${{ inputs.ref }}
+      run: |
+        docker_tag=$(printf '%s' "$RAW_REF" | sed -E 's#[^[:alnum:]_.-]+#-#g; s#^[.-]+##; s#-+#-#g' | cut -c1-128)
+        if [[ -z "$docker_tag" ]]; then
+          echo "::error::Unable to derive a valid Docker tag from ref '$RAW_REF'"
+          exit 1
+        fi
+        echo "tag=${docker_tag}" >> "$GITHUB_OUTPUT"
+      shell: bash

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -389,6 +389,12 @@ jobs:
         with:
           distrib: ${{ matrix.distrib }}
 
+      - name: Compute Docker tag
+        id: docker-tag
+        uses: ./.github/actions/compute-docker-tag
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
       - name: Restore packages
         id: restore-packages
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -435,7 +441,7 @@ jobs:
           pull: true
           push: true
           load: true
-          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.project }}-${{ matrix.distrib }}:${{ github.head_ref || github.ref_name }}
+          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.project }}-${{ matrix.distrib }}:${{ steps.docker-tag.outputs.tag }}
           secrets: |
             "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"

--- a/.github/workflows/docker-gorgone-testing.yml
+++ b/.github/workflows/docker-gorgone-testing.yml
@@ -59,6 +59,12 @@ jobs:
           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
 
+      - name: Compute Docker tag
+        id: docker-tag
+        uses: ./.github/actions/compute-docker-tag
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
@@ -72,7 +78,7 @@ jobs:
             "PNPM_VERSION=10.24.0"
           pull: true
           push: true
-          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-dependencies-${{ matrix.distrib }}:${{ needs.get-environment.outputs.stability == 'unstable' && needs.get-environment.outputs.major_version || github.head_ref || github.ref_name }}
+          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-dependencies-${{ matrix.distrib }}:${{ needs.get-environment.outputs.stability == 'unstable' && needs.get-environment.outputs.major_version || steps.docker-tag.outputs.tag }}
           secrets: |
             "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -289,14 +289,26 @@ jobs:
         with:
           distrib: ${{ matrix.operating_system }}
 
+      - name: Compute Docker tag
+        id: docker-tag
+        uses: ./.github/actions/compute-docker-tag
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Compute base ref Docker tag
+        id: base-docker-tag
+        uses: ./.github/actions/compute-docker-tag
+        with:
+          ref: ${{ github.base_ref || github.ref_name }}
+
       - name: Get FROM image tag
         id: from_image_version
         env:
           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
           OPERATING_SYSTEM: ${{ matrix.operating_system }}
           REGISTRY_URL: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
-          GH_BASE_REF: ${{ github.base_ref || github.ref_name }}
+          GH_HEAD_REF: ${{ steps.docker-tag.outputs.tag }}
+          GH_BASE_REF: ${{ steps.base-docker-tag.outputs.tag }}
           PROJECT: ${{ env.project }}
         run: |
           FROM_IMAGE_VERSION="$MAJOR_VERSION"
@@ -373,13 +385,13 @@ jobs:
           pull: true
           push: true
           load: true
-          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ matrix.operating_system }}:${{ github.head_ref || github.ref_name }}
+          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ matrix.operating_system }}:${{ steps.docker-tag.outputs.tag }}
 
       - name: Store image in local archive
         env:
           REGISTRY_URL: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
           OPERATING_SYSTEM: ${{ matrix.operating_system }}
-          GH_REF: ${{ github.head_ref || github.ref_name }}
+          GH_REF: ${{ steps.docker-tag.outputs.tag }}
         run: |
           docker tag "$REGISTRY_URL/gorgone-testing-$OPERATING_SYSTEM:$GH_REF" "gorgone-testing-$OPERATING_SYSTEM:$GH_REF"
           mkdir -p docker-image
@@ -390,7 +402,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPERATING_SYSTEM: ${{ matrix.operating_system }}
-          GH_REF: ${{ github.head_ref || github.ref_name }}
+          GH_REF: ${{ steps.docker-tag.outputs.tag }}
         run: |
           curl \
             -X DELETE \
@@ -403,7 +415,7 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./docker-image
-          key: docker-image-gorgone-testing-${{ matrix.operating_system }}-${{ github.head_ref || github.ref_name }}
+          key: docker-image-gorgone-testing-${{ matrix.operating_system }}-${{ steps.docker-tag.outputs.tag }}
 
   robot-test:
     needs: [get-environment, changes, dockerize]

--- a/.github/workflows/robot-test-gorgone.yml
+++ b/.github/workflows/robot-test-gorgone.yml
@@ -49,6 +49,12 @@ jobs:
         with:
           distrib: ${{ inputs.distrib }}
 
+      - name: Compute Docker tag
+        id: docker-tag
+        uses: ./.github/actions/compute-docker-tag
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
       - name: Restore gorgone image from cache
         id: cache-docker
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -56,7 +62,7 @@ jobs:
         timeout-minutes: 6
         with:
           path: ./docker-image
-          key: docker-image-gorgone-testing-${{ inputs.distrib }}-${{ github.head_ref || github.ref_name }}
+          key: docker-image-gorgone-testing-${{ inputs.distrib }}-${{ steps.docker-tag.outputs.tag }}
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
@@ -64,7 +70,7 @@ jobs:
         if: ${{ steps.cache-docker.outputs.cache-hit == 'true' }}
         env:
           DISTRIB: ${{ inputs.distrib }}
-          IMAGE_TAG: ${{ github.head_ref || github.ref_name }}
+          IMAGE_TAG: ${{ steps.docker-tag.outputs.tag }}
           REGISTRY_URL: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
         run: |
           docker load --input "./docker-image/gorgone-testing-$DISTRIB.tar"
@@ -84,7 +90,7 @@ jobs:
 
       - name: ${{ format('Test {0}', matrix.feature) }}
         env:
-          GORGONE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ inputs.distrib }}:${{ github.head_ref || github.ref_name }}
+          GORGONE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ inputs.distrib }}:${{ steps.docker-tag.outputs.tag }}
           FEATURE: gorgone/tests/robot/tests/${{ matrix.feature }}
         run: |
           docker compose -f ./.github/docker/docker-compose.yml up --exit-code-from gorgone
@@ -94,7 +100,7 @@ jobs:
       - name: Get gorgone container logs
         if: failure()
         env:
-          GORGONE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ inputs.distrib }}:${{ github.head_ref || github.ref_name }}
+          GORGONE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ inputs.distrib }}:${{ steps.docker-tag.outputs.tag }}
           FEATURE: gorgone/tests/robot/tests/${{ matrix.feature }}
           FEATURE_NAME_WITH_DASH: ${{ steps.feature-path.outputs.feature_name_with_dash }}
         run: |


### PR DESCRIPTION
## Summary

Branch names such as `bugfix/MON-XXXXX-something` are valid git branch names but invalid Docker tags: our dockerize jobs use `github.head_ref || github.ref_name` directly as the tag, and Docker tags don't allow `/`.

`dockerize-engine-broker` (collect.yml) and `dockerize` (docker-gorgone.yml) already had a "Compute Docker tag" step (added in MON-196927) that sanitizes the ref (POSIX alnum, collapse dashes, fail on empty) before using it as a tag. This PR extracts that logic into a reusable composite action (`.github/actions/compute-docker-tag`) and wires it into the remaining producer/consumer pairs that were still using the raw ref:

- `collect.yml`: `dockerize` job (centreon-poller/web image)
- `gorgone.yml`: `dockerize` job (build/push, local archive, cache key, FROM-image lookup for both head and base ref)
- `docker-gorgone-testing.yml`: `dockerize` job (gorgone-testing-dependencies image)
- `robot-test-gorgone.yml`: consumer (cache key, image load/tag, GORGONE_IMAGE env) — recomputes the same sanitized value so producer and consumer agree on the tag

Cache keys unrelated to Docker tags (RPM/DEB package caches, etc.) and the git-branch-existence lookups (`Get linked branch of centreon repository`, stability detection) are left untouched — they tolerate `/` or need the literal branch name.

The two existing inline "Compute Docker tag" steps (collect.yml `dockerize-engine-broker`, `docker-gorgone.yml` `dockerize`) are left as-is (working code, out of scope) but now duplicate the sanitize regex that lives in the new composite action — flagging this intentionally so it isn't "fixed" by a reviewer as drift.

## Out of scope

The `centreon-poller` image built here is consumed by `centreon`'s `web.yml` e2e workflow, which still uses the raw ref. Fully supporting slash-branches end-to-end would need the same sanitization applied there — separate ticket/repo.

## Test plan
- [x] Local sanitizer test: `bugfix/MON-205804-something` -> `bugfix-MON-205804-something`, `develop` -> `develop`, empty/`///` -> fails with a clear error
- [x] `actionlint` clean on all touched workflow files
- [ ] Live run on this branch's own PR (branch name deliberately contains `/`) to confirm dockerize/gorgone/robot-test-gorgone all resolve to the same sanitized tag end-to-end

MON-205804