### PR TITLE
feat(ci): point gorgone trixie/alma10 test images at pulp repositories

### DIFF
--- a/.github/docker/gorgone/alma10/Dockerfile.testing-dependencies
+++ b/.github/docker/gorgone/alma10/Dockerfile.testing-dependencies
@@ -8,9 +8,7 @@ ARG PNPM_VERSION=10.24.0
 
 COPY .github/docker/gorgone/package.json .github/docker/gorgone/pnpm-lock.yaml /usr/local/src/
 
-RUN --mount=type=secret,id=ARTIFACTORY_INTERNAL_REPO_USERNAME \
-    --mount=type=secret,id=ARTIFACTORY_INTERNAL_REPO_PASSWORD \
-    bash -e <<EOF
+RUN bash -e <<EOF
 
 echo 'install_weak_deps=False' >> /etc/dnf/dnf.conf
 echo 'max_parallel_downloads=10' >> /etc/dnf/dnf.conf
@@ -19,13 +17,33 @@ echo 'fastestmirror=True' >> /etc/dnf/dnf.conf
 dnf install -y dnf-plugins-core zstd mariadb iproute epel-release procps lsof
 dnf config-manager --set-enabled crb
 
+ROOT_REPO="rpm-standard"
 if [[ "${IS_CLOUD}" == "true" ]]; then
-  dnf config-manager --add-repo https://$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_USERNAME):$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_PASSWORD)@packages.centreon.com/rpm-standard-internal/${VERSION}/el10/centreon-${VERSION}-internal.repo
-  sed -i "s#packages.centreon.com/rpm-standard-internal#$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_USERNAME):$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_PASSWORD)@packages.centreon.com/rpm-standard-internal#" /etc/yum.repos.d/centreon-${VERSION}-internal.repo
-else
-  dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/${VERSION}/el10/centreon-${VERSION}.repo
+  ROOT_REPO="rpm-standard-internal"
 fi
-dnf config-manager --set-enabled 'centreon*'
+
+# pulp-served repositories; packages keep their CES signature so gpgcheck stays on
+add_repo() {
+  echo "[\$1]
+name=\$1
+baseurl=\$2
+enabled=1
+gpgcheck=1
+gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES
+module_hotfixes=1
+skip_if_unavailable=1
+" >> /etc/yum.repos.d/centreon-${VERSION}.repo
+}
+for ARCH in x86_64 noarch; do
+  add_repo "centreon-${VERSION}-stable-\$ARCH" "https://packages.apps.centreon.com/standard-stable/\$ROOT_REPO/${VERSION}/el10/stable/\$ARCH/"
+  for STABILITY in testing-release testing-hotfix unstable; do
+    add_repo "centreon-${VERSION}-\$STABILITY-\$ARCH" "https://packages.apps.centreon.com/standard/\$ROOT_REPO/${VERSION}/el10/\$STABILITY/\$ARCH/"
+  done
+  add_repo "centreon-plugins-stable-\$ARCH" "https://packages.apps.centreon.com/plugins-stable/rpm-plugins/el10/stable/\$ARCH/"
+  for STABILITY in testing unstable; do
+    add_repo "centreon-plugins-\$STABILITY-\$ARCH" "https://packages.apps.centreon.com/plugins/rpm-plugins/el10/\$STABILITY/\$ARCH/"
+  done
+done
 
 dnf install -y python3.12 python3.12-pip
 pip3.12 install robotframework robotframework-examples robotframework-databaselibrary pymysql robotframework-requests robotframework-jsonlibrary

--- a/.github/docker/gorgone/trixie/Dockerfile.testing-dependencies
+++ b/.github/docker/gorgone/trixie/Dockerfile.testing-dependencies
@@ -10,9 +10,7 @@ COPY .github/docker/gorgone/package.json .github/docker/gorgone/pnpm-lock.yaml /
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN --mount=type=secret,id=ARTIFACTORY_INTERNAL_REPO_USERNAME \
-    --mount=type=secret,id=ARTIFACTORY_INTERNAL_REPO_PASSWORD \
-    bash -e <<EOF
+RUN bash -e <<EOF
 
 echo '
 Acquire::Retries "10";
