### PR TITLE
enh(docker): wire Alpine (musl) engine/broker images into the real CI

### DIFF
--- a/.github/actions/parse-distrib/action.yml
+++ b/.github/actions/parse-distrib/action.yml
@@ -107,6 +107,14 @@ runs:
           DISTRIB_FAMILY="ubuntu"
           DISTRIB_NAME="noble"
           REPO_DISTRIB_NAME="noble"
+        elif [[ "$DISTRIB" == "alpine" ]]; then
+          PACKAGE_DISTRIB_SEPARATOR="-"
+          PACKAGE_VERSION_SEPARATOR="-"
+          PACKAGE_DISTRIB_NAME="alpine3.20"
+          PACKAGE_EXTENSION="apk"
+          DISTRIB_FAMILY="alpine"
+          DISTRIB_NAME="alpine"
+          REPO_DISTRIB_NAME="alpine"
         else
           echo "::error::Distrib $DISTRIB cannot be parsed"
           exit 1

--- a/.github/docker/Dockerfile.packaging-centreon-collect-alpine
+++ b/.github/docker/Dockerfile.packaging-centreon-collect-alpine
@@ -1,0 +1,104 @@
+ARG REGISTRY_URL
+
+FROM ${REGISTRY_URL}/alpine:3.20 AS centreon_collect_packaging
+
+RUN apk add --no-cache \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    make \
+    perl \
+    sudo \
+    unzip \
+    wget \
+    zip \
+    zstd
+
+# nfpm has no apk repo of its own on Alpine - fetch the upstream static
+# Go binary release directly (same version pinned as the trixie image).
+RUN bash -e <<EOF
+
+ARCH=\$(uname -m)
+if [ "\$ARCH" = "aarch64" ]; then
+  NFPM_ARCH="arm64"
+else
+  NFPM_ARCH="x86_64"
+fi
+
+curl -fsSL -o /tmp/nfpm.tar.gz "https://github.com/goreleaser/nfpm/releases/download/v2.41.1/nfpm_2.41.1_Linux_\${NFPM_ARCH}.tar.gz"
+tar -xzf /tmp/nfpm.tar.gz -C /usr/local/bin nfpm
+chmod +x /usr/local/bin/nfpm
+rm -f /tmp/nfpm.tar.gz
+
+EOF
+
+FROM centreon_collect_packaging AS centreon_collect_packaging_vcpkg
+
+RUN bash -e <<EOF
+
+apk add --no-cache \
+    build-base \
+    cmake \
+    curl-dev \
+    gdb \
+    gnutls-dev \
+    libgcrypt-dev \
+    lua5.4-dev \
+    mariadb-connector-c-dev \
+    musl-dev \
+    openssl \
+    openssl-dev \
+    perl-dev \
+    pkgconf \
+    python3 \
+    rrdtool-dev \
+    samurai \
+    libssh2-dev \
+    strace \
+    zlib-dev
+
+# Alpine has no ninja apk package - samurai is a drop-in, vcpkg/CMake just
+# need a binary named "ninja" on PATH.
+ln -sf "\$(command -v samu)" /usr/local/bin/ninja
+
+EOF
+
+COPY vcpkg.json /root/vcpkg.json
+COPY overlays /overlays
+COPY custom-triplets /custom-triplets
+
+ARG TRIPLET
+
+RUN bash -e <<EOF
+
+if [ "${TRIPLET}" = "arm64-linux" ] ; then
+  export VCPKG_FORCE_SYSTEM_BINARIES=arm
+fi
+
+git clone --depth 1 -b 2026.05.25 https://github.com/Microsoft/vcpkg.git
+#jobs have to share all cpus of the host but see all cpus
+#so, if we not limit concurrency, each job will start ntotal_cpu+1 gcc
+export VCPKG_MAX_CONCURRENCY=8
+export VCPKG_FORCE_SYSTEM_BINARIES=1
+./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+export VCPKG_ROOT=/vcpkg
+export PATH=\$VCPKG_ROOT:\$PATH
+
+mkdir /src
+cp /root/vcpkg.json /src/vcpkg.json
+
+/vcpkg/vcpkg install \
+  --clean-after-build \
+  --overlay-triplets=custom-triplets \
+  --triplet ${TRIPLET}-release \
+  --vcpkg-root vcpkg \
+  --x-wait-for-lock \
+  --x-manifest-root=/src \
+  --x-install-root=vcpkg_installed \
+  --overlay-ports=overlays
+
+EOF
+
+WORKDIR /src

--- a/.github/docker/Dockerfile.packaging-centreon-collect-alpine
+++ b/.github/docker/Dockerfile.packaging-centreon-collect-alpine
@@ -69,15 +69,19 @@ apk add --no-cache \
 # need a binary named "ninja" on PATH.
 ln -sf "\$(command -v samu)" /usr/local/bin/ninja
 
-# Alpine's lua5.4/lua5.4-dev only ship versioned library symlinks
-# (/usr/lib/lua5.4/liblua5.4.so.X) - by design, so multiple Lua versions
-# can coexist without colliding, with pkg-config as the intended discovery
-# path. CMake's find_package(Lua) isn't pkg-config-aware though; it looks
-# for a plain unversioned liblua5.4.so via find_library(), which doesn't
-# exist here. Without it, LUA_LIBRARIES silently resolves empty (no
-# CMake error - find_package(Lua) still succeeds off the header alone),
-# and every Lua C API symbol ends up undefined at final link time instead.
-ln -sf /usr/lib/lua5.4/liblua5.4.so.* /usr/lib/liblua5.4.so
+# Alpine's lua5.4-dev ships its library as /usr/lib/lua5.4/liblua.so(.a)
+# - unversioned in name, but tucked in a version-numbered subdirectory
+# (so multiple Lua versions can coexist), with pkg-config as the intended
+# discovery path. CMake's find_package(Lua) isn't pkg-config-aware
+# though: find_library() only searches standard lib dirs for names like
+# "lua5.4"/"lua", so it finds neither. That failure is silent - no CMake
+# error, find_package(Lua) still "succeeds" off the header alone - and
+# every Lua C API symbol ends up undefined at final link time instead.
+# Alias both name variants CMake's FindLua.cmake tries into /usr/lib.
+ln -sf lua5.4/liblua.so /usr/lib/liblua5.4.so
+ln -sf lua5.4/liblua.a  /usr/lib/liblua5.4.a
+ln -sf lua5.4/liblua.so /usr/lib/liblua.so
+ln -sf lua5.4/liblua.a  /usr/lib/liblua.a
 
 EOF
 

--- a/.github/docker/Dockerfile.packaging-centreon-collect-alpine
+++ b/.github/docker/Dockerfile.packaging-centreon-collect-alpine
@@ -2,6 +2,11 @@ ARG REGISTRY_URL
 
 FROM ${REGISTRY_URL}/alpine:3.20 AS centreon_collect_packaging
 
+# GNU tar (not busybox's) is required: actions/cache (and other GitHub
+# Actions tooling) shell out to `tar --posix ...`, a flag busybox's tar
+# applet doesn't understand ("unrecognized option: posix") - it fails
+# silently there without failing the step, so package caching (used by
+# the dockerize job) silently produces an empty/missing cache entry.
 RUN apk add --no-cache \
     bash \
     ca-certificates \
@@ -10,6 +15,7 @@ RUN apk add --no-cache \
     make \
     perl \
     sudo \
+    tar \
     unzip \
     wget \
     zip \
@@ -62,6 +68,16 @@ apk add --no-cache \
 # Alpine has no ninja apk package - samurai is a drop-in, vcpkg/CMake just
 # need a binary named "ninja" on PATH.
 ln -sf "\$(command -v samu)" /usr/local/bin/ninja
+
+# Alpine's lua5.4/lua5.4-dev only ship versioned library symlinks
+# (/usr/lib/lua5.4/liblua5.4.so.X) - by design, so multiple Lua versions
+# can coexist without colliding, with pkg-config as the intended discovery
+# path. CMake's find_package(Lua) isn't pkg-config-aware though; it looks
+# for a plain unversioned liblua5.4.so via find_library(), which doesn't
+# exist here. Without it, LUA_LIBRARIES silently resolves empty (no
+# CMake error - find_package(Lua) still succeeds off the header alone),
+# and every Lua C API symbol ends up undefined at final link time instead.
+ln -sf /usr/lib/lua5.4/liblua5.4.so.* /usr/lib/liblua5.4.so
 
 EOF
 

--- a/.github/docker/Dockerfile.packaging-centreon-collect-alpine
+++ b/.github/docker/Dockerfile.packaging-centreon-collect-alpine
@@ -44,6 +44,7 @@ apk add --no-cache \
     gdb \
     gnutls-dev \
     libgcrypt-dev \
+    linux-headers \
     lua5.4-dev \
     mariadb-connector-c-dev \
     musl-dev \

--- a/.github/docker/Dockerfile.packaging-centreon-collect-alpine
+++ b/.github/docker/Dockerfile.packaging-centreon-collect-alpine
@@ -56,6 +56,7 @@ apk add --no-cache \
     musl-dev \
     openssl \
     openssl-dev \
+    perl-app-cpanminus \
     perl-dev \
     pkgconf \
     python3 \
@@ -82,6 +83,15 @@ ln -sf lua5.4/liblua.so /usr/lib/liblua5.4.so
 ln -sf lua5.4/liblua.a  /usr/lib/liblua5.4.a
 ln -sf lua5.4/liblua.so /usr/lib/liblua.so
 ln -sf lua5.4/liblua.a  /usr/lib/liblua.a
