### PR TITLE
feat(ci): add provenance attestation and SBOM for ghcr.io poller images

### DIFF
--- a/.github/actions/attest-ghcr-image/action.yml
+++ b/.github/actions/attest-ghcr-image/action.yml
@@ -1,10 +1,12 @@
 name: "attest ghcr.io image (SBOM)"
 description: >
-  Generate an SBOM attestation for an image already promoted to ghcr.io, and
-  push it as an OCI referrer. Call after promote-docker-to-ghcr using its
-  digest/amd64_digest outputs — wrap with continue-on-error and a distinct
-  warning, since a failure here doesn't mean delivery failed. Build
-  provenance is attested separately, at build time.
+  Generate one SBOM attestation per platform (amd64, arm64) for an image
+  already promoted to ghcr.io, both attached to the multi-arch index digest
+  so tag-based `gh attestation verify` finds them. Call after
+  promote-docker-to-ghcr using its digest/amd64_digest/arm64_digest outputs —
+  wrap with continue-on-error and a distinct warning, since a failure here
+  doesn't mean delivery failed. Build provenance is attested separately, at
+  build time.
 inputs:
   ghcr_image:
     description: "Image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-gorgone)"
@@ -13,27 +15,48 @@ inputs:
     description: "Digest of the promoted manifest list to attest (sha256:...)"
     required: true
   amd64_digest:
-    description: "Digest of the amd64 platform manifest, scanned for the SBOM"
+    description: "Digest of the amd64 platform manifest, scanned for its SBOM"
+    required: true
+  arm64_digest:
+    description: "Digest of the arm64 platform manifest, scanned for its SBOM"
     required: true
 
 runs:
   using: "composite"
   steps:
     - name: Generate SBOM (amd64 platform manifest)
-      id: sbom
+      id: sbom-amd64
       uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
       with:
         image: "${{ inputs.ghcr_image }}@${{ inputs.amd64_digest }}"
         format: spdx-json
-        output-file: sbom.spdx.json
+        output-file: sbom-amd64.spdx.json
         upload-artifact: false
 
-    - name: Attest SBOM
+    - name: Attest SBOM (amd64)
       # attest-sbom is deprecated in favor of attest
       uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:
         subject-name: ${{ inputs.ghcr_image }}
         subject-digest: ${{ inputs.digest }}
-        sbom-path: sbom.spdx.json
+        sbom-path: sbom-amd64.spdx.json
+        push-to-registry: true
+        create-storage-record: false
+
+    - name: Generate SBOM (arm64 platform manifest)
+      id: sbom-arm64
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        image: "${{ inputs.ghcr_image }}@${{ inputs.arm64_digest }}"
+        format: spdx-json
+        output-file: sbom-arm64.spdx.json
+        upload-artifact: false
+
+    - name: Attest SBOM (arm64)
+      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+      with:
+        subject-name: ${{ inputs.ghcr_image }}
+        subject-digest: ${{ inputs.digest }}
+        sbom-path: sbom-arm64.spdx.json
         push-to-registry: true
         create-storage-record: false

--- a/.github/actions/attest-ghcr-image/action.yml
+++ b/.github/actions/attest-ghcr-image/action.yml
@@ -1,0 +1,53 @@
+name: "attest ghcr.io image (provenance + SBOM)"
+description: >
+  Generate GitHub-native, Sigstore-signed build provenance and SBOM
+  attestations for an image already promoted to ghcr.io, and push them to
+  the registry as OCI referrers (MON-207622). Meant to be called right after
+  promote-docker-to-ghcr, using its `digest`/`amd64_digest` outputs — callers
+  should wrap this with continue-on-error and warn on failure, distinctly
+  from a promote failure: an attest failure means the image reached ghcr.io
+  but is unattested, not that delivery failed.
+  MON-207622 decision: the Harbor-side attestation manifest that
+  promote-docker-to-ghcr's script deliberately excludes is BuildKit's
+  default, unsigned in-toto provenance — it has no Sigstore trust chain, so
+  copying it would never satisfy `gh attestation verify`. These attestations
+  are generated fresh against the ghcr.io digest instead.
+inputs:
+  ghcr_image:
+    description: "Image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-gorgone)"
+    required: true
+  digest:
+    description: "Digest of the promoted manifest list to attest (sha256:...)"
+    required: true
+  amd64_digest:
+    description: "Digest of the amd64 platform manifest, scanned for the SBOM"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate SBOM (amd64 platform manifest)
+      id: sbom
+      uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      with:
+        image: "${{ inputs.ghcr_image }}@${{ inputs.amd64_digest }}"
+        format: spdx-json
+        output-file: sbom.spdx.json
+        upload-artifact: false
+
+    - name: Attest build provenance
+      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+      with:
+        subject-name: ${{ inputs.ghcr_image }}
+        subject-digest: ${{ inputs.digest }}
+        push-to-registry: true
+
+    - name: Attest SBOM
+      # actions/attest-sbom is deprecated in favor of actions/attest — see
+      # https://github.com/actions/attest-sbom (deprecation notice).
+      uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+      with:
+        subject-name: ${{ inputs.ghcr_image }}
+        subject-digest: ${{ inputs.digest }}
+        sbom-path: sbom.spdx.json
+        push-to-registry: true

--- a/.github/actions/attest-ghcr-image/action.yml
+++ b/.github/actions/attest-ghcr-image/action.yml
@@ -1,9 +1,10 @@
-name: "attest ghcr.io image (provenance + SBOM)"
+name: "attest ghcr.io image (SBOM)"
 description: >
-  Generate provenance + SBOM attestations for an image already promoted to
-  ghcr.io, and push them as OCI referrers. Call after promote-docker-to-ghcr
-  using its digest/amd64_digest outputs — wrap with continue-on-error and a
-  distinct warning, since a failure here doesn't mean delivery failed.
+  Generate an SBOM attestation for an image already promoted to ghcr.io, and
+  push it as an OCI referrer. Call after promote-docker-to-ghcr using its
+  digest/amd64_digest outputs — wrap with continue-on-error and a distinct
+  warning, since a failure here doesn't mean delivery failed. Build
+  provenance is attested separately, at build time.
 inputs:
   ghcr_image:
     description: "Image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-gorgone)"
@@ -26,17 +27,6 @@ runs:
         format: spdx-json
         output-file: sbom.spdx.json
         upload-artifact: false
-
-    - name: Attest build provenance
-      uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
-      with:
-        subject-name: ${{ inputs.ghcr_image }}
-        subject-digest: ${{ inputs.digest }}
-        push-to-registry: true
-        # No artifact-metadata:write permission granted (least privilege) —
-        # the storage record is an optional catalog entry, not needed for
-        # gh attestation verify/download.
-        create-storage-record: false
 
     - name: Attest SBOM
       # attest-sbom is deprecated in favor of attest

--- a/.github/actions/attest-ghcr-image/action.yml
+++ b/.github/actions/attest-ghcr-image/action.yml
@@ -33,6 +33,10 @@ runs:
         subject-name: ${{ inputs.ghcr_image }}
         subject-digest: ${{ inputs.digest }}
         push-to-registry: true
+        # No artifact-metadata:write permission granted (least privilege) —
+        # the storage record is an optional catalog entry, not needed for
+        # gh attestation verify/download.
+        create-storage-record: false
 
     - name: Attest SBOM
       # attest-sbom is deprecated in favor of attest
@@ -42,3 +46,4 @@ runs:
         subject-digest: ${{ inputs.digest }}
         sbom-path: sbom.spdx.json
         push-to-registry: true
+        create-storage-record: false

--- a/.github/actions/attest-ghcr-image/action.yml
+++ b/.github/actions/attest-ghcr-image/action.yml
@@ -32,6 +32,10 @@ runs:
         format: spdx-json
         output-file: sbom-amd64.spdx.json
         upload-artifact: false
+        # Defaults to true and would need contents:write on tag pushes with a
+        # matching GitHub Release; we deliver via the attestation, not a
+        # release asset.
+        upload-release-assets: false
 
     - name: Attest SBOM (amd64)
       # attest-sbom is deprecated in favor of attest
