### PR TITLE
fix(gorgone): re-push nodes to proxy-httpserver on ready to avoid pullwss connection loss

### DIFF
--- a/gorgone/gorgone/modules/core/proxy/hooks.pm
+++ b/gorgone/gorgone/modules/core/proxy/hooks.pm
@@ -210,6 +210,31 @@ sub routing {
             }
         } elsif (defined($data->{httpserver})) {
             $httpserver->{ready} = 1;
+            # The proxy-httpserver child may start after the nodes module already
+            # broadcast its resync, and its own startup CENTREONNODESSYNC request can be
+            # lost -> it then stays with an empty node table and refuses every pullwss
+            # poller ("unknown poller id/uid") until the next periodic resync. The parent
+            # already holds the authoritative node list, so replay it now that the child
+            # is ready (mirrors the pool-child re-push above).
+            my $httpserver_nodes = [];
+            my %httpserver_seen;
+            foreach my $hk (keys %$register_nodes) {
+                my $hn = $register_nodes->{$hk};
+                next if (!defined($hn->{id}) || $hk ne $hn->{id});
+                next if (defined($httpserver_seen{$hn->{id}}));
+                $httpserver_seen{$hn->{id}} = 1;
+                push @$httpserver_nodes, $hn;
+            }
+            if (scalar(@$httpserver_nodes) > 0) {
+                $options{logger}->writeLogInfo("[proxy] httpserver ready: re-pushing " . scalar(@$httpserver_nodes) . " node(s) to proxy-httpserver");
+                $options{gorgone}->send_internal_message(
+                    identity    => "gorgone-proxy-httpserver",
+                    action      => "PROXYADDNODE",
+                    json_encode => 1,
+                    data        => $httpserver_nodes,
+                    token       => $options{token}
+                );
+            }
         } elsif (defined($data->{node_id}) && defined($synctime_nodes->{ $data->{node_id} })) {
             $synctime_nodes->{ $data->{node_id} }->{channel_ready} = 1;
             $synctime_nodes->{ $data->{node_uid} }->{channel_ready} = 1;


### PR DESCRIPTION
## Description

Ref: [MON-207047](https://centreon.atlassian.net/browse/MON-207047)

On a Cloud platform, pullwss pollers can lose their connection to the central and stay disconnected after a configuration export, even though their `nagios_server.uid` is valid.

### Root cause

Pullwss poller authentication is gated by the in-memory node table of the `gorgone-proxy-httpserver` child (`core/proxy/httpserver.pm`, `$self->{nodes}`). That table is populated **only** by a `centreon/nodes` resync (`REGISTERNODESFROMDB`, forwarded by the proxy parent to the child).

When the httpserver child starts **after** the nodes module has already broadcast its resync, and its own one-shot startup `CENTREONNODESSYNC` request is lost (a race the code already documents in `httpserver.pm` `run()`), the child is left with an **empty node table**. It then refuses every connecting poller with `client connection for unknown poller id/uid` until the next periodic resync (`resync_time`, default 600s) — or until a resync is forced. Creating or editing a pullwss poller forces that resync (`triggerGorgoneNodesSyncIfPullwss`), which is why "editing the poller reconnects it" and "pollers created after the incident work".

The proxy parent already re-pushes the node list to **pool** children when they signal ready, but for the **httpserver** child the `PROXYREADY` handler only set `ready = 1` and never replayed the nodes.

### Fix

In the `PROXYREADY` handler (`core/proxy/hooks.pm`), on the `httpserver` branch, replay the parent's authoritative `$register_nodes` list to the httpserver child as a `PROXYADDNODE` as soon as the child registers — mirroring the existing pool-child re-push. This closes the startup race deterministically and is a no-op when no nodes are known yet.

### How it was tested

Reproduced on a CDE cloud central (gorgone 26.09) with a real pullwss poller and a Mojo WSS client:

- **Before:** with the child started after the nodes broadcast and its startup sync lost, the poller was refused (`unknown poller id/uid`) continuously with no self-recovery; only a forced `NodesSync` restored it.
- **After (this fix):** under the identical race the parent logs `httpserver ready: re-pushing N node(s) to proxy-httpserver`, the child logs `adding node X as pullwss`, and the poller connects automatically (`httpserver client X is logged`) with no manual action.


[MON-207047]: https://centreon.atlassian.net/browse/MON-207047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