+
+# common/http/test/vault_test.cc shells out to tests/vault/vault-server.pl,
+# a local mock HTTPS server used to exercise the real TLS client code path
+# end-to-end (rather than mocking it). It needs HTTP::Daemon::SSL and JSON,
+# neither of which Alpine's apk repos carry at all (checked both main and
+# community) - install via cpanm instead. This is a build-time-only need
+# for WITH_TESTING=On unit-test runs, unrelated to the openssl/openssl-dev
+# already installed for the actual product build.
+cpanm --notest HTTP::Daemon::SSL JSON
 
 EOF
 

--- a/.github/docker/Dockerfile.packaging-centreon-collect-alpine
+++ b/.github/docker/Dockerfile.packaging-centreon-collect-alpine
@@ -64,6 +64,7 @@ apk add --no-cache \
     samurai \
     libssh2-dev \
     strace \
+    tzdata \
     zlib-dev
 
 # Alpine has no ninja apk package - samurai is a drop-in, vcpkg/CMake just

--- a/.github/docker/centreon-broker/alpine/Dockerfile
+++ b/.github/docker/centreon-broker/alpine/Dockerfile
@@ -61,6 +61,8 @@ RUN addgroup -g 900 centreon && \
 RUN apk add --no-cache \
     python3 \
     py3-pip \
+    libgcc \
+    libstdc++ \
     mariadb-connector-c \
     rrdtool \
     gnutls \
