### PR TITLE
MON-207821-whitelist-broker-stats

### DIFF
--- a/gorgone/packaging/configuration/whitelist.conf.d/centreon.yaml
+++ b/gorgone/packaging/configuration/whitelist.conf.d/centreon.yaml
@@ -3,7 +3,7 @@
 - ^sudo\s+(/bin/|/usr/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd|centreon_vmware)(\.service)?\s*$
 - ^(sudo\s+)?(/usr/bin/)?service\s+(centengine|centreontrapd|cbd|cbd-sql)\s+(reload|restart)\s*$
 - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/+centengine\.cfg\s*$
-- ^cat\s+/var/lib/centreon-engine/+[a-zA-Z0-9\-]+-stats\.json\s*$
+- ^cat\s+/var/lib/centreon-(engine|broker)/+[a-zA-Z0-9\-]+-stats\.json\s*$
 - ^(sudo\s+)?/usr/lib/centreon/plugins/.*$
 - ^(sudo\s+)?/usr/lib(64)?/nagios/plugins/.*$ # NRPE Plugins, can be installed in /usr/lib or /usr/lib64 (RHEL based)
 - ^/bin/perl /usr/share/centreon/bin/anomaly_detection --seasonality >> /var/log/centreon/anomaly_detection\.log 2>&1\s*$


### PR DESCRIPTION
## Description

Add centreon-broker as allowed folder for stats retrieval


**Fixes** MON-207821

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [X] master

<h2> How this pull request can be tested ? </h2>

setup a gorgone with whitelist enabled (the default) with this new version this api call should work : 
```bash
curl --request POST "http://localhost:8085/api/core/action/command" --header "Accept: application/json" --header "Content-Type: application/json" --data "[ { \"command\": \"cat /var/lib/centreon-enginea/ceva-rmtaus-01-rrd-stats.json\" }]"
```
you can see the logs of the execution with 
```
curl --request GET "http://127.0.0.1:8085/api/log/TOKEN" | jq .
```


## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