@@ -51,6 +55,7 @@ runs:
         format: spdx-json
         output-file: sbom-arm64.spdx.json
         upload-artifact: false
+        upload-release-assets: false
 
     - name: Attest SBOM (arm64)
       uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2

--- a/.github/actions/attest-ghcr-image/action.yml
+++ b/.github/actions/attest-ghcr-image/action.yml
@@ -1,17 +1,9 @@
 name: "attest ghcr.io image (provenance + SBOM)"
 description: >
-  Generate GitHub-native, Sigstore-signed build provenance and SBOM
-  attestations for an image already promoted to ghcr.io, and push them to
-  the registry as OCI referrers (MON-207622). Meant to be called right after
-  promote-docker-to-ghcr, using its `digest`/`amd64_digest` outputs — callers
-  should wrap this with continue-on-error and warn on failure, distinctly
-  from a promote failure: an attest failure means the image reached ghcr.io
-  but is unattested, not that delivery failed.
-  MON-207622 decision: the Harbor-side attestation manifest that
-  promote-docker-to-ghcr's script deliberately excludes is BuildKit's
-  default, unsigned in-toto provenance — it has no Sigstore trust chain, so
-  copying it would never satisfy `gh attestation verify`. These attestations
-  are generated fresh against the ghcr.io digest instead.
+  Generate provenance + SBOM attestations for an image already promoted to
+  ghcr.io, and push them as OCI referrers. Call after promote-docker-to-ghcr
+  using its digest/amd64_digest outputs — wrap with continue-on-error and a
+  distinct warning, since a failure here doesn't mean delivery failed.
 inputs:
   ghcr_image:
     description: "Image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-gorgone)"
@@ -43,8 +35,7 @@ runs:
         push-to-registry: true
 
     - name: Attest SBOM
-      # actions/attest-sbom is deprecated in favor of actions/attest — see
-      # https://github.com/actions/attest-sbom (deprecation notice).
+      # attest-sbom is deprecated in favor of attest
       uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
       with:
         subject-name: ${{ inputs.ghcr_image }}

--- a/.github/actions/promote-docker-to-ghcr/action.yml
+++ b/.github/actions/promote-docker-to-ghcr/action.yml
@@ -35,7 +35,7 @@ outputs:
     description: "Digest of the promoted ghcr.io manifest list (identical across all ghcr_tags)"
     value: ${{ steps.promote.outputs.digest }}
   amd64_digest:
-    description: "Digest of the amd64 platform manifest, for SBOM scanning (MON-207622)"
+    description: "Digest of the amd64 platform manifest, for SBOM scanning"
     value: ${{ steps.promote.outputs.amd64_digest }}
 
 runs:

--- a/.github/actions/promote-docker-to-ghcr/action.yml
+++ b/.github/actions/promote-docker-to-ghcr/action.yml
@@ -30,6 +30,14 @@ inputs:
     required: false
     default: "linux/amd64,linux/arm64"
 
+outputs:
+  digest:
+    description: "Digest of the promoted ghcr.io manifest list (identical across all ghcr_tags)"
+    value: ${{ steps.promote.outputs.digest }}
+  amd64_digest:
+    description: "Digest of the amd64 platform manifest, for SBOM scanning (MON-207622)"
+    value: ${{ steps.promote.outputs.amd64_digest }}
+
 runs:
   using: "composite"
   steps:
@@ -45,6 +53,7 @@ runs:
         fi
 
     - name: Promote Harbor candidate to ghcr.io
+      id: promote
       shell: bash
       env:
         GHCR_IMAGE: ${{ inputs.ghcr_image }}

--- a/.github/actions/promote-docker-to-ghcr/action.yml
+++ b/.github/actions/promote-docker-to-ghcr/action.yml
@@ -37,6 +37,9 @@ outputs:
   amd64_digest:
     description: "Digest of the amd64 platform manifest, for SBOM scanning"
     value: ${{ steps.promote.outputs.amd64_digest }}
+  arm64_digest:
+    description: "Digest of the arm64 platform manifest, for SBOM scanning"
+    value: ${{ steps.promote.outputs.arm64_digest }}
 
 runs:
   using: "composite"

--- a/.github/scripts/docker-push-to-ghcr.sh
+++ b/.github/scripts/docker-push-to-ghcr.sh
@@ -34,6 +34,7 @@
 # Outputs ($GITHUB_OUTPUT, best-effort — may be absent):
 #   digest       promoted manifest-list digest
 #   amd64_digest amd64 platform digest, for SBOM scanning
+#   arm64_digest arm64 platform digest, for SBOM scanning
 set -euo pipefail
 
 if [[ -z "${GHCR_TAGS// /}" ]]; then
@@ -83,6 +84,7 @@ echo "::endgroup::"
 echo "::group::Resolve promoted digest (for attestation, best-effort)"
 GHCR_DIGEST=""
 AMD64_DIGEST=""
+ARM64_DIGEST=""
 DIGEST_RESOLUTION_OK=true
 for tag in $GHCR_TAGS; do
   [[ -z "$tag" ]] && continue
@@ -95,18 +97,20 @@ for tag in $GHCR_TAGS; do
   if [[ -z "$GHCR_DIGEST" ]]; then
     GHCR_DIGEST="$tag_digest"
     AMD64_DIGEST=$(echo "$DEST_MANIFEST" | jq -r '.manifests[]? | select(.platform.architecture == "amd64") | .digest' | head -n1)
+    ARM64_DIGEST=$(echo "$DEST_MANIFEST" | jq -r '.manifests[]? | select(.platform.architecture == "arm64") | .digest' | head -n1)
   elif [[ "$tag_digest" != "$GHCR_DIGEST" ]]; then
     echo "::warning::Published tags resolved to different digests ($GHCR_DIGEST vs $tag_digest for tag $tag) — skipping attestation for this promote run (ambiguous subject, image is still published)"
     DIGEST_RESOLUTION_OK=false
     break
   fi
 done
-if [[ "$DIGEST_RESOLUTION_OK" == true && "$GHCR_DIGEST" =~ ^sha256:[0-9a-f]{64}$ && -n "$AMD64_DIGEST" ]]; then
-  echo "Resolved digest: $GHCR_DIGEST (amd64 platform digest for SBOM: $AMD64_DIGEST)"
+if [[ "$DIGEST_RESOLUTION_OK" == true && "$GHCR_DIGEST" =~ ^sha256:[0-9a-f]{64}$ && -n "$AMD64_DIGEST" && -n "$ARM64_DIGEST" ]]; then
+  echo "Resolved digest: $GHCR_DIGEST (amd64: $AMD64_DIGEST, arm64: $ARM64_DIGEST)"
   echo "digest=$GHCR_DIGEST" >> "$GITHUB_OUTPUT"
   echo "amd64_digest=$AMD64_DIGEST" >> "$GITHUB_OUTPUT"
+  echo "arm64_digest=$ARM64_DIGEST" >> "$GITHUB_OUTPUT"
 else
-  echo "::warning::Could not resolve a usable digest/amd64_digest for $GHCR_IMAGE — attestation step will be skipped for this promote run (image is still published)"
+  echo "::warning::Could not resolve a usable digest/amd64_digest/arm64_digest for $GHCR_IMAGE — attestation step will be skipped for this promote run (image is still published)"
 fi
 echo "::endgroup::"
 

--- a/.github/scripts/docker-push-to-ghcr.sh
+++ b/.github/scripts/docker-push-to-ghcr.sh
@@ -19,12 +19,34 @@
 # registries choke on committing a manifest that includes that attestation
 # subject). Harbor keeps full provenance; only the ghcr.io copy omits it.
 #