@@ -53,23 +51,18 @@ VERSION_CODENAME=\$(
   echo \$VERSION_CODENAME
 )
 
+# pulp-served repositories; apt metadata is not signed yet, hence [trusted=yes]
 if [[ "${IS_CLOUD}" == "true" ]]; then
-  APT_AUTH_CONF_FILE="/etc/apt/auth.conf.d/centreon-${VERSION}-internal.conf"
-  echo "deb https://packages.centreon.com/apt-standard-internal/ \$VERSION_CODENAME-${VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
-  echo "machine packages.centreon.com" > \$APT_AUTH_CONF_FILE
-  echo "login $(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_USERNAME)" >> \$APT_AUTH_CONF_FILE
-  echo "password $(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_PASSWORD)" >> \$APT_AUTH_CONF_FILE
-  chmod 600 \$APT_AUTH_CONF_FILE
+  echo "deb [trusted=yes] https://packages.apps.centreon.com/standard/apt-standard-internal/ \$VERSION_CODENAME-${VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
 else
-  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${VERSION}-stable main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
-  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${VERSION}-testing-hotfix main" | tee -a /etc/apt/sources.list.d/centreon-testing-hotfix.list
-  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${VERSION}-testing-release main" | tee -a /etc/apt/sources.list.d/centreon-testing-release.list
-  echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
+  echo "deb [trusted=yes] https://packages.apps.centreon.com/standard-stable/apt-standard/ \$VERSION_CODENAME-${VERSION} main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
+  echo "deb [trusted=yes] https://packages.apps.centreon.com/standard/apt-standard/ \$VERSION_CODENAME-${VERSION}-testing-hotfix main" | tee -a /etc/apt/sources.list.d/centreon-testing-hotfix.list
+  echo "deb [trusted=yes] https://packages.apps.centreon.com/standard/apt-standard/ \$VERSION_CODENAME-${VERSION}-testing-release main" | tee -a /etc/apt/sources.list.d/centreon-testing-release.list
+  echo "deb [trusted=yes] https://packages.apps.centreon.com/standard/apt-standard/ \$VERSION_CODENAME-${VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
 fi
-echo "deb https://packages.centreon.com/apt-plugins-stable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
-echo "deb https://packages.centreon.com/apt-plugins-testing/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list
-echo "deb https://packages.centreon.com/apt-plugins-unstable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-unstable.list
-wget -O- https://packages.centreon.com/api/security/keypair/APT-GPG-KEY/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
+echo "deb [trusted=yes] https://packages.apps.centreon.com/plugins-stable/apt-plugins-stable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
+echo "deb [trusted=yes] https://packages.apps.centreon.com/plugins/apt-plugins/ \$VERSION_CODENAME-testing main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list
+echo "deb [trusted=yes] https://packages.apps.centreon.com/plugins/apt-plugins/ \$VERSION_CODENAME-unstable main" | tee -a /etc/apt/sources.list.d/centreon-plugins-unstable.list
 
 apt-get update
 


### PR DESCRIPTION
## Description

