### PR TITLE
enh(delivery): mirror 24.x stable promotions into the dedicated legacy suite

### DIFF
--- a/.github/actions/promote-to-stable-pulp/action.yml
+++ b/.github/actions/promote-to-stable-pulp/action.yml
@@ -113,6 +113,7 @@ runs:
         TESTING_SUITE: ${{ steps.pulp-properties.outputs.testing_suite }}
         STABLE_SUITE: ${{ steps.pulp-properties.outputs.stable_suite }}
         STABLE_LEGACY_SUITE: ${{ steps.pulp-properties.outputs.stable_legacy_suite }}
+        STABLE_LEGACY_REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.stable_legacy_repository_name }}
         STABLE_REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.stable_repository_name }}
         STABLE_BASE_PATH: ${{ steps.pulp-properties.outputs.stable_base_path }}
         PACKAGE_DISTRIB_NAME: ${{ steps.pulp-properties.outputs.package_distrib_name }}

--- a/.github/actions/promote-to-stable-pulp/action.yml
+++ b/.github/actions/promote-to-stable-pulp/action.yml
@@ -112,6 +112,7 @@ runs:
         TESTING_POOL_PATH: ${{ steps.pulp-properties.outputs.testing_pool_path }}
         TESTING_SUITE: ${{ steps.pulp-properties.outputs.testing_suite }}
         STABLE_SUITE: ${{ steps.pulp-properties.outputs.stable_suite }}
+        STABLE_LEGACY_SUITE: ${{ steps.pulp-properties.outputs.stable_legacy_suite }}
         STABLE_REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.stable_repository_name }}
         STABLE_BASE_PATH: ${{ steps.pulp-properties.outputs.stable_base_path }}
         PACKAGE_DISTRIB_NAME: ${{ steps.pulp-properties.outputs.package_distrib_name }}