+# MON-207622: that Harbor attestation manifest is BuildKit's default,
+# unsigned in-toto provenance — it has no Sigstore/Fulcio/Rekor trust chain,
+# so `gh attestation verify`/`cosign verify-attestation` (which only validate
+# GitHub-native, Sigstore-signed attestations) could never verify it even if
+# it were copied across registries. Decision: leave the exclusion above
+# untouched, and instead generate fresh, GitHub-native provenance + SBOM
+# attestations against the ghcr.io digest after promotion (see the caller
+# composite action `attest-ghcr-image`). To make that possible, this script
+# also resolves and emits the promoted manifest-list digest (and the amd64
+# platform digest, since an SBOM must target a single-platform manifest, not
+# a multi-arch index) as step outputs — resolved from the ghcr.io side after
+# publish, not assumed from Harbor, since imagetools create's cross-registry
+# digest preservation is a property to verify, not to bet delivery on.
+# Resolution failures here are non-fatal (a warning, no outputs): they would
+# only skip attestation, never turn a successful publish into a reported
+# failure — that distinction is what the caller's attest-ghcr-image step and
+# its separate warning message rely on.
+#
 # Expected env vars:
 #   GHCR_IMAGE   destination image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-gorgone)
 #   HARBOR_IMAGE source image ref on Harbor, no tag
 #   HARBOR_TAG   source tag on Harbor to promote (e.g. release-26.10-next)
 #   GHCR_TAGS    space-separated list of tags to create on ghcr.io (e.g. "26.10.5 26.10")
 #   PLATFORMS    comma-separated platform list, informational only (e.g. linux/amd64,linux/arm64)
+#
+# Outputs (written to $GITHUB_OUTPUT, best-effort — may be absent):
+#   digest       digest of the promoted ghcr.io manifest list (identical across all GHCR_TAGS)
+#   amd64_digest digest of the amd64 platform manifest, for SBOM scanning
 set -euo pipefail
 
 if [[ -z "${GHCR_TAGS// /}" ]]; then
@@ -69,6 +91,36 @@ for tag in $GHCR_TAGS; do
   echo "Publishing $GHCR_IMAGE:$tag from $SRC_REF (${#SRC_REFS[@]} platform manifest(s))"
   retry_imagetools_create "$GHCR_IMAGE:$tag" "${SRC_REFS[@]}"
 done
+echo "::endgroup::"
+
+echo "::group::Resolve promoted digest (for attestation, best-effort)"
+GHCR_DIGEST=""
+AMD64_DIGEST=""
+DIGEST_RESOLUTION_OK=true
+for tag in $GHCR_TAGS; do
+  [[ -z "$tag" ]] && continue
+  if ! DEST_MANIFEST=$(docker buildx imagetools inspect "$GHCR_IMAGE:$tag" --format '{{json .Manifest}}'); then
+    echo "::warning::Could not inspect $GHCR_IMAGE:$tag after publish — skipping attestation for this promote run (image is still published)"
+    DIGEST_RESOLUTION_OK=false
+    break
+  fi
+  tag_digest=$(echo "$DEST_MANIFEST" | jq -r '.digest')
+  if [[ -z "$GHCR_DIGEST" ]]; then
+    GHCR_DIGEST="$tag_digest"
+    AMD64_DIGEST=$(echo "$DEST_MANIFEST" | jq -r '.manifests[]? | select(.platform.architecture == "amd64") | .digest' | head -n1)
+  elif [[ "$tag_digest" != "$GHCR_DIGEST" ]]; then
+    echo "::warning::Published tags resolved to different digests ($GHCR_DIGEST vs $tag_digest for tag $tag) — skipping attestation for this promote run (ambiguous subject, image is still published)"
+    DIGEST_RESOLUTION_OK=false
+    break
+  fi
+done
+if [[ "$DIGEST_RESOLUTION_OK" == true && "$GHCR_DIGEST" =~ ^sha256:[0-9a-f]{64}$ && -n "$AMD64_DIGEST" ]]; then
+  echo "Resolved digest: $GHCR_DIGEST (amd64 platform digest for SBOM: $AMD64_DIGEST)"
+  echo "digest=$GHCR_DIGEST" >> "$GITHUB_OUTPUT"
+  echo "amd64_digest=$AMD64_DIGEST" >> "$GITHUB_OUTPUT"
+else
+  echo "::warning::Could not resolve a usable digest/amd64_digest for $GHCR_IMAGE — attestation step will be skipped for this promote run (image is still published)"
+fi
 echo "::endgroup::"
 
 echo "ghcr.io stable promote complete: $GHCR_IMAGE ($GHCR_TAGS)"

--- a/.github/scripts/docker-push-to-ghcr.sh
+++ b/.github/scripts/docker-push-to-ghcr.sh
@@ -19,23 +19,10 @@
 # registries choke on committing a manifest that includes that attestation
 # subject). Harbor keeps full provenance; only the ghcr.io copy omits it.
 #
-# MON-207622: that Harbor attestation manifest is BuildKit's default,
-# unsigned in-toto provenance — it has no Sigstore/Fulcio/Rekor trust chain,
-# so `gh attestation verify`/`cosign verify-attestation` (which only validate
-# GitHub-native, Sigstore-signed attestations) could never verify it even if
-# it were copied across registries. Decision: leave the exclusion above
-# untouched, and instead generate fresh, GitHub-native provenance + SBOM
-# attestations against the ghcr.io digest after promotion (see the caller
-# composite action `attest-ghcr-image`). To make that possible, this script
-# also resolves and emits the promoted manifest-list digest (and the amd64
-# platform digest, since an SBOM must target a single-platform manifest, not
-# a multi-arch index) as step outputs — resolved from the ghcr.io side after
-# publish, not assumed from Harbor, since imagetools create's cross-registry
-# digest preservation is a property to verify, not to bet delivery on.
-# Resolution failures here are non-fatal (a warning, no outputs): they would
-# only skip attestation, never turn a successful publish into a reported
-# failure — that distinction is what the caller's attest-ghcr-image step and
-# its separate warning message rely on.
+# MON-207622: Harbor's attestation manifest is unsigned (no Sigstore chain),
+# so `gh attestation verify` couldn't validate it even if copied. Provenance
+# + SBOM are instead generated fresh against the ghcr.io digest by the caller
+# (attest-ghcr-image). Digest resolution below is best-effort and non-fatal.
 #
 # Expected env vars:
 #   GHCR_IMAGE   destination image ref on ghcr.io, no tag (e.g. ghcr.io/centreon/centreon-gorgone)
@@ -44,9 +31,9 @@
 #   GHCR_TAGS    space-separated list of tags to create on ghcr.io (e.g. "26.10.5 26.10")
 #   PLATFORMS    comma-separated platform list, informational only (e.g. linux/amd64,linux/arm64)
 #
-# Outputs (written to $GITHUB_OUTPUT, best-effort — may be absent):
-#   digest       digest of the promoted ghcr.io manifest list (identical across all GHCR_TAGS)
-#   amd64_digest digest of the amd64 platform manifest, for SBOM scanning
+# Outputs ($GITHUB_OUTPUT, best-effort — may be absent):
+#   digest       promoted manifest-list digest
+#   amd64_digest amd64 platform digest, for SBOM scanning
 set -euo pipefail
 
 if [[ -z "${GHCR_TAGS// /}" ]]; then

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -761,6 +761,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -809,6 +811,28 @@ jobs:
         if: steps.promote-ghcr.outcome == 'failure'
         run: |
           echo "::warning::ghcr.io delivery failed for ${{ matrix.image }}-${{ matrix.distrib }}. This release is available on Harbor but was NOT published to ghcr.io — see the 'Promote to ghcr.io stable' step for the missing-candidate or push error, and investigate before relying on public delivery for this version."
