### PR TITLE
Poller profile docker-compose silently failed

### DIFF
--- a/.github/docker/centreon-poller/alma9/Dockerfile
+++ b/.github/docker/centreon-poller/alma9/Dockerfile
@@ -35,6 +35,9 @@ fi
 
 dnf install -y /tmp/packages-centreon/centreon-*.rpm centreon-gorgone
 
+usermod -aG centreon-gorgone centreon-engine
+usermod -aG centreon-gorgone centreon-broker
+
 systemctl stop gorgoned
 systemctl stop centengine
 

--- a/.github/docker/centreon-poller/alma9/Dockerfile
+++ b/.github/docker/centreon-poller/alma9/Dockerfile
@@ -35,8 +35,8 @@ fi
 
 dnf install -y /tmp/packages-centreon/centreon-*.rpm centreon-gorgone
 
-usermod -aG centreon-gorgone centreon-engine
-usermod -aG centreon-gorgone centreon-broker
+usermod -aG centreon-engine centreon-gorgone
+usermod -aG centreon-broker centreon-gorgone
 
 systemctl stop gorgoned
 systemctl stop centengine


### PR DESCRIPTION
## Description

Since the package dependency rework centreon-poller is now required as an umbrella package to properly install all groups, to work around the issue, users are added manually to the right group to avoid permission issues on config generation

**Fixes**
`usermod -aG centreon-gorgone centreon-engine`
`usermod -aG centreon-gorgone centreon-engine`

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Run `docker compose --profile poller`. After a few seconds, the poller will show up in a running state in the GUI

