### PR TITLE
fix(ci): handle branch names with non docker tag friendly characters

### DIFF
--- a/.github/actions/compute-docker-tag/action.yml
+++ b/.github/actions/compute-docker-tag/action.yml
@@ -1,0 +1,26 @@
+name: "compute-docker-tag"
+description: "Sanitize a git ref (branch or tag name) into a valid Docker tag."
+inputs:
+  ref:
+    description: "The raw git ref to sanitize (e.g. github.head_ref || github.ref_name)"
+    required: true
+outputs:
+  tag:
+    description: "The sanitized, Docker-tag-friendly value"
+    value: ${{ steps.compute-docker-tag.outputs.tag }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Compute Docker tag
+      id: compute-docker-tag
+      env:
+        RAW_REF: ${{ inputs.ref }}
+      run: |
+        docker_tag=$(printf '%s' "$RAW_REF" | sed -E 's#[^[:alnum:]_.-]+#-#g; s#^[.-]+##; s#-+#-#g' | cut -c1-128)
+        if [[ -z "$docker_tag" ]]; then
+          echo "::error::Unable to derive a valid Docker tag from ref '$RAW_REF'"
+          exit 1
+        fi
+        echo "tag=${docker_tag}" >> "$GITHUB_OUTPUT"
+      shell: bash

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -364,6 +364,12 @@ jobs:
         with:
           distrib: ${{ matrix.distrib }}
 
+      - name: Compute Docker tag
+        id: docker-tag
+        uses: ./.github/actions/compute-docker-tag
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
       - name: Restore packages
         id: restore-packages
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -410,7 +416,7 @@ jobs:
           pull: true
           push: true
           load: true
-          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.project }}-${{ matrix.distrib }}:${{ github.head_ref || github.ref_name }}
+          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.project }}-${{ matrix.distrib }}:${{ steps.docker-tag.outputs.tag }}
           secrets: |
             "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"

--- a/.github/workflows/docker-gorgone-testing.yml
+++ b/.github/workflows/docker-gorgone-testing.yml
@@ -59,6 +59,12 @@ jobs:
           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
 
+      - name: Compute Docker tag
+        id: docker-tag
+        uses: ./.github/actions/compute-docker-tag
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
@@ -72,7 +78,7 @@ jobs:
             "PNPM_VERSION=10.24.0"
           pull: true
           push: true
-          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-dependencies-${{ matrix.distrib }}:${{ needs.get-environment.outputs.stability == 'unstable' && needs.get-environment.outputs.major_version || github.head_ref || github.ref_name }}
+          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-dependencies-${{ matrix.distrib }}:${{ needs.get-environment.outputs.stability == 'unstable' && needs.get-environment.outputs.major_version || steps.docker-tag.outputs.tag }}
           secrets: |
             "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -286,14 +286,26 @@ jobs:
         with:
           distrib: ${{ matrix.operating_system }}
 
+      - name: Compute Docker tag
+        id: docker-tag
+        uses: ./.github/actions/compute-docker-tag
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Compute base ref Docker tag
+        id: base-docker-tag
+        uses: ./.github/actions/compute-docker-tag
+        with:
+          ref: ${{ github.base_ref || github.ref_name }}
+
       - name: Get FROM image tag
         id: from_image_version
         env:
           MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
           OPERATING_SYSTEM: ${{ matrix.operating_system }}
           REGISTRY_URL: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
-          GH_BASE_REF: ${{ github.base_ref || github.ref_name }}
+          GH_HEAD_REF: ${{ steps.docker-tag.outputs.tag }}
+          GH_BASE_REF: ${{ steps.base-docker-tag.outputs.tag }}
           PROJECT: ${{ env.project }}
         run: |
           FROM_IMAGE_VERSION="$MAJOR_VERSION"
@@ -370,13 +382,13 @@ jobs:
           pull: true
           push: true
           load: true
-          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ matrix.operating_system }}:${{ github.head_ref || github.ref_name }}
+          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ matrix.operating_system }}:${{ steps.docker-tag.outputs.tag }}
 
       - name: Store image in local archive
         env:
           REGISTRY_URL: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
           OPERATING_SYSTEM: ${{ matrix.operating_system }}
