### PR TITLE
fix(ci): detect on-premise vs cloud version from .10/not .10 minor only

### DIFF
--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -549,10 +549,10 @@ jobs:
             const isNightly = process.env.IS_NIGHTLY;
 
             const currentMajorVersion = process.env.CURRENT_MAJOR_VERSION;
-            // Centreon versioning: even minor (e.g. .04, .10) => on-premise, odd minor => cloud/SaaS.
-            const currentMinor = Number(currentMajorVersion.split(".")[1]);
-            const isCloudCandidate = currentMinor % 2 !== 0;
-
+            // if month number is not 10 => it is a cloud version
+            // anything else => onprem
+            const isCloudCandidate =
+              !currentMajorVersion.match(/\.10$/);
             let releaseScope = "unknown";
 
             // in a nightly context, whatever the event_name is, the release context does not matter

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -536,7 +536,6 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           IS_NIGHTLY: ${{ steps.get_nightly_status.outputs.is_nightly }}
-          DEVELOP_MAJOR_VERSION: ${{ steps.latest_major_version.outputs.latest_major_version }}
           CURRENT_MAJOR_VERSION: ${{ steps.get_version.outputs.major_version }}
           EVENT_NAME: ${{ github.event_name }}
           PR_PATH: ${{ steps.pr_path.outputs.result || '[]' }}
@@ -549,14 +548,10 @@ jobs:
             const baseRef = process.env.GITHUB_BASE_REF; // only set for pull_request
             const isNightly = process.env.IS_NIGHTLY;
 
-            const developMajorVersion = process.env.DEVELOP_MAJOR_VERSION;
             const currentMajorVersion = process.env.CURRENT_MAJOR_VERSION;
-            // if major version is higher than develop major version => it is a cloud version
-            // if month number is not 10 => it is a cloud version
-            // anything else => onprem
-            const isCloudCandidate =
-              Number(currentMajorVersion) >= Number(developMajorVersion) ||
-              !currentMajorVersion.match(/\.10$/);
+            // Centreon versioning: even minor (e.g. .04, .10) => on-premise, odd minor => cloud/SaaS.
+            const currentMinor = Number(currentMajorVersion.split(".")[1]);
+            const isCloudCandidate = currentMinor % 2 !== 0;
 
             let releaseScope = "unknown";
 


### PR DESCRIPTION
## Summary
- Fixes the cloud/on-premise detection heuristic in `get-environment.yml`, which misclassified `dev-26.10.x` as a **cloud** build because `26.10 >= 26.09` (develop's current cloud version).
- That caused the docker build to target the internal *cloud* package repo path (which doesn't exist for `26.10`) instead of the already-published on-premise repo.
- Replaces the numeric comparison against develop's version with the actual versioning rule: even minor (`.04`, `.10`) = on-premise, odd minor = cloud/SaaS.

## Context
Seen on run https://github.com/centreon/centreon-collect/actions/runs/31091692378 (`docker-gorgone-testing` on `dev-26.10.x`).

## Test plan
- [ ] Merge this PR and the companion PR on `dev-26.10.x`
- [ ] Re-run `docker-gorgone-testing` (workflow_dispatch) on `dev-26.10.x` and confirm `releaseScope: onprem` and the dockerize jobs succeed