### PR TITLE
fix(ci): detect on-premise vs cloud version from .10/not .10 minor only

### DIFF
--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -536,7 +536,6 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           IS_NIGHTLY: ${{ steps.get_nightly_status.outputs.is_nightly }}
-          DEVELOP_MAJOR_VERSION: ${{ steps.latest_major_version.outputs.latest_major_version }}
           CURRENT_MAJOR_VERSION: ${{ steps.get_version.outputs.major_version }}
           EVENT_NAME: ${{ github.event_name }}
           PR_PATH: ${{ steps.pr_path.outputs.result || '[]' }}
@@ -549,14 +548,10 @@ jobs:
             const baseRef = process.env.GITHUB_BASE_REF; // only set for pull_request
             const isNightly = process.env.IS_NIGHTLY;
 
-            const developMajorVersion = process.env.DEVELOP_MAJOR_VERSION;
             const currentMajorVersion = process.env.CURRENT_MAJOR_VERSION;
-            // if major version is higher than develop major version => it is a cloud version
-            // if month number is not 10 => it is a cloud version
-            // anything else => onprem
-            const isCloudCandidate =
-              Number(currentMajorVersion) >= Number(developMajorVersion) ||
-              !currentMajorVersion.match(/\.10$/);
+            // Centreon versioning: even minor (e.g. .04, .10) => on-premise, odd minor => cloud/SaaS.
+            const currentMinor = Number(currentMajorVersion.split(".")[1]);
+            const isCloudCandidate = currentMinor % 2 !== 0;
 
             let releaseScope = "unknown";
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -549,10 +549,10 @@ jobs:
             const isNightly = process.env.IS_NIGHTLY;
 
             const currentMajorVersion = process.env.CURRENT_MAJOR_VERSION;
-            // Centreon versioning: even minor (e.g. .04, .10) => on-premise, odd minor => cloud/SaaS.
-            const currentMinor = Number(currentMajorVersion.split(".")[1]);
-            const isCloudCandidate = currentMinor % 2 !== 0;
-
+            // if month number is not 10 => it is a cloud version
+            // anything else => onprem
+            const isCloudCandidate =
+              !currentMajorVersion.match(/\.10$/);
             let releaseScope = "unknown";
 
             // in a nightly context, whatever the event_name is, the release context does not matter


### PR DESCRIPTION
Cherry-pick of #3622 onto `dev-26.10.x`.

## Summary
- Fixes the cloud/on-premise detection heuristic in `get-environment.yml`, which misclassified this branch as **cloud** because `26.10 >= 26.09` (develop's current cloud version).
- That caused the docker build to target the internal *cloud* package repo path (which doesn't exist for `26.10`) instead of the already-published on-premise repo.
- Replaces the numeric comparison against develop's version with the actual versioning rule: even minor (`.04`, `.10`) = on-premise, odd minor = cloud/SaaS.

## Context
Seen on run https://github.com/centreon/centreon-collect/actions/runs/31091692378 (`docker-gorgone-testing` on `dev-26.10.x`).

## Test plan
- [ ] Merge this PR
- [ ] Re-run `docker-gorgone-testing` (workflow_dispatch) on `dev-26.10.x` and confirm `releaseScope: onprem` and the dockerize jobs succeed