--- a/.github/actions/promote-to-stable-pulp/promote-deb.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-deb.sh
@@ -139,10 +139,15 @@ STABLE_REPOSITORY_HREF=$(pulp deb repository show --name "$STABLE_REPOSITORY_NAM
 # create-repos): mirror every candidate package association into that suite so
 # both suites always list the same stable content. Idempotent (rerun safe).
 ensure_legacy_suite_associations() {
-  [[ -z "${STABLE_LEGACY_SUITE:-}" ]] && return 0
+  [[ -z "${STABLE_LEGACY_REPOSITORY_NAME:-}" ]] && return 0
   refresh_pulp_token
-  local latest legacy_rc
-  latest=$(pulp deb repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.latest_version_href')
+  if ! pulp_resource_exists "repositories/deb/apt" "$STABLE_LEGACY_REPOSITORY_NAME"; then
+    echo "::error::Dedicated legacy repository $STABLE_LEGACY_REPOSITORY_NAME does not exist. Pulp repositories are provisioned centrally by delivery-tooling create-repos; run create-repos before promoting."
+    return 1
+  fi
+  local legacy_repo_href latest legacy_rc
+  legacy_repo_href=$(pulp deb repository show --name "$STABLE_LEGACY_REPOSITORY_NAME" | jq -r '.pulp_href')
+  latest=$(pulp deb repository show --name "$STABLE_LEGACY_REPOSITORY_NAME" | jq -r '.latest_version_href')
   legacy_rc=$(
     curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" \
       "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/release_components/?$(
@@ -151,10 +156,10 @@ ensure_legacy_suite_associations() {
       )" | jq -r '.results[0].pulp_href // empty'
   )
   if [[ -z "$legacy_rc" ]]; then
-    echo "::error::Cannot resolve the $STABLE_LEGACY_SUITE/main release component (dedicated legacy suite, provisioned by create-repos)"
+    echo "::error::Cannot resolve the $STABLE_LEGACY_SUITE/main release component of $STABLE_LEGACY_REPOSITORY_NAME (provisioned by create-repos)"
     return 1
   fi
-  echo "[INFO] Mirroring $PACKAGES_COUNT package association(s) into $STABLE_LEGACY_SUITE/main (dedicated legacy suite)"
+  echo "[INFO] Mirroring $PACKAGES_COUNT package association(s) into $STABLE_LEGACY_REPOSITORY_NAME $STABLE_LEGACY_SUITE/main"
   local units_file body_file sha href out code body prc n=0
   units_file=$(mktemp)
   while read -r sha; do
@@ -189,14 +194,15 @@ ensure_legacy_suite_associations() {
   rm -f "$units_file"
   local task rc
   for _ in 1 2 3; do
-    task=$(start_modify_task "$PULP_URL${STABLE_REPOSITORY_HREF}modify/" "$body_file")
+    task=$(start_modify_task "$PULP_URL${legacy_repo_href}modify/" "$body_file")
     wait_task_race "$task" && rc=0 || rc=$?
     if [[ $rc -eq 0 ]]; then
       rm -f "$body_file"
+      create_publication deb "$STABLE_LEGACY_REPOSITORY_NAME" --structured
       return 0
     fi
   done
-  echo "::error::Cannot add the $STABLE_LEGACY_SUITE mirror associations to $STABLE_REPOSITORY_NAME"
+  echo "::error::Cannot add the $STABLE_LEGACY_SUITE mirror associations to $STABLE_LEGACY_REPOSITORY_NAME"
   return 1
 }
 

--- a/.github/actions/promote-to-stable-pulp/promote-deb.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-deb.sh
@@ -134,6 +134,72 @@ if ! pulp_resource_exists "repositories/deb/apt" "$STABLE_REPOSITORY_NAME"; then
 fi
 STABLE_REPOSITORY_HREF=$(pulp deb repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.pulp_href')
 
+# 24.x standard clients use the dedicated legacy repository form
+# (apt-standard-24.10-stable/ with a plain-codename suite, provisioned by
+# create-repos): mirror every candidate package association into that suite so
+# both suites always list the same stable content. Idempotent (rerun safe).
+ensure_legacy_suite_associations() {
+  [[ -z "${STABLE_LEGACY_SUITE:-}" ]] && return 0
+  refresh_pulp_token
+  local latest legacy_rc
+  latest=$(pulp deb repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.latest_version_href')
+  legacy_rc=$(
+    curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" \
+      "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/release_components/?$(
+        printf 'repository_version=%s&distribution=%s&component=main&limit=1' \
+          "$(jq -rn --arg v "$latest" '$v | @uri')" "$(jq -rn --arg v "$STABLE_LEGACY_SUITE" '$v | @uri')"
+      )" | jq -r '.results[0].pulp_href // empty'
+  )
+  if [[ -z "$legacy_rc" ]]; then
+    echo "::error::Cannot resolve the $STABLE_LEGACY_SUITE/main release component (dedicated legacy suite, provisioned by create-repos)"
+    return 1
+  fi
+  echo "[INFO] Mirroring $PACKAGES_COUNT package association(s) into $STABLE_LEGACY_SUITE/main (dedicated legacy suite)"
+  local units_file body_file sha href out code body prc n=0
+  units_file=$(mktemp)
+  while read -r sha; do
+    if ((n % 40 == 0)); then refresh_pulp_token; fi
+    n=$((n + 1))
+    href=$(lookup_deb_content "packages" "--data-urlencode sha256=$sha")
+    if [[ -z "$href" ]]; then
+      echo "::error::Cannot resolve the promoted package (sha256 $sha) for the $STABLE_LEGACY_SUITE mirror"
+      return 1
+    fi
+    out=$(post_json "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/package_release_components/" \
+      "{\"package\": \"$href\", \"release_component\": \"$legacy_rc\"}") || out=$'\n000'
+    code="${out##*$'\n'}"
+    body="${out%$'\n'*}"
+    prc=""
+    if [[ "$code" == 2* ]]; then
+      prc=$(echo "$body" | jq -r '.pulp_href // empty' 2>/dev/null) || prc=""
+    fi
+    if [[ -z "$prc" ]]; then
+      # the api answers 500 on a duplicate synchronous create; expected on a rerun
+      prc=$(lookup_deb_content "package_release_components" \
+        "--data-urlencode package=$href --data-urlencode release_component=$legacy_rc")
+    fi
+    if [[ -z "$prc" ]]; then
+      echo "::error::Legacy suite association failed for sha256 $sha (HTTP $code)"
+      return 1
+    fi
+    printf '%s\n%s\n' "$href" "$prc" >> "$units_file"
+  done < <(echo "$PACKAGES" | jq -r '.[].sha256')
+  body_file=$(mktemp)
+  jq -R . "$units_file" | jq -cs '{add_content_units: ([.[] | select(. != "")] | unique)}' > "$body_file"
+  rm -f "$units_file"
+  local task rc
+  for _ in 1 2 3; do
+    task=$(start_modify_task "$PULP_URL${STABLE_REPOSITORY_HREF}modify/" "$body_file")
+    wait_task_race "$task" && rc=0 || rc=$?
+    if [[ $rc -eq 0 ]]; then
+      rm -f "$body_file"
+      return 0
+    fi
+  done
+  echo "::error::Cannot add the $STABLE_LEGACY_SUITE mirror associations to $STABLE_REPOSITORY_NAME"
+  return 1
+}
+
 # "already promoted" is decided against the stable repository's OWN version
 # (it's always dedicated, never shared, so it only ever receives stable content)
 STABLE_SHAS_FILE=$(mktemp)
@@ -210,6 +276,7 @@ if ((${#UNPROMOTED_HREFS[@]} == 0)); then
       --arg suite "$STABLE_SUITE" \
       '{filename: (.relative_path | sub(".*/"; "")), name: .package, version, arch: .architecture, sha256, repository: $repository, base_path: $base_path, suite: $suite, relative_path}')"
   done < <(echo "$PACKAGES" | jq -c '.[]')
+  ensure_legacy_suite_associations
   create_publication deb "$STABLE_REPOSITORY_NAME" --structured
   echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}/ $STABLE_SUITE main"
   manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "$STABILITY" "promote" "$PULP_CONTENT_URL"
@@ -308,6 +375,7 @@ if ((${#BATCH_PACKAGES[@]} > 0)); then
     # a promotion interrupted after its repository modify only misses the
     # publication: republish and re-check every candidate before giving up
     echo "[WARN] Cannot deduce the $STABLE_SUITE/main release component (got: ${STABLE_RC_SET:-none}); republishing to check for an interrupted promotion"
+    ensure_legacy_suite_associations
     create_publication deb "$STABLE_REPOSITORY_NAME" --structured
     RECHECK_SHAS_FILE=$(suite_sha_file "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" "$STABLE_SUITE")
     MISSING_COUNT=0
@@ -417,6 +485,7 @@ while read -r PACKAGE; do
     '{filename: (.relative_path | sub(".*/"; "")), name: .package, version, arch: .architecture, sha256, repository: $repository, base_path: $base_path, suite: $suite, relative_path}')"
 done < <(echo "$PACKAGES" | jq -c '.[]')
 
+ensure_legacy_suite_associations
 echo "[INFO] Publishing repository $STABLE_REPOSITORY_NAME"
 create_publication deb "$STABLE_REPOSITORY_NAME" --structured
 

--- a/.github/actions/pulp-repository-properties/action.yml
+++ b/.github/actions/pulp-repository-properties/action.yml
@@ -99,6 +99,9 @@ outputs:
   stable_suite:
     description: "Apt suite of stable deb packages"
     value: ${{ steps.properties.outputs.stable_suite }}
+  stable_legacy_suite:
+    description: "Plain-codename suite of the dedicated 24.x standard stable legacy repos (empty otherwise)"
+    value: ${{ steps.properties.outputs.stable_legacy_suite }}
   stable_repository_name:
     description: "Repository holding the stable deb packages (one deb repository per stability)"
     value: ${{ steps.properties.outputs.stable_repository_name }}

--- a/.github/actions/pulp-repository-properties/action.yml
+++ b/.github/actions/pulp-repository-properties/action.yml
@@ -100,8 +100,11 @@ outputs:
     description: "Apt suite of stable deb packages"
     value: ${{ steps.properties.outputs.stable_suite }}
   stable_legacy_suite:
-    description: "Plain-codename suite of the dedicated 24.x standard stable legacy repos (empty otherwise)"
+    description: "Plain-codename suite of the dedicated 24.x stable legacy repositories (empty otherwise)"
     value: ${{ steps.properties.outputs.stable_legacy_suite }}
+  stable_legacy_repository_name:
+    description: "Dedicated 24.x stable legacy repository fed by the promote mirror (empty otherwise)"
+    value: ${{ steps.properties.outputs.stable_legacy_repository_name }}
   stable_repository_name:
     description: "Repository holding the stable deb packages (one deb repository per stability)"
     value: ${{ steps.properties.outputs.stable_repository_name }}

--- a/.github/actions/pulp-repository-properties/properties.sh
+++ b/.github/actions/pulp-repository-properties/properties.sh
@@ -79,6 +79,7 @@ TESTING_BASE_PATH=""
 TESTING_SUITE=""
 STABLE_SUITE=""
 STABLE_LEGACY_SUITE=""
+STABLE_LEGACY_REPOSITORY_NAME=""
 POOL_PATH=""
 TESTING_POOL_PATH=""
 STABLE_POOL_PATH=""
@@ -188,12 +189,17 @@ else
     STABLE_REPOSITORY_NAME="${DEB_PREFIX}${DEB_INFIX}stable"
     STABLE_BASE_PATH="$STABLE_REPOSITORY_NAME"
     STABLE_SUITE="$DISTRIB-$VERSION-stable"
-    # 24.x standard clients use the dedicated legacy stable repos
-    # (apt-standard-24.10-stable/) with plain-codename suites: the promote
-    # mirrors its associations into that suite
-    if [[ "$REPO_BASE" == "standard" && -z "$DEB_INFIX" ]] \
-      && [[ "$VERSION" == "24.04" || "$VERSION" == "24.10" ]]; then
-      STABLE_LEGACY_SUITE="$DISTRIB"
+    # 24.x clients use dedicated legacy stable repositories with plain-codename
+    # suites (apt|ubuntu-standard-<major>-stable, apt-<major>-business-stable):
+    # the promote mirrors its package associations into them
+    if [[ -z "$DEB_INFIX" && ( "$VERSION" == "24.04" || "$VERSION" == "24.10" ) ]]; then
+      if [[ "$REPO_BASE" == "standard" ]]; then
+        STABLE_LEGACY_REPOSITORY_NAME="${DEB_PREFIX}standard-$VERSION-stable"
+        STABLE_LEGACY_SUITE="$DISTRIB"
+      elif [[ "$REPO_BASE" == "business" && "$DEB_PREFIX" == "apt-" ]]; then
+        STABLE_LEGACY_REPOSITORY_NAME="apt-$VERSION-business-stable"
+        STABLE_LEGACY_SUITE="$DISTRIB"
+      fi
     fi
     LEGACY_DEB_ROOT="${DEB_PREFIX}${REPO_BASE}"
     [[ -n "$DEB_INFIX" ]] && LEGACY_DEB_ROOT="${DEB_PREFIX}${REPO_BASE}-internal"
@@ -261,6 +267,7 @@ echo "[DEBUG] - stable_domain: $STABLE_DOMAIN"
   echo "testing_suite=$TESTING_SUITE"
   echo "stable_suite=$STABLE_SUITE"
   echo "stable_legacy_suite=$STABLE_LEGACY_SUITE"
+  echo "stable_legacy_repository_name=$STABLE_LEGACY_REPOSITORY_NAME"
   echo "stable_repository_name=$STABLE_REPOSITORY_NAME"
   echo "stable_base_path=$STABLE_BASE_PATH"
   echo "pool_path=$POOL_PATH"

--- a/.github/actions/pulp-repository-properties/properties.sh
+++ b/.github/actions/pulp-repository-properties/properties.sh
@@ -78,6 +78,7 @@ TESTING_REPOSITORY_NAME=""
 TESTING_BASE_PATH=""
 TESTING_SUITE=""
 STABLE_SUITE=""
+STABLE_LEGACY_SUITE=""
 POOL_PATH=""
 TESTING_POOL_PATH=""
 STABLE_POOL_PATH=""
@@ -187,6 +188,13 @@ else
     STABLE_REPOSITORY_NAME="${DEB_PREFIX}${DEB_INFIX}stable"
     STABLE_BASE_PATH="$STABLE_REPOSITORY_NAME"
     STABLE_SUITE="$DISTRIB-$VERSION-stable"
+    # 24.x standard clients use the dedicated legacy stable repos
+    # (apt-standard-24.10-stable/) with plain-codename suites: the promote
+    # mirrors its associations into that suite
+    if [[ "$REPO_BASE" == "standard" && -z "$DEB_INFIX" ]] \
+      && [[ "$VERSION" == "24.04" || "$VERSION" == "24.10" ]]; then
+      STABLE_LEGACY_SUITE="$DISTRIB"
+    fi
     LEGACY_DEB_ROOT="${DEB_PREFIX}${REPO_BASE}"
     [[ -n "$DEB_INFIX" ]] && LEGACY_DEB_ROOT="${DEB_PREFIX}${REPO_BASE}-internal"
     LEGACY_BASE_PATH="$LEGACY_DEB_ROOT"
@@ -252,6 +260,7 @@ echo "[DEBUG] - stable_domain: $STABLE_DOMAIN"
   echo "testing_base_path=$TESTING_BASE_PATH"
   echo "testing_suite=$TESTING_SUITE"
   echo "stable_suite=$STABLE_SUITE"
+  echo "stable_legacy_suite=$STABLE_LEGACY_SUITE"
   echo "stable_repository_name=$STABLE_REPOSITORY_NAME"
   echo "stable_base_path=$STABLE_BASE_PATH"
   echo "pool_path=$POOL_PATH"


### PR DESCRIPTION
Related to: [MON-202540](https://centreon.atlassian.net/browse/MON-202540)

24.04/24.10 clients configure **dedicated** stable repositories with **plain-codename** suites — `apt-standard-24.10-stable/ bookworm main`, `ubuntu-standard-24.10-stable/ jammy main` (standard) and `apt-24.10-business-stable/ bookworm main` (business, apt only) — verified on packages.centreon.com. Both majors ship a `bookworm` suite, so these are real pulp repositories carrying the historical names (provisioned by create-repos, served by the front — [delivery-tooling#302](https://github.com/centreon/delivery-tooling/pull/302)).

This PR makes the deb promote keep them in sync:
- `pulp-repository-properties` emits `stable_legacy_repository_name` + `stable_legacy_suite` (empty outside 24.04/24.10 standard/business non-internal);
- `promote-deb.sh` mirrors every candidate package into that repository by href association (same domain, no re-upload; idempotent and rerun-safe) and publishes it, before each stable publication path.

To merge together with [delivery-tooling#302](https://github.com/centreon/delivery-tooling/pull/302) — same train.

[MON-202540]: https://centreon.atlassian.net/browse/MON-202540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