@@ -119,8 +121,8 @@ RUN set -e; \
     test -f /usr/sbin/cbwd; \
     ls /usr/share/centreon/lib/centreon-broker/*.so >/dev/null; \
     ls /etc/centreon-broker/*.json >/dev/null; \
-    ! ldd /usr/sbin/cbd | grep -q "not found"; \
-    ! ldd /usr/sbin/cbwd | grep -q "not found"
+    ! ldd /usr/sbin/cbd 2>&1 | grep -qE "not found|Error loading shared library|Error relocating"; \
+    ! ldd /usr/sbin/cbwd 2>&1 | grep -qE "not found|Error loading shared library|Error relocating"
 
 # Pre-install Python API dependencies at build time (10-15s startup improvement)
 RUN python3 -m venv /opt/centreon/venv && \

--- a/.github/docker/centreon-broker/alpine/Dockerfile
+++ b/.github/docker/centreon-broker/alpine/Dockerfile
@@ -1,0 +1,177 @@
+# syntax=docker/dockerfile:1
+
+#############################################
+# Stage 1: Extract files from .apk packages
+#############################################
+FROM alpine:3.20 AS extractor
+
+ARG TARGETARCH
+
+# Extract .apk packages (mounted via --mount during build). apk packages are
+# plain tar archives with a .PKGINFO/control tarball prepended - tar -x on
+# the whole file skips the leading control/signature tarballs harmlessly and
+# just overlays the data payload, same effect as dpkg-deb -x on trixie.
+# NOTE: packages-centreon/ is shared with the sibling centreon-engine build in
+# CI and contains engine/connector packages too - skip anything engine/
+# connector-specific here, mirroring the trixie extractor's filtering.
+RUN --mount=type=bind,source=packages-centreon,target=/packages \
+    mkdir -p /extracted && \
+    cd /packages/${TARGETARCH} && \
+    for apk in *.apk; do \
+        case "$apk" in \
+            *centreon-engine*|*connector*) continue ;; \
+        esac; \
+        tar -xzf "$apk" -C /extracted; \
+    done && \
+    rm -rf /extracted/usr/share/doc/* \
+           /extracted/usr/share/man/* \
+           /extracted/usr/share/info/* \
+           /extracted/usr/share/locale/* \
+           /extracted/usr/share/licenses/* \
+           /extracted/var/cache/* \
+           /extracted/var/log/* \
+           /extracted/.PKGINFO \
+           /extracted/.SIGN.*
+
+#############################################
+# Stage 2: Runtime - Minimal final image
+#############################################
+FROM alpine:3.20 AS runtime
+
+ARG VERSION
+ARG IS_CLOUD
+ARG STABILITY
+
+# Create users and groups (must match current setup for compatibility)
+RUN addgroup -g 900 centreon && \
+    adduser -u 900 -G centreon -h /var/spool/centreon -s /bin/sh -D -H centreon && \
+    addgroup -g 901 centreon-engine && \
+    adduser -u 901 -G centreon-engine -h /var/lib/centreon-engine -s /bin/sh -D -H centreon-engine && \
+    addgroup -g 902 centreon-broker && \
+    adduser -u 902 -G centreon-broker -h /var/lib/centreon-broker -s /bin/sh -D -H centreon-broker && \
+    addgroup -g 903 centreon-gorgone && \
+    adduser -u 903 -G centreon-gorgone -h /var/lib/centreon-gorgone -s /bin/sh -D -H centreon-gorgone && \
+    addgroup centreon-broker centreon-engine && \
+    addgroup centreon-engine centreon-broker && \
+    addgroup centreon-broker centreon-gorgone && \
+    addgroup centreon-broker centreon && \
+    mkdir -p /var/lib/centreon-engine /var/lib/centreon-gorgone /var/spool/centreon
+
+# Install ONLY runtime dependencies (no -dev packages, no package overhead)
+RUN apk add --no-cache \
+    python3 \
+    py3-pip \
+    mariadb-connector-c \
+    rrdtool \
+    gnutls \
+    lua5.4-libs \
+    openssl \
+    libssh2 \
+    libcurl \
+    zlib \
+    sudo \
+    ca-certificates
+
+# Create directory structure
+RUN mkdir -p /etc/centreon-broker \
+             /var/lib/centreon-broker \
+             /var/log/centreon-broker \
+             /usr/share/centreon/lib/centreon-broker \
+             /usr/share/centreon-broker/lua && \
+    chown -R centreon-broker:centreon-broker \
+             /etc/centreon-broker \
+             /var/lib/centreon-broker \
+             /var/log/centreon-broker \
+             /usr/share/centreon-broker && \
+    chmod 775 /etc/centreon-broker \
+              /var/lib/centreon-broker \
+              /var/log/centreon-broker \
+              /usr/share/centreon-broker \
+              /usr/share/centreon-broker/lua && \
+    chmod 0755 /var/spool/centreon \
+               /var/lib/centreon-engine \
+               /var/lib/centreon-gorgone
+
+# Copy runtime files from extractor in bulk (binaries, libraries, modules).
+# See the trixie Dockerfile for why this must be a single non-wildcard
+# destination - the extractor stage above already excludes engine/connector
+# packages, so nothing unrelated ends up in /extracted/usr/ to begin with.
+COPY --from=extractor --link --chmod=755 \
+    /extracted/usr/ /usr/
+
+# Configuration files (--chown prevents --link)
+COPY --from=extractor --chown=centreon-broker:centreon-broker --chmod=664 \
+     /extracted/etc/ /etc/
+
+# COPY --chmod applies the same mode to every copied entry, files and
+# directories alike - re-assert 0775 on /etc/centreon-broker defensively
+# (see trixie Dockerfile for the equivalent bug this guards against).
+RUN chmod 0775 /etc/centreon-broker
+
+# Copy entrypoint scripts (from source repo, not from .apk packages)
+COPY --chmod=755 --chown=centreon-broker:centreon-broker \
+     ./.github/docker/centreon-broker/alpine/entrypoint /var/lib/centreon-broker
+
+# Verify critical runtime files, including that the dynamic linker can
+# actually resolve cbd/cbwd's shared libs.
+RUN set -e; \
+    test -f /usr/sbin/cbd; \
+    test -f /usr/sbin/cbwd; \
+    ls /usr/share/centreon/lib/centreon-broker/*.so >/dev/null; \
+    ls /etc/centreon-broker/*.json >/dev/null; \
+    ! ldd /usr/sbin/cbd | grep -q "not found"; \
+    ! ldd /usr/sbin/cbwd | grep -q "not found"
+
+# Pre-install Python API dependencies at build time (10-15s startup improvement)
+RUN python3 -m venv /opt/centreon/venv && \
+    /opt/centreon/venv/bin/pip install --no-cache-dir --upgrade pip && \
+    /opt/centreon/venv/bin/pip install --no-cache-dir \
+        fastapi==0.140.0 \
+        starlette==1.3.1 \
+        uvicorn==0.32.0 && \
+    chown -R centreon-broker:centreon-broker /opt/centreon/venv
+
+ENV PATH="/opt/centreon/venv/bin:$PATH"
+
+# OCI image metadata for supply chain traceability (used by Scout, registries, and auditing)
+ARG BUILD_DATE
+ARG BUILD_VERSION=unknown
+ARG PACKAGE_SOURCES=unknown
+ARG GIT_REVISION=unknown
+
+LABEL org.opencontainers.image.title="Centreon Broker" \
+      org.opencontainers.image.description="Centreon Broker event broker (BBDO protocol)" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.revision="${GIT_REVISION}" \
+      org.opencontainers.image.source="https://github.com/centreon/centreon-collect" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Centreon" \
+      org.centreon.package-sources="${PACKAGE_SOURCES}" \
+      org.centreon.base-image="alpine:3.20" \
+      org.centreon.release-stage="beta"
+
+# Expose ports (same as current Dockerfile)
+# gRPC central-module
+EXPOSE 51003
+# bbdo central-broker
+EXPOSE 5669
+# gRPC central-broker
+EXPOSE 51001
+# bbdo central-rrd
+EXPOSE 5670
+# gRPC central-rrd
+EXPOSE 51002
+
+WORKDIR /var/lib/centreon-broker
+
+USER centreon-broker
+
+# container.sh touches /tmp/docker.ready once startup has completed.
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \
+    CMD test -f /tmp/docker.ready || exit 1
+
+ENTRYPOINT ["/var/lib/centreon-broker/container.sh"]
+
+# TODO: CMD depend on restart/reload management (grpc) TBD later
+CMD ["/bin/sh"]

--- a/.github/docker/centreon-broker/alpine/entrypoint/container.sh
+++ b/.github/docker/centreon-broker/alpine/entrypoint/container.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+[ "${DEBUG:-0}" = "1" ] && set -x
+
+rm -f /tmp/docker.ready
+
+export PATH="/opt/centreon/venv/bin:$PATH"
+
+touch /tmp/docker.ready
+echo "Centreon is ready"
+
+exec "$@"

--- a/.github/docker/centreon-engine/alpine/Dockerfile
+++ b/.github/docker/centreon-engine/alpine/Dockerfile
@@ -81,6 +81,8 @@ RUN addgroup -g 33 www-data 2>/dev/null || true && \
 RUN apk add --no-cache \
     monitoring-plugins \
     libcap-utils \
+    libgcc \
+    libstdc++ \
     mariadb-connector-c \
     gnutls \
     lua5.4-libs \
@@ -153,11 +155,14 @@ COPY --chmod=755 --chown=centreon-engine:centreon-engine \
 COPY --chmod=600 ./.github/docker/centreon-engine/sudoersCentreon /etc/sudoers.d/centreon
 
 # Verify critical runtime files, including that the dynamic linker can
-# actually resolve centengine's shared libs.
+# actually resolve centengine's shared libs. musl's ldd/dynamic linker
+# reports unresolved libs differently from glibc's ("Error loading shared
+# library ...: No such file or directory" rather than "=> not found") -
+# match both patterns.
 RUN set -e; \
     test -f /usr/sbin/centengine; \
     test -d /etc/centreon-engine/; \
-    ! ldd /usr/sbin/centengine | grep -q "not found"
+    ! ldd /usr/sbin/centengine 2>&1 | grep -qE "not found|Error loading shared library|Error relocating"
 
 # OCI image metadata for supply chain traceability (used by Scout, registries, and auditing)
 ARG BUILD_DATE

--- a/.github/docker/centreon-engine/alpine/Dockerfile
+++ b/.github/docker/centreon-engine/alpine/Dockerfile
@@ -1,0 +1,194 @@
+# syntax=docker/dockerfile:1
+
+#############################################
+# Stage 1: Extract files from .apk packages
+#############################################
+FROM alpine:3.20 AS extractor
+
+ARG TARGETARCH
+
+# Extract .apk packages (mounted via --mount during build). apk packages are
+# plain tar archives with control/signature tarballs prepended - tar -x on
+# the whole file skips them harmlessly and overlays the data payload, same
+# effect as dpkg-deb -x on trixie.
+# Engine installs all except broker-cbd (not needed for engine).
+RUN --mount=type=bind,source=packages-centreon,target=/packages \
+    mkdir -p /extracted && \
+    cd /packages/${TARGETARCH} && \
+    for apk in centreon*.apk; do \
+        case "$apk" in \
+            *broker-cbd*) continue ;; \
+        esac; \
+        tar -xzf "$apk" -C /extracted; \
+    done && \
+    rm -rf /extracted/usr/share/doc/* \
+           /extracted/usr/share/man/* \
+           /extracted/usr/share/info/* \
+           /extracted/usr/share/locale/* \
+           /extracted/usr/share/licenses/* \
+           /extracted/var/cache/* \
+           /extracted/var/log/* \
+           /extracted/.PKGINFO \
+           /extracted/.SIGN.*
+
+#############################################
+# Stage 2: Runtime - Minimal final image
+#############################################
+FROM alpine:3.20 AS runtime
+
+ARG VERSION
+ARG IS_CLOUD
+ARG STABILITY
+
+ENV GORGONE_UID= \
+    NAME= \
+    GORGONE_TOKEN= \
+    CENTRAL_HOST= \
+    APP_SECRET= \
+    SALT=
+
+# Create users and groups (must match current setup for compatibility)
+RUN addgroup -g 33 www-data 2>/dev/null || true && \
+    addgroup -g 900 centreon && \
+    adduser -u 900 -G centreon -h /var/spool/centreon -s /bin/sh -D -H centreon && \
+    addgroup -g 901 centreon-engine && \
+    adduser -u 901 -G centreon-engine -h /var/lib/centreon-engine -s /bin/sh -D -H centreon-engine && \
+    addgroup -g 902 centreon-broker && \
+    adduser -u 902 -G centreon-broker -h /var/lib/centreon-broker -s /bin/sh -D -H centreon-broker && \
+    addgroup -g 903 centreon-gorgone && \
+    adduser -u 903 -G centreon-gorgone -h /var/lib/centreon-gorgone -s /bin/sh -D -H centreon-gorgone && \
+    addgroup centreon-engine centreon-broker && \
+    addgroup centreon-broker centreon-engine && \
+    addgroup centreon-engine centreon-gorgone && \
+    addgroup centreon-engine centreon && \
+    addgroup centreon-engine www-data && \
+    mkdir -p /var/lib/centreon-broker /var/lib/centreon-gorgone /var/spool/centreon
+
+# Runtime dependencies, apk-native equivalents of the trixie image's apt list.
+#
+# KNOWN GAP (documented, not silently dropped): the trixie image additionally
+# pulls Centreon's own apt-plugins-stable repo for libnet-curl-perl,
+# libcrypt-openssl-aes-perl, libssh-session-perl and
+# centreon-plugin-applications-monitoring-centreon-poller, none of which have
+# an Alpine/apk equivalent today. Its container.d/40-/41-/45-/46-*.sh scripts
+# (dynamic plugin/custom-deps install from plugins.json/custom-deps.json via
+# apt) have no apk-repo fallback yet and are intentionally NOT copied into
+# this image - see .github/docker/centreon-engine/alpine/entrypoint. Alpine's
+# own monitoring-plugins package covers the C-language checks (check_icmp,
+# check_snmp) on its own; Perl-based plugins that depend on those 3 missing
+# CPAN XS modules will not work until an Alpine apk repo/build path exists
+# for them.
+RUN apk add --no-cache \
+    monitoring-plugins \
+    libcap-utils \
+    mariadb-connector-c \
+    gnutls \
+    lua5.4-libs \
+    openssl \
+    libssh2 \
+    libgcrypt \
+    libcurl \
+    zlib \
+    sudo \
+    ca-certificates && \
+    setcap cap_net_raw+ep /usr/lib/monitoring-plugins/check_icmp && \
+    apk del libcap-utils
+
+# Create directory structure
+RUN mkdir -p /etc/centreon-engine \
+             /etc/centreon-engine/conf.d \
+             /etc/centreon-broker \
+             /var/lib/centreon-engine \
+             /var/lib/centreon-engine/rw \
+             /var/log/centreon-engine \
+             /var/log/centreon-engine/archives \
+             /var/lib/centreon/centplugins \
+             /usr/share/centreon/lib/centreon-broker \
+             /usr/lib64/centreon-engine \
+             /usr/lib64/nagios \
+             /usr/lib/nagios/plugins/custom && \
+    ln -s /usr/lib/monitoring-plugins /usr/lib64/nagios/plugins && \
+    chown -R centreon-engine:centreon-engine \
+             /etc/centreon-engine \
+             /var/lib/centreon-engine \
+             /var/log/centreon-engine \
+             /var/lib/centreon/centplugins \
+             /usr/lib/nagios/plugins/custom && \
+    chown -R centreon-broker:centreon-broker \
+              /etc/centreon-broker && \
+    chmod 775 /etc/centreon-engine \
+              /etc/centreon-broker \
+              /etc/centreon-engine/conf.d \
+              /var/lib/centreon-engine \
+              /var/lib/centreon-engine/rw && \
+    chmod 755 /var/log/centreon-engine \
+              /var/log/centreon-engine/archives \
+              /usr/share/centreon/lib/centreon-broker && \
+    chmod 0755 /var/spool/centreon \
+               /var/lib/centreon-broker \
+               /var/lib/centreon-gorgone
+
+COPY --chown=centreon-engine:centreon-engine <<EOF /etc/centreon-engine/engine-context.json
+{"app_secret":"","salt":""}
+EOF
+
+# Copy runtime files from extractor in bulk (see trixie Dockerfile for why a
+# single non-wildcard destination is required here).
+COPY --from=extractor --link --chmod=755 \
+    /extracted/usr/ /usr/
+
+# Configuration files (--chown prevents --link)
+COPY --from=extractor --chown=centreon-engine:centreon-engine --chmod=664 \
+     /extracted/etc/ /etc/
+
+# COPY --chmod applies the same mode to every copied entry, files and
+# directories alike - re-assert 0775 on the config dirs (see trixie
+# Dockerfile for the equivalent bug this guards against).
+RUN chmod 0775 /etc/centreon-engine /etc/centreon-engine/conf.d /etc/centreon-broker
+
+# Copy entrypoint and sudoers (from source repo, not from .apk packages)
+COPY --chmod=755 --chown=centreon-engine:centreon-engine \
+     ./.github/docker/centreon-engine/alpine/entrypoint /var/lib/centreon-engine
+
+COPY --chmod=600 ./.github/docker/centreon-engine/sudoersCentreon /etc/sudoers.d/centreon
+
+# Verify critical runtime files, including that the dynamic linker can
+# actually resolve centengine's shared libs.
+RUN set -e; \
+    test -f /usr/sbin/centengine; \
+    test -d /etc/centreon-engine/; \
+    ! ldd /usr/sbin/centengine | grep -q "not found"
+
+# OCI image metadata for supply chain traceability (used by Scout, registries, and auditing)
+ARG BUILD_DATE
+ARG BUILD_VERSION=unknown
+ARG PACKAGE_SOURCES=unknown
+ARG GIT_REVISION=unknown
+
+LABEL org.opencontainers.image.title="Centreon Engine" \
+      org.opencontainers.image.description="Centreon Engine monitoring scheduler/executor" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.version="${BUILD_VERSION}" \
+      org.opencontainers.image.revision="${GIT_REVISION}" \
+      org.opencontainers.image.source="https://github.com/centreon/centreon-collect" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.vendor="Centreon" \
+      org.centreon.package-sources="${PACKAGE_SOURCES}" \
+      org.centreon.base-image="alpine:3.20" \
+      org.centreon.release-stage="beta"
+
+# gRPC engine management API (inter-container, no host mapping needed)
+EXPOSE 50155
+
+WORKDIR /var/lib/centreon-engine
+
+USER centreon-engine
+
+# /tmp/docker.ready is touched by 99-logs.sh once every container.d/*.sh
+# entrypoint script has run, right before centengine itself is exec'd.
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \
+    CMD test -f /tmp/docker.ready || exit 1
+
+ENTRYPOINT ["/var/lib/centreon-engine/container.sh"]
+
+CMD ["/usr/sbin/centengine", "/etc/centreon-engine/centengine.cfg"]

--- a/.github/docker/centreon-engine/alpine/Dockerfile
+++ b/.github/docker/centreon-engine/alpine/Dockerfile
@@ -78,8 +78,13 @@ RUN addgroup -g 33 www-data 2>/dev/null || true && \
 # check_snmp) on its own; Perl-based plugins that depend on those 3 missing
 # CPAN XS modules will not work until an Alpine apk repo/build path exists
 # for them.
+#
+# check_snmp itself doesn't link net-snmp - it execs the snmpget/snmpbulkget
+# CLI tools as a subprocess (confirmed against a real SNMP target: without
+# net-snmp-tools it fails with "External command error", exit code 3).
 RUN apk add --no-cache \
     monitoring-plugins \
+    net-snmp-tools \
     libcap-utils \
     libgcc \
     libstdc++ \

--- a/.github/docker/centreon-engine/alpine/entrypoint/container.d/00-init.sh
+++ b/.github/docker/centreon-engine/alpine/entrypoint/container.d/00-init.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+rm -f /tmp/docker.ready
+
+# centengine logs to this file (log_v2_logger=file); 10-log-tail_background.sh
+# streams it to stdout. Clear it so tail -F starts clean on restart.
+> /var/log/centreon-engine/centengine.log 2>/dev/null || true
+rm -rf /var/log/centreon-engine/archives/* 2>/dev/null || true
+
+# NOTE: the trixie image refreshes apt package lists here so 40-engine.sh/
+# 41-custom-deps.sh can install plugins at runtime. This image has no apk-repo
+# equivalent for that dynamic install path yet (see the Dockerfile's "KNOWN
+# GAP" comment) - those scripts are intentionally not shipped, so there is
+# nothing to refresh.

--- a/.github/docker/centreon-engine/alpine/entrypoint/container.d/05-engine-config.sh
+++ b/.github/docker/centreon-engine/alpine/entrypoint/container.d/05-engine-config.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# Patch centengine.cfg for Docker operation.
+# rpc_listen_address is not yet exported by Centreon web — inject it here
+# so the gRPC API is reachable from other containers (gorgone).
+# Once the web export includes it, this becomes a no-op sed replace.
+CFG="/etc/centreon-engine/centengine.cfg"
+
+if [ -f "$CFG" ]; then
+    if grep -q "^rpc_listen_address=" "$CFG"; then
+        sed -i 's/^rpc_listen_address=.*/rpc_listen_address=0.0.0.0/' "$CFG"
+    else
+        echo "rpc_listen_address=0.0.0.0" >> "$CFG"
+    fi
+fi