+        shell: bash
+
+      - name: Attest provenance + SBOM on ghcr.io (best-effort, non-blocking)
+        # MON-207622: generates GitHub-native, Sigstore-signed provenance and
+        # SBOM attestations against the image just promoted above. Only runs
+        # when the promote step actually succeeded. continue-on-error keeps
+        # an attestation-side failure from blocking the release — the image
+        # is already live on ghcr.io either way; the warning below is worded
+        # distinctly from the "was NOT published" one above.
+        if: steps.promote-ghcr.outcome == 'success' && steps.promote-ghcr.outputs.digest != ''
+        continue-on-error: true
+        id: attest-ghcr
+        uses: ./.github/actions/attest-ghcr-image
+        with:
+          ghcr_image: ghcr.io/centreon/${{ matrix.image }}
+          digest: ${{ steps.promote-ghcr.outputs.digest }}
+          amd64_digest: ${{ steps.promote-ghcr.outputs.amd64_digest }}
+
+      - name: Warn if ghcr.io attestation failed
+        if: steps.attest-ghcr.outcome == 'failure'
+        run: |
+          echo "::warning::Provenance/SBOM attestation failed for ${{ matrix.image }}-${{ matrix.distrib }}. The image WAS published to ghcr.io but is unattested — see the 'Attest provenance + SBOM on ghcr.io' step and investigate before relying on gh attestation verify for this version."
         shell: bash
 
   robot-test:

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -470,6 +470,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -573,6 +575,7 @@ jobs:
         shell: bash
 
       - name: Build and push image
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         env:
           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
@@ -588,6 +591,11 @@ jobs:
             "STABILITY=${{ needs.get-environment.outputs.stability }}"
           pull: true
           push: true
+          # Disabled: BuildKit's own attestation manifests would make this
+          # digest diverge from the ghcr.io one docker-push-to-ghcr.sh
+          # reconstructs later.
+          provenance: false
+          sbom: false
           # version_tag is deliberately NOT pushed here: it's only applied by
           # promote-docker-version-tag below, once docker-boot-test/
           # docker-config-wiring-test have validated this exact image. Pushing
@@ -598,6 +606,18 @@ jobs:
           secrets: |
             "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
+
+      - name: Attest build provenance (deterministic candidate only)
+        # Only for builds with a version_tag (real promotion candidates).
+        # push-to-registry:false since ghcr.io doesn't have this image yet;
+        # discoverable later by digest once promoted.
+        if: steps.compute-tag.outputs.version_tag != ''
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ghcr.io/centreon/${{ matrix.image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: false
+          create-storage-record: false
 
   docker-boot-test:
     needs: [get-environment, dockerize-engine-broker]
@@ -813,7 +833,7 @@ jobs:
           echo "::warning::ghcr.io delivery failed for ${{ matrix.image }}-${{ matrix.distrib }}. This release is available on Harbor but was NOT published to ghcr.io — see the 'Promote to ghcr.io stable' step for the missing-candidate or push error, and investigate before relying on public delivery for this version."
         shell: bash
 
-      - name: Attest provenance + SBOM on ghcr.io (best-effort, non-blocking)
+      - name: Attest SBOM on ghcr.io (best-effort, non-blocking)
         if: steps.promote-ghcr.outcome == 'success' && steps.promote-ghcr.outputs.digest != ''
         continue-on-error: true
         id: attest-ghcr
@@ -826,7 +846,7 @@ jobs:
       - name: Warn if ghcr.io attestation failed
         if: steps.attest-ghcr.outcome == 'failure'
         run: |
-          echo "::warning::Provenance/SBOM attestation failed for ${{ matrix.image }}-${{ matrix.distrib }}. The image WAS published to ghcr.io but is unattested — see the 'Attest provenance + SBOM on ghcr.io' step and investigate before relying on gh attestation verify for this version."
+          echo "::warning::SBOM attestation failed for ${{ matrix.image }}-${{ matrix.distrib }}. The image WAS published to ghcr.io but is unattested — see the 'Attest SBOM on ghcr.io' step and investigate before relying on gh attestation verify for this version."
         shell: bash
 
   robot-test:

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -612,12 +612,20 @@ jobs:
         # push-to-registry:false since ghcr.io doesn't have this image yet;
         # discoverable later by digest once promoted.
         if: steps.compute-tag.outputs.version_tag != ''
+        continue-on-error: true
+        id: attest-build-provenance
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/centreon/${{ matrix.image }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: false
           create-storage-record: false
+
+      - name: Warn if build provenance attestation failed
+        if: steps.attest-build-provenance.outcome == 'failure'
+        run: |
+          echo "::warning::Build provenance attestation failed for ${{ matrix.image }}-${{ matrix.distrib }}. Image build/delivery continues; investigate before relying on provenance verification for this version."
+        shell: bash
 
   docker-boot-test:
     needs: [get-environment, dockerize-engine-broker]

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -814,12 +814,6 @@ jobs:
         shell: bash
 
       - name: Attest provenance + SBOM on ghcr.io (best-effort, non-blocking)
-        # MON-207622: generates GitHub-native, Sigstore-signed provenance and
-        # SBOM attestations against the image just promoted above. Only runs
-        # when the promote step actually succeeded. continue-on-error keeps
-        # an attestation-side failure from blocking the release — the image
-        # is already live on ghcr.io either way; the warning below is worded
-        # distinctly from the "was NOT published" one above.
         if: steps.promote-ghcr.outcome == 'success' && steps.promote-ghcr.outputs.digest != ''
         continue-on-error: true
         id: attest-ghcr

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -614,7 +614,7 @@ jobs:
         if: steps.compute-tag.outputs.version_tag != ''
         continue-on-error: true
         id: attest-build-provenance
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-name: ghcr.io/centreon/${{ matrix.image }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -842,6 +842,7 @@ jobs:
           ghcr_image: ghcr.io/centreon/${{ matrix.image }}
           digest: ${{ steps.promote-ghcr.outputs.digest }}
           amd64_digest: ${{ steps.promote-ghcr.outputs.amd64_digest }}
+          arm64_digest: ${{ steps.promote-ghcr.outputs.arm64_digest }}
 
       - name: Warn if ghcr.io attestation failed
         if: steps.attest-ghcr.outcome == 'failure'

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,10 +373,10 @@ jobs:
               stability = getStability(ref);
             }
 
-            // TEMP TEST HACK (MON-207622) stage 1 — remove before merging PR #3647.
+            // TEMP TEST HACK (MON-207622) stage 2 — remove before merging PR #3647.
             if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
-              console.log('TEMP TEST HACK (MON-207622): forcing stability=testing (stage 1 - produce Harbor candidate)');
-              stability = 'testing';
+              console.log('TEMP TEST HACK (MON-207622): forcing stability=stable (stage 2 - ghcr.io promote + attest test)');
+              stability = 'stable';
             }
 
             console.log(`Final stability: ${stability}`);

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,12 +373,6 @@ jobs:
               stability = getStability(ref);
             }
 
-            // TEMP TEST HACK (MON-207622) — remove before merging PR #3647.
-            if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
-              console.log('TEMP TEST HACK (MON-207622): forcing stability=stable');
-              stability = 'stable';
-            }
-
             console.log(`Final stability: ${stability}`);
             core.setOutput('stability', stability);
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,9 +373,9 @@ jobs:
               stability = getStability(ref);
             }
 
-            // TEMP TEST HACK (MON-207622) stage 2 — remove before merging PR #3647.
+            // TEMP TEST HACK (MON-207622) stage 1 — remove before merging PR #3647.
             if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
-              stability = 'stable';
+              stability = 'testing';
             }
 
             console.log(`Final stability: ${stability}`);

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,9 +373,9 @@ jobs:
               stability = getStability(ref);
             }
 
-            // TEMP TEST HACK (MON-207622) stage 1 — remove before merging PR #3647.
+            // TEMP TEST HACK (MON-207622) stage 2 — remove before merging PR #3647.
             if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
-              stability = 'testing';
+              stability = 'stable';
             }
 
             console.log(`Final stability: ${stability}`);

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,10 +373,10 @@ jobs:
               stability = getStability(ref);
             }
 
-            // TEMP TEST HACK (MON-207622) stage 1 — remove before merging PR #3647.
+            // TEMP TEST HACK (MON-207622) stage 2 — remove before merging PR #3647.
             if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
-              console.log('TEMP TEST HACK (MON-207622): forcing stability=testing (stage 1 - produce Harbor candidate)');
-              stability = 'testing';
+              console.log('TEMP TEST HACK (MON-207622): forcing stability=stable (stage 2 - ghcr.io promote digest compare)');
+              stability = 'stable';
             }
 
             console.log(`Final stability: ${stability}`);

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,10 +373,10 @@ jobs:
               stability = getStability(ref);
             }
 
