### PR TITLE
enh(delivery): target jfrog artifactory through its native hostname

### DIFF
--- a/.github/actions/deb-delivery/action.yml
+++ b/.github/actions/deb-delivery/action.yml
@@ -38,7 +38,7 @@ runs:
 
     - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
 
     - name: Parse distrib name

--- a/.github/actions/promote-to-stable/action.yml
+++ b/.github/actions/promote-to-stable/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
 
     - name: Parse distrib name

--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -38,13 +38,13 @@ runs:
 
     - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
 
     - name: Publish RPMs
       shell: bash
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
         MODULE_NAME: ${{ inputs.module_name }}
         DISTRIB: ${{ inputs.distrib }}

--- a/.github/docker/gorgone/bookworm/Dockerfile.testing-dependencies
+++ b/.github/docker/gorgone/bookworm/Dockerfile.testing-dependencies
@@ -59,7 +59,7 @@ echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${VERSI
 echo "deb https://packages.centreon.com/apt-plugins-stable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
 echo "deb https://packages.centreon.com/apt-plugins-testing/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list
 echo "deb https://packages.centreon.com/apt-plugins-unstable/ \$VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-unstable.list
-wget -O- https://packages.centreon.com/api/security/keypair/APT-GPG-KEY/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
+wget -O- https://apt-key.centreon.com/ | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 
 apt-get update
 

--- a/.github/scripts/deliver-cma-assets.sh
+++ b/.github/scripts/deliver-cma-assets.sh
@@ -134,14 +134,14 @@ search_artifactory() {
     -H "Authorization: Bearer ${ARTIFACTORY_TOKEN}" \
     -H "Content-Type: text/plain" \
     --data "$aql" \
-    "https://packages.centreon.com/artifactory/api/search/aql"
+    "https://centreon.jfrog.io/artifactory/api/search/aql"
 }
 
 download_from_artifactory() {
   local repo="$1" art_path="$2" name="$3" dest_dir="$4"
   curl --fail --silent \
     -H "Authorization: Bearer ${ARTIFACTORY_TOKEN}" \
-    "https://packages.centreon.com/artifactory/${repo}/${art_path}/${name}" \
+    "https://centreon.jfrog.io/artifactory/${repo}/${art_path}/${name}" \
     -o "${dest_dir}/${name}"
   echo "${dest_dir}/${name}"
 }


### PR DESCRIPTION
Backport of #3664 to `release-24.10-next` (cherry-pick). Related to: [MON-207928](https://centreon.atlassian.net/browse/MON-207928)

Everything that writes to or reads from jfrog artifactory in CI targets its native hostname `https://centreon.jfrog.io` instead of `https://packages.centreon.com`, so artifactory deliveries keep working when `packages.centreon.com` switches to pulp. Client-facing URLs are untouched.

[MON-207928]: https://centreon.atlassian.net/browse/MON-207928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