--- a/.github/docker/centreon-engine/alpine/entrypoint/container.d/10-log-tail_background.sh
+++ b/.github/docker/centreon-engine/alpine/entrypoint/container.d/10-log-tail_background.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# centengine logs to a file (log_v2_logger=file in centengine.cfg — Engine has
+# no "stdout" logger, only "file" or "syslog"). Stream that file into the
+# container's stdout so `docker logs` shows checks/notifications/etc.,
+# not just the startup config messages emitted before the file logger takes over.
+CFG="/etc/centreon-engine/centengine.cfg"
+DEFAULT_LOG="/var/log/centreon-engine/centengine.log"
+
+LOG_FILE=$(grep -E '^log_file=' "$CFG" 2>/dev/null | cut -d= -f2-)
+LOG_FILE="${LOG_FILE:-$DEFAULT_LOG}"
+
+# If log_file already points at a stdout-like special path (e.g. /dev/stdout,
+# /proc/1/fd/1), centengine is already writing straight to the container's
+# stdout — tailing it would just be tailing our own output.
+case "$LOG_FILE" in
+    /dev/std*|/proc/*/fd/*)
+        return 0
+        ;;
+esac
+
+touch "$LOG_FILE" 2>/dev/null || true
+exec tail -F "$LOG_FILE" > /proc/1/fd/1 2>&1

--- a/.github/docker/centreon-engine/alpine/entrypoint/container.d/99-logs.sh
+++ b/.github/docker/centreon-engine/alpine/entrypoint/container.d/99-logs.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+touch /tmp/docker.ready
+echo "Centreon Engine is ready"
+
+# centengine logs to a file (log_v2_logger=file); 10-log-tail_background.sh
+# streams that file to stdout, so docker logs shows it too.
+exec "$@"

--- a/.github/docker/centreon-engine/alpine/entrypoint/container.sh
+++ b/.github/docker/centreon-engine/alpine/entrypoint/container.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+[ "${DEBUG:-0}" = "1" ] && set -x
+
+# Run each startup script located in BASEDIR.
+# ls is required to ensure that the scripts are properly sorted by name.
+BASEDIR="/var/lib/centreon-engine/container.d"
+for file in `ls $BASEDIR` ; do
+  case "$file" in
+    *_background*)
+      # Execute background script and store PID
+      . "$BASEDIR/$file" &
+      echo $! >> /tmp/background_pids
+      ;;
+    *)
+      if ! . "$BASEDIR/$file"; then
+        echo "Error executing $file"
+        exit 1
+      fi
+      ;;
+  esac
+done

--- a/.github/scripts/centreon-engine-docker-config-wiring-test.sh
+++ b/.github/scripts/centreon-engine-docker-config-wiring-test.sh
@@ -29,6 +29,19 @@ LOG_FILE=/tmp/centreon-engine-config-wiring-test.log
 : > "$LOG_FILE"
 READY_TIMEOUT="${READY_TIMEOUT:-60}"
 
+# The custom-deps.json/plugins.json scenarios below drive apt/dpkg-query
+# directly - they don't apply to the Alpine image, which has no apt-based
+# dynamic plugin install path yet (see the "KNOWN GAP" comment in
+# .github/docker/centreon-engine/alpine/Dockerfile). Detect that once up
+# front and skip those scenarios instead of letting them fail on a missing
+# dpkg-query - with `set -e` they'd otherwise abort the whole script before
+# ever reaching the wiring scenarios below, which are the ones that matter.
+HAS_APT=true
+if ! docker run --rm --entrypoint sh "$IMAGE" -c 'command -v apt-get' > /dev/null 2>&1; then
+  HAS_APT=false
+  echo "NOTE: $IMAGE has no apt-get - skipping the custom-deps.json/plugins.json scenarios for this image."
+fi
+
 # buf (used as "buf curl") is a build tool for the *test runner*, not the
 # image under test - same tool .github/docker/centreon-gorgone/trixie/Dockerfile
 # uses for the same purpose (see rationale there: buf releases monthly with
@@ -130,6 +143,8 @@ create_with_configs() {
   docker start "$container" > /dev/null
 }
 
+if [ "$HAS_APT" = "true" ]; then
+
 summary_step_start "custom-deps.json installs a plain valid apt package"
 echo "=== [config:custom-deps-install] custom-deps.json installs a plain valid apt package ==="
 deps_file=$(mktemp); TMPFILES+=("$deps_file")
@@ -209,6 +224,8 @@ if docker logs centreon-engine-cfg-skip-$$ 2>&1 | grep -q "Installing plugins fr
 fi
 echo "OK: plugins.json correctly skipped an already up-to-date package."
 summary_step_pass
+
+fi # HAS_APT
 
 summary_step_start "Custom plugin volume mount is usable"
 echo "=== [config:custom-plugins-volume] a script mounted at /usr/lib/nagios/plugins/custom is usable ==="

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -476,7 +476,7 @@ jobs:
       fail-fast: false
       matrix:
         image: [centreon-engine, centreon-broker]
-        distrib: [trixie]
+        distrib: [trixie, alpine]
 
     name: dockerize ${{ matrix.image }}-${{ matrix.distrib }}
 
@@ -492,38 +492,52 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Parse distrib name
+        id: parse-distrib
+        uses: ./.github/actions/parse-distrib
+        with:
+          distrib: ${{ matrix.distrib }}
+
       - name: Restore amd64 packages
         id: restore-amd64
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ./*.deb
-          key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-collect-${{ matrix.distrib }}-amd64-${{ github.head_ref || github.ref_name }}
+          path: ./*.${{ steps.parse-distrib.outputs.package_extension }}
+          key: ${{ github.run_id }}-${{ github.sha }}-${{ steps.parse-distrib.outputs.package_extension }}-centreon-collect-${{ matrix.distrib }}-amd64-${{ github.head_ref || github.ref_name }}
 
+      # Alpine ships amd64 only (no arm64 packages built for it yet).
       - name: Restore arm64 packages
         id: restore-arm64
+        if: matrix.distrib != 'alpine'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ./*.deb
-          key: ${{ github.run_id }}-${{ github.sha }}-deb-centreon-collect-${{ matrix.distrib }}-arm64-${{ github.head_ref || github.ref_name }}
+          path: ./*.${{ steps.parse-distrib.outputs.package_extension }}
+          key: ${{ github.run_id }}-${{ github.sha }}-${{ steps.parse-distrib.outputs.package_extension }}-centreon-collect-${{ matrix.distrib }}-arm64-${{ github.head_ref || github.ref_name }}
 
       - name: Fail if packages cache is missing
-        if: steps.restore-amd64.outputs.cache-hit != 'true' || steps.restore-arm64.outputs.cache-hit != 'true'
+        if: steps.restore-amd64.outputs.cache-hit != 'true' || (matrix.distrib != 'alpine' && steps.restore-arm64.outputs.cache-hit != 'true')
         run: |
-          [[ "${{ steps.restore-amd64.outputs.cache-hit }}" != 'true' ]] && echo "::error::No deb cache for ${{ matrix.distrib }} amd64 — ensure ${{ matrix.distrib }} amd64 is in collect_matrix (get-environment.yml)."
-          [[ "${{ steps.restore-arm64.outputs.cache-hit }}" != 'true' ]] && echo "::error::No deb cache for ${{ matrix.distrib }} arm64 — ensure ${{ matrix.distrib }} arm64 is in collect_matrix (get-environment.yml)."
+          [[ "${{ steps.restore-amd64.outputs.cache-hit }}" != 'true' ]] && echo "::error::No package cache for ${{ matrix.distrib }} amd64 — ensure ${{ matrix.distrib }} amd64 is in collect_matrix (get-environment.yml)."
+          [[ "${{ matrix.distrib }}" != "alpine" && "${{ steps.restore-arm64.outputs.cache-hit }}" != 'true' ]] && echo "::error::No package cache for ${{ matrix.distrib }} arm64 — ensure ${{ matrix.distrib }} arm64 is in collect_matrix (get-environment.yml)."
           exit 1
         shell: bash
 
       - name: Prepare packages directory
+        env:
+          PACKAGE_EXTENSION: ${{ steps.parse-distrib.outputs.package_extension }}
+          MAJOR_VERSION: ${{ needs.get-environment.outputs.major_version }}
         run: |
           mkdir -p packages-centreon/amd64 packages-centreon/arm64
-          for deb in centreon-{clib,protobuf-lib,engine,engine-daemon,engine-opentelemetry,broker,broker-core,broker-cbd,connector-perl,connector-ssh}_${{ needs.get-environment.outputs.major_version }}*.deb; do
-            [[ ! -f "$deb" ]] && continue
-            if [[ "$deb" == *_amd64.deb ]]; then
-              mv "$deb" packages-centreon/amd64/
-            elif [[ "$deb" == *_arm64.deb ]]; then
-              mv "$deb" packages-centreon/arm64/
-            fi
+          for pkg in centreon-{clib,protobuf-lib,engine,engine-daemon,engine-opentelemetry,broker,broker-core,broker-cbd,connector-perl,connector-ssh}_${MAJOR_VERSION}*."$PACKAGE_EXTENSION"; do
+            [[ ! -f "$pkg" ]] && continue
+            # nfpm names apk artifacts with Alpine's arch strings (x86_64/aarch64)
+            # instead of Docker's (amd64/arm64) - match both.
+            case "$pkg" in
+              *_amd64."$PACKAGE_EXTENSION"|*_x86_64."$PACKAGE_EXTENSION")
+                mv "$pkg" packages-centreon/amd64/ ;;
+              *_arm64."$PACKAGE_EXTENSION"|*_aarch64."$PACKAGE_EXTENSION")
+                mv "$pkg" packages-centreon/arm64/ ;;
+            esac
           done
           ls -lhR packages-centreon/
         shell: bash
@@ -590,14 +604,14 @@ jobs:
         with:
           file: .github/docker/${{ matrix.image }}/${{ matrix.distrib }}/Dockerfile
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.distrib == 'alpine' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           build-args: |
             "VERSION=${{ needs.get-environment.outputs.major_version }}"
             "IS_CLOUD=${{ needs.get-environment.outputs.is_cloud }}"
             "STABILITY=${{ needs.get-environment.outputs.stability }}"
             "BUILD_DATE=${{ steps.build-date.outputs.date }}"
             "BUILD_VERSION=${{ needs.get-environment.outputs.major_version }}.${{ needs.get-environment.outputs.minor_version }}-${{ needs.get-environment.outputs.release }}"
-            "PACKAGE_SOURCES=centreon-collect ${{ matrix.image }} (Debian ${{ matrix.distrib }})"
+            "PACKAGE_SOURCES=centreon-collect ${{ matrix.image }} (${{ matrix.distrib == 'alpine' && 'Alpine' || 'Debian' }} ${{ matrix.distrib }})"
             "GIT_REVISION=${{ github.event.pull_request.head.sha || github.sha }}"
           pull: true
           push: ${{ github.event.pull_request.head.repo.fork != true }}
@@ -647,8 +661,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [trixie]
+        distrib: [trixie, alpine]
         platform: [linux/amd64, linux/arm64]
+        # Alpine ships amd64 only.
+        exclude:
+          - distrib: alpine
+            platform: linux/arm64
     name: docker boot test centreon-engine-${{ matrix.distrib }} (${{ matrix.platform }})
     env:
       ENGINE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-engine-${{ matrix.distrib }}:${{ needs.dockerize-engine-broker.outputs.image_tag }}
@@ -712,7 +730,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [trixie]
+        distrib: [trixie, alpine]
     name: docker config/wiring test centreon-engine-${{ matrix.distrib }}
     env:
       ENGINE_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-engine-${{ matrix.distrib }}:${{ needs.dockerize-engine-broker.outputs.image_tag }}
@@ -809,7 +827,7 @@ jobs:
       fail-fast: false
       matrix:
         image: [centreon-engine, centreon-broker]
-        distrib: [trixie]
+        distrib: [trixie, alpine]
     name: docker trivy cves ${{ matrix.image }}-${{ matrix.distrib }}
     permissions:
       contents: read

--- a/.github/workflows/docker-packaging.yml
+++ b/.github/workflows/docker-packaging.yml
@@ -62,6 +62,8 @@ jobs:
             distrib: noble
           - runner: centreon-collect-arm64
             distrib: noble
+          - runner: centreon-collect
+            distrib: alpine
 
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -793,6 +793,7 @@ jobs:
             const trixie_mysql_8_4       = cfg('trixie',   'mysql:8.4');
             const jammy_mariadb_10_11    = cfg('jammy',    'mariadb:10.11');
             const noble_mariadb_10_11    = cfg('noble',    'mariadb:10.11');
+            const alpine_mariadb_11_8    = cfg('alpine',   'mariadb:11.8');
 
             // Fixed weekday -> preferred configuration (0=sunday, 1=monday, ..., 6=saturday)
             const dailyConfigByDayOfWeek = {
@@ -812,7 +813,7 @@ jobs:
               return preferred && configs.includes(preferred) ? preferred : configs[0];
             };
 
-            const configs = [alma10_mysql_8_4, alma9_mariadb_11_8, trixie_mariadb_11_8]
+            const configs = [alma10_mysql_8_4, alma9_mariadb_11_8, trixie_mariadb_11_8, alpine_mariadb_11_8]
             const cmaConfigs = [
               alma10_mariadb_11_8, alma9_mysql_8_0, alma8_mariadb_10_11,
               bookworm_mariadb_10_11, trixie_mysql_8_4,

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -848,11 +848,14 @@ jobs:
               cmaMatrix = withArch(cmaMatrix);
             }
 
-            // Ensure trixie amd64+arm64 are packaged when the dockerize-engine-broker job is requested,
-            // otherwise the deb cache it restores does not exist and the job fails.
+            // Ensure trixie amd64+arm64 and alpine amd64 are packaged when the
+            // dockerize-engine-broker job is requested, otherwise the
+            // deb/apk cache it restores does not exist and the job fails.
+            // Alpine has no arm64 leg (not in ARM64_DISTROS above).
             if (wantsDockerCollect) {
               collectMatrix.push({ operating_system: 'trixie', arch: 'amd64' });
               collectMatrix.push({ operating_system: 'trixie', arch: 'arm64' });
+              collectMatrix.push({ operating_system: 'alpine', arch: 'amd64' });
             }
 
             // deduplicate by os+arch (no database dimension needed for build/packaging)

--- a/.github/workflows/package-collect.yml
+++ b/.github/workflows/package-collect.yml
@@ -146,14 +146,15 @@ jobs:
           done
         shell: bash
 
-      - name: Remove selinux packaging files on debian
-        if: ${{ steps.parse-distrib.outputs.package_extension == 'deb' }}
+      - name: Remove selinux packaging files on debian/alpine
+        if: ${{ steps.parse-distrib.outputs.package_extension == 'deb' || steps.parse-distrib.outputs.package_extension == 'apk' }}
         run: rm -f packaging/centreon-*/*-selinux.yaml
         shell: bash
 
       - name: Compile sources
         env:
           PACKAGE_EXTENSION: ${{ steps.parse-distrib.outputs.package_extension }}