-            // TEMP TEST HACK (MON-207622) stage 1 — remove before merging PR #3647.
+            // TEMP TEST HACK (MON-207622) — remove before merging PR #3647.
             if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
-              console.log('TEMP TEST HACK (MON-207622): forcing stability=testing (stage 1 - produce Harbor candidate)');
-              stability = 'testing';
+              console.log('TEMP TEST HACK (MON-207622): forcing stability=stable');
+              stability = 'stable';
             }
 
             console.log(`Final stability: ${stability}`);

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,6 +373,11 @@ jobs:
               stability = getStability(ref);
             }
 
+            // TEMP TEST HACK (MON-207622) — remove before merging PR #3647.
+            if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
+              stability = 'stable';
+            }
+
             console.log(`Final stability: ${stability}`);
             core.setOutput('stability', stability);
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,6 +373,11 @@ jobs:
               stability = getStability(ref);
             }
 
+            // TEMP TEST HACK (MON-207622) stage 1 — remove before merging PR #3647.
+            if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
+              stability = 'testing';
+            }
+
             console.log(`Final stability: ${stability}`);
             core.setOutput('stability', stability);
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,6 +373,12 @@ jobs:
               stability = getStability(ref);
             }
 
+            // TEMP TEST HACK (MON-207622) stage 1 — remove before merging PR #3647.
+            if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
+              console.log('TEMP TEST HACK (MON-207622): forcing stability=testing (stage 1 - produce Harbor candidate)');
+              stability = 'testing';
+            }
+
             console.log(`Final stability: ${stability}`);
             core.setOutput('stability', stability);
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,6 +373,12 @@ jobs:
               stability = getStability(ref);
             }
 
+            // TEMP TEST HACK (MON-207622) — remove before merging PR #3647.
+            if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
+              console.log('TEMP TEST HACK (MON-207622): forcing stability=stable');
+              stability = 'stable';
+            }
+
             console.log(`Final stability: ${stability}`);
             core.setOutput('stability', stability);
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,11 +373,6 @@ jobs:
               stability = getStability(ref);
             }
 
-            // TEMP TEST HACK (MON-207622) stage 1 — remove before merging PR #3647.
-            if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
-              stability = 'testing';
-            }
-
             console.log(`Final stability: ${stability}`);
             core.setOutput('stability', stability);
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,12 +373,6 @@ jobs:
               stability = getStability(ref);
             }
 
-            // TEMP TEST HACK (MON-207622) stage 1 — remove before merging PR #3647.
-            if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
-              console.log('TEMP TEST HACK (MON-207622): forcing stability=testing (stage 1 - produce Harbor candidate)');
-              stability = 'testing';
-            }
-
             console.log(`Final stability: ${stability}`);
             core.setOutput('stability', stability);
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,10 +373,10 @@ jobs:
               stability = getStability(ref);
             }
 
-            // TEMP TEST HACK (MON-207622) stage 2 — remove before merging PR #3647.
+            // TEMP TEST HACK (MON-207622) stage 1 — remove before merging PR #3647.
             if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
-              console.log('TEMP TEST HACK (MON-207622): forcing stability=stable (stage 2 - ghcr.io promote + attest test)');
-              stability = 'stable';
+              console.log('TEMP TEST HACK (MON-207622): forcing stability=testing (stage 1 - produce Harbor candidate)');
+              stability = 'testing';
             }
 
             console.log(`Final stability: ${stability}`);

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,11 +373,6 @@ jobs:
               stability = getStability(ref);
             }
 
-            // TEMP TEST HACK (MON-207622) — remove before merging PR #3647.
-            if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
-              stability = 'stable';
-            }
-
             console.log(`Final stability: ${stability}`);
             core.setOutput('stability', stability);
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,10 +373,10 @@ jobs:
               stability = getStability(ref);
             }
 
-            // TEMP TEST HACK (MON-207622) stage 2 — remove before merging PR #3647.
+            // TEMP TEST HACK (MON-207622) stage 1 — remove before merging PR #3647.
             if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
-              console.log('TEMP TEST HACK (MON-207622): forcing stability=stable (stage 2 - ghcr.io promote digest compare)');
-              stability = 'stable';
+              console.log('TEMP TEST HACK (MON-207622): forcing stability=testing (stage 1 - produce Harbor candidate)');
+              stability = 'testing';
             }
 
             console.log(`Final stability: ${stability}`);

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -373,10 +373,10 @@ jobs:
               stability = getStability(ref);
             }
 
-            // TEMP TEST HACK (MON-207622) — remove before merging PR #3647.
+            // TEMP TEST HACK (MON-207622) stage 1 — remove before merging PR #3647.
             if (ref === 'MON-207622-provenance-attestation-sbom-ghcr' && process.env.GITHUB_WORKFLOW === 'gorgone') {
-              console.log('TEMP TEST HACK (MON-207622): forcing stability=stable');
-              stability = 'stable';
+              console.log('TEMP TEST HACK (MON-207622): forcing stability=testing (stage 1 - produce Harbor candidate)');
+              stability = 'testing';
             }
 
             console.log(`Final stability: ${stability}`);

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -1003,7 +1003,7 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.stability == 'stable' &&
-      github.event_name != 'workflow_dispatch' &&
+      (github.event_name != 'workflow_dispatch' || (github.head_ref || github.ref_name) == 'MON-207622-provenance-attestation-sbom-ghcr') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -1060,26 +1060,6 @@ jobs:
           echo "::warning::Provenance/SBOM attestation failed for centreon-gorgone-${{ matrix.operating_system }}. The image WAS published to ghcr.io but is unattested — see the 'Attest provenance + SBOM on ghcr.io' step and investigate before relying on gh attestation verify for this version."
         shell: bash
 
-  # TEMP SCRATCH TEST (MON-207622) — DO NOT MERGE. Tests whether an
-  # attestation recorded with a Harbor subject-name and push-to-registry:false
-  # is still discoverable by digest via GitHub's Attestations API, independent
-  # of the ghcr.io package's registry visibility. Delete before merging.
-  mon207622-scratch-provenance-test:
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      (github.head_ref || github.ref_name) == 'MON-207622-provenance-attestation-sbom-ghcr'
-    runs-on: centreon-ubuntu-22.04
-    permissions:
-      id-token: write
-      attestations: write
-    steps:
-      - name: Attest against Harbor subject-name (no registry push)
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
-        with:
-          subject-name: docker.centreon.com/centreon/centreon-gorgone-trixie
-          subject-digest: sha256:f1bcffce1f88e420a7f238c177bfced2ba0b5c37f24dc3d5057e7be1c19b2e1b
-          push-to-registry: false
-
   set-skip-label:
     needs: [get-environment, deliver-rpm, deliver-deb, promote]
     if: |

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -1011,7 +1011,7 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.stability == 'stable' &&
-      github.event_name != 'workflow_dispatch' &&
+      (github.event_name != 'workflow_dispatch' || (github.head_ref || github.ref_name) == 'MON-207622-provenance-attestation-sbom-ghcr') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -585,7 +585,7 @@ jobs:
         if: steps.compute-tag.outputs.version_tag != ''
         continue-on-error: true
         id: attest-build-provenance
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-name: ghcr.io/centreon/centreon-gorgone
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -536,7 +536,9 @@ jobs:
           # needed to find the candidate to promote. This job only runs after
           # robot-test succeeds, so this candidate is e2e-tested before it can
           # ever be promoted to ghcr.io stable.
-          if [[ "$RAW_REF" =~ ^(release|hotfix)-[0-9]+\.[0-9]+-next$ ]]; then
+          # TEMP TEST HACK (MON-207622) — remove the branch-name alternative
+          # below before merging PR #3647.
+          if [[ "$RAW_REF" =~ ^(release|hotfix)-[0-9]+\.[0-9]+-next$ ]] || [[ "$RAW_REF" == "MON-207622-provenance-attestation-sbom-ghcr" ]]; then
             echo "version_tag=${MAJOR_VERSION}.${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "version_tag=" >> "$GITHUB_OUTPUT"