Fixes: [MON-199319](https://centreon.atlassian.net/browse/MON-199319)

Point the gorgone testing-dependencies images for **trixie** and **alma10** at the Pulp content endpoint (`packages.apps.centreon.com`) instead of Artifactory (`packages.centreon.com`), so that building these images (and running the gorgone robot tests on them) validates package download from the Pulp-served repositories.

### URL mapping (Pulp Domains)

| Artifactory | Pulp |
|---|---|
| `packages.centreon.com/rpm-standard[-internal]/<v>/el10/<stability>/...` | `packages.apps.centreon.com/standard/rpm-standard[-internal]/<v>/el10/<stability>/<arch>/` |
| same, `stable` | `packages.apps.centreon.com/standard-stable/rpm-standard[-internal]/<v>/el10/stable/<arch>/` |
| `packages.centreon.com/rpm-plugins/el10/...` | `packages.apps.centreon.com/plugins[-stable]/rpm-plugins/el10/...` |
| `apt-standard[-internal]/ <codename>-<v>-<stability>` | `standard/apt-standard[-internal]/ <codename>-<v>-<stability>` |
| `apt-standard/ <codename>-<v>-stable` | `standard-stable/apt-standard/ <codename>-<v>` |
| `apt-plugins-{stable,testing,unstable}/ <codename>` | `plugins-stable/apt-plugins-stable/ <codename>`, `plugins/apt-plugins/ <codename>-{testing,unstable}` |

### Notes

- **el10**: the Artifactory-hosted `.repo` file cannot be reused (it hardcodes `packages.centreon.com`), so the repo definitions are now written inline. RPMs served by Pulp keep their CES signature (verified on a downloaded package), so `gpgcheck=1` is kept. `skip_if_unavailable=1` keeps the image build from being held hostage by one broken stability tier (see the `testing-hotfix` finding below).
- **trixie**: Pulp apt metadata is not signed yet (no `InRelease`/`Release.gpg` published), hence `[trusted=yes]` on every entry. The GPG keyring import is dropped along with it.
- Pulp distributions have no content guard, so the Artifactory basic-auth plumbing (secret mounts, `auth.conf.d`, creds-in-URL `sed`) is removed. The workflow can keep passing the secrets; they are simply no longer mounted.

### Validation (against the live Pulp stack, version 26.09)

- **alma10**: full local image build with `IS_CLOUD=true` **succeeds**; `dnf repoquery --installed ... %{from_repo}` confirms `perl-Libssh-Session`, `perl-Net-Curl`, `perl-ZMQ-FFI` come from `centreon-plugins-unstable-*` and `centreon-engine-daemon` from `centreon-26.09-unstable-x86_64`, all downloaded from `packages.apps.centreon.com`.
- **trixie**: `centreon-engine-daemon` installs fine from `standard/apt-standard-internal trixie-26.09-unstable`. The image build itself is currently blocked: `libssh-session-perl` and `libnet-curl-perl` are not yet delivered to the Pulp `apt-plugins` repositories (`trixie-unstable` only contains `libcrypt-blowfish-pp-perl` and `libzmq-libzmq4-perl` today).
- The non-cloud (`IS_CLOUD=false`) variants will stay broken until non-internal repositories receive deliveries on Pulp (`rpm-standard/26.09/el10/unstable` and `apt-standard trixie-26.09-unstable` are currently empty).

### Server-side findings surfaced by this validation

- Every **RPM `testing-hotfix` publication returns HTTP 500** on `repodata/repomd.xml` (checked el9/el10, x86_64/noarch, `rpm-standard-internal`) while `unstable`/`testing-release`/`stable` and all apt suites serve fine — the publication itself looks broken, to investigate on the Pulp side.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

```
docker build -f .github/docker/gorgone/alma10/Dockerfile.testing-dependencies \
  --build-arg VERSION=26.09 --build-arg IS_CLOUD=true -t gorgone-testing-alma10 .
docker build -f .github/docker/gorgone/trixie/Dockerfile.testing-dependencies \
  --build-arg VERSION=26.09 --build-arg IS_CLOUD=true -t gorgone-testing-trixie .
```

The alma10 build must succeed with every Centreon package fetched from `packages.apps.centreon.com`. The trixie build will fail on `libssh-session-perl` / `libnet-curl-perl` until those are delivered to the Pulp `apt-plugins` repositories.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation.**
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-199319]: https://centreon.atlassian.net/browse/MON-199319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