+          DISTRIB_FAMILY: ${{ steps.parse-distrib.outputs.distrib_family }}
           ARCH: ${{ inputs.arch }}
           LEGACY_ENGINE: ${{ inputs.legacy_engine }}
         run: |
@@ -173,6 +174,15 @@ jobs:
 
           mv /root/.cache /github/home/
 
+          # Alpine has no systemd - use a plain sysv-style startup script
+          # instead (accepted by both engine/CMakeLists.txt and
+          # broker/CMakeLists.txt's WITH_STARTUP_SCRIPT validation).
+          if [ "$DISTRIB_FAMILY" = "alpine" ]; then
+            STARTUP_SCRIPT="sysv"
+          else
+            STARTUP_SCRIPT="systemd"
+          fi
+
           $CMAKE \
                   -B build \
                   -DVCPKG_OVERLAY_TRIPLETS=/custom-triplets \
@@ -184,7 +194,7 @@ jobs:
                   -DWITH_BENCH=ON \
                   -DWITH_MODULE_SIMU=OFF \
                   -DCMAKE_INSTALL_PREFIX=/usr \
-                  -DWITH_STARTUP_SCRIPT=systemd \
+                  -DWITH_STARTUP_SCRIPT=$STARTUP_SCRIPT \
                   -DWITH_ENGINE_LOGROTATE_SCRIPT=ON \
                   -DWITH_USER_BROKER=centreon-broker \
                   -DWITH_GROUP_BROKER=centreon-broker \