-          GH_REF: ${{ github.head_ref || github.ref_name }}
+          GH_REF: ${{ steps.docker-tag.outputs.tag }}
         run: |
           docker tag "$REGISTRY_URL/gorgone-testing-$OPERATING_SYSTEM:$GH_REF" "gorgone-testing-$OPERATING_SYSTEM:$GH_REF"
           mkdir -p docker-image
@@ -387,7 +399,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPERATING_SYSTEM: ${{ matrix.operating_system }}
-          GH_REF: ${{ github.head_ref || github.ref_name }}
+          GH_REF: ${{ steps.docker-tag.outputs.tag }}
         run: |
           curl \
             -X DELETE \
@@ -400,7 +412,7 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./docker-image
-          key: docker-image-gorgone-testing-${{ matrix.operating_system }}-${{ github.head_ref || github.ref_name }}
+          key: docker-image-gorgone-testing-${{ matrix.operating_system }}-${{ steps.docker-tag.outputs.tag }}
 
   robot-test:
     needs: [get-environment, changes, dockerize]

--- a/.github/workflows/robot-test-gorgone.yml
+++ b/.github/workflows/robot-test-gorgone.yml
@@ -49,6 +49,12 @@ jobs:
         with:
           distrib: ${{ inputs.distrib }}
 
+      - name: Compute Docker tag
+        id: docker-tag
+        uses: ./.github/actions/compute-docker-tag
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
       - name: Restore gorgone image from cache
         id: cache-docker
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -56,7 +62,7 @@ jobs:
         timeout-minutes: 6
         with:
           path: ./docker-image
-          key: docker-image-gorgone-testing-${{ inputs.distrib }}-${{ github.head_ref || github.ref_name }}
+          key: docker-image-gorgone-testing-${{ inputs.distrib }}-${{ steps.docker-tag.outputs.tag }}
         env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
@@ -64,7 +70,7 @@ jobs:
         if: ${{ steps.cache-docker.outputs.cache-hit == 'true' }}
         env:
           DISTRIB: ${{ inputs.distrib }}
-          IMAGE_TAG: ${{ github.head_ref || github.ref_name }}
+          IMAGE_TAG: ${{ steps.docker-tag.outputs.tag }}
           REGISTRY_URL: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
         run: |
           docker load --input "./docker-image/gorgone-testing-$DISTRIB.tar"
@@ -84,7 +90,7 @@ jobs:
 
       - name: ${{ format('Test {0}', matrix.feature) }}
         env:
-          GORGONE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ inputs.distrib }}:${{ github.head_ref || github.ref_name }}
+          GORGONE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ inputs.distrib }}:${{ steps.docker-tag.outputs.tag }}
           FEATURE: gorgone/tests/robot/tests/${{ matrix.feature }}
         run: |
           docker compose -f ./.github/docker/docker-compose.yml up --exit-code-from gorgone
@@ -94,7 +100,7 @@ jobs:
       - name: Get gorgone container logs
         if: failure()
         env:
-          GORGONE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ inputs.distrib }}:${{ github.head_ref || github.ref_name }}
+          GORGONE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ inputs.distrib }}:${{ steps.docker-tag.outputs.tag }}
           FEATURE: gorgone/tests/robot/tests/${{ matrix.feature }}
           FEATURE_NAME_WITH_DASH: ${{ steps.feature-path.outputs.feature_name_with_dash }}
         run: |


### PR DESCRIPTION
## Description
Backport of #3619 to `dev-25.10.x`.

Branch names like `bugfix/MON-XXXXX-something` are valid git branches but invalid Docker tags (`/` is not allowed). This PR extracts the existing ref-sanitizing logic into a reusable composite action (`.github/actions/compute-docker-tag`) and wires it into the remaining producer/consumer workflow pairs that were still using the raw ref: `collect.yml` (dockerize job), `gorgone.yml` (dockerize job), `docker-gorgone-testing.yml` (dockerize job), and `robot-test-gorgone.yml` (consumer, recomputing the same sanitized value).

Ref: MON-206420

**Fixes** MON-206420

## Type of change
- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## How this pull request can be tested ?
Same testing procedure as #3619.

## Checklist
#### Community contributors & Centreon team
- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).