### PR TITLE
test(delivery): centreon-common unstable delivery through centreon.jfrog.io — do not merge

### DIFF
--- a/.github/actions/deb-delivery/action.yml
+++ b/.github/actions/deb-delivery/action.yml
@@ -38,7 +38,7 @@ runs:
 
     - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
 
     - name: Parse distrib name

--- a/.github/actions/promote-to-stable/action.yml
+++ b/.github/actions/promote-to-stable/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
 
     - name: Parse distrib name

--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -44,14 +44,14 @@ runs:
 
     - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
 
     - if: inputs.delivery_type == 'feature'
       name: Create a rpm feature repository
       shell: bash
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
         GH_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         CENTREON_TECHNIQUE_PAT: ${{ inputs.centreon_technique_pat }}
@@ -99,7 +99,7 @@ runs:
     - name: Publish RPMs
       shell: bash
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
         GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
         MODULE_NAME: ${{ inputs.module_name }}

--- a/.github/docker/gorgone/trixie/Dockerfile.testing-dependencies
+++ b/.github/docker/gorgone/trixie/Dockerfile.testing-dependencies
@@ -69,7 +69,7 @@ fi
 echo "deb https://packages.centreon.com/apt-plugins-stable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
 echo "deb https://packages.centreon.com/apt-plugins-testing/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list
 echo "deb https://packages.centreon.com/apt-plugins-unstable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-unstable.list
-wget -O- https://packages.centreon.com/api/security/keypair/APT-GPG-KEY/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
+wget -O- https://apt-key.centreon.com/ | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 
 apt-get update
 

--- a/.github/scripts/deliver-cma-assets.sh
+++ b/.github/scripts/deliver-cma-assets.sh
@@ -134,14 +134,14 @@ search_artifactory() {
     -H "Authorization: Bearer ${ARTIFACTORY_TOKEN}" \
     -H "Content-Type: text/plain" \
     --data "$aql" \
-    "https://packages.centreon.com/artifactory/api/search/aql"
+    "https://centreon.jfrog.io/artifactory/api/search/aql"
 }
 
 download_from_artifactory() {
   local repo="$1" art_path="$2" name="$3" dest_dir="$4"
   curl --fail --silent \
     -H "Authorization: Bearer ${ARTIFACTORY_TOKEN}" \
-    "https://packages.centreon.com/artifactory/${repo}/${art_path}/${name}" \
+    "https://centreon.jfrog.io/artifactory/${repo}/${art_path}/${name}" \
     -o "${dest_dir}/${name}"
   echo "${dest_dir}/${name}"
 }

--- a/.github/workflows/delete-feature-repositories.yml
+++ b/.github/workflows/delete-feature-repositories.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: jfrog/setup-jfrog-cli@deda456d982fc5e9a7a020b63eb0d2968aedd33e # v5.1.0
         env:
-          JF_URL: https://packages.centreon.com
+          JF_URL: https://centreon.jfrog.io
           JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
 
       - name: Check if feature branch had associated feature repository

--- a/.github/workflows/monitoring-agent.yml
+++ b/.github/workflows/monitoring-agent.yml
@@ -700,7 +700,7 @@ jobs:
     steps:
       - uses: jfrog/setup-jfrog-cli@deda456d982fc5e9a7a020b63eb0d2968aedd33e # v5.1.0
         env:
-          JF_URL: https://packages.centreon.com
+          JF_URL: https://centreon.jfrog.io
           JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
 
       - name: Restore cache monitoring agent
@@ -841,7 +841,7 @@ jobs:
 
       - uses: jfrog/setup-jfrog-cli@deda456d982fc5e9a7a020b63eb0d2968aedd33e # v5.1.0
         env:
-          JF_URL: https://packages.centreon.com
+          JF_URL: https://centreon.jfrog.io
           JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
 
       - name: Promote testing to stable

--- a/packaging/centreon-common/centreon-common.yaml
+++ b/packaging/centreon-common/centreon-common.yaml
@@ -1,3 +1,4 @@
+# do-not-merge: transient marker to exercise the unstable artifactory delivery (MON-207928)
 name: "centreon-common"
 arch: "all"
 platform: "linux"


### PR DESCRIPTION
Related to: [MON-207928](https://centreon.atlassian.net/browse/MON-207928)

**Test PR — do not merge.** Based on [#3656](https://github.com/centreon/centreon-collect/pull/3656) (`JF_URL: https://centreon.jfrog.io`), plus a transient packaging marker to trigger `common.yml`. The branch name matches the `prepare-release-cloud*` stability pattern, so this pull request run carries the **unstable** stability and executes the real `deliver-rpm`/`deliver-deb` jobs: **centreon-common is delivered to jfrog artifactory through its native `centreon.jfrog.io` hostname** (the pulp delivery jobs run too, as on any develop delivery).

Will be closed after the delivery verification.

[MON-207928]: https://centreon.atlassian.net/browse/MON-207928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