### PR TITLE
fix(broker/bam) : a cancel downtime is over even if it's no actual_end_time .

### DIFF
--- a/bbdo/CMakeLists.txt
+++ b/bbdo/CMakeLists.txt
@@ -66,6 +66,7 @@ foreach(name IN LISTS otl_protobuf_files)
   set(proto_file "${name}.proto")
   add_custom_command(
     OUTPUT "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.cc"
+           "${CMAKE_SOURCE_DIR}/bbdo/${name}.pb.h"
     COMMENT "Generating interface files of the otl file ${proto_file}"
     #DEPENDS ${CMAKE_BINARY_DIR}/opentelemetry-proto/${proto_file}
     DEPENDS opentelemetry-proto-files

--- a/broker/CMakeLists.txt
+++ b/broker/CMakeLists.txt
@@ -376,7 +376,8 @@ set(LIBROKER_SOURCES
 add_library(rokerbase STATIC ${LIBROKER_SOURCES})
 set_target_properties(rokerbase PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_precompile_headers(rokerbase REUSE_FROM multiplexing)
-add_dependencies(rokerbase pb_broker_lib pb_bbdo_lib pb_extcmd_lib pb_neb_lib process_stat)
+add_dependencies(rokerbase pb_broker_lib pb_bbdo_lib pb_extcmd_lib pb_neb_lib
+                 process_stat pb_storage_lib)
 target_include_directories(rokerbase
                            PRIVATE ${PROJECT_SOURCE_DIR}/core
                            ${PROJECT_SOURCE_DIR}/bam/inc)

--- a/broker/bam/CMakeLists.txt
+++ b/broker/bam/CMakeLists.txt
@@ -148,7 +148,8 @@ target_link_libraries("${BAM}" bbdo_storage bbdo_bam centreon_pb_bbdo
 target_precompile_headers(${BAM} PRIVATE precomp_inc/precomp.hpp)
 set_target_properties("${BAM}" PROPERTIES PREFIX ""
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/broker/lib")
-add_dependencies("${BAM}" pb_open_telemetry_lib pb_bam_lib process_stat)
+add_dependencies("${BAM}" pb_open_telemetry_lib pb_bam_lib process_stat
+                 target_broker_message)
 
 # Testing.
 if(WITH_TESTING)

--- a/broker/bam/src/ba.cc
+++ b/broker/bam/src/ba.cc
@@ -306,8 +306,10 @@ void ba::service_update(const std::shared_ptr<neb::downtime>& dt,
         "{})",
         _id, _name, _host_id, _service_id);
 
-    // Check if there was a change.
-    bool in_downtime(dt->was_started && dt->actual_end_time.is_null());
+    // Check if there was a change. A cancelled downtime is over, even when it
+    // carries no actual_end_time (poller restart cancellation).
+    bool in_downtime(dt->was_started && dt->actual_end_time.is_null() &&
+                     !dt->was_cancelled);
     if (_in_downtime != in_downtime) {
       SPDLOG_LOGGER_TRACE(_logger, "ba: service_update downtime: {}",
                           _in_downtime);
@@ -341,9 +343,11 @@ void ba::service_update(const std::shared_ptr<neb::pb_downtime>& dt,
   assert(downtime.host_id() == _host_id &&
          downtime.service_id() == _service_id);
 
-  // Check if there was a change.
+  // Check if there was a change. A cancelled downtime is over, even when it
+  // carries no actual_end_time (poller restart cancellation).
   bool in_downtime(downtime.started() &&
-                   time_is_undefined(downtime.actual_end_time()));
+                   time_is_undefined(downtime.actual_end_time()) &&
+                   !downtime.cancelled());
 
   // Log message.
   SPDLOG_LOGGER_DEBUG(

--- a/broker/bam/src/kpi_service.cc
+++ b/broker/bam/src/kpi_service.cc
@@ -416,11 +416,16 @@ void kpi_service::service_update(const std::shared_ptr<neb::downtime>& dt,
       "kpi_service:service_update on downtime {}: was started {} ; actual end "
       "time {}",
       dt->internal_id, dt->was_started, dt->actual_end_time.get_time_t());
-  // Update information.
-  bool downtimed = dt->was_started && dt->actual_end_time.is_null();
+  // Update information. A cancelled downtime is over, even when it carries no
+  // actual_end_time (poller restart cancellation).
+  bool downtimed =
+      dt->was_started && dt->actual_end_time.is_null() && !dt->was_cancelled;
   bool changed = false;
 
-  if (_downtime_ids.contains(dt->internal_id) && dt->deletion_time.is_null()) {
+  /* Only a duplicated *start* may be skipped here: an event that ends the
+   * downtime must always be handled, otherwise the kpi stays in downtime. */
+  if (downtimed && _downtime_ids.contains(dt->internal_id) &&
+      dt->deletion_time.is_null()) {
     _logger->trace("Downtime {} already handled in this kpi service",
                    dt->internal_id);
     return;
@@ -478,16 +483,20 @@ void kpi_service::service_update(const std::shared_ptr<neb::downtime>& dt,
 void kpi_service::service_update(const std::shared_ptr<neb::pb_downtime>& dt,
                                  io::stream* visitor) {
   auto& downtime = dt->obj();
-  // Update information.
-  bool downtimed =
-      downtime.started() && time_is_undefined(downtime.actual_end_time());
+  // Update information. A cancelled downtime is over, even when it carries no
+  // actual_end_time (poller restart cancellation).
+  bool downtimed = downtime.started() &&
+                   time_is_undefined(downtime.actual_end_time()) &&
+                   !downtime.cancelled();
   bool changed = false;
   if (!_downtimed && downtimed) {
     _downtimed = true;
     changed = true;
   }
 
-  if (_downtime_ids.contains(downtime.id()) &&
+  /* Only a duplicated *start* may be skipped here: an event that ends the
+   * downtime must always be handled, otherwise the kpi stays in downtime. */
+  if (downtimed && _downtime_ids.contains(downtime.id()) &&
       time_is_undefined(downtime.deletion_time())) {
     _logger->trace("Downtime {} already handled in this kpi service",
                    downtime.id());

--- a/broker/bam/src/kpi_service.cc
+++ b/broker/bam/src/kpi_service.cc
@@ -456,7 +456,16 @@ void kpi_service::service_update(const std::shared_ptr<neb::downtime>& dt,
   }
 
   if (!_event || _event->in_downtime() != _downtimed) {
-    _last_check = _downtimed ? dt->actual_start_time : dt->actual_end_time;
+    if (_downtimed)
+      _last_check = dt->actual_start_time;
+    else if (!dt->actual_end_time.is_null())
+      _last_check = dt->actual_end_time;
+    else if (!dt->deletion_time.is_null())
+      _last_check = dt->deletion_time;
+    else if (_event)
+      /* A cancelled downtime may carry no end time at all. When no event
+       * last_check is untouched */
+      _last_check = time(nullptr);
     _logger->trace("kpi service {} update, last check set to {}", _id,
                    _last_check);
   }
@@ -519,8 +528,16 @@ void kpi_service::service_update(const std::shared_ptr<neb::pb_downtime>& dt,
   }
 
   if (!_event || _event->in_downtime() != _downtimed) {
-    _last_check =
-        _downtimed ? downtime.actual_start_time() : downtime.actual_end_time();
+    if (_downtimed)
+      _last_check = downtime.actual_start_time();
+    else if (!time_is_undefined(downtime.actual_end_time()))
+      _last_check = downtime.actual_end_time();
+    else if (!time_is_undefined(downtime.deletion_time()))
+      _last_check = downtime.deletion_time();
+    else if (_event)
+      /* A cancelled downtime may carry no end time at all. When no event
+       * last_check is untouched */
+      _last_check = time(nullptr);
     _logger->trace("kpi service {} update, last check set to {}", _id,
                    _last_check);
   }

--- a/broker/bam/src/kpi_service.cc
+++ b/broker/bam/src/kpi_service.cc
@@ -422,10 +422,13 @@ void kpi_service::service_update(const std::shared_ptr<neb::downtime>& dt,
       dt->was_started && dt->actual_end_time.is_null() && !dt->was_cancelled;
   bool changed = false;
 
-  /* Only a duplicated *start* may be skipped here: an event that ends the
-   * downtime must always be handled, otherwise the kpi stays in downtime. */
-  if (downtimed && _downtime_ids.contains(dt->internal_id) &&
-      dt->deletion_time.is_null()) {
+  /* Only an event that really ends the downtime may reach the code below: a
+   * plain re-announcement (engine restart re-sends DOWNTIME_ADD for every
+   * still-running downtime) or a duplicated start carries no end information
+   * and must not close the kpi event. */
+  bool ends_downtime = dt->was_cancelled || !dt->actual_end_time.is_null() ||
+                       !dt->deletion_time.is_null();
+  if (!ends_downtime && _downtime_ids.contains(dt->internal_id)) {
     _logger->trace("Downtime {} already handled in this kpi service",
                    dt->internal_id);
     return;
@@ -498,18 +501,23 @@ void kpi_service::service_update(const std::shared_ptr<neb::pb_downtime>& dt,
                    time_is_undefined(downtime.actual_end_time()) &&
                    !downtime.cancelled();
   bool changed = false;
-  if (!_downtimed && downtimed) {
-    _downtimed = true;
-    changed = true;
-  }
 
-  /* Only a duplicated *start* may be skipped here: an event that ends the
-   * downtime must always be handled, otherwise the kpi stays in downtime. */
-  if (downtimed && _downtime_ids.contains(downtime.id()) &&
-      time_is_undefined(downtime.deletion_time())) {
+  /* Only an event that really ends the downtime may reach the code below: a
+   * plain re-announcement (engine restart re-sends DOWNTIME_ADD for every
+   * still-running downtime) or a duplicated start carries no end information
+   * and must not close the kpi event. */
+  bool ends_downtime = downtime.cancelled() ||
+                       !time_is_undefined(downtime.actual_end_time()) ||
+                       !time_is_undefined(downtime.deletion_time());
+  if (!ends_downtime && _downtime_ids.contains(downtime.id())) {
     _logger->trace("Downtime {} already handled in this kpi service",
                    downtime.id());
     return;
+  }
+
+  if (!_downtimed && downtimed) {
+    _downtimed = true;
+    changed = true;
   }
 
   if (downtimed) {

--- a/broker/bam/test/ba/kpi_service.cc
+++ b/broker/bam/test/ba/kpi_service.cc
@@ -597,6 +597,124 @@ TEST_F(BamBA, KpiServiceDtInheritAllCriticalPb) {
   }
 }
 
+/**
+ * A downtime cancelled by broker itself (poller restart) keeps actual_end_time
+ * NULL. Such a downtime is over and must not pin the kpi -- and therefore the
+ * BA inherited downtime -- forever.
+ */
+TEST_F(BamBA, KpiServiceDtCancelledWithoutEndTime) {
+  std::shared_ptr<bam::ba> test_ba{
+      std::make_shared<bam::ba_ratio_percent>(1, 1, 4, true, _logger)};
+  test_ba->set_level_critical(100);
+  test_ba->set_level_warning(75);
+  test_ba->set_downtime_behaviour(bam::configuration::ba::dt_inherit);
+
+  std::vector<std::shared_ptr<bam::kpi_service>> kpis;
+  for (int i = 0; i < 4; i++) {
+    auto s = std::make_shared<bam::kpi_service>(
+        i + 1, 1, i + 1, 1, fmt::format("service {}", i), _logger);
+    s->set_state_hard(bam::state_critical);
+    s->set_state_soft(s->get_state_hard());
+    test_ba->add_impact(s);
+    s->add_parent(test_ba);
+    kpis.push_back(s);
+  }
+
+  time_t now(time(nullptr));
+
+  auto ss{std::make_shared<neb::service_status>()};
+  ss->service_id = 1;
+
+  /* Every kpi goes critical then in downtime: the BA inherits the downtime. */
+  for (size_t j = 0; j < kpis.size(); j++) {
+    ss->last_check = now + 1;
+    ss->host_id = j + 1;
+    ss->last_hard_state = 2;
+    kpis[j]->service_update(ss, _visitor.get());
+
+    auto dt{std::make_shared<neb::downtime>()};
+    dt->internal_id = j + 1;
+    dt->host_id = ss->host_id;
+    dt->service_id = 1;
+    dt->was_started = true;
+    dt->actual_start_time = now + 2;
+    dt->actual_end_time = 0;
+    kpis[j]->service_update(dt, _visitor.get());
+  }
+  ASSERT_TRUE(test_ba->in_downtime());
+
+  /* The downtime of the first kpi is cancelled without any actual_end_time nor
+   * deletion_time, as broker does when its poller restarts. */
+  auto cancelled{std::make_shared<neb::downtime>()};
+  cancelled->internal_id = 1;
+  cancelled->host_id = 1;
+  cancelled->service_id = 1;
+  cancelled->was_started = true;
+  cancelled->was_cancelled = true;
+  cancelled->actual_start_time = now + 2;
+  cancelled->actual_end_time = 0;
+  kpis[0]->service_update(cancelled, _visitor.get());
+
+  ASSERT_FALSE(kpis[0]->in_downtime());
+  ASSERT_FALSE(test_ba->in_downtime());
+}
+
+TEST_F(BamBA, KpiServiceDtCancelledWithoutEndTimePb) {
+  std::shared_ptr<bam::ba> test_ba{
+      std::make_shared<bam::ba_ratio_percent>(1, 1, 4, true, _logger)};
+  test_ba->set_level_critical(100);
+  test_ba->set_level_warning(75);
+  test_ba->set_downtime_behaviour(bam::configuration::ba::dt_inherit);
+
+  std::vector<std::shared_ptr<bam::kpi_service>> kpis;
+  for (int i = 0; i < 4; i++) {
+    auto s = std::make_shared<bam::kpi_service>(
+        i + 1, 1, i + 1, 1, fmt::format("service {}", i), _logger);
+    s->set_state_hard(bam::state_critical);
+    s->set_state_soft(s->get_state_hard());
+    test_ba->add_impact(s);
+    s->add_parent(test_ba);
+    kpis.push_back(s);
+  }
+
+  time_t now(time(nullptr));
+
+  auto ss{std::make_shared<neb::service_status>()};
+  ss->service_id = 1;
+
+  for (size_t j = 0; j < kpis.size(); j++) {
+    ss->last_check = now + 1;
+    ss->host_id = j + 1;
+    ss->last_hard_state = 2;
+    kpis[j]->service_update(ss, _visitor.get());
+
+    auto dt{std::make_shared<neb::pb_downtime>()};
+    auto& downtime = dt->mut_obj();
+    downtime.set_id(j + 1);
+    downtime.set_host_id(ss->host_id);
+    downtime.set_service_id(1);
+    downtime.set_started(true);
+    downtime.set_actual_start_time(now + 2);
+    downtime.set_actual_end_time(0);
+    kpis[j]->service_update(dt, _visitor.get());
+  }
+  ASSERT_TRUE(test_ba->in_downtime());
+
+  auto cancelled{std::make_shared<neb::pb_downtime>()};
+  auto& cancelled_obj = cancelled->mut_obj();
+  cancelled_obj.set_id(1);
+  cancelled_obj.set_host_id(1);
+  cancelled_obj.set_service_id(1);
+  cancelled_obj.set_started(true);
+  cancelled_obj.set_cancelled(true);
+  cancelled_obj.set_actual_start_time(now + 2);
+  cancelled_obj.set_actual_end_time(0);
+  kpis[0]->service_update(cancelled, _visitor.get());
+
+  ASSERT_FALSE(kpis[0]->in_downtime());
+  ASSERT_FALSE(test_ba->in_downtime());
+}
+
 TEST_F(BamBA, KpiServiceDtInheritOneOK) {
   std::shared_ptr<bam::ba> test_ba{
       std::make_shared<bam::ba_ratio_percent>(1, 1, 4, true, _logger)};
@@ -1416,6 +1534,8 @@ TEST_F(BamBA, KpiServiceDt) {
     dt->actual_start_time = now + 2 + 10 * i;
     dt->actual_end_time = 0;
     dt->was_started = true;
+    /* The downtime restarts: it is no longer the cancelled one. */
+    dt->was_cancelled = false;
     std::cout << "service_update 1" << std::endl;
     kpis[0]->service_update(dt, _visitor.get());
 
@@ -1580,6 +1700,8 @@ TEST_F(BamBA, KpiServiceDtPb) {
     dt_obj.set_actual_start_time(now + 2 + 10 * i);
     dt_obj.set_actual_end_time(0);
     dt_obj.set_started(true);
+    /* The downtime restarts: it is no longer the cancelled one. */
+    dt_obj.set_cancelled(false);
     std::cout << "service_update 1" << std::endl;
     kpis[0]->service_update(dt, _visitor.get());
 

--- a/broker/bam/test/ba/kpi_service.cc
+++ b/broker/bam/test/ba/kpi_service.cc
@@ -19,6 +19,7 @@
 #include "com/centreon/broker/bam/kpi_service.hh"
 #include <fmt/format.h>
 #include <gtest/gtest.h>
+#include <optional>
 #include <regex>
 #include "bbdo/bam/state.hh"
 #include "com/centreon/broker/bam/ba_best.hh"
@@ -598,6 +599,37 @@ TEST_F(BamBA, KpiServiceDtInheritAllCriticalPb) {
 }
 
 /**
+ * Return the kpi events emitted for the given kpi, in emission order. The
+ * availability computation is fed by those events, not by kpi::in_downtime(),
+ * so a downtime that ends must be observable here.
+ */
+static std::vector<test_visitor::test_event> kpi_events(
+    const std::unique_ptr<test_visitor>& visitor,
+    uint32_t kpi_id) {
+  std::vector<test_visitor::test_event> result;
+  for (auto& e : visitor->queue()) {
+    if (e.typ == test_visitor::test_event::kpi && e.kpi_id == kpi_id)
+      result.push_back(e);
+  }
+  return result;
+}
+
+/**
+ * Return the last snapshot of the kpi event flagged in downtime. The visitor
+ * keeps every snapshot, so an event appears once when it is opened (end_time
+ * still -1) and once when it is closed.
+ */
+static std::optional<test_visitor::test_event> last_downtime_event(
+    const std::vector<test_visitor::test_event>& events) {
+  std::optional<test_visitor::test_event> result;
+  for (auto& e : events) {
+    if (e.in_downtime)
+      result = e;
+  }
+  return result;
+}
+
+/**
  * A downtime cancelled by broker itself (poller restart) keeps actual_end_time
  * NULL. Such a downtime is over and must not pin the kpi -- and therefore the
  * BA inherited downtime -- forever.
@@ -627,7 +659,7 @@ TEST_F(BamBA, KpiServiceDtCancelledWithoutEndTime) {
 
   /* Every kpi goes critical then in downtime: the BA inherits the downtime. */
   for (size_t j = 0; j < kpis.size(); j++) {
-    ss->last_check = now + 1;
+    ss->last_check = now - 10;
     ss->host_id = j + 1;
     ss->last_hard_state = 2;
     kpis[j]->service_update(ss, _visitor.get());
@@ -637,7 +669,7 @@ TEST_F(BamBA, KpiServiceDtCancelledWithoutEndTime) {
     dt->host_id = ss->host_id;
     dt->service_id = 1;
     dt->was_started = true;
-    dt->actual_start_time = now + 2;
+    dt->actual_start_time = now - 5;
     dt->actual_end_time = 0;
     kpis[j]->service_update(dt, _visitor.get());
   }
@@ -651,15 +683,167 @@ TEST_F(BamBA, KpiServiceDtCancelledWithoutEndTime) {
   cancelled->service_id = 1;
   cancelled->was_started = true;
   cancelled->was_cancelled = true;
-  cancelled->actual_start_time = now + 2;
+  cancelled->actual_start_time = now - 5;
   cancelled->actual_end_time = 0;
   kpis[0]->service_update(cancelled, _visitor.get());
 
   ASSERT_FALSE(kpis[0]->in_downtime());
   ASSERT_FALSE(test_ba->in_downtime());
+
+  /* The in-memory flag is not enough: the kpi event opened when the downtime
+   * started must be closed, otherwise the reporting keeps the kpi in downtime
+   * and the availability stays inflated. */
+  auto events = kpi_events(_visitor, 1);
+  ASSERT_FALSE(events.empty());
+  ASSERT_FALSE(events.back().in_downtime)
+      << "the last kpi event is still flagged in downtime";
+  auto dt_event = last_downtime_event(events);
+  ASSERT_TRUE(dt_event.has_value()) << "the kpi never entered downtime";
+  ASSERT_GT(dt_event->end_time, 0)
+      << "the in-downtime kpi event was left open, the reporting keeps the kpi "
+         "in downtime";
 }
 
 TEST_F(BamBA, KpiServiceDtCancelledWithoutEndTimePb) {
+  std::shared_ptr<bam::ba> test_ba{
+      std::make_shared<bam::ba_ratio_percent>(1, 1, 4, true, _logger)};
+  test_ba->set_level_critical(100);
+  test_ba->set_level_warning(75);
+  test_ba->set_downtime_behaviour(bam::configuration::ba::dt_inherit);
+
+  std::vector<std::shared_ptr<bam::kpi_service>> kpis;
+  for (int i = 0; i < 4; i++) {
+    auto s = std::make_shared<bam::kpi_service>(
+        i + 1, 1, i + 1, 1, fmt::format("service {}", i), _logger);
+    s->set_state_hard(bam::state_critical);
+    s->set_state_soft(s->get_state_hard());
+    test_ba->add_impact(s);
+    s->add_parent(test_ba);
+    kpis.push_back(s);
+  }
+
+  time_t now(time(nullptr));
+
+  auto ss{std::make_shared<neb::service_status>()};
+  ss->service_id = 1;
+
+  for (size_t j = 0; j < kpis.size(); j++) {
+    ss->last_check = now - 10;
+    ss->host_id = j + 1;
+    ss->last_hard_state = 2;
+    kpis[j]->service_update(ss, _visitor.get());
+
+    auto dt{std::make_shared<neb::pb_downtime>()};
+    auto& downtime = dt->mut_obj();
+    downtime.set_id(j + 1);
+    downtime.set_host_id(ss->host_id);
+    downtime.set_service_id(1);
+    downtime.set_started(true);
+    downtime.set_actual_start_time(now - 5);
+    downtime.set_actual_end_time(0);
+    kpis[j]->service_update(dt, _visitor.get());
+  }
+  ASSERT_TRUE(test_ba->in_downtime());
+
+  auto cancelled{std::make_shared<neb::pb_downtime>()};
+  auto& cancelled_obj = cancelled->mut_obj();
+  cancelled_obj.set_id(1);
+  cancelled_obj.set_host_id(1);
+  cancelled_obj.set_service_id(1);
+  cancelled_obj.set_started(true);
+  cancelled_obj.set_cancelled(true);
+  cancelled_obj.set_actual_start_time(now - 5);
+  cancelled_obj.set_actual_end_time(0);
+  kpis[0]->service_update(cancelled, _visitor.get());
+
+  ASSERT_FALSE(kpis[0]->in_downtime());
+  ASSERT_FALSE(test_ba->in_downtime());
+
+  auto events = kpi_events(_visitor, 1);
+  ASSERT_FALSE(events.empty());
+  ASSERT_FALSE(events.back().in_downtime)
+      << "the last kpi event is still flagged in downtime";
+  auto dt_event = last_downtime_event(events);
+  ASSERT_TRUE(dt_event.has_value()) << "the kpi never entered downtime";
+  ASSERT_GT(dt_event->end_time, 0)
+      << "the in-downtime kpi event was left open, the reporting keeps the kpi "
+         "in downtime";
+}
+
+/**
+ * A downtime that reaches its end carries an actual_end_time but no
+ * deletion_time. Such an event ends the downtime and must never be discarded
+ * as a duplicated start, otherwise the kpi -- and the BA inheriting from it --
+ * stays in downtime forever.
+ */
+TEST_F(BamBA, KpiServiceDtEndsWithoutDeletionTime) {
+  std::shared_ptr<bam::ba> test_ba{
+      std::make_shared<bam::ba_ratio_percent>(1, 1, 4, true, _logger)};
+  test_ba->set_level_critical(100);
+  test_ba->set_level_warning(75);
+  test_ba->set_downtime_behaviour(bam::configuration::ba::dt_inherit);
+
+  std::vector<std::shared_ptr<bam::kpi_service>> kpis;
+  for (int i = 0; i < 4; i++) {
+    auto s = std::make_shared<bam::kpi_service>(
+        i + 1, 1, i + 1, 1, fmt::format("service {}", i), _logger);
+    s->set_state_hard(bam::state_critical);
+    s->set_state_soft(s->get_state_hard());
+    test_ba->add_impact(s);
+    s->add_parent(test_ba);
+    kpis.push_back(s);
+  }
+
+  time_t now(time(nullptr));
+
+  auto ss{std::make_shared<neb::service_status>()};
+  ss->service_id = 1;
+
+  for (size_t j = 0; j < kpis.size(); j++) {
+    ss->last_check = now + 1;
+    ss->host_id = j + 1;
+    ss->last_hard_state = 2;
+    kpis[j]->service_update(ss, _visitor.get());
+
+    auto dt{std::make_shared<neb::downtime>()};
+    dt->internal_id = j + 1;
+    dt->host_id = ss->host_id;
+    dt->service_id = 1;
+    dt->was_started = true;
+    dt->actual_start_time = now + 2;
+    dt->actual_end_time = 0;
+    kpis[j]->service_update(dt, _visitor.get());
+
+    /* A duplicated start is the only event the kpi may discard. */
+    kpis[j]->service_update(dt, _visitor.get());
+  }
+  ASSERT_TRUE(test_ba->in_downtime());
+
+  /* The downtime of the first kpi reaches its end. It is neither cancelled nor
+   * deleted, so deletion_time stays null. */
+  auto ended{std::make_shared<neb::downtime>()};
+  ended->internal_id = 1;
+  ended->host_id = 1;
+  ended->service_id = 1;
+  ended->was_started = true;
+  ended->actual_start_time = now + 2;
+  ended->actual_end_time = now + 10;
+  kpis[0]->service_update(ended, _visitor.get());
+
+  ASSERT_FALSE(kpis[0]->in_downtime());
+  ASSERT_FALSE(test_ba->in_downtime());
+
+  auto events = kpi_events(_visitor, 1);
+  ASSERT_FALSE(events.empty());
+  ASSERT_FALSE(events.back().in_downtime)
+      << "the last kpi event is still flagged in downtime";
+  auto dt_event = last_downtime_event(events);
+  ASSERT_TRUE(dt_event.has_value()) << "the kpi never entered downtime";
+  ASSERT_EQ(dt_event->end_time, now + 10)
+      << "the in-downtime kpi event was not closed at the downtime end";
+}
+
+TEST_F(BamBA, KpiServiceDtEndsWithoutDeletionTimePb) {
   std::shared_ptr<bam::ba> test_ba{
       std::make_shared<bam::ba_ratio_percent>(1, 1, 4, true, _logger)};
   test_ba->set_level_critical(100);
@@ -697,22 +881,32 @@ TEST_F(BamBA, KpiServiceDtCancelledWithoutEndTimePb) {
     downtime.set_actual_start_time(now + 2);
     downtime.set_actual_end_time(0);
     kpis[j]->service_update(dt, _visitor.get());
+
+    kpis[j]->service_update(dt, _visitor.get());
   }
   ASSERT_TRUE(test_ba->in_downtime());
 
-  auto cancelled{std::make_shared<neb::pb_downtime>()};
-  auto& cancelled_obj = cancelled->mut_obj();
-  cancelled_obj.set_id(1);
-  cancelled_obj.set_host_id(1);
-  cancelled_obj.set_service_id(1);
-  cancelled_obj.set_started(true);
-  cancelled_obj.set_cancelled(true);
-  cancelled_obj.set_actual_start_time(now + 2);
-  cancelled_obj.set_actual_end_time(0);
-  kpis[0]->service_update(cancelled, _visitor.get());
+  auto ended{std::make_shared<neb::pb_downtime>()};
+  auto& ended_obj = ended->mut_obj();
+  ended_obj.set_id(1);
+  ended_obj.set_host_id(1);
+  ended_obj.set_service_id(1);
+  ended_obj.set_started(true);
+  ended_obj.set_actual_start_time(now + 2);
+  ended_obj.set_actual_end_time(now + 10);
+  kpis[0]->service_update(ended, _visitor.get());
 
   ASSERT_FALSE(kpis[0]->in_downtime());
   ASSERT_FALSE(test_ba->in_downtime());
+
+  auto events = kpi_events(_visitor, 1);
+  ASSERT_FALSE(events.empty());
+  ASSERT_FALSE(events.back().in_downtime)
+      << "the last kpi event is still flagged in downtime";
+  auto dt_event = last_downtime_event(events);
+  ASSERT_TRUE(dt_event.has_value()) << "the kpi never entered downtime";
+  ASSERT_EQ(dt_event->end_time, now + 10)
+      << "the in-downtime kpi event was not closed at the downtime end";
 }
 
 TEST_F(BamBA, KpiServiceDtInheritOneOK) {

--- a/broker/bam/test/ba/kpi_service.cc
+++ b/broker/bam/test/ba/kpi_service.cc
@@ -2314,3 +2314,132 @@ TEST_F(BamBA, KpiServiceAcknowledgementPb) {
 
   _visitor->print_events();
 }
+
+/* On every engine start, send_initial_configuration() -> send_downtimes_list()
+ * re-announces every still-scheduled downtime as NEBTYPE_DOWNTIME_ADD, which
+ * cbmod::add_downtime emits with started=false, cancelled=false,
+ * actual_end_time=-1 and deletion_time=-1. Such an event carries no end
+ * information: it must not close the open in-downtime kpi_event nor drop the
+ * parent BA out of inherited downtime. */
+TEST_F(BamBA, DtAddResentOnEngineRestart) {
+  std::shared_ptr<bam::ba> test_ba{
+      std::make_shared<bam::ba_impact>(1, 1, 1, true, _logger)};
+  test_ba->set_level_critical(0);
+  test_ba->set_level_warning(50);
+  test_ba->set_downtime_behaviour(bam::configuration::ba::dt_inherit);
+
+  auto kpi = std::make_shared<bam::kpi_service>(1, 1, 1, 1, "service 1", _logger);
+  kpi->set_impact_critical(100);
+  kpi->set_state_hard(bam::state_critical);
+  kpi->set_state_soft(kpi->get_state_hard());
+  test_ba->add_impact(kpi);
+  kpi->add_parent(test_ba);
+
+  time_t now(time(nullptr));
+
+  auto ss{std::make_shared<neb::service_status>()};
+  ss->host_id = 1;
+  ss->service_id = 1;
+  ss->last_check = now;
+  ss->last_hard_state = 2;
+  kpi->service_update(ss, _visitor.get());
+
+  /* 1. The downtime really starts. */
+  auto dt{std::make_shared<neb::downtime>()};
+  dt->internal_id = 42;
+  dt->host_id = 1;
+  dt->service_id = 1;
+  dt->was_started = true;
+  dt->actual_start_time = now + 1;
+  dt->actual_end_time = -1;
+  dt->deletion_time = -1;
+  dt->was_cancelled = false;
+  kpi->service_update(dt, _visitor.get());
+  ASSERT_TRUE(test_ba->in_downtime()) << "precondition: BA must be in downtime";
+
+  size_t events_before = _visitor->queue().size();
+
+  /* 2. Engine restarts: the SAME still-running downtime is re-announced as
+   *    DOWNTIME_ADD, i.e. exactly what cbmod::add_downtime emits. */
+  auto readd{std::make_shared<neb::downtime>()};
+  readd->internal_id = 42;
+  readd->host_id = 1;
+  readd->service_id = 1;
+  readd->was_started = false;   /* add_downtime: set_started(false)      */
+  readd->actual_start_time = -1;/* add_downtime: set_actual_start_time(-1)*/
+  readd->actual_end_time = -1;  /* add_downtime: set_actual_end_time(-1)  */
+  readd->deletion_time = -1;    /* add_downtime: set_deletion_time(-1)    */
+  readd->was_cancelled = false; /* add_downtime: set_cancelled(false)     */
+  kpi->service_update(readd, _visitor.get());
+
+  auto events = _visitor->queue();
+  std::cout << "=== events emitted by the re-sent DOWNTIME_ADD: "
+            << (events.size() - events_before) << " ===" << std::endl;
+  _visitor->print_events();
+
+  EXPECT_TRUE(test_ba->in_downtime())
+      << "BA left downtime because a plain DOWNTIME_ADD was treated as an end";
+  EXPECT_EQ(events.size(), events_before)
+      << "the re-sent DOWNTIME_ADD split the kpi_event";
+}
+
+TEST_F(BamBA, DtAddResentOnEngineRestartPb) {
+  std::shared_ptr<bam::ba> test_ba{
+      std::make_shared<bam::ba_impact>(1, 1, 1, true, _logger)};
+  test_ba->set_level_critical(0);
+  test_ba->set_level_warning(50);
+  test_ba->set_downtime_behaviour(bam::configuration::ba::dt_inherit);
+
+  auto kpi = std::make_shared<bam::kpi_service>(1, 1, 1, 1, "service 1", _logger);
+  kpi->set_impact_critical(100);
+  kpi->set_state_hard(bam::state_critical);
+  kpi->set_state_soft(kpi->get_state_hard());
+  test_ba->add_impact(kpi);
+  kpi->add_parent(test_ba);
+
+  time_t now(time(nullptr));
+
+  auto ss{std::make_shared<neb::service_status>()};
+  ss->host_id = 1;
+  ss->service_id = 1;
+  ss->last_check = now;
+  ss->last_hard_state = 2;
+  kpi->service_update(ss, _visitor.get());
+
+  auto dt{std::make_shared<neb::pb_downtime>()};
+  auto& o = dt->mut_obj();
+  o.set_id(42);
+  o.set_host_id(1);
+  o.set_service_id(1);
+  o.set_started(true);
+  o.set_actual_start_time(now + 1);
+  o.set_actual_end_time(-1);
+  o.set_deletion_time(-1);
+  o.set_cancelled(false);
+  kpi->service_update(dt, _visitor.get());
+  ASSERT_TRUE(test_ba->in_downtime()) << "precondition: BA must be in downtime";
+
+  size_t events_before = _visitor->queue().size();
+
+  auto readd{std::make_shared<neb::pb_downtime>()};
+  auto& r = readd->mut_obj();
+  r.set_id(42);
+  r.set_host_id(1);
+  r.set_service_id(1);
+  r.set_started(false);
+  r.set_actual_start_time(-1);
+  r.set_actual_end_time(-1);
+  r.set_deletion_time(-1);
+  r.set_cancelled(false);
+  kpi->service_update(readd, _visitor.get());
+
+  auto events = _visitor->queue();
+  std::cout << "=== pb: events emitted by the re-sent DOWNTIME_ADD: "
+            << (events.size() - events_before) << " ===" << std::endl;
+  _visitor->print_events();
+
+  EXPECT_TRUE(test_ba->in_downtime())
+      << "BA left downtime because a plain DOWNTIME_ADD was treated as an end";
+  EXPECT_EQ(events.size(), events_before)
+      << "the re-sent DOWNTIME_ADD split the kpi_event";
+}

--- a/broker/core/bbdo/CMakeLists.txt
+++ b/broker/core/bbdo/CMakeLists.txt
@@ -21,7 +21,9 @@ include_directories(${CMAKE_BINARY_DIR}/bbdo)
 add_library(bbdo STATIC acceptor.cc connector.cc factory.cc
                         internal.cc stream.cc)
 
-add_dependencies(bbdo pb_bbdo_lib pb_extcmd_lib process_stat pb_open_telemetry_lib pb_neb_lib)
+add_dependencies(bbdo pb_bbdo_lib pb_extcmd_lib process_stat
+                 pb_open_telemetry_lib pb_neb_lib pb_storage_lib
+                 target_broker_message)
 target_precompile_headers(bbdo PRIVATE precomp_inc/precomp.hh)
 
 set_target_properties(bbdo PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/broker/core/cache/CMakeLists.txt
+++ b/broker/core/cache/CMakeLists.txt
@@ -54,7 +54,8 @@ add_custom_command(
 
 
 target_precompile_headers(global_cache PRIVATE precomp_inc/precomp.hpp)
-add_dependencies(global_cache  pb_common_lib process_stat)
+add_dependencies(global_cache pb_common_lib pb_header_lib pb_neb_lib pb_bam_lib
+                 process_stat)
 set_target_properties(global_cache PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Testing.
@@ -64,6 +65,7 @@ if(WITH_TESTING)
   )
 
   target_precompile_headers(ut_cache REUSE_FROM  global_cache )
+  add_dependencies(ut_cache pb_common_lib pb_header_lib pb_neb_lib pb_bam_lib)
   set_target_properties(ut_cache PROPERTIES POSITION_INDEPENDENT_CODE ON)
   set(TESTS_SOURCES
       ${TESTS_SOURCES} 

--- a/broker/core/cache/CMakeLists.txt
+++ b/broker/core/cache/CMakeLists.txt
@@ -43,6 +43,11 @@ add_custom_command(
       Comment,AdaptiveService,Host,Service,Tag,Instance,HostGroup,ServiceGroup,DimensionBaEvent,DimensionBvEvent 
   VERBATIM)
 
+# protobuf.hh is included by targets all over the tree (lua, http_tsdb, ...),
+# so expose its generation as a target they can depend on.
+add_custom_target(target_cache_protobuf
+                  DEPENDS ${SRC_DIR}/protobuf.cc ${INC_DIR}/protobuf.hh)
+
 add_custom_command(
   OUTPUT ${TEST_DIR}/protobuf_test_classes.cc ${TEST_DIR}/protobuf_test_classes.hh
   COMMENT "Generating protobuf_test_classes.hh and protobuf_test_classes.cc from protobuf files"
@@ -55,7 +60,7 @@ add_custom_command(
 
 target_precompile_headers(global_cache PRIVATE precomp_inc/precomp.hpp)
 add_dependencies(global_cache pb_common_lib pb_header_lib pb_neb_lib pb_bam_lib
-                 process_stat)
+                 process_stat pb_storage_lib target_broker_message)
 set_target_properties(global_cache PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Testing.

--- a/broker/core/cache/CMakeLists.txt
+++ b/broker/core/cache/CMakeLists.txt
@@ -60,7 +60,8 @@ add_custom_command(
 
 target_precompile_headers(global_cache PRIVATE precomp_inc/precomp.hpp)
 add_dependencies(global_cache pb_common_lib pb_header_lib pb_neb_lib pb_bam_lib
-                 process_stat pb_storage_lib target_broker_message)
+                 process_stat pb_storage_lib pb_open_telemetry_lib
+                 target_broker_message)
 set_target_properties(global_cache PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Testing.

--- a/broker/core/multiplexing/CMakeLists.txt
+++ b/broker/core/multiplexing/CMakeLists.txt
@@ -29,7 +29,8 @@ set(SOURCES ${SRC_DIR}/engine.cc ${SRC_DIR}/muxer.cc ${SRC_DIR}/publisher.cc)
 
 # Static libraries.
 add_library(multiplexing STATIC ${SOURCES})
-add_dependencies(multiplexing pb_bbdo_lib pb_extcmd_lib process_stat global_cache)
+add_dependencies(multiplexing pb_bbdo_lib pb_extcmd_lib process_stat
+                 global_cache target_broker_message)
 
 set_target_properties(multiplexing PROPERTIES COMPILE_FLAGS "-fPIC")
 target_precompile_headers(multiplexing PRIVATE ../precomp_inc/precomp.hpp)

--- a/broker/core/sql/CMakeLists.txt
+++ b/broker/core/sql/CMakeLists.txt
@@ -84,7 +84,7 @@ add_library(sql STATIC ${SOURCES})
 set_target_properties(sql PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_precompile_headers(sql PRIVATE ../precomp_inc/precomp.hpp)
 target_link_libraries(sql PRIVATE mariadb ctnvault centreon_http fmt::fmt)
-add_dependencies(sql process_stat pb_common_lib)
+add_dependencies(sql process_stat pb_common_lib target_broker_message)
 
 if(WITH_TESTING)
   set(TESTS_SOURCES

--- a/broker/event_script/CMakeLists.txt
+++ b/broker/event_script/CMakeLists.txt
@@ -38,7 +38,8 @@ target_precompile_headers("80-event_script" PRIVATE precomp_inc/precomp.hpp)
 set_target_properties("80-event_script" PROPERTIES PREFIX ""
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/broker/lib")
 
-add_dependencies("80-event_script" process_stat)
+add_dependencies("80-event_script" process_stat pb_common_lib
+                 target_broker_message)
 
 #Testing.
 if(WITH_TESTING)

--- a/broker/graphite/CMakeLists.txt
+++ b/broker/graphite/CMakeLists.txt
@@ -49,7 +49,8 @@ target_link_libraries("${GRAPHITE}"
 target_precompile_headers(${GRAPHITE} PRIVATE precomp_inc/precomp.hpp)
 set_target_properties("${GRAPHITE}" PROPERTIES PREFIX ""
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/broker/lib")
-add_dependencies("${GRAPHITE}" nebbase)
+add_dependencies("${GRAPHITE}" nebbase target_broker_message
+                 target_cache_protobuf)
 
 # Testing.
 if (WITH_TESTING)

--- a/broker/grpc/CMakeLists.txt
+++ b/broker/grpc/CMakeLists.txt
@@ -49,6 +49,7 @@ set(GRPC
 add_library(${GRPC} SHARED ${SOURCES})
 set_target_properties(${GRPC} PROPERTIES PREFIX ""
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/broker/lib")
+add_dependencies(${GRPC} target_broker_message target_process_stat_proto)
 target_link_libraries(
   ${GRPC}
   centreon_grpc

--- a/broker/http_tsdb/CMakeLists.txt
+++ b/broker/http_tsdb/CMakeLists.txt
@@ -45,12 +45,9 @@ set(HEADERS
 )
 
 add_library(http_tsdb STATIC ${SOURCES} ${HEADERS})
-add_dependencies(http_tsdb
-	pb_neb_lib
-	pb_header_lib
-	process_stat
-	pb_storage_lib
-	)
+add_dependencies(http_tsdb pb_neb_lib pb_header_lib process_stat pb_storage_lib
+                 pb_bam_lib pb_common_lib target_broker_message
+                 target_cache_protobuf)
 target_include_directories(http_tsdb PRIVATE ${INC_DIR})
 
 target_precompile_headers(http_tsdb PRIVATE precomp_inc/precomp.hh)

--- a/broker/influxdb/CMakeLists.txt
+++ b/broker/influxdb/CMakeLists.txt
@@ -58,7 +58,8 @@ target_link_libraries(
 target_precompile_headers(${INFLUXDB} PRIVATE precomp_inc/precomp.hpp)
 set_target_properties("${INFLUXDB}" PROPERTIES PREFIX ""
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/broker/lib")
-add_dependencies("${INFLUXDB}" nebbase process_stat)
+add_dependencies("${INFLUXDB}" nebbase process_stat target_broker_message
+                 target_cache_protobuf)
 
 # Testing.
 if(WITH_TESTING)

--- a/broker/lua/CMakeLists.txt
+++ b/broker/lua/CMakeLists.txt
@@ -62,7 +62,8 @@ add_library(
   "${INC_DIR}/luabinding.hh"
   "${INC_DIR}/stream.hh")
 add_dependencies(${LUA} pb_neb_lib pb_storage_lib pb_bam_lib process_stat
-                 pb_open_telemetry_lib)
+                 pb_open_telemetry_lib target_broker_message
+                 target_cache_protobuf)
 
 target_link_libraries(
   "${LUA}"

--- a/broker/neb/CMakeLists.txt
+++ b/broker/neb/CMakeLists.txt
@@ -79,7 +79,7 @@ add_library(
   # Main source.
   ${SRC_DIR}/broker.cc)
 
-add_dependencies(${NEB} nebbase)
+add_dependencies(${NEB} nebbase target_broker_message)
 
 # Flags needed to include all symbols in binary.
 target_link_libraries(${NEB} PRIVATE -Wl,--whole-archive nebbase -Wl,--no-whole-archive fmt::fmt)
@@ -96,6 +96,7 @@ add_library(cbmod SHARED ${SRC_DIR}/cbmod.cc
                          ${PROJECT_SOURCE_DIR}/core/src/config/applier/init.cc)
 
 set_target_properties(cbmod PROPERTIES PREFIX "" POSITION_INDEPENDENT_CODE ON)
+add_dependencies(cbmod target_state_proto)
 
 target_precompile_headers(cbmod REUSE_FROM nebbase)
 target_link_libraries(

--- a/broker/rrd/CMakeLists.txt
+++ b/broker/rrd/CMakeLists.txt
@@ -87,7 +87,8 @@ add_library(
 set_target_properties("${RRD}" PROPERTIES PREFIX ""
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/broker/lib")
 target_precompile_headers(${RRD} PRIVATE precomp_inc/precomp.hpp)
-add_dependencies("${RRD}" pb_rebuild_message_lib pb_remove_graph_message_lib process_stat)
+add_dependencies("${RRD}" pb_rebuild_message_lib pb_remove_graph_message_lib
+                 process_stat target_broker_message)
 
 # Compile with librrd flags.
 if(LIBRRD_CFLAGS)

--- a/broker/simu/CMakeLists.txt
+++ b/broker/simu/CMakeLists.txt
@@ -46,8 +46,8 @@ add_library(
   "${INC_DIR}/luabinding.hh"
   "${INC_DIR}/stream.hh")
 add_dependencies(${SIMU} pb_neb_lib pb_header_lib pb_storage_lib pb_bam_lib
-                 process_stat
-                 pb_open_telemetry_lib)
+                 process_stat pb_open_telemetry_lib pb_common_lib
+                 target_broker_message)
 
 target_link_libraries("${SIMU}" PRIVATE ${LUA_LIBRARIES} fmt::fmt)
 target_precompile_headers(${SIMU} PRIVATE precomp_inc/precomp.hpp)

--- a/broker/sql/CMakeLists.txt
+++ b/broker/sql/CMakeLists.txt
@@ -42,12 +42,9 @@ add_library("${SQL}" SHARED
   "${INC_DIR}/com/centreon/broker/sql/factory.hh"
   "${INC_DIR}/com/centreon/broker/sql/stream.hh"
 )
-add_dependencies(${SQL}
-	pb_neb_lib
-	process_stat
-	pb_header_lib
-	pb_open_telemetry_lib
-	)
+add_dependencies(${SQL} pb_neb_lib process_stat pb_header_lib
+                 pb_open_telemetry_lib pb_common_lib target_broker_message
+                 target_state_proto)
 
 set_target_properties("${SQL}" PROPERTIES
     PREFIX ""

--- a/broker/stats/CMakeLists.txt
+++ b/broker/stats/CMakeLists.txt
@@ -46,7 +46,7 @@ set_target_properties("${STATS}" PROPERTIES PREFIX ""
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/broker/lib")
 target_link_libraries("${STATS}" PRIVATE fmt::fmt)
 target_precompile_headers(${STATS} PRIVATE precomp_inc/precomp.hpp)
-add_dependencies(${STATS} process_stat pb_common_lib)
+add_dependencies(${STATS} process_stat pb_common_lib target_broker_message)
 
 # Testing.
 if(WITH_TESTING)

--- a/broker/storage/CMakeLists.txt
+++ b/broker/storage/CMakeLists.txt
@@ -42,8 +42,8 @@ set(CONFLICTMGR
     PARENT_SCOPE)
 add_dependencies(conflictmgr process_stat pb_bbdo_lib pb_neb_lib
                  pb_rebuild_message_lib pb_remove_graph_message_lib
-                 pb_storage_lib table_max_size target_broker_message
-                 target_state_proto)
+                 pb_storage_lib pb_open_telemetry_lib table_max_size
+                 target_broker_message target_state_proto)
 
 set_target_properties(conflictmgr PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(conflictmgr PRIVATE fmt::fmt)

--- a/broker/storage/CMakeLists.txt
+++ b/broker/storage/CMakeLists.txt
@@ -40,9 +40,10 @@ add_library(
 set(CONFLICTMGR
     conflictmgr
     PARENT_SCOPE)
-add_dependencies(conflictmgr
-	process_stat
-	)
+add_dependencies(conflictmgr process_stat pb_bbdo_lib pb_neb_lib
+                 pb_rebuild_message_lib pb_remove_graph_message_lib
+                 pb_storage_lib table_max_size target_broker_message
+                 target_state_proto)
 
 set_target_properties(conflictmgr PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(conflictmgr PRIVATE fmt::fmt)

--- a/broker/storage/src/conflict_manager_sql.cc
+++ b/broker/storage/src/conflict_manager_sql.cc
@@ -108,10 +108,11 @@ void conflict_manager::_clean_tables(uint64_t instance_id) {
    * makes every consumer (BAM in_downtime computation, availability reporting)
    * consider the downtime still running forever. */
   query = fmt::format(
-      "UPDATE downtimes SET cancelled=1,actual_end_time={} WHERE "
+      "UPDATE downtimes SET cancelled=1,actual_end_time={},deletion_time={} "
+      "WHERE "
       "actual_end_time IS NULL AND cancelled=0 "
       "AND instance_id={}",
-      time(nullptr), instance_id);
+      time(nullptr), time(nullptr), instance_id);
 
   _mysql.run_query(query, database::mysql_error::clean_downtimes, conn);
   _add_action(conn, actions::downtimes);

--- a/broker/storage/src/conflict_manager_sql.cc
+++ b/broker/storage/src/conflict_manager_sql.cc
@@ -104,11 +104,14 @@ void conflict_manager::_clean_tables(uint64_t instance_id) {
   // Cancellation of downtimes.
   _logger_sql->debug("SQL: Cancellation of downtimes (instance_id: {})",
                      instance_id);
+  /* A cancelled downtime must also be terminated: leaving actual_end_time NULL
+   * makes every consumer (BAM in_downtime computation, availability reporting)
+   * consider the downtime still running forever. */
   query = fmt::format(
-      "UPDATE downtimes SET cancelled=1 WHERE actual_end_time IS NULL AND "
-      "cancelled=0 "
+      "UPDATE downtimes SET cancelled=1,actual_end_time={} WHERE "
+      "actual_end_time IS NULL AND cancelled=0 "
       "AND instance_id={}",
-      instance_id);
+      time(nullptr), instance_id);
 
   _mysql.run_query(query, database::mysql_error::clean_downtimes, conn);
   _add_action(conn, actions::downtimes);

--- a/broker/tcp/CMakeLists.txt
+++ b/broker/tcp/CMakeLists.txt
@@ -41,7 +41,7 @@ set_target_properties("${TCP}" PROPERTIES PREFIX ""
   POSITION_INDEPENDENT_CODE ON
 	LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/broker/lib"
 )
-add_dependencies("${TCP}" process_stat pb_common_lib)
+add_dependencies("${TCP}" process_stat pb_common_lib target_broker_message)
 target_link_libraries("${TCP}" fmt::fmt)
 target_precompile_headers(${TCP} PRIVATE precomp_inc/precomp.hpp)
 

--- a/broker/tls/CMakeLists.txt
+++ b/broker/tls/CMakeLists.txt
@@ -63,7 +63,7 @@ add_library("${TLS}" SHARED
 
 target_link_libraries("${TLS}" PRIVATE ${GNUTLS_LIBRARIES} fmt::fmt)
 target_precompile_headers(${TLS} PRIVATE precomp_inc/precomp.hpp)
-add_dependencies("${TLS}" process_stat pb_common_lib)
+add_dependencies("${TLS}" process_stat pb_common_lib target_broker_message)
 
 set_target_properties("${TLS}" PROPERTIES PREFIX ""
 	LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/broker/lib"

--- a/broker/unified_sql/CMakeLists.txt
+++ b/broker/unified_sql/CMakeLists.txt
@@ -58,10 +58,8 @@ set_target_properties("${UNIFIED_SQL}" PROPERTIES PREFIX ""
   POSITION_INDEPENDENT_CODE TRUE
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/broker/lib")
 add_dependencies("${UNIFIED_SQL}" pb_rebuild_message_lib
-                 pb_remove_graph_message_lib
-                  process_stat
-                 pb_neb_lib
-                 pb_open_telemetry_lib)
+                 pb_remove_graph_message_lib process_stat pb_neb_lib
+                 pb_open_telemetry_lib target_broker_message)
 target_precompile_headers(${UNIFIED_SQL} PRIVATE precomp_inc/precomp.hpp)
 target_link_libraries(
   ${UNIFIED_SQL} PRIVATE

--- a/broker/unified_sql/src/stream_sql.cc
+++ b/broker/unified_sql/src/stream_sql.cc
@@ -166,9 +166,10 @@ void stream::_clean_tables(uint64_t instance_id) {
    * makes every consumer (BAM in_downtime computation, availability
    * reporting)*/
   query = fmt::format(
-      "UPDATE downtimes SET cancelled=1,actual_end_time={} WHERE "
+      "UPDATE downtimes SET cancelled=1,actual_end_time={},deletion_time={} "
+      "WHERE "
       "actual_end_time IS NULL AND cancelled=0 AND instance_id={}",
-      time(nullptr), instance_id);
+      time(nullptr), time(nullptr), instance_id);
 
   _mysql.run_query(query, database::mysql_error::clean_downtimes, conn);
   _add_action(conn, actions::downtimes);

--- a/broker/unified_sql/src/stream_sql.cc
+++ b/broker/unified_sql/src/stream_sql.cc
@@ -162,10 +162,13 @@ void stream::_clean_tables(uint64_t instance_id) {
   SPDLOG_LOGGER_DEBUG(
       _logger_sql, "unified_sql: Cancellation of downtimes (instance_id: {})",
       instance_id);
+  /* A cancelled downtime must also be terminated: leaving actual_end_time NULL
+   * makes every consumer (BAM in_downtime computation, availability
+   * reporting)*/
   query = fmt::format(
-      "UPDATE downtimes SET cancelled=1 WHERE actual_end_time IS NULL AND "
-      "cancelled=0 AND instance_id={}",
-      instance_id);
+      "UPDATE downtimes SET cancelled=1,actual_end_time={} WHERE "
+      "actual_end_time IS NULL AND cancelled=0 AND instance_id={}",
+      time(nullptr), instance_id);
 
   _mysql.run_query(query, database::mysql_error::clean_downtimes, conn);
   _add_action(conn, actions::downtimes);

--- a/broker/victoria_metrics/CMakeLists.txt
+++ b/broker/victoria_metrics/CMakeLists.txt
@@ -55,6 +55,8 @@ add_library("${VICTORIA_METRICS}" SHARED
 )
 set_target_properties("${VICTORIA_METRICS}" PROPERTIES PREFIX ""
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/broker/lib")
+add_dependencies("${VICTORIA_METRICS}" target_broker_message
+                 target_cache_protobuf)
 target_link_libraries("${VICTORIA_METRICS}"
   http_tsdb
   centreon_http

--- a/common/process_stat/CMakeLists.txt
+++ b/common/process_stat/CMakeLists.txt
@@ -31,6 +31,17 @@ add_custom_command(
   --proto_path=${CMAKE_CURRENT_SOURCE_DIR} process_stat.proto
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
+# process_stat.pb.h is included by targets outside this directory; expose its
+# generation separately so they can order against it without depending on the
+# process_stat library itself (which reuses centreon_common's precompiled
+# header, and would therefore create a dependency cycle).
+add_custom_target(target_process_stat_proto
+  DEPENDS
+    ${CMAKE_BINARY_DIR}/common/process_stat/process_stat.pb.cc
+    ${CMAKE_BINARY_DIR}/common/process_stat/process_stat.pb.h
+    ${CMAKE_BINARY_DIR}/common/process_stat/process_stat.grpc.pb.cc
+    ${CMAKE_BINARY_DIR}/common/process_stat/process_stat.grpc.pb.h)
+
 add_library(process_stat STATIC
   ${CMAKE_BINARY_DIR}/common/process_stat/process_stat.pb.cc
   process_stat.cc

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -499,7 +499,7 @@ include_directories(enginerpc ${CMAKE_SOURCE_DIR}/common/src
 
 # centenginestats target.
 add_executable(centenginestats "${SRC_DIR}/centenginestats.cc")
-add_dependencies(centenginestats centreon_clib)
+add_dependencies(centenginestats centreon_clib pb_neb_lib target_state_proto)
 target_link_libraries(centenginestats PRIVATE centreon_clib fmt::fmt absl::log absl::base absl::log_internal_check_op)
 
 target_precompile_headers(centenginestats PRIVATE ${PRECOMP_HEADER})

--- a/engine/enginerpc/CMakeLists.txt
+++ b/engine/enginerpc/CMakeLists.txt
@@ -73,7 +73,7 @@ add_library(
   "${INC_DIR}/engine_impl.hh" "${INC_DIR}/enginerpc.hh")
 
 add_dependencies(enginerpc centreon_common process_stat cerpc pb_neb_lib
-                 pb_storage_lib target_state_proto)
+                 pb_storage_lib pb_open_telemetry_lib target_state_proto)
 target_precompile_headers(enginerpc PRIVATE precomp_inc/precomp.hh)
 
 # Prettier name.

--- a/engine/enginerpc/CMakeLists.txt
+++ b/engine/enginerpc/CMakeLists.txt
@@ -72,7 +72,8 @@ add_library(
   # Headers.
   "${INC_DIR}/engine_impl.hh" "${INC_DIR}/enginerpc.hh")
 
-add_dependencies(enginerpc centreon_common process_stat cerpc)
+add_dependencies(enginerpc centreon_common process_stat cerpc pb_neb_lib
+                 pb_storage_lib target_state_proto)
 target_precompile_headers(enginerpc PRIVATE precomp_inc/precomp.hh)
 
 # Prettier name.

--- a/engine/modules/external_commands/CMakeLists.txt
+++ b/engine/modules/external_commands/CMakeLists.txt
@@ -37,7 +37,7 @@ set_property(TARGET "externalcmd" PROPERTY PREFIX "")
 target_precompile_headers("externalcmd" PRIVATE precomp_inc/precomp.hh)
 
 add_dependencies(externalcmd centreon_clib pb_neb_lib pb_storage_lib
-                 target_state_proto)
+                 pb_open_telemetry_lib target_state_proto)
 target_link_libraries(externalcmd PRIVATE centreon_clib)
 
 install(

--- a/engine/modules/external_commands/CMakeLists.txt
+++ b/engine/modules/external_commands/CMakeLists.txt
@@ -36,7 +36,8 @@ add_library(
 set_property(TARGET "externalcmd" PROPERTY PREFIX "")
 target_precompile_headers("externalcmd" PRIVATE precomp_inc/precomp.hh)
 
-add_dependencies(externalcmd centreon_clib pb_neb_lib)
+add_dependencies(externalcmd centreon_clib pb_neb_lib pb_storage_lib
+                 target_state_proto)
 target_link_libraries(externalcmd PRIVATE centreon_clib)
 
 install(

--- a/engine/modules/opentelemetry/CMakeLists.txt
+++ b/engine/modules/opentelemetry/CMakeLists.txt
@@ -107,7 +107,7 @@ target_link_libraries(
           ctncrypto)
 
 add_dependencies(opentelemetry pb_open_telemetry_lib pb_header_lib pb_neb_lib
-                 engine_rpc target_timeperiod_proto)
+                 engine_rpc target_timeperiod_proto target_process_stat_proto)
 
 target_include_directories(
   opentelemetry

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -167,6 +167,7 @@ if(WITH_TESTING)
       "${TESTS_DIR}/test_engine.hh"
       "${TESTS_DIR}/timeperiod/utils.hh")
   add_library(ut_engine_utils STATIC "${TESTS_DIR}/timeperiod/utils.cc")
+  add_dependencies(ut_engine_utils target_state_proto)
   target_link_libraries(ut_engine_utils PRIVATE dl)
   add_executable(ut_engine ${ut_sources})
   target_include_directories(

--- a/tests/bam/inherited_downtime.robot
+++ b/tests/bam/inherited_downtime.robot
@@ -367,5 +367,5 @@ Ctn BAM Setup
     ${date}    Get Current Date    result_format=epoch
     Log To Console    date=${date}
     Execute SQL String
-    ...    UPDATE downtimes SET deletion_time=${date}, actual_end_time=${date} WHERE actual_end_time is null
+    ...    UPDATE downtimes SET deletion_time=${date}, actual_end_time=${date} WHERE deletion_time IS NULL
     Disconnect From Database

--- a/tests/bam/pb_inherited_downtime.robot
+++ b/tests/bam/pb_inherited_downtime.robot
@@ -401,7 +401,7 @@ Ctn BAM Setup
     ${date}    Get Current Date    result_format=epoch
     Log To Console    Cleaning downtimes at date=${date}
     Execute SQL String
-    ...    UPDATE downtimes SET deletion_time=${date}, actual_end_time=${date} WHERE actual_end_time is null
+    ...    UPDATE downtimes SET deletion_time=${date}, actual_end_time=${date} WHERE deletion_time IS NULL
     Execute SQL String    UPDATE services SET scheduled_downtime_depth=0
     Execute SQL String    UPDATE hosts SET scheduled_downtime_depth=0
     Execute SQL String    UPDATE resources SET in_downtime=0

--- a/tests/broker-engine/downtimes.robot
+++ b/tests/broker-engine/downtimes.robot
@@ -676,6 +676,71 @@ DT_WITH_QUOTES
     [Teardown]    Ctn Stop Engine Broker And Save Logs
 
 
+BEDTCANCELCLEAN
+    [Documentation]    Given a downtime running on a poller that is lost brutally
+    ...    When the poller comes back without its retention
+    ...    Then unified_sql cancels the orphaned downtime AND sets its actual_end_time
+    ...    So that availability reporting does not consider it running forever.
+    [Tags]    broker    engine    downtime    MON-198964
+    Ctn Clear Logs
+    Ctn Config Engine    ${1}
+    Ctn Config Broker    rrd
+    Ctn Config Broker    central
+    Ctn Config Broker    module    ${1}
+    Ctn Broker Config Log    central    sql    debug
+    Ctn Config Broker Sql Output    central    unified_sql
+    Ctn Config BBDO3    1
+    Ctn Clear Retention
+
+    ${start}    Ctn Get Round Current Date
+    Ctn Start Broker
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${start}    ${1}
+
+    # A fixed downtime on a host also puts its 20 services in downtime.
+    Ctn Schedule Host Fixed Downtime    ${0}    host_1    ${3600}
+    ${content}    Create List    HOST DOWNTIME ALERT: host_1;STARTED; Host has entered a period of scheduled downtime
+    ${result}    Ctn Find In Log With Timeout    ${engineLog0}    ${start}    ${content}    60
+    Should Be True    ${result}    The downtime on host_1 should have started.
+
+    ${result}    Ctn Check Number Of Downtimes    ${21}    ${start}    ${60}
+    Should Be True    ${result}    We should have 21 downtimes (1 host + 20 services) enabled.
+
+    Connect To Database    pymysql    ${DBName}    ${DBUser}    ${DBPass}    ${DBHost}    ${DBPort}
+
+    # The downtimes are running: neither cancelled nor terminated.
+    ${running}    Catenate    SELECT downtime_id FROM downtimes
+    ...    WHERE start_time >= ${start} AND started=1 AND cancelled=0 AND actual_end_time IS NULL
+    Check Row Count    ${running}    ==    21    retry_timeout=60s    retry_pause=2s
+
+    # The poller is lost brutally: engine has no chance to terminate its
+    # downtimes, so they stay open in the database. A graceful stop would
+    # terminate them itself and would not exercise _clean_tables().
+    Ctn Kill Engine
+    Check Row Count    ${running}    ==    21    retry_timeout=30s    retry_pause=2s
+
+    # The poller comes back with no retention: it does not resend the downtimes,
+    # and its instance event makes unified_sql run _clean_tables().
+    Ctn Clear Retention
+    ${restart}    Ctn Get Round Current Date
+    Ctn Start Engine
+    Ctn Wait For Engine To Be Ready    ${restart}    ${1}
+
+    # Regression MON-198964: before the fix actual_end_time stayed NULL, so every
+    # consumer kept considering these downtimes as still running.
+    ${terminated}    Catenate    SELECT downtime_id FROM downtimes
+    ...    WHERE start_time >= ${start} AND cancelled=1 AND actual_end_time IS NOT NULL
+    Check Row Count    ${terminated}    ==    21    retry_timeout=60s    retry_pause=2s
+
+    ${dangling}    Catenate    SELECT downtime_id FROM downtimes
+    ...    WHERE start_time >= ${start} AND actual_end_time IS NULL
+    Check Row Count    ${dangling}    ==    0    retry_timeout=30s    retry_pause=2s
+
+    Disconnect From Database
+
+    [Teardown]    Ctn Stop Engine Broker And Save Logs
+
+
 *** Keywords ***
 Ctn Clean Downtimes Before Suite
     Ctn Clean Before Suite


### PR DESCRIPTION
fix(broker/bam): set deletion_time to time now in clean_table.
fix(broker/bam): close the kpi event when a downtime ends with no end time
fix(broker) : a cancel downtime is over even if it's no actual_end_time.

refs: MON-198964