### PR TITLE
fix(delivery-feature): fetch number of expected repo files to find in rpm feature delivery creation check

### DIFF
--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -84,9 +84,9 @@ runs:
 
         attempt=0
         count=$(jf rt search rpm-standard-feature/$feature_ticket/$major_version/*.repo 2>/dev/null | jq '. | length' 2>/dev/null || echo "0")
-        until [[ $count -eq 2 || $attempt -ge 40 ]]; do
+        until [[ $count -eq 3 || $attempt -ge 40 ]]; do
           attempt=$((attempt+1))
-          echo "[INFO] Checking is the feature repository has been created... [ATTEMPT $attempt]"
+          echo "[INFO] Checking if the feature repository has been created... [ATTEMPT $attempt]"
           sleep 15
           count=$(jf rt search rpm-standard-feature/$feature_ticket/$major_version/*.repo 2>/dev/null | jq '. | length' 2>/dev/null || echo "0")
         done


### PR DESCRIPTION
## Description

updated count of expected files from 2 to 3 to take into account el8, el9 and el10; maybe something should be made to make this check less shaky
Fixes # MON-206334

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

