### PR TITLE
enh(delivery): promote pulp content by href instead of re-uploading

### DIFF
--- a/.github/actions/promote-to-stable-pulp/promote-deb.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-deb.sh
@@ -181,40 +181,6 @@ lookup_deb_content() {
   done
 }
 
-# wait for a content-create task and emit its created content href; fall
-# back to a lookup (content already existing on a job re-run)
-resolve_task_content() {
-  local task_href=$1 endpoint=$2 fallback_query=$3
-  local body state content attempt
-  for ((attempt = 0; attempt < 200; attempt++)); do
-    refresh_pulp_token
-    body=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null) || body=""
-    state=$(echo "$body" | jq -r '.state' 2>/dev/null) || state=""
-    case "$state" in
-      completed)
-        content=$(echo "$body" | jq -r '.created_resources[0] // empty')
-        if [[ -n "$content" ]]; then
-          echo "$content"
-          return 0
-        fi
-        break
-        ;;
-      failed | canceled)
-        break
-        ;;
-      *)
-        sleep 3
-        ;;
-    esac
-  done
-  content=$(lookup_deb_content "$endpoint" "$fallback_query")
-  if [[ -z "$content" ]]; then
-    echo "::error::Cannot resolve the created deb content for task $task_href" >&2
-    return 1
-  fi
-  echo "$content"
-}
-
 # emit the release-component hrefs a package is associated with
 lookup_prcs() {
   local package_href=$1
@@ -250,13 +216,12 @@ if ((${#UNPROMOTED_HREFS[@]} == 0)); then
   exit 0
 fi
 
-# batched promote, mirroring the batched delivery. Since the domain merge,
-# testing and stable share their domain (and content): the re-download/
-# re-upload below is deduplicated server-side by sha256, kept only because the
-# battle-tested flow predates the merge — a direct href association would skip
-# the transfers entirely (follow-up optimization). The FIRST package of each
-# arch still goes through the legacy path to establish the release component
-# (see deliver-deb.sh).
+# batched promote, mirroring the batched delivery. Testing and stable share
+# their domain (and content) since the domain merge: the batch below associates
+# the testing package hrefs directly, no re-download/re-upload. Only the FIRST
+# package of each arch goes through the legacy upload path, to establish the
+# release component and deduce its href (see deliver-deb.sh; listing release
+# components requires admin rights).
 declare -A ARCH_SEEN=()
 LEGACY_PACKAGES=()
 BATCH_PACKAGES=()
@@ -367,70 +332,18 @@ if ((${#BATCH_PACKAGES[@]} > 0)); then
   fi
   echo "[INFO] Release component of $STABLE_SUITE/main: $STABLE_RC"
 
-  # remaining packages: parallel re-download+upload (pool of 8, marker-file
-  # based like rpm/deliver-deb), associated with the stable release component below
-  echo "[INFO] Re-uploading ${#BATCH_PACKAGES[@]} package(s) from $BASE_PATH into the stable domain"
-  DOWNLOAD_DIR=$(mktemp -d)
-  MAX_PARALLEL=8
-  for i in "${!BATCH_PACKAGES[@]}"; do
-    if ((i % 40 == 0)); then
-      refresh_pulp_token
-    fi
-    (
-      refresh_pulp_token
-      PACKAGE="${BATCH_PACKAGES[$i]}"
-      RELATIVE_PATH=$(echo "$PACKAGE" | jq -r '.relative_path')
-      SHA256=$(echo "$PACKAGE" | jq -r '.sha256')
-      ARCH=$(echo "$PACKAGE" | jq -r '.architecture')
-      FILE_NAME=$(basename "$RELATIVE_PATH")
-      FILE="$DOWNLOAD_DIR/$i-$FILE_NAME"
-      download_testing_package "$SHA256" "$ARCH" "$FILE"
-      pulp_upload \
-        -F "file=@\"$FILE\"" \
-        -F "relative_path=$RELATIVE_PATH" \
-        -F "pulp_labels=$PULP_LABELS" \
-        "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/packages/" > "$DOWNLOAD_DIR/$i.task"
-    ) &
-    while (($(jobs -rp | wc -l) >= MAX_PARALLEL)); do
-      wait -n || true
-    done
-  done
-  wait || true
-
-  for i in "${!BATCH_PACKAGES[@]}"; do
-    if [[ ! -s "$DOWNLOAD_DIR/$i.task" ]]; then
-      echo "::error::Re-upload into the stable domain failed for $(echo "${BATCH_PACKAGES[$i]}" | jq -r '.package') ($(echo "${BATCH_PACKAGES[$i]}" | jq -r '.architecture')), see the worker error above"
-      exit 1
-    fi
-  done
-
-  echo "[INFO] Resolving ${#BATCH_PACKAGES[@]} uploaded package(s)"
-  for i in "${!BATCH_PACKAGES[@]}"; do
-    if ((i % 40 == 0)); then
-      refresh_pulp_token
-    fi
-    (
-      resolve_task_content "$(cat "$DOWNLOAD_DIR/$i.task")" "packages" \
-        "--data-urlencode sha256=$(echo "${BATCH_PACKAGES[$i]}" | jq -r '.sha256')" > "$DOWNLOAD_DIR/$i.content"
-    ) &
-    while (($(jobs -rp | wc -l) >= MAX_PARALLEL)); do
-      wait -n || true
-    done
-  done
-  wait || true
+  # remaining packages: the testing content hrefs are associated with the
+  # stable release component directly (same domain, shared content); the
+  # packages keep their delivery-time labels
   PACKAGE_HREFS=()
-  for i in "${!BATCH_PACKAGES[@]}"; do
-    if [[ ! -s "$DOWNLOAD_DIR/$i.content" ]]; then
-      echo "::error::Cannot resolve the promoted content for $(echo "${BATCH_PACKAGES[$i]}" | jq -r '.package') (see the worker error above)"
-      exit 1
-    fi
-    PACKAGE_HREFS+=("$(cat "$DOWNLOAD_DIR/$i.content")")
+  for PACKAGE in "${BATCH_PACKAGES[@]}"; do
+    PACKAGE_HREFS+=("$(echo "$PACKAGE" | jq -r '.pulp_href')")
   done
-  rm -rf "$DOWNLOAD_DIR"
 
   # package_release_components create is synchronous (201 with the unit, no
   # task); a failed create (already existing on a job re-run) falls back to a lookup
   echo "[INFO] Associating ${#PACKAGE_HREFS[@]} package(s) with $STABLE_SUITE/main"
+  MAX_PARALLEL=8
   PRC_DIR=$(mktemp -d)
   for i in "${!PACKAGE_HREFS[@]}"; do
     if ((i % 40 == 0)); then

--- a/.github/actions/promote-to-stable-pulp/promote-rpm.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-rpm.sh
@@ -13,89 +13,6 @@ PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
 # now equals PULP_DOMAIN); the read/write phase switch is kept as a no-op
 PULP_DOMAIN="${PULP_DOMAIN:-default}"
 PULP_STABLE_DOMAIN="${PULP_STABLE_DOMAIN:-default}"
-# switch_pulp_domain overwrites PULP_DOMAIN itself once the write phase
-# starts; keep our own copy for the testing-domain content-app fetch after that
-TESTING_DOMAIN="$PULP_DOMAIN"
-
-# re-applied on the re-upload into stable (this promote run's own git context,
-# not the original delivery's); check-rpm.sh's verification query needs at
-# least "module" to find the promoted content
-PULP_LABELS=$(jq -cn \
-  --arg mod        "$MODULE_NAME" \
-  --arg git_commit "${GITHUB_SHA:-}" \
-  --arg git_ref    "${GITHUB_REF:-}" \
-  --arg run_id     "${GITHUB_RUN_ID:-}" \
-  --arg actor      "${GITHUB_ACTOR:-}" \
-  --arg workflow   "${GITHUB_WORKFLOW:-}" \
-  '{"module": $mod, "git_commit": $git_commit, "git_ref": $git_ref, "github_run_id": $run_id, "github_actor": $actor, "github_workflow": $workflow}')
-
-# mirrors deliver-rpm.sh's resolve_uploaded_content, scoped to the stable domain
-resolve_promoted_content() {
-  local task_href=$1 sha256=$2
-  local body state content attempt
-  for ((attempt = 0; attempt < 200; attempt++)); do
-    refresh_pulp_token
-    body=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null) || body=""
-    state=$(echo "$body" | jq -r '.state' 2>/dev/null) || state=""
-    case "$state" in
-      completed)
-        content=$(echo "$body" | jq -r '.created_resources[0] // empty')
-        if [[ -n "$content" ]]; then
-          echo "$content"
-          return 0
-        fi
-        break
-        ;;
-      failed | canceled)
-        break
-        ;;
-      *)
-        sleep 3
-        ;;
-    esac
-  done
-  content=$(
-    curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" -G \
-      --data-urlencode "sha256=$sha256" \
-      --data-urlencode "limit=1" \
-      "$PULP_URL/$PULP_STABLE_DOMAIN/api/v3/content/rpm/packages/" | jq -r '.results[0].pulp_href // empty'
-  )
-  if [[ -z "$content" ]]; then
-    echo "::error::Cannot resolve the promoted content for task $task_href (sha256 $sha256)" >&2
-    return 1
-  fi
-  echo "$content"
-}
-
-# resolve a package's served location by sha256 (mirrors check-rpm.sh's
-# resolve_href): pulp_rpm publishes under Packages/<letter>/<file>, which
-# doesn't match the content API's location_href (the upload-time relative path)
-resolve_rpm_href() {
-  local primary_file=$1 sha=$2
-  [[ -s "$primary_file" ]] || return 0
-  awk -v sha="$sha" '
-    BEGIN { RS = "</package>" }
-    index($0, ">" sha "</checksum>") {
-      if (match($0, /<location[^>]*href="[^"]+"/)) {
-        s = substr($0, RSTART, RLENGTH)
-        sub(/.*href="/, "", s); sub(/"$/, "", s)
-        print s; exit
-      }
-    }' "$primary_file"
-}
-
-# fetch the published primary.xml for a base_path into $3 (a single fetch:
-# promote processes one base_path per arch sequentially, unlike check-rpm.sh's
-# many-packages-in-parallel caching)
-fetch_primary_xml() {
-  local domain=$1 base_path=$2 out=$3 repomd primary_href
-  repomd=$(content_curl -fsSL "$PULP_CONTENT_URL/$domain/$base_path/repodata/repomd.xml" 2>/dev/null || true)
-  primary_href=$(printf '%s' "$repomd" | grep -oP '<location href="\K[^"]+primary\.xml[^"]*' | head -1 || true)
-  if [[ -n "$primary_href" ]]; then
-    content_curl -fsSL "$PULP_CONTENT_URL/$domain/$base_path/$primary_href" 2>/dev/null | gunzip -c 2>/dev/null > "$out" || true
-  fi
-}
-
 declare -A ARCH_CONTENT
 declare -A ARCH_RESULTS
 TOTAL_PACKAGES_COUNT=0
@@ -166,7 +83,6 @@ for ARCH in noarch x86_64; do
 
   STABLE_REPOSITORY_NAME="$STABLE_REPOSITORY_PREFIX-$ARCH"
   STABLE_BASE_PATH="$STABLE_BASE_PATH_PREFIX/$ARCH"
-  TESTING_BASE_PATH="$TESTING_BASE_PATH_PREFIX/$ARCH"
 
   if ! pulp_resource_exists "repositories/rpm/rpm" "$STABLE_REPOSITORY_NAME"; then
     echo "::error::stable rpm repository $STABLE_REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before promoting."
@@ -180,59 +96,10 @@ for ARCH in noarch x86_64; do
 
   STABLE_REPOSITORY_HREF=$(pulp rpm repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.pulp_href')
 
-  # Since the domain merge, testing and stable share their domain (and
-  # content): this re-download/re-upload is deduplicated server-side by
-  # sha256, kept only because the battle-tested flow predates the merge — a
-  # direct href association would skip the transfers entirely (follow-up
-  # optimization). Same shape as the JFrog promote job always had.
-  echo "[INFO] Re-uploading $ARCH_PACKAGES_COUNT package(s) from $TESTING_BASE_PATH into the stable domain"
-  DOWNLOAD_DIR=$(mktemp -d)
-  UPLOAD_DIR=$(mktemp -d)
-  MAX_PARALLEL_UPLOADS=8
-  TESTING_PRIMARY_XML=$(mktemp)
-  fetch_primary_xml "$TESTING_DOMAIN" "$TESTING_BASE_PATH" "$TESTING_PRIMARY_XML"
-  mapfile -t PKG_ROWS < <(echo "$RESULTS" | jq -c '.[]')
-  for i in "${!PKG_ROWS[@]}"; do
-    if ((i % 40 == 0)); then
-      refresh_pulp_token
-    fi
-    (
-      refresh_pulp_token
-      location_href=$(echo "${PKG_ROWS[$i]}" | jq -r '.location_href')
-      sha256=$(echo "${PKG_ROWS[$i]}" | jq -r '.sha256')
-      served_href=$(resolve_rpm_href "$TESTING_PRIMARY_XML" "$sha256")
-      if [[ -z "$served_href" ]]; then
-        echo "::error::Cannot resolve the published location of $(echo "${PKG_ROWS[$i]}" | jq -r '.name') (sha256 $sha256) in $TESTING_BASE_PATH" >&2
-        exit 1
-      fi
-      dest="$DOWNLOAD_DIR/$i-$(basename "$location_href")"
-      content_curl -fsSL --retry 3 --retry-delay 5 -o "$dest" "$PULP_CONTENT_URL/$TESTING_DOMAIN/$TESTING_BASE_PATH/$served_href"
-      pulp_upload -F "file=@\"$dest\"" -F "pulp_labels=$PULP_LABELS" \
-        "$PULP_URL/$PULP_STABLE_DOMAIN/api/v3/content/rpm/packages/" > "$UPLOAD_DIR/$i.task"
-    ) &
-    while (($(jobs -rp | wc -l) >= MAX_PARALLEL_UPLOADS)); do
-      wait -n || true
-    done
-  done
-  wait || true
-
-  NEW_HREFS=()
-  for i in "${!PKG_ROWS[@]}"; do
-    if [[ ! -s "$UPLOAD_DIR/$i.task" ]]; then
-      echo "::error::Re-upload into the stable domain failed for $(echo "${PKG_ROWS[$i]}" | jq -r '.name') ($ARCH), see the worker error above"
-      exit 1
-    fi
-    new_href=$(resolve_promoted_content "$(cat "$UPLOAD_DIR/$i.task")" "$(echo "${PKG_ROWS[$i]}" | jq -r '.sha256')") || new_href=""
-    if [[ -z "$new_href" ]]; then
-      echo "::error::Cannot resolve the promoted content for $(echo "${PKG_ROWS[$i]}" | jq -r '.name') ($ARCH)"
-      exit 1
-    fi
-    NEW_HREFS+=("$new_href")
-  done
-  rm -rf "$DOWNLOAD_DIR" "$UPLOAD_DIR"
-  rm -f "$TESTING_PRIMARY_XML"
-  CONTENT=$(printf '%s\n' "${NEW_HREFS[@]}" | jq -R . | jq -cs .)
-
+  # Same-domain promotion: testing and stable share their domain, so the
+  # testing content hrefs (already collected above) are associated with the
+  # stable repository directly — no re-download/re-upload, the packages keep
+  # their delivery-time labels (check-rpm.sh only needs "module").
   echo "[INFO] Promoting $ARCH_PACKAGES_COUNT packages to $STABLE_REPOSITORY_NAME"
   # pulp-cli repository content modify does not resolve content by pulp_href, use the api directly
   ADD_BODY_FILE=$(mktemp)


### PR DESCRIPTION
## Description

Fixes: [MON-207621](https://centreon.atlassian.net/browse/MON-207621)

Since the pulp domain merge (MON-207474), testing and stable share their domain and content units. The promotion still re-downloaded every candidate from testing and re-uploaded it (split-domain era flow); uploads were deduplicated server-side by sha256, making the transfers pure waste.

- `promote-rpm.sh`: testing content hrefs are associated directly with the stable repository — the download/re-upload/resolve block and its helpers are gone.
- `promote-deb.sh`: same for the batched packages; only the legacy first-per-arch upload remains (it establishes the release component and allows deducing its href).
- Packages keep their delivery-time labels; the post-promote verification only relies on the `module` label.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

On the dev pulp stack: deliver a component to testing then promote it to stable (see the MON-207474 dsm validation flow) and check that the promote job transfers no package payload (rpm) / a single package per arch (deb) while the post-promote verification stays green.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).


[MON-207621]: https://centreon.atlassian.net/browse/MON-207621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