@@ -742,9 +744,13 @@ jobs:
       needs.changes.outputs.trigger_delivery == 'true' &&
       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
+    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
+    # before merging PR #3647. Prevents a real RPM delivery from the forced
+    # 'testing' stability hack in get-environment.yml.
 
     strategy:
       fail-fast: false
@@ -778,9 +784,12 @@ jobs:
       needs.changes.outputs.trigger_delivery == 'true' &&
       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
+    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
+    # before merging PR #3647.
 
     strategy:
       fail-fast: false
@@ -826,10 +835,13 @@ jobs:
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.changes.outputs.trigger_delivery == 'true' &&
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
+    # before merging PR #3647.
 
     strategy:
       fail-fast: false
@@ -860,10 +872,13 @@ jobs:
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.changes.outputs.trigger_delivery == 'true' &&
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
+    # before merging PR #3647.
 
     strategy:
       fail-fast: false

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -538,9 +538,7 @@ jobs:
           # needed to find the candidate to promote. This job only runs after
           # robot-test succeeds, so this candidate is e2e-tested before it can
           # ever be promoted to ghcr.io stable.
-          # TEMP TEST HACK (MON-207622) — remove the branch-name alternative
-          # below before merging PR #3647.
-          if [[ "$RAW_REF" =~ ^(release|hotfix)-[0-9]+\.[0-9]+-next$ ]] || [[ "$RAW_REF" == "MON-207622-provenance-attestation-sbom-ghcr" ]]; then
+          if [[ "$RAW_REF" =~ ^(release|hotfix)-[0-9]+\.[0-9]+-next$ ]]; then
             echo "version_tag=${MAJOR_VERSION}.${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "version_tag=" >> "$GITHUB_OUTPUT"
@@ -764,7 +762,6 @@ jobs:
       needs.changes.outputs.trigger_delivery == 'true' &&
       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
@@ -801,7 +798,6 @@ jobs:
       needs.changes.outputs.trigger_delivery == 'true' &&
       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
@@ -850,7 +846,6 @@ jobs:
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.changes.outputs.trigger_delivery == 'true' &&
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
@@ -885,7 +880,6 @@ jobs:
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.changes.outputs.trigger_delivery == 'true' &&
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -992,6 +992,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -1040,6 +1042,28 @@ jobs:
         if: steps.promote-ghcr.outcome == 'failure'
         run: |
           echo "::warning::ghcr.io delivery failed for centreon-gorgone-${{ matrix.operating_system }}. This release is available on Harbor but was NOT published to ghcr.io — see the 'Promote to ghcr.io stable' step for the missing-candidate or push error, and investigate before relying on public delivery for this version."
+        shell: bash
+
+      - name: Attest provenance + SBOM on ghcr.io (best-effort, non-blocking)
+        # MON-207622: generates GitHub-native, Sigstore-signed provenance and
+        # SBOM attestations against the image just promoted above. Only runs
+        # when the promote step actually succeeded. continue-on-error keeps
+        # an attestation-side failure from blocking the release — the image
+        # is already live on ghcr.io either way; the warning below is worded
+        # distinctly from the "was NOT published" one above.
+        if: steps.promote-ghcr.outcome == 'success' && steps.promote-ghcr.outputs.digest != ''
+        continue-on-error: true
+        id: attest-ghcr
+        uses: ./.github/actions/attest-ghcr-image
+        with:
+          ghcr_image: ghcr.io/centreon/centreon-gorgone
+          digest: ${{ steps.promote-ghcr.outputs.digest }}
+          amd64_digest: ${{ steps.promote-ghcr.outputs.amd64_digest }}
+
+      - name: Warn if ghcr.io attestation failed
+        if: steps.attest-ghcr.outcome == 'failure'
+        run: |
+          echo "::warning::Provenance/SBOM attestation failed for centreon-gorgone-${{ matrix.operating_system }}. The image WAS published to ghcr.io but is unattested — see the 'Attest provenance + SBOM on ghcr.io' step and investigate before relying on gh attestation verify for this version."
         shell: bash
 
   set-skip-label:

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -536,9 +536,7 @@ jobs:
           # needed to find the candidate to promote. This job only runs after
           # robot-test succeeds, so this candidate is e2e-tested before it can
           # ever be promoted to ghcr.io stable.
-          # TEMP TEST HACK (MON-207622) — remove the branch-name alternative
-          # below before merging PR #3647.
-          if [[ "$RAW_REF" =~ ^(release|hotfix)-[0-9]+\.[0-9]+-next$ ]] || [[ "$RAW_REF" == "MON-207622-provenance-attestation-sbom-ghcr" ]]; then
+          if [[ "$RAW_REF" =~ ^(release|hotfix)-[0-9]+\.[0-9]+-next$ ]]; then
             echo "version_tag=${MAJOR_VERSION}.${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "version_tag=" >> "$GITHUB_OUTPUT"
@@ -546,7 +544,6 @@ jobs:
         shell: bash
 
       - name: Docker build and push
-        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         env:
           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
@@ -562,14 +559,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
-          # MON-207622: BuildKit's default provenance/SBOM attestation
-          # manifests give the pushed manifest list a digest that differs
-          # from the one docker-push-to-ghcr.sh reconstructs on ghcr.io
-          # (which excludes them) — disabled so the digest reported here
-          # matches the eventual ghcr.io digest byte for byte, letting
-          # MON-207622's own provenance attestation be generated here too.
-          provenance: false
-          sbom: false
           # version_tag is deliberately NOT pushed here: it's only applied by
           # promote-docker-version-tag below, once docker-boot-test/
           # docker-config-wiring-test have validated this exact image. Pushing
@@ -580,10 +569,6 @@ jobs:
           secrets: |
             "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
-
-      - name: Show build digest (MON-207622 scratch test)
-        run: echo "Harbor build digest: ${{ steps.build.outputs.digest }}"
-        shell: bash
 
   docker-boot-test:
     needs: [get-environment, dockerize-image]
@@ -757,12 +742,9 @@ jobs:
       needs.changes.outputs.trigger_delivery == 'true' &&
       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
-    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
-    # before merging PR #3647.
 
     strategy:
       fail-fast: false
@@ -796,12 +778,9 @@ jobs:
       needs.changes.outputs.trigger_delivery == 'true' &&
       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
-    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
-    # before merging PR #3647.
 
     strategy:
       fail-fast: false
@@ -847,13 +826,10 @@ jobs:
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.changes.outputs.trigger_delivery == 'true' &&
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
-    # before merging PR #3647.
 
     strategy:
       fail-fast: false
@@ -884,13 +860,10 @@ jobs:
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.changes.outputs.trigger_delivery == 'true' &&
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
-    # before merging PR #3647.
 
     strategy:
       fail-fast: false

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -1060,6 +1060,26 @@ jobs:
           echo "::warning::Provenance/SBOM attestation failed for centreon-gorgone-${{ matrix.operating_system }}. The image WAS published to ghcr.io but is unattested — see the 'Attest provenance + SBOM on ghcr.io' step and investigate before relying on gh attestation verify for this version."
         shell: bash
 
+  # TEMP SCRATCH TEST (MON-207622) — DO NOT MERGE. Tests whether an
+  # attestation recorded with a Harbor subject-name and push-to-registry:false
+  # is still discoverable by digest via GitHub's Attestations API, independent
+  # of the ghcr.io package's registry visibility. Delete before merging.
+  mon207622-scratch-provenance-test:
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      (github.head_ref || github.ref_name) == 'MON-207622-provenance-attestation-sbom-ghcr'
+    runs-on: centreon-ubuntu-22.04
+    permissions:
+      id-token: write
+      attestations: write
+    steps:
+      - name: Attest against Harbor subject-name (no registry push)
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: docker.centreon.com/centreon/centreon-gorgone-trixie
+          subject-digest: sha256:f1bcffce1f88e420a7f238c177bfced2ba0b5c37f24dc3d5057e7be1c19b2e1b
+          push-to-registry: false
+
   set-skip-label:
     needs: [get-environment, deliver-rpm, deliver-deb, promote]
     if: |

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -538,7 +538,9 @@ jobs:
           # needed to find the candidate to promote. This job only runs after
           # robot-test succeeds, so this candidate is e2e-tested before it can
           # ever be promoted to ghcr.io stable.