--- a/broker/bam/CMakeLists.txt
+++ b/broker/bam/CMakeLists.txt
@@ -148,7 +148,7 @@ target_link_libraries("${BAM}" bbdo_storage bbdo_bam centreon_pb_bbdo
 target_precompile_headers(${BAM} PRIVATE precomp_inc/precomp.hpp)
 set_target_properties("${BAM}" PROPERTIES PREFIX ""
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/broker/lib")
-add_dependencies("${BAM}" pb_open_telemetry_lib pb_bam_lib process_stat)
+add_dependencies("${BAM}" pb_open_telemetry_lib pb_bam_lib pb_broker_lib process_stat)
 
 # Testing.
 if(WITH_TESTING)

--- a/broker/core/cache/CMakeLists.txt
+++ b/broker/core/cache/CMakeLists.txt
@@ -54,7 +54,7 @@ add_custom_command(
 
 
 target_precompile_headers(global_cache PRIVATE precomp_inc/precomp.hpp)
-add_dependencies(global_cache  pb_common_lib process_stat)
+add_dependencies(global_cache  pb_common_lib pb_neb_lib pb_header_lib pb_bam_lib process_stat)
 set_target_properties(global_cache PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Testing.

--- a/broker/core/multiplexing/CMakeLists.txt
+++ b/broker/core/multiplexing/CMakeLists.txt
@@ -29,7 +29,7 @@ set(SOURCES ${SRC_DIR}/engine.cc ${SRC_DIR}/muxer.cc ${SRC_DIR}/publisher.cc)
 
 # Static libraries.
 add_library(multiplexing STATIC ${SOURCES})
-add_dependencies(multiplexing pb_bbdo_lib pb_extcmd_lib process_stat global_cache)
+add_dependencies(multiplexing pb_bbdo_lib pb_extcmd_lib pb_neb_lib process_stat global_cache)
 
 set_target_properties(multiplexing PROPERTIES COMPILE_FLAGS "-fPIC")
 target_precompile_headers(multiplexing PRIVATE ../precomp_inc/precomp.hpp)

--- a/broker/core/src/modules/handle.cc
+++ b/broker/core/src/modules/handle.cc
@@ -69,12 +69,18 @@ void handle::_close() {
       bool (*code)();
       void* data;
     } sym;
+    // dlerror() reports the error for the *last* failed dl*() call, not
+    // necessarily this one - e.g. load_file()'s dlsym() lookup of the
+    // (usually absent) parents_list symbol leaves a stale, unconsumed
+    // error behind for every module with no parents. Clear it first so
+    // the check below reflects this dlsym() call, not a leftover one.
+    dlerror();
     sym.data = dlsym(_handle, deinitialization);
 
     bool can_unload = true;
     // Could not find deinitialization routine.
-    char const* error_str{dlerror()};
-    if (error_str) {
+    if (!sym.data) {
+      char const* error_str{dlerror()};
       _logger->info(
           "modules: could not find deinitialization routine in '{}': {}",
           _filename, error_str);

--- a/broker/http_tsdb/CMakeLists.txt
+++ b/broker/http_tsdb/CMakeLists.txt
@@ -50,6 +50,7 @@ add_dependencies(http_tsdb
 	pb_header_lib
 	process_stat
 	pb_storage_lib
+	global_cache
 	)
 target_include_directories(http_tsdb PRIVATE ${INC_DIR})
 

--- a/broker/lua/CMakeLists.txt
+++ b/broker/lua/CMakeLists.txt
@@ -62,7 +62,7 @@ add_library(
   "${INC_DIR}/luabinding.hh"
   "${INC_DIR}/stream.hh")
 add_dependencies(${LUA} pb_neb_lib pb_storage_lib pb_bam_lib process_stat
-                 pb_open_telemetry_lib)
+                 pb_open_telemetry_lib global_cache)
 
 target_link_libraries(
   "${LUA}"

--- a/broker/storage/CMakeLists.txt
+++ b/broker/storage/CMakeLists.txt
@@ -42,10 +42,11 @@ set(CONFLICTMGR
     PARENT_SCOPE)
 add_dependencies(conflictmgr
 	process_stat
+	pb_broker_lib
 	)
 
 set_target_properties(conflictmgr PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(conflictmgr PRIVATE fmt::fmt)
+target_link_libraries(conflictmgr PRIVATE centreon_pb_bbdo fmt::fmt)
 target_precompile_headers(conflictmgr PRIVATE precomp_inc/precomp.hpp)
 
 # Storage module.

--- a/broker/unified_sql/CMakeLists.txt
+++ b/broker/unified_sql/CMakeLists.txt
@@ -61,6 +61,7 @@ add_dependencies("${UNIFIED_SQL}" pb_rebuild_message_lib
                  pb_remove_graph_message_lib
                   process_stat
                  pb_neb_lib
+                 pb_broker_lib
                  pb_open_telemetry_lib)
 target_precompile_headers(${UNIFIED_SQL} PRIVATE precomp_inc/precomp.hpp)
 target_link_libraries(

--- a/clib/inc/com/centreon/timestamp.hh
+++ b/clib/inc/com/centreon/timestamp.hh
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <ctime>
 #include <ostream>
+#include <sys/time.h>
 
 namespace com::centreon {
 

--- a/common/file_system/file_system.cc
+++ b/common/file_system/file_system.cc
@@ -15,6 +15,7 @@
  *
  * For more information : contact@centreon.com
  */
+#include <cstdint>
 #include <dirent.h>
 
 #include "absl/strings/numbers.h"
@@ -22,6 +23,26 @@
 #include "file_system.hh"
 
 namespace com::centreon::common {
+
+namespace {
+// Layout of the Linux kernel's getdents64(2) raw syscall result - this is
+// a fixed kernel ABI, independent of any libc. It must NOT be aliased to
+// libc's struct dirent/dirent64: glibc's plain struct dirent has a
+// different layout (its d_off/d_reclen fields don't line up with the raw
+// syscall buffer), which silently misparses d_reclen and walks the buffer
+// out of alignment - corrupting the heap only detected much later (e.g.
+// "double free or corruption" at an unrelated point). glibc's own
+// struct dirent64 happens to match this exactly, but relying on that
+// libc-specific type is what broke on musl (which doesn't define it), so
+// define the kernel layout locally instead - correct and portable on both.
+struct linux_dirent64 {
+  uint64_t d_ino;
+  int64_t d_off;
+  unsigned short d_reclen;
+  unsigned char d_type;
+  char d_name[];
+};
+}  // namespace
 
 /**
  * @brief Reads the content of a text file and returns it in an std::string.
@@ -192,7 +213,7 @@ static void _dir_content_impl(const std::filesystem::path& dir_path,
       break;
 
     for (long pos = 0; pos < nread;) {
-      auto* entry = reinterpret_cast<struct dirent*>(buf + pos);
+      auto* entry = reinterpret_cast<struct linux_dirent64*>(buf + pos);
       pos += entry->d_reclen;
 
       std::string_view name(entry->d_name);

--- a/common/file_system/file_system.cc
+++ b/common/file_system/file_system.cc
@@ -192,7 +192,7 @@ static void _dir_content_impl(const std::filesystem::path& dir_path,
       break;
 
     for (long pos = 0; pos < nread;) {
-      auto* entry = reinterpret_cast<struct dirent64*>(buf + pos);
+      auto* entry = reinterpret_cast<struct dirent*>(buf + pos);
       pos += entry->d_reclen;
 
       std::string_view name(entry->d_name);

--- a/connectors/perl/src/check_child.cc
+++ b/connectors/perl/src/check_child.cc
@@ -252,7 +252,7 @@ int check_child::_run(int stdin_fd, int stdout_fd, int) {
           if (pfd[0].revents & (POLLIN | POLLHUP | POLLERR)) {
             nb_read = ::read(stdout_pipe_fd[0], buffer, sizeof(buffer));
             if (nb_read > 0) {
-              res->mutable_stdout()->append(buffer, nb_read);
+              res->mutable_std_out()->append(buffer, nb_read);
               stdout_received = true;
             }
           }
@@ -280,7 +280,7 @@ int check_child::_run(int stdin_fd, int stdout_fd, int) {
               re2::RE2::Replace(&to_clean, exit_code_pattern, "");
               re2::RE2::Replace(&to_clean, exit_code_pattern_without_exit_code,
                                 "");
-              res->mutable_stderr()->append(to_clean);
+              res->mutable_std_err()->append(to_clean);
               stderr_received = true;
             }
           }
@@ -288,10 +288,10 @@ int check_child::_run(int stdin_fd, int stdout_fd, int) {
         if (!status_decoded) {
           SPDLOG_LOGGER_ERROR(
               _logger, "pid: {} fail to decode status stderr: {} stdout: {}",
-              getpid(), common::ascii_hex_dump(res->stderr()),
-              common::ascii_hex_dump(res->stdout()));
+              getpid(), common::ascii_hex_dump(res->std_err()),
+              common::ascii_hex_dump(res->std_out()));
           res->set_status(3);  // UNKNOWN
-          res->set_stdout("script status no decoded " + res->stdout());
+          res->set_std_out("script status no decoded " + res->std_out());
         }
         load new_load = measure_load();
         if (!_after_first_check_load) {

--- a/connectors/perl/src/perl_connector.proto
+++ b/connectors/perl/src/perl_connector.proto
@@ -31,8 +31,8 @@ message Result {
     uint64 cmd_id = 1;
     int64 pid = 2;
     int32 status = 3;
-    string stdout = 4;
-    string stderr = 5;
+    string std_out = 4;
+    string std_err = 5;
     CheckChildStatistics after_first_check = 6;
     CheckChildStatistics after_last_check = 7;
 }

--- a/connectors/perl/src/policy.cc
+++ b/connectors/perl/src/policy.cc
@@ -376,7 +376,7 @@ void policy::_from_script_child(std::shared_ptr<script_child> script_chld,
     if (erased > 0) {  // we send result only for known queries not for pending
                        // erased by timeout
       _reporter->send_result(
-          result(res.cmd_id(), res.status(), res.stdout(), res.stderr()));
+          result(res.cmd_id(), res.status(), res.std_out(), res.std_err()));
     }
   } else if (from_script_mess.has_child_end()) {
     _check_child_stats.get<1>().erase(from_script_mess.child_end().pid());

--- a/connectors/perl/src/script_child.cc
+++ b/connectors/perl/src/script_child.cc
@@ -508,7 +508,7 @@ void script_child::_every_second_timer_handler() {
       auto res = timeout_result.mutable_result();
       res->set_cmd_id(timeout_iter->query->execute().cmd_id());
       res->set_status(3);
-      res->set_stderr("(Process Timeout)");
+      res->set_std_err("(Process Timeout)");
       _send_to_main_process(timeout_result);
     }
     timeout_index.erase(timeout_index.begin(), upper_limit);
@@ -834,7 +834,7 @@ void script_child::_on_child_script_end(int pid) {
     auto res = bad_terminate.mutable_result();
     res->set_cmd_id(pending->query->execute().cmd_id());
     res->set_status(3);
-    res->set_stdout(
+    res->set_std_out(
         fmt::format("Process pid:{} died during check execution", pid));
     _send_to_main_process(bad_terminate);
     pid_index.erase(pending);

--- a/connectors/perl/test/protocol_test.cc
+++ b/connectors/perl/test/protocol_test.cc
@@ -259,7 +259,7 @@ TEST_F(ProtocolTest, OnRecvCompleteConnectorMess) {
   auto* res = sent.mutable_result();
   res->set_cmd_id(77);
   res->set_status(1);
-  res->set_stdout("PING OK - Packet loss = 0%");
+  res->set_std_out("PING OK - Packet loss = 0%");
   auto* after_first = res->mutable_after_first_check();
   after_first->set_used_memory(1024);
   after_first->set_nb_opened_fd(5);
@@ -285,7 +285,7 @@ TEST_F(ProtocolTest, OnRecvCompleteConnectorMess) {
   ASSERT_TRUE(got.has_result());
   EXPECT_EQ(got.result().cmd_id(), 77u);
   EXPECT_EQ(got.result().status(), 1);
-  EXPECT_EQ(got.result().stdout(), "PING OK - Packet loss = 0%");
+  EXPECT_EQ(got.result().std_out(), "PING OK - Packet loss = 0%");
   EXPECT_EQ(got.result().after_first_check().used_memory(), 1024u);
   EXPECT_EQ(got.result().after_first_check().nb_opened_fd(), 5u);
   EXPECT_EQ(got.result().after_first_check().nb_thread(), 2u);

--- a/connectors/perl/test/script_child_test.cc
+++ b/connectors/perl/test/script_child_test.cc
@@ -237,7 +237,7 @@ TEST_F(ScriptChildTest, OkCheck) {
   ASSERT_TRUE(_received[0].has_result());
   EXPECT_EQ(_received[0].result().cmd_id(), 1u);
   EXPECT_EQ(_received[0].result().status(), 0);
-  EXPECT_NE(_received[0].result().stdout().find("OK"), std::string::npos);
+  EXPECT_NE(_received[0].result().std_out().find("OK"), std::string::npos);
 }
 
 /**
@@ -318,7 +318,7 @@ TEST_F(ScriptChildTest, CmdIdRoundTrip) {
  * distinct diagnostic to stderr ("STDERR_MARKER"), then calls exit(0).
  * The loader's BEGIN block intercepts exit() and appends "SCRIPT_EXIT_CODE:0\n"
  * to stderr; check_child strips that marker, decodes the exit status, and
- * forwards the remaining stderr text ("STDERR_MARKER") to result.stderr().
+ * forwards the remaining stderr text ("STDERR_MARKER") to result.std_err().
  */
 TEST_F(ScriptChildTest, StdoutAndStderrBothCaptured) {
   _temp_script = write_temp_script(
@@ -337,10 +337,10 @@ TEST_F(ScriptChildTest, StdoutAndStderrBothCaptured) {
   const auto& res = _received[0].result();
   EXPECT_EQ(res.cmd_id(), 70u);
   EXPECT_EQ(res.status(), 0);
-  EXPECT_NE(res.stdout().find("STDOUT_MARKER"), std::string::npos)
-      << "stdout not captured in result.stdout(); got: " << res.stdout();
-  EXPECT_NE(res.stderr().find("STDERR_MARKER"), std::string::npos)
-      << "stderr not captured in result.stderr(); got: " << res.stderr();
+  EXPECT_NE(res.std_out().find("STDOUT_MARKER"), std::string::npos)
+      << "stdout not captured in result.std_out(); got: " << res.std_out();
+  EXPECT_NE(res.std_err().find("STDERR_MARKER"), std::string::npos)
+      << "stderr not captured in result.std_err(); got: " << res.std_err();
 }
 
 // ============================================================
@@ -521,7 +521,7 @@ TEST_F(ScriptChildTest, LargeStdout) {
   absl::MutexLock l(_mu);
   ASSERT_TRUE(_received[0].has_result());
   EXPECT_EQ(_received[0].result().status(), 0);
-  EXPECT_GE(_received[0].result().stdout().size(), 50000u);
+  EXPECT_GE(_received[0].result().std_out().size(), 50000u);
 }
 
 // ============================================================
@@ -670,7 +670,7 @@ TEST_F(ScriptChildTest, ScriptReceivesMultipleArgs) {
   ASSERT_TRUE(_received[0].has_result());
   EXPECT_EQ(_received[0].result().cmd_id(), 50u);
   EXPECT_EQ(_received[0].result().status(), 0);
-  const std::string& out = _received[0].result().stdout();
+  const std::string& out = _received[0].result().std_out();
   EXPECT_NE(out.find("--host"), std::string::npos);
   EXPECT_NE(out.find("192.168.1.1"), std::string::npos);
   EXPECT_NE(out.find("--port"), std::string::npos);
@@ -709,9 +709,9 @@ TEST_F(ScriptChildTest, ScriptArgsDifferPerSequentialCall) {
     ASSERT_TRUE(last.has_result());
     EXPECT_EQ(last.result().cmd_id(), 60 + i);
     EXPECT_EQ(last.result().status(), 0);
-    EXPECT_NE(last.result().stdout().find(targets[i]), std::string::npos)
+    EXPECT_NE(last.result().std_out().find(targets[i]), std::string::npos)
         << "Expected '" << targets[i] << "' in stdout for cmd_id=" << 60 + i;
-    EXPECT_EQ(last.result().stdout().find("server-alpha") != std::string::npos,
+    EXPECT_EQ(last.result().std_out().find("server-alpha") != std::string::npos,
               i == 0)
         << "server-alpha should only appear in the first result";
   }

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -499,7 +499,12 @@ include_directories(enginerpc ${CMAKE_SOURCE_DIR}/common/src
 
 # centenginestats target.
 add_executable(centenginestats "${SRC_DIR}/centenginestats.cc")
-add_dependencies(centenginestats centreon_clib)
+# centenginestats.cc pulls in notifier.hh, which includes the generated
+# bbdo/neb.pb.h - without this, ninja has no edge forcing pb_neb_lib's
+# protoc generation to run before this target compiles, a race that only
+# some build-graph schedulings expose (see cce_core's identical dependency
+# below, added for the same header).
+add_dependencies(centenginestats centreon_clib pb_neb_lib)
 target_link_libraries(centenginestats PRIVATE centreon_clib fmt::fmt absl::log absl::base absl::log_internal_check_op)
 
 target_precompile_headers(centenginestats PRIVATE ${PRECOMP_HEADER})

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -500,11 +500,13 @@ include_directories(enginerpc ${CMAKE_SOURCE_DIR}/common/src
 # centenginestats target.
 add_executable(centenginestats "${SRC_DIR}/centenginestats.cc")
 # centenginestats.cc pulls in notifier.hh, which includes the generated
-# bbdo/neb.pb.h - without this, ninja has no edge forcing pb_neb_lib's
-# protoc generation to run before this target compiles, a race that only
-# some build-graph schedulings expose (see cce_core's identical dependency
-# below, added for the same header).
-add_dependencies(centenginestats centreon_clib pb_neb_lib)
+# bbdo/neb.pb.h and (via contactgroup.hh -> contactgroup_helper.hh ->
+# message_helper.hh) the generated common/engine_conf/state.pb.h - without
+# these, ninja has no edge forcing pb_neb_lib's protoc generation or
+# target_state_proto to run before this target compiles, a race that only
+# some build-graph schedulings expose (see cce_core's identical
+# dependencies below, added for the same headers).
+add_dependencies(centenginestats centreon_clib pb_neb_lib target_state_proto)
 target_link_libraries(centenginestats PRIVATE centreon_clib fmt::fmt absl::log absl::base absl::log_internal_check_op)
 
 target_precompile_headers(centenginestats PRIVATE ${PRECOMP_HEADER})

--- a/engine/enginerpc/CMakeLists.txt
+++ b/engine/enginerpc/CMakeLists.txt
@@ -72,7 +72,7 @@ add_library(
   # Headers.
   "${INC_DIR}/engine_impl.hh" "${INC_DIR}/enginerpc.hh")
 
-add_dependencies(enginerpc centreon_common process_stat cerpc)
+add_dependencies(enginerpc centreon_common process_stat cerpc target_state_proto)
 target_precompile_headers(enginerpc PRIVATE precomp_inc/precomp.hh)
 
 # Prettier name.

--- a/engine/modules/external_commands/CMakeLists.txt
+++ b/engine/modules/external_commands/CMakeLists.txt
@@ -36,7 +36,7 @@ add_library(
 set_property(TARGET "externalcmd" PROPERTY PREFIX "")
 target_precompile_headers("externalcmd" PRIVATE precomp_inc/precomp.hh)
 
-add_dependencies(externalcmd centreon_clib pb_neb_lib)
+add_dependencies(externalcmd centreon_clib pb_neb_lib target_state_proto)
 target_link_libraries(externalcmd PRIVATE centreon_clib)
 
 install(

--- a/engine/tests/CMakeLists.txt
+++ b/engine/tests/CMakeLists.txt
@@ -167,6 +167,10 @@ if(WITH_TESTING)
       "${TESTS_DIR}/test_engine.hh"
       "${TESTS_DIR}/timeperiod/utils.hh")
   add_library(ut_engine_utils STATIC "${TESTS_DIR}/timeperiod/utils.cc")
+  # utils.cc includes common/engine_conf/timeperiod_helper.hh, which pulls in
+  # the generated state.pb.h - without this, ninja has no edge forcing
+  # target_state_proto to run before this target compiles on a clean build.
+  add_dependencies(ut_engine_utils target_state_proto)
   target_link_libraries(ut_engine_utils PRIVATE dl)
   add_executable(ut_engine ${ut_sources})
   target_include_directories(

--- a/engine/tests/custom_vars/extcmd.cc
+++ b/engine/tests/custom_vars/extcmd.cc
@@ -94,7 +94,7 @@ TEST_F(CustomVar, UpdateHostCustomVar) {
   ASSERT_EQ(processed_cmd,
             "/check_icmp -H 127.0.0.1 -n 42 -w 200,20% -c 400,50% user");
 
-  char* msg = strdupa("hst_test;PACKETNUMBER;44");
+  char msg[] = "hst_test;PACKETNUMBER;44";
   cmd_change_object_custom_var(CMD_CHANGE_CUSTOM_HOST_VAR, msg);
   grab_host_macros_r(macros, hst_found->second.get());
   std::string processed_cmd2(

--- a/engine/tests/custom_vars/pbextcmd.cc
+++ b/engine/tests/custom_vars/pbextcmd.cc
@@ -102,7 +102,7 @@ TEST_F(PbCustomVar, UpdateHostCustomVar) {
   ASSERT_EQ(processed_cmd,
             "/check_icmp -H 127.0.0.1 -n 42 -w 200,20% -c 400,50% user");
 
-  char* msg = strdupa("hst_test;PACKETNUMBER;44");
+  char msg[] = "hst_test;PACKETNUMBER;44";
   cmd_change_object_custom_var(CMD_CHANGE_CUSTOM_HOST_VAR, msg);
   grab_host_macros_r(macros, hst_found->second.get());
   std::string processed_cmd2(

--- a/packaging/centreon-collect/centreon-clib-debuginfo.yaml
+++ b/packaging/centreon-collect/centreon-clib-debuginfo.yaml
@@ -23,6 +23,10 @@ contents:
     dst: "/usr/lib/debug/usr/lib/"
     packager: deb
 
+  - src: "../../build/clib/libcentreon_clib.so.debug"
+    dst: "/usr/lib/debug/usr/lib/"
+    packager: apk
+
 overrides:
   rpm:
     depends:

--- a/packaging/centreon-collect/centreon-clib.yaml
+++ b/packaging/centreon-collect/centreon-clib.yaml
@@ -24,6 +24,10 @@ contents:
     dst: "/usr/lib/"
     packager: deb
 
+  - src: "../../build/clib/libcentreon_clib.so"
+    dst: "/usr/lib/"
+    packager: apk
+
 overrides:
   rpm:
     conflicts:

--- a/packaging/centreon-collect/centreon-engine-daemon.yaml
+++ b/packaging/centreon-collect/centreon-engine-daemon.yaml
@@ -85,6 +85,10 @@ contents:
     dst: "/usr/lib/"
     packager: deb
 
+  - src: "../../build/broker/neb/cbmod.so"
+    dst: "/usr/lib/"
+    packager: apk
+
   - src: "../../build/engine/centenginestats"
     dst: "/usr/sbin/centenginestats"
 

--- a/packaging/centreon-collect/centreon-protobuf-lib-debuginfo.yaml
+++ b/packaging/centreon-collect/centreon-protobuf-lib-debuginfo.yaml
@@ -23,6 +23,10 @@ contents:
     dst: "/usr/lib/debug/usr/lib/"
     packager: deb
 
+  - src: "../../build/bbdo/libcentreon_pb_bbdo.so.debug"
+    dst: "/usr/lib/debug/usr/lib/"
+    packager: apk
+
   - src: "../../build/common/engine_conf/libcentreon_engine_conf.so.debug"
     dst: "/usr/lib/debug/usr/lib64/"
     packager: rpm
@@ -30,6 +34,10 @@ contents:
   - src: "../../build/common/engine_conf/libcentreon_engine_conf.so.debug"
     dst: "/usr/lib/debug/usr/lib/"
     packager: deb
+
+  - src: "../../build/common/engine_conf/libcentreon_engine_conf.so.debug"
+    dst: "/usr/lib/debug/usr/lib/"
+    packager: apk
 
 overrides:
   rpm:

--- a/packaging/centreon-collect/centreon-protobuf-lib.yaml
+++ b/packaging/centreon-collect/centreon-protobuf-lib.yaml
@@ -24,6 +24,10 @@ contents:
     dst: "/usr/lib/"
     packager: deb
 
+  - src: "../../build/bbdo/libcentreon_pb_bbdo.so"
+    dst: "/usr/lib/"
+    packager: apk
+
   - src: "../../build/common/engine_conf/libcentreon_engine_conf.so"
     dst: "/usr/lib64/"
     packager: rpm
@@ -31,6 +35,10 @@ contents:
   - src: "../../build/common/engine_conf/libcentreon_engine_conf.so"
     dst: "/usr/lib/"
     packager: deb
+
+  - src: "../../build/common/engine_conf/libcentreon_engine_conf.so"
+    dst: "/usr/lib/"
+    packager: apk
 
 rpm:
   summary: Centreon protobuf object libraries.


### PR DESCRIPTION
## Summary

Exploratory CI validation for MON-208201 — a local PoC already proved `centengine`/`cbd` compile, link, package, and run correctly against musl on Alpine, including a real
cbmod→broker BBDO wiring test. This PR reproduces that on the real GitHub
Actions pipeline: **package → dockerize → boot-test → wiring-test → trivy scan**, for both `centreon-engine` and `centreon-broker`.

Delivery/promotion jobs (`promote-docker-tag`, `promote-docker-to-ghcr`, `deliver-rpm`, `deliver-deb`, `deliver-*-pulp`, `promote`, `promote-pulp`) are explicitly **out of scope** — nothing here pushes an Alpine artifact to
production Artifactory/Pulp/GHCR.

- 3 source fixes for musl/Alpine compatibility (protobuf field name   collision with musl's `stdio.h` macros, a missing `<sys/time.h>` include,  a glibc-specific `dirent64` alias) — reasoned safe for glibc, not independently re-verified on a glibc build this session.
- `parse-distrib` gains an `alpine` branch (`apk`, family `alpine`,  `alpine3.20` package suffix).
- New `.github/docker/Dockerfile.packaging-centreon-collect-alpine` packaging image (apk-based, Alpine's own `cmake`/`samurai` instead of the pinned glibc Kitware installer / apt `ninja-build`).
- `package-collect.yml`: sysv startup script instead of `systemd` for the alpine family (no systemd on Alpine); selinux-file removal now also covers `apk`.
- `get-environment.yml`: new `alpine`/`mariadb:11.8` config entry in the full-run matrix, plus alpine amd64 forced into `collect_matrix` whenever Docker builds are requested (same treatment trixie already gets).
- New Alpine runtime Dockerfiles for `centreon-engine`/`centreon-broker` (apk-based two-stage extract+runtime, same UID scheme, same entrypoint contract). **Known gap, documented in the engine Dockerfile**: the
  apt-based dynamic plugin/custom-deps install path (`plugins.json`/`custom-deps.json`, 3 CPAN XS Perl modules, the Centreon poller plugin package from `apt-plugins-stable`) has no apk equivalent yet, so those 4 entrypoint scripts are not shipped in the Alpine engine image. Alpine's own `monitoring-plugins` package covers `check_icmp`/ `check_snmp` fine on its own.
- `collect.yml`: alpine wired into `dockerize-engine-broker`, `docker-boot-test`, `docker-config-wiring-test`, `docker-trivy-cves` (amd64-only — the package-cache restore, build platforms, and boot-test platform matrix are all made conditional).
- `centreon-engine-docker-config-wiring-test.sh`: the apt/dpkg-query-based scenarios are skipped (not failed) when the image under test has no `apt-get`, so the Alpine leg still reaches the `[wiring:cbmod-tcp-connect]` and gRPC `GetVersion` scenarios instead of aborting on the first apt-dependent check.

## Test plan

- [ ] `unit-test` + `package` succeed for the new `alpine` matrix entry
- [ ] `dockerize-engine-broker` builds both Alpine images
- [ ] `docker-boot-test` passes for the alpine leg
- [ ] `docker-config-wiring-test`: `[wiring:cbmod-tcp-connect]` and gRPC `GetVersion` pass on alpine; apt-based scenarios are skipped (not failed) as documented
- [ ] `docker-trivy-cves` reports a real CVE count for the alpine images
- [ ] No regression on existing distros (bullseye/bookworm/trixie/jammy/noble/alma8/9/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)