### PR TITLE
fix(ci): gate promote-docker-to-ghcr on on-prem releases

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -998,7 +998,8 @@ jobs:
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
+      github.repository == 'centreon/centreon-collect' &&
+      needs.get-environment.outputs.is_cloud == 'false'
     runs-on: centreon-ubuntu-22.04
     permissions:
       contents: read

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -1242,7 +1242,8 @@ jobs:
       ! cancelled() &&
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled') &&
-      github.repository == 'centreon/centreon-collect'
+      github.repository == 'centreon/centreon-collect' &&
+      needs.get-environment.outputs.is_cloud == 'false'
     runs-on: centreon-ubuntu-22.04
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Add `needs.get-environment.outputs.is_cloud == 'false'` to the `promote-docker-to-ghcr` job's `if:` condition in `collect.yml` and `gorgone.yml`, matching the gating already used by `deliver-sources` in the same workflows.
- Without this, a cloud stable release publishes/moves public ghcr.io poller image tags (`centreon-engine`, `centreon-broker`, `centreon-gorgone`) that no cloud install ever resolves to, and could regress what existing cloud pollers pull if a floating tag moves.
- Only an on-prem `26.10.x` (and later `YY.10.x`) stable release can now publish or move ghcr.io poller tags.

Part 1 of MON-208333. Part 2 (reworking `install-poller`'s tag resolution so a cloud platform's generated install script pulls the previous on-prem major) is tracked separately and not included here.

Jira: https://centreon.atlassian.net/browse/MON-208333

## Test plan
- [ ] Workflow YAML parses (checked automatically by GitHub Actions on this PR)
- [ ] Next on-prem `26.10.x` stable promote still publishes `26.10.<patch>` / `26.10` to ghcr.io for `centreon-engine`, `centreon-broker`, `centreon-gorgone`
- [ ] Next cloud stable promote creates/moves no ghcr.io tag for those images