-          if [[ "$RAW_REF" =~ ^(release|hotfix)-[0-9]+\.[0-9]+-next$ ]]; then
+          # TEMP TEST HACK (MON-207622) — remove the branch-name alternative
+          # below before merging PR #3647.
+          if [[ "$RAW_REF" =~ ^(release|hotfix)-[0-9]+\.[0-9]+-next$ ]] || [[ "$RAW_REF" == "MON-207622-provenance-attestation-sbom-ghcr" ]]; then
             echo "version_tag=${MAJOR_VERSION}.${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "version_tag=" >> "$GITHUB_OUTPUT"
@@ -762,6 +764,7 @@ jobs:
       needs.changes.outputs.trigger_delivery == 'true' &&
       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
@@ -798,6 +801,7 @@ jobs:
       needs.changes.outputs.trigger_delivery == 'true' &&
       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
@@ -846,6 +850,7 @@ jobs:
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.changes.outputs.trigger_delivery == 'true' &&
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
@@ -880,6 +885,7 @@ jobs:
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.changes.outputs.trigger_delivery == 'true' &&
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -1045,12 +1045,6 @@ jobs:
         shell: bash
 
       - name: Attest provenance + SBOM on ghcr.io (best-effort, non-blocking)
-        # MON-207622: generates GitHub-native, Sigstore-signed provenance and
-        # SBOM attestations against the image just promoted above. Only runs
-        # when the promote step actually succeeded. continue-on-error keeps
-        # an attestation-side failure from blocking the release — the image
-        # is already live on ghcr.io either way; the warning below is worded
-        # distinctly from the "was NOT published" one above.
         if: steps.promote-ghcr.outcome == 'success' && steps.promote-ghcr.outputs.digest != ''
         continue-on-error: true
         id: attest-ghcr

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -536,7 +536,9 @@ jobs:
           # needed to find the candidate to promote. This job only runs after
           # robot-test succeeds, so this candidate is e2e-tested before it can
           # ever be promoted to ghcr.io stable.
-          if [[ "$RAW_REF" =~ ^(release|hotfix)-[0-9]+\.[0-9]+-next$ ]]; then
+          # TEMP TEST HACK (MON-207622) — remove the branch-name alternative
+          # below before merging PR #3647.
+          if [[ "$RAW_REF" =~ ^(release|hotfix)-[0-9]+\.[0-9]+-next$ ]] || [[ "$RAW_REF" == "MON-207622-provenance-attestation-sbom-ghcr" ]]; then
             echo "version_tag=${MAJOR_VERSION}.${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "version_tag=" >> "$GITHUB_OUTPUT"
@@ -544,6 +546,7 @@ jobs:
         shell: bash
 
       - name: Docker build and push
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         env:
           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
@@ -559,6 +562,14 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
+          # MON-207622: BuildKit's default provenance/SBOM attestation
+          # manifests give the pushed manifest list a digest that differs
+          # from the one docker-push-to-ghcr.sh reconstructs on ghcr.io
+          # (which excludes them) — disabled so the digest reported here
+          # matches the eventual ghcr.io digest byte for byte, letting
+          # MON-207622's own provenance attestation be generated here too.
+          provenance: false
+          sbom: false
           # version_tag is deliberately NOT pushed here: it's only applied by
           # promote-docker-version-tag below, once docker-boot-test/
           # docker-config-wiring-test have validated this exact image. Pushing
@@ -569,6 +580,10 @@ jobs:
           secrets: |
             "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
+
+      - name: Show build digest (MON-207622 scratch test)
+        run: echo "Harbor build digest: ${{ steps.build.outputs.digest }}"
+        shell: bash
 
   docker-boot-test:
     needs: [get-environment, dockerize-image]
@@ -742,9 +757,12 @@ jobs:
       needs.changes.outputs.trigger_delivery == 'true' &&
       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
+    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
+    # before merging PR #3647.
 
     strategy:
       fail-fast: false
@@ -778,9 +796,12 @@ jobs:
       needs.changes.outputs.trigger_delivery == 'true' &&
       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
+      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
+    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
+    # before merging PR #3647.
 
     strategy:
       fail-fast: false
@@ -826,10 +847,13 @@ jobs:
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.changes.outputs.trigger_delivery == 'true' &&
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
+    # before merging PR #3647.
 
     strategy:
       fail-fast: false
@@ -860,10 +884,13 @@ jobs:
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.changes.outputs.trigger_delivery == 'true' &&
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
+      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
+    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
+    # before merging PR #3647.
 
     strategy:
       fail-fast: false

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -983,11 +983,13 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.stability == 'stable' &&
-      github.event_name != 'workflow_dispatch' &&
+      (github.event_name != 'workflow_dispatch' || (github.head_ref || github.ref_name) == 'MON-207622-provenance-attestation-sbom-ghcr') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       github.repository == 'centreon/centreon-collect'
+    # TEMP TEST HACK (MON-207622) — remove the branch-name alternative above
+    # before merging PR #3647.
     runs-on: centreon-ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -1073,6 +1073,7 @@ jobs:
           ghcr_image: ghcr.io/centreon/centreon-gorgone
           digest: ${{ steps.promote-ghcr.outputs.digest }}
           amd64_digest: ${{ steps.promote-ghcr.outputs.amd64_digest }}
+          arm64_digest: ${{ steps.promote-ghcr.outputs.arm64_digest }}
 
       - name: Warn if ghcr.io attestation failed
         if: steps.attest-ghcr.outcome == 'failure'

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -582,8 +582,7 @@ jobs:
             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
 
       - name: Show build digest (MON-207622 scratch test)
-        run: |
-          echo "Harbor build digest: ${{ steps.build.outputs.digest }}"
+        run: echo "Harbor build digest: ${{ steps.build.outputs.digest }}"
         shell: bash
 
   docker-boot-test:

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -1003,7 +1003,7 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.stability == 'stable' &&
-      (github.event_name != 'workflow_dispatch' || (github.head_ref || github.ref_name) == 'MON-207622-provenance-attestation-sbom-ghcr') &&
+      github.event_name != 'workflow_dispatch' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -983,13 +983,11 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.stability == 'stable' &&
-      (github.event_name != 'workflow_dispatch' || (github.head_ref || github.ref_name) == 'MON-207622-provenance-attestation-sbom-ghcr') &&
+      github.event_name != 'workflow_dispatch' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       github.repository == 'centreon/centreon-collect'
-    # TEMP TEST HACK (MON-207622) — remove the branch-name alternative above
-    # before merging PR #3647.
     runs-on: centreon-ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -1009,7 +1009,7 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.stability == 'stable' &&
-      (github.event_name != 'workflow_dispatch' || (github.head_ref || github.ref_name) == 'MON-207622-provenance-attestation-sbom-ghcr') &&
+      github.event_name != 'workflow_dispatch' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -583,12 +583,20 @@ jobs:
         # push-to-registry:false since ghcr.io doesn't have this image yet;
         # discoverable later by digest once promoted.
         if: steps.compute-tag.outputs.version_tag != ''
+        continue-on-error: true
+        id: attest-build-provenance
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/centreon/centreon-gorgone
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: false
           create-storage-record: false
+
+      - name: Warn if build provenance attestation failed
+        if: steps.attest-build-provenance.outcome == 'failure'
+        run: |
+          echo "::warning::Build provenance attestation failed for centreon-gorgone-${{ matrix.operating_system }}. Image build/delivery continues; investigate before relying on provenance verification for this version."
+        shell: bash
 
   docker-boot-test:
     needs: [get-environment, dockerize-image]

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -1011,7 +1011,7 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.stability == 'stable' &&
-      (github.event_name != 'workflow_dispatch' || (github.head_ref || github.ref_name) == 'MON-207622-provenance-attestation-sbom-ghcr') &&
+      github.event_name != 'workflow_dispatch' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -1009,7 +1009,7 @@ jobs:
     needs: [get-environment]
     if: |
       needs.get-environment.outputs.stability == 'stable' &&
-      github.event_name != 'workflow_dispatch' &&
+      (github.event_name != 'workflow_dispatch' || (github.head_ref || github.ref_name) == 'MON-207622-provenance-attestation-sbom-ghcr') &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -536,9 +536,7 @@ jobs:
           # needed to find the candidate to promote. This job only runs after
           # robot-test succeeds, so this candidate is e2e-tested before it can
           # ever be promoted to ghcr.io stable.
-          # TEMP TEST HACK (MON-207622) — remove the branch-name alternative
-          # below before merging PR #3647.
-          if [[ "$RAW_REF" =~ ^(release|hotfix)-[0-9]+\.[0-9]+-next$ ]] || [[ "$RAW_REF" == "MON-207622-provenance-attestation-sbom-ghcr" ]]; then
+          if [[ "$RAW_REF" =~ ^(release|hotfix)-[0-9]+\.[0-9]+-next$ ]]; then
             echo "version_tag=${MAJOR_VERSION}.${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
           else
             echo "version_tag=" >> "$GITHUB_OUTPUT"
@@ -744,13 +742,9 @@ jobs:
       needs.changes.outputs.trigger_delivery == 'true' &&
       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
-    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
-    # before merging PR #3647. Prevents a real RPM delivery from the forced
-    # 'testing' stability hack in get-environment.yml.
 
     strategy:
       fail-fast: false
@@ -784,12 +778,9 @@ jobs:
       needs.changes.outputs.trigger_delivery == 'true' &&
       ((needs.get-environment.outputs.delivery_type == 'feature' && contains(github.event.pull_request.labels.*.name, 'delivery-feature')) ||
       contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability)) &&
-      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
-    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
-    # before merging PR #3647.
 
     strategy:
       fail-fast: false
@@ -835,13 +826,10 @@ jobs:
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.changes.outputs.trigger_delivery == 'true' &&
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
-    # before merging PR #3647.
 
     strategy:
       fail-fast: false
@@ -872,13 +860,10 @@ jobs:
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.changes.outputs.trigger_delivery == 'true' &&
       contains(fromJson('["unstable", "testing"]'), needs.get-environment.outputs.stability) &&
-      (github.head_ref || github.ref_name) != 'MON-207622-provenance-attestation-sbom-ghcr' &&
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
       (needs.get-environment.outputs.is_cloud == 'false' || needs.get-environment.outputs.stability == 'unstable')
-    # TEMP TEST HACK (MON-207622) — remove the branch-name condition above
-    # before merging PR #3647.
 
     strategy:
       fail-fast: false

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -463,6 +463,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -544,6 +546,7 @@ jobs:
         shell: bash
 
       - name: Docker build and push
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         env:
           DOCKER_BUILD_CHECKS_ANNOTATIONS: false
@@ -559,6 +562,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           pull: true
           push: true
+          # Disabled: BuildKit's own attestation manifests would make this
+          # digest diverge from the ghcr.io one docker-push-to-ghcr.sh
+          # reconstructs later.
+          provenance: false
+          sbom: false
           # version_tag is deliberately NOT pushed here: it's only applied by
           # promote-docker-version-tag below, once docker-boot-test/
           # docker-config-wiring-test have validated this exact image. Pushing
@@ -569,6 +577,18 @@ jobs:
           secrets: |
             "ARTIFACTORY_INTERNAL_REPO_USERNAME=${{ secrets.ARTIFACTORY_INTERNAL_REPO_USERNAME }}"
             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
+
+      - name: Attest build provenance (deterministic candidate only)
+        # Only for builds with a version_tag (real promotion candidates).
+        # push-to-registry:false since ghcr.io doesn't have this image yet;
+        # discoverable later by digest once promoted.
+        if: steps.compute-tag.outputs.version_tag != ''
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-name: ghcr.io/centreon/centreon-gorgone
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: false
+          create-storage-record: false
 
   docker-boot-test:
     needs: [get-environment, dockerize-image]
@@ -1044,7 +1064,7 @@ jobs:
           echo "::warning::ghcr.io delivery failed for centreon-gorgone-${{ matrix.operating_system }}. This release is available on Harbor but was NOT published to ghcr.io — see the 'Promote to ghcr.io stable' step for the missing-candidate or push error, and investigate before relying on public delivery for this version."
         shell: bash
 
-      - name: Attest provenance + SBOM on ghcr.io (best-effort, non-blocking)
+      - name: Attest SBOM on ghcr.io (best-effort, non-blocking)
         if: steps.promote-ghcr.outcome == 'success' && steps.promote-ghcr.outputs.digest != ''
         continue-on-error: true
         id: attest-ghcr
@@ -1057,7 +1077,7 @@ jobs:
       - name: Warn if ghcr.io attestation failed
         if: steps.attest-ghcr.outcome == 'failure'
         run: |
-          echo "::warning::Provenance/SBOM attestation failed for centreon-gorgone-${{ matrix.operating_system }}. The image WAS published to ghcr.io but is unattested — see the 'Attest provenance + SBOM on ghcr.io' step and investigate before relying on gh attestation verify for this version."
+          echo "::warning::SBOM attestation failed for centreon-gorgone-${{ matrix.operating_system }}. The image WAS published to ghcr.io but is unattested — see the 'Attest SBOM on ghcr.io' step and investigate before relying on gh attestation verify for this version."
         shell: bash
 
   set-skip-label:

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -582,7 +582,8 @@ jobs:
             "ARTIFACTORY_INTERNAL_REPO_PASSWORD=${{ secrets.ARTIFACTORY_INTERNAL_REPO_PASSWORD }}"
 
       - name: Show build digest (MON-207622 scratch test)
-        run: echo "Harbor build digest: ${{ steps.build.outputs.digest }}"
+        run: |
+          echo "Harbor build digest: ${{ steps.build.outputs.digest }}"
         shell: bash
 
   docker-boot-test:


### PR DESCRIPTION
## Summary
- Generates GitHub-native, Sigstore-signed build provenance (`actions/attest-build-provenance`) and an SBOM (`anchore/sbom-action` + `actions/attest`, since `actions/attest-sbom` is deprecated) for `centreon-engine`, `centreon-broker`, and `centreon-gorgone` after they're promoted from Harbor to ghcr.io.
- New composite action `.github/actions/attest-ghcr-image` is invoked as a separate, distinctly-warned step after `promote-docker-to-ghcr`, so an attestation failure is never confused with a delivery failure — the image is still live on ghcr.io either way.
- `promote-docker-to-ghcr` now resolves and exposes the promoted manifest-list digest + amd64 platform digest as outputs (best-effort, from the ghcr.io side post-publish — never blocks delivery if resolution fails).
- Adds `id-token: write` + `attestations: write` to the two `promote-docker-to-ghcr` jobs (`collect.yml`, `gorgone.yml`), alongside the existing `contents: read`, `packages: write`.

## Decision recorded (MON-207622 AC #1)
The Harbor-side attestation manifest that `docker-push-to-ghcr.sh` already excludes is BuildKit's default, unsigned in-toto provenance — no Sigstore/Fulcio/Rekor trust chain. `gh attestation verify`/`cosign verify-attestation` only validate GitHub-native, Sigstore-signed attestations, so copying that manifest across registries would never satisfy verification. Decision: leave the existing exclusion untouched, generate provenance + SBOM fresh against the ghcr.io digest instead. Recorded in the script header and as a Jira comment.

## Status
- Implemented and lint-clean (`actionlint`), not yet runtime-verified: the promote jobs only run on real stable releases (`stability == 'stable' && event != workflow_dispatch`), so `gh attestation verify`/`gh attestation download` evidence for AC #2/#3 is still pending a real (or scratch) run.
- Self-hosted runner egress to Sigstore's public-good endpoints was checked against Infrastructure's Terraform/NACL config (open egress on 443, no domain allowlist) — expected to work, not yet exercised live.

Companion PR: centreon/centreon (same pattern, for centreon-snmptrapd/centreontrapd).
Related: MON-207531 (original ghcr.io publish), MON-207622 (this ticket).