### PR TITLE
chore(ci): backport the Pulp and Artifactory package delivery actions

### DIFF
--- a/.github/actions/deb-delivery/action.yml
+++ b/.github/actions/deb-delivery/action.yml
@@ -38,7 +38,7 @@ runs:
 
     - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
 
     - name: Parse distrib name

--- a/.github/actions/package-delivery-pulp/action.yml
+++ b/.github/actions/package-delivery-pulp/action.yml
@@ -38,16 +38,13 @@ inputs:
     default: "true"
   pulp_url:
     description: "The pulp server api url"
-    required: false
-    default: "https://pulp-api.apps.centreon.com"
+    required: true
   pulp_content_url:
     description: "The pulp server content url"
-    required: false
-    default: "https://packages.apps.centreon.com"
+    required: true
   audience:
     description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
-    required: false
-    default: "https://pulp.dev.centreon.io"
+    required: true
 
 runs:
   using: "composite"
@@ -92,6 +89,7 @@ runs:
       with:
         pulp_url: ${{ inputs.pulp_url }}
         audience: ${{ inputs.audience }}
+        domain: ${{ steps.pulp-properties.outputs.domain }}
 
     - name: Deliver RPM packages
       id: deliver-rpm
@@ -104,7 +102,10 @@ runs:
         REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.repository_prefix }}
         STABLE_REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.stable_repository_prefix }}
         BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.base_path_prefix }}
+        LEGACY_BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.legacy_base_path_prefix }}
         PULP_URL: ${{ inputs.pulp_url }}
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
+        PULP_STABLE_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
         PULP_TOKEN: ${{ env.PULP_TOKEN }}
         PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
       run: ${{ github.action_path }}/deliver-rpm.sh
@@ -119,11 +120,15 @@ runs:
         STABILITY: ${{ inputs.stability }}
         REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.repository_name }}
         BASE_PATH: ${{ steps.pulp-properties.outputs.base_path }}
+        LEGACY_BASE_PATH: ${{ steps.pulp-properties.outputs.legacy_base_path }}
+        LEGACY_STABLE_BASE_PATH: ${{ steps.pulp-properties.outputs.legacy_stable_base_path }}
         SUITE: ${{ steps.pulp-properties.outputs.suite }}
         STABLE_SUITE: ${{ steps.pulp-properties.outputs.stable_suite }}
         STABLE_BASE_PATH: ${{ steps.pulp-properties.outputs.stable_base_path }}
         POOL_PATH: ${{ steps.pulp-properties.outputs.pool_path }}
         PULP_URL: ${{ inputs.pulp_url }}
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
+        PULP_STABLE_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
         PULP_TOKEN: ${{ env.PULP_TOKEN }}
         PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
       run: ${{ github.action_path }}/deliver-deb.sh
@@ -138,6 +143,7 @@ runs:
         DISTRIB: ${{ inputs.distrib }}
         STABILITY: ${{ inputs.stability }}
         PULP_URL: ${{ inputs.pulp_url }}
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
         PULP_TOKEN: ${{ env.PULP_TOKEN }}
         PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
       run: |
@@ -154,6 +160,7 @@ runs:
         DISTRIB: ${{ inputs.distrib }}
         STABILITY: ${{ inputs.stability }}
         PULP_URL: ${{ inputs.pulp_url }}
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
         PULP_TOKEN: ${{ env.PULP_TOKEN }}
         PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
       run: |

--- a/.github/actions/package-delivery-pulp/deliver-deb.sh
+++ b/.github/actions/package-delivery-pulp/deliver-deb.sh
@@ -7,61 +7,95 @@ source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
 # shellcheck source=.github/scripts/pulp/api.sh
 source "$(dirname "$0")/../../scripts/pulp/api.sh"
 
-# use the org-variable values, falling back to the defaults when passed empty
-# (an unset org variable is forwarded as an empty string, overriding the default)
-PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
-PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
+# an unset org variable is forwarded as an empty string, overriding the default
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
+PULP_DOMAIN="${PULP_DOMAIN:-default}"
+# read through the public content-app, no auth/grant needed (see api.sh's content_curl)
+PULP_STABLE_DOMAIN="${PULP_STABLE_DOMAIN:-default}"
 
-# refuse delivering a package that is already published in the stable suite.
-# rebuilding a testing/unstable version with a different content is fine, but a
-# version that already reached stable must never be re-delivered: pulp
-# deduplicates packages by (package, version, architecture) repository wide, so
-# the new content would silently evict the stable one. bump the version instead.
+# fetch the stable suite's Release file and print its advertised architectures
+# (empty output = suite doesn't exist yet, i.e. nothing published to guard against).
+# Fails closed (non-zero) on anything but a clean 404.
+stable_suite_architectures() {
+  local release_file http_code
+  release_file=$(mktemp)
+  http_code=$(content_curl -sSL --retry 3 --retry-delay 5 -o "$release_file" -w '%{http_code}' \
+    "$PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/${STABLE_BASE_PATH:-$BASE_PATH}}/dists/$STABLE_SUITE/Release" 2>/dev/null || echo 000)
+  case "$http_code" in
+    404) rm -f "$release_file"; return 0 ;;
+    200) awk -F': ' '/^Architectures:/ {print $2}' "$release_file"; rm -f "$release_file" ;;
+    *)
+      rm -f "$release_file"
+      echo "::error::Cannot verify the stable suite $STABLE_SUITE (HTTP $http_code) to guard an Architecture: all package; refusing to deliver. Retry once the content endpoint is reachable." >&2
+      return 1
+      ;;
+  esac
+}
+
+# fetch one architecture's Packages index from the stable suite (empty output = not
+# published for that architecture). Fails closed on anything but a clean 404.
+fetch_stable_packages_index() {
+  local a=$1 pkg_file http_code
+  pkg_file=$(mktemp)
+  http_code=$(content_curl -sSL --retry 3 --retry-delay 5 -o "$pkg_file" -w '%{http_code}' \
+    "$PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/${STABLE_BASE_PATH:-$BASE_PATH}}/dists/$STABLE_SUITE/main/binary-$a/Packages" 2>/dev/null || echo 000)
+  case "$http_code" in
+    404) rm -f "$pkg_file"; return 0 ;;
+    200) cat "$pkg_file"; rm -f "$pkg_file" ;;
+    *)
+      rm -f "$pkg_file"
+      echo "::error::Cannot verify the stable suite $STABLE_SUITE binary-$a index; refusing to deliver. Retry once the content endpoint is reachable." >&2
+      return 1
+      ;;
+  esac
+}
+
+# refuse delivering a package version already published in the stable suite:
+# pulp dedupes by (package, version, arch) repository-wide, so re-delivering
+# would silently evict the stable one
 assert_not_in_stable() {
-  local file=$1 name version arch packages http_code pkg_file
+  local file=$1 name version arch arches a packages
   name=$(dpkg-deb -f "$file" Package)
   version=$(dpkg-deb -f "$file" Version)
   arch=$(dpkg-deb -f "$file" Architecture)
 
-  # the published stable suite is the source of truth for what reached stable.
-  # the release_components api is not listable by the OIDC ci-user (403, and no
-  # grantable permission exists for it), so check the served Packages index
-  # instead: no api access needed and it reflects exactly what stable publishes.
-  # distinguish "not published yet" (404 -> not in stable) from a fetch failure
-  # (network / 5xx -> unknown): fail closed on the latter, so a transient content
-  # endpoint error cannot let an already-stable version slip through and evict it
-  # (the rpm guardrail is likewise fail-closed).
-  pkg_file=$(mktemp)
-  http_code=$(content_curl -sSL --retry 3 --retry-delay 5 -o "$pkg_file" -w '%{http_code}' \
-    "$PULP_CONTENT_URL/${STABLE_BASE_PATH:-$BASE_PATH}/dists/$STABLE_SUITE/main/binary-$arch/Packages" 2>/dev/null || echo 000)
-  case "$http_code" in
-    404) rm -f "$pkg_file"; return 0 ;;
-    200) packages=$(cat "$pkg_file"); rm -f "$pkg_file" ;;
-    *)
-      rm -f "$pkg_file"
-      echo "::error::Cannot verify the stable suite $STABLE_SUITE (HTTP $http_code) to guard $name $version ($arch); refusing to deliver. Retry once the content endpoint is reachable."
-      return 1
-      ;;
-  esac
-  # empty index -> nothing in stable
-  [[ -z "$packages" ]] && return 0
-
-  # a package is in stable if a Packages stanza matches both name and version
-  if printf '%s\n' "$packages" | awk -v n="$name" -v v="$version" '
-       BEGIN { RS = ""; FS = "\n" }
-       {
-         has_name = 0; has_version = 0
-         for (i = 1; i <= NF; i++) {
-           if ($i == "Package: " n) has_name = 1
-           if ($i == "Version: " v) has_version = 1
-         }
-         if (has_name && has_version) found = 1
-       }
-       END { exit found ? 0 : 1 }
-     '; then
-    echo "::error::$name $version ($arch) is already published in the stable suite $STABLE_SUITE; refusing to deliver it to $SUITE. Bump the package version for a new build."
-    return 1
+  # the release_components api isn't listable by the OIDC ci-user (403), so
+  # check the served Packages index(es) instead. "Architecture: all" packages are
+  # listed in every binary-<arch>/Packages index the suite advertises, not a
+  # synthetic "binary-all" one that doesn't exist -- resolve the suite's actual
+  # architectures from its Release file and check each of them; other
+  # architectures still only ever need their own single index.
+  if [[ "$arch" == "all" ]]; then
+    arches=$(stable_suite_architectures) || return 1
+    # no Release yet (fresh suite) -> nothing published, nothing to guard against
+    [[ -z "$arches" ]] && return 0
+  else
+    arches="$arch"
   fi
+
+  for a in $arches; do
+    packages=$(fetch_stable_packages_index "$a") || return 1
+    # empty index -> nothing in stable for this architecture
+    [[ -z "$packages" ]] && continue
+
+    # a package is in stable if a Packages stanza matches both name and version
+    if printf '%s\n' "$packages" | awk -v n="$name" -v v="$version" '
+         BEGIN { RS = ""; FS = "\n" }
+         {
+           has_name = 0; has_version = 0
+           for (i = 1; i <= NF; i++) {
+             if ($i == "Package: " n) has_name = 1
+             if ($i == "Version: " v) has_version = 1
+           }
+           if (has_name && has_version) found = 1
+         }
+         END { exit found ? 0 : 1 }
+       '; then
+      echo "::error::$name $version ($arch) is already published in the stable suite $STABLE_SUITE; refusing to deliver it to $SUITE. Bump the package version for a new build."
+      return 1
+    fi
+  done
 }
 
 FILES=(*.deb)
@@ -91,30 +125,20 @@ PULP_LABELS=$(jq -cn \
   --arg workflow   "${GITHUB_WORKFLOW:-}" \
   '{"module": $mod, "git_commit": $git_commit, "git_ref": $git_ref, "github_run_id": $run_id, "github_actor": $actor, "github_workflow": $workflow}')
 
-# Batched delivery, deb flavor. Unlike
-# rpm, a repository-less deb upload ignores the distribution/component
-# parameters (pulp_deb only creates the suite association inside the
-# repository code path), so the suite association is created explicitly as
-# PackageReleaseComponent content units. The release_components api is not
-# listable by the OIDC ci-user, so the FIRST package of each architecture is
-# delivered through the legacy repository code path - that also
-# get_or_creates the ReleaseComponent and the ReleaseArchitecture of the
-# suite - and its PackageReleaseComponent (listable) yields the release
-# component href for the whole batch. Everything else is uploaded as
-# unassociated content in a client-side pool, associated in parallel tasks
-# (no repository lock), then added to the repository with a single modify.
+# a repository-less deb upload ignores distribution/component, so the FIRST
+# package of each arch goes through the legacy repository path instead to
+# establish the suite's release component; the rest upload unassociated and
+# get associated explicitly, then all of it is added in a single modify.
 lookup_deb_content() {
-  # emit the href of a deb content unit matching the query, empty if absent.
-  # Every caller sits on a fallback path where the content is expected to
-  # exist, so an empty result is retried too: the api has been observed
-  # answering an empty page for content committed seconds earlier (stale
-  # read), and a transient error must not read as "content absent" either.
+  # emit the href of a matching deb content unit, empty if absent. Retried:
+  # the api has been observed answering an empty page for content committed
+  # seconds earlier (stale read)
   local endpoint=$1 query=$2 out attempt
   for attempt in 1 2 3 4 5; do
-    out=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Github $PULP_TOKEN" -G \
+    out=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" -G \
       --data-urlencode "limit=1" \
       $query \
-      "$PULP_URL/api/v3/content/deb/$endpoint/" | jq -r '.results[0].pulp_href // empty') || out=""
+      "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/$endpoint/" | jq -r '.results[0].pulp_href // empty') || out=""
     if [[ -n "$out" ]]; then
       echo "$out"
       return 0
@@ -131,7 +155,7 @@ resolve_task_content() {
   local body state content attempt
   for ((attempt = 0; attempt < 200; attempt++)); do
     refresh_pulp_token
-    body=$(curl -fsSL -H "Authorization: Github $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null) || body=""
+    body=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null) || body=""
     state=$(echo "$body" | jq -r '.state' 2>/dev/null) || state=""
     case "$state" in
       completed)
@@ -161,20 +185,18 @@ resolve_task_content() {
 # emit the release-component hrefs a package is associated with
 lookup_prcs() {
   local package_href=$1
-  curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Github $PULP_TOKEN" -G \
+  curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" -G \
     --data-urlencode "package=$package_href" \
     --data-urlencode "limit=100" \
-    "$PULP_URL/api/v3/content/deb/package_release_components/" \
+    "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/package_release_components/" \
     | jq -r '.results[].release_component'
 }
 
-# group the files by architecture: one file per arch goes through the legacy
-# path so the suite association targets of that arch exist. Prefer a file
-# whose content does NOT exist in pulp yet: a fresh upload carries exactly
-# one suite association afterwards, which identifies the release component
-# unambiguously. Content reused across suites (identical bytes delivered to
-# another suite before) keeps its prior associations, so for a reused
-# representative the pre-upload association set is captured to diff later.
+# pick one file per arch for the legacy path. Prefer content that doesn't
+# exist in pulp yet: a fresh upload carries exactly one suite association
+# afterwards, identifying the release component unambiguously. For a reused
+# representative (identical bytes delivered before), capture its pre-upload
+# associations to diff against later.
 declare -A LEGACY_FOR_ARCH=()
 declare -A LEGACY_FRESH=()
 declare -A LEGACY_BEFORE=()
@@ -217,9 +239,7 @@ for FILE in "${LEGACY_FILES[@]}"; do
   assert_not_in_stable "$FILE"
 done
 # sequential with retry: the legacy path creates a repository version, and
-# concurrent legs of the shared repository can lose the version race
-# (wait_task_race rc 2); re-uploading converges, content and suite structure
-# are get_or_created server-side
+# concurrent legs of the shared repository can lose the version race (rc 2)
 for FILE in "${LEGACY_FILES[@]}"; do
   for legacy_attempt in 1 2 3; do
     echo "[INFO] Uploading $FILE to $POOL_PATH/ ($SUITE/main, module $MODULE_NAME) [legacy path, attempt $legacy_attempt]"
@@ -231,7 +251,7 @@ for FILE in "${LEGACY_FILES[@]}"; do
         -F "component=main" \
         -F "repository=$REPOSITORY_HREF" \
         -F "pulp_labels=$PULP_LABELS" \
-        "$PULP_URL/api/v3/content/deb/packages/"
+        "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/packages/"
     )
     wait_task_race "$LEGACY_TASK" && rc=0 || rc=$?
     if [[ $rc -eq 0 ]]; then
@@ -246,10 +266,9 @@ for FILE in "${LEGACY_FILES[@]}"; do
   done
 done
 
-# the release component href of $SUITE/main, deduced from the association the
-# legacy uploads just created. A FRESH representative now carries exactly one
-# association; a reused one carries its prior associations too, so the href is
-# the difference between its post- and pre-upload association sets.
+# deduce the release component href from the association the legacy uploads
+# just created: a fresh representative now carries exactly one association; a
+# reused one carries its prior ones too, so diff post- against pre-upload
 refresh_pulp_token
 RELEASE_COMPONENT_HREF=""
 for i in "${!LEGACY_FILES[@]}"; do
@@ -273,9 +292,7 @@ for i in "${!LEGACY_FILES[@]}"; do
       RELEASE_COMPONENT_HREF="$new_rcs"
       break
     elif [[ $(echo "$after" | grep -c .) -eq 1 ]]; then
-      # rerun of a partially delivered leg: the association was created by
-      # the previous attempt (empty diff) and is the only one the
-      # representative carries - it IS the suite release component.
+      # rerun of a partially delivered leg: empty diff, but it's the only association
       RELEASE_COMPONENT_HREF=$(echo "$after" | grep .)
       break
     fi
@@ -296,8 +313,7 @@ for i in "${!ORPHAN_FILES[@]}"; do
     refresh_pulp_token
   fi
   (
-    # subshell-local refresh: under server slowdowns the inherited token can
-    # outlive its validity between two parent refreshes
+    # subshell-local: the inherited token can go stale between parent refreshes
     refresh_pulp_token
     assert_not_in_stable "$FILE"
     echo "[INFO] Uploading $FILE to $POOL_PATH/ ($SUITE/main, module $MODULE_NAME)"
@@ -305,7 +321,7 @@ for i in "${!ORPHAN_FILES[@]}"; do
       -F "file=@\"$FILE\"" \
       -F "relative_path=$POOL_PATH/$FILE" \
       -F "pulp_labels=$PULP_LABELS" \
-      "$PULP_URL/api/v3/content/deb/packages/" > "$UPLOAD_DIR/$i.task"
+      "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/packages/" > "$UPLOAD_DIR/$i.task"
   ) &
   while (($(jobs -rp | wc -l) >= MAX_PARALLEL_UPLOADS)); do
     wait -n || true
@@ -345,11 +361,8 @@ for i in "${!ORPHAN_FILES[@]}"; do
   PACKAGE_HREFS+=("$(cat "$UPLOAD_DIR/$i.content")")
 done
 
-# associate every uploaded package with the suite component. The
-# package_release_components create is a plain synchronous DRF create (201
-# with the created unit, no task), so the href comes straight out of the
-# response; a failed create (unit already existing on a job re-run) falls
-# back to a lookup.
+# package_release_components create is synchronous (201 with the unit, no
+# task); a failed create (already existing on a job re-run) falls back to a lookup
 echo "[INFO] Associating ${#PACKAGE_HREFS[@]} package(s) with $SUITE/main"
 for i in "${!PACKAGE_HREFS[@]}"; do
   if ((i % 40 == 0)); then
@@ -357,22 +370,20 @@ for i in "${!PACKAGE_HREFS[@]}"; do
   fi
   (
     refresh_pulp_token
-    out=$(post_json "$PULP_URL/api/v3/content/deb/package_release_components/" \
+    out=$(post_json "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/package_release_components/" \
       "{\"package\": \"${PACKAGE_HREFS[$i]}\", \"release_component\": \"$RELEASE_COMPONENT_HREF\"}") || out=$'\n000'
     code="${out##*$'\n'}"
     body="${out%$'\n'*}"
     href=""
     if [[ "$code" == 2* ]]; then
-      # tolerate a non-json body (gateway error page behind a 2xx): a jq
-      # failure inside the substitution would silently kill this subshell
+      # tolerate a non-json body (gateway error page behind a 2xx)
       href=$(echo "$body" | jq -r '.pulp_href // .task // empty' 2>/dev/null) || href=""
     fi
     if [[ -z "$href" ]]; then
       href=$(lookup_deb_content "package_release_components" \
         "--data-urlencode package=${PACKAGE_HREFS[$i]} --data-urlencode release_component=$RELEASE_COMPONENT_HREF")
       if [[ -n "$href" ]]; then
-        # the api answers 500 on a duplicate synchronous content create; on a
-        # rerun the association simply pre-exists, nothing is wrong
+        # api answers 500 on a duplicate synchronous create; expected on a rerun
         echo "[INFO] ${ORPHAN_FILES[$i]}: suite association already exists (HTTP $code on create, expected on a rerun), reusing it"
       else
         echo "[WARN] Suite association create for ${ORPHAN_FILES[$i]} returned HTTP $code: $(echo "$body" | head -c 300)" >&2
@@ -408,8 +419,7 @@ if ((${#PACKAGE_HREFS[@]} > 0)); then
   # body through a file: thousands of hrefs exceed the argv limit
   ADD_BODY_FILE=$(mktemp)
   printf '%s\n' "${PACKAGE_HREFS[@]}" "${PRC_HREFS[@]}" | jq -R . | jq -cs '{add_content_units: .}' > "$ADD_BODY_FILE"
-  # retried like the legacy uploads: the modify also creates a repository
-  # version and can lose the same race against a concurrent delivery
+  # retried like the legacy uploads: same repository-version race
   for modify_attempt in 1 2 3; do
     MODIFY_TASK=$(start_modify_task "$PULP_URL${REPOSITORY_HREF}modify/" "$ADD_BODY_FILE")
     wait_task_race "$MODIFY_TASK" && rc=0 || rc=$?
@@ -434,13 +444,13 @@ for FILE in "${FILES[@]}"; do
   manifest_add "$(jq -cn \
     --arg filename "$FILE" --arg name "$name" --arg version "$version" \
     --arg arch "$arch" --arg sha256 "$sha256" --arg repository "$REPOSITORY_NAME" \
-    --arg base_path "$BASE_PATH" --arg suite "$SUITE" --arg relative_path "$POOL_PATH/$FILE" \
+    --arg base_path "${LEGACY_BASE_PATH:-$PULP_DOMAIN/$BASE_PATH}" --arg suite "$SUITE" --arg relative_path "$POOL_PATH/$FILE" \
     '{filename:$filename,name:$name,version:$version,arch:$arch,sha256:$sha256,repository:$repository,base_path:$base_path,suite:$suite,relative_path:$relative_path}')"
 done
 
 echo "[INFO] Publishing repository $REPOSITORY_NAME"
 create_publication deb "$REPOSITORY_NAME" --structured
 
-echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/$BASE_PATH/ $SUITE main"
+echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/${LEGACY_BASE_PATH:-$PULP_DOMAIN/$BASE_PATH}/ $SUITE main"
 
 manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "${STABILITY:-}" "delivery" "$PULP_CONTENT_URL"

--- a/.github/actions/package-delivery-pulp/deliver-rpm.sh
+++ b/.github/actions/package-delivery-pulp/deliver-rpm.sh
@@ -7,16 +7,14 @@ source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
 # shellcheck source=.github/scripts/pulp/api.sh
 source "$(dirname "$0")/../../scripts/pulp/api.sh"
 
-# use the org-variable values, falling back to the defaults when passed empty
-# (an unset org variable is forwarded as an empty string, overriding the default)
-PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
-PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
+# an unset org variable is forwarded as an empty string, overriding the default
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
+PULP_DOMAIN="${PULP_DOMAIN:-default}"
+# read-only grant into the stable domain, used by assert_not_in_stable below
+PULP_STABLE_DOMAIN="${PULP_STABLE_DOMAIN:-default}"
 
-# refuse delivering a package that is already published in the stable repository.
-# rebuilding a testing/unstable version with a different content is fine, but a
-# version that already reached stable must never be re-delivered. rpm uses a
-# dedicated repository per stability, so this is a policy check (deliveries to
-# testing/unstable cannot evict stable, unlike a shared repository).
+# refuse delivering a package version already published in the stable repository
 assert_not_in_stable() {
   local file=$1 arch=$2 base name version release stable_repository repository_version count
   base=$(basename "$file" .rpm)
@@ -27,15 +25,13 @@ assert_not_in_stable() {
   name=${base%-*}
 
   stable_repository="$STABLE_REPOSITORY_PREFIX-$arch"
-  # fail closed on an unreachable api (a transient 5xx must not bypass the
-  # guard nor silently kill the calling worker), fail open only on the repo
-  # genuinely not existing yet
+  # fail closed on an unreachable api, fail open only if the repo doesn't exist yet
   local repo_page
   repo_page=$(
-    curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Github $PULP_TOKEN" -G \
+    curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" -G \
       --data-urlencode "name=$stable_repository" \
       --data-urlencode "limit=1" \
-      "$PULP_URL/api/v3/repositories/rpm/rpm/"
+      "$PULP_URL/$PULP_STABLE_DOMAIN/api/v3/repositories/rpm/rpm/"
   ) || {
     echo "::error::Cannot check the stable repository $stable_repository to guard $name $version-$release ($arch); refusing to deliver. Retry once the api is reachable."
     return 1
@@ -45,14 +41,14 @@ assert_not_in_stable() {
   [[ -z "$repository_version" ]] && return 0
 
   count=$(
-    curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Github $PULP_TOKEN" -G \
+    curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" -G \
       --data-urlencode "repository_version=$repository_version" \
       --data-urlencode "name=$name" \
       --data-urlencode "version=$version" \
       --data-urlencode "release=$release" \
       --data-urlencode "arch=$arch" \
       --data-urlencode "limit=1" \
-      "$PULP_URL/api/v3/content/rpm/packages/" | jq -r '.count'
+      "$PULP_URL/$PULP_STABLE_DOMAIN/api/v3/content/rpm/packages/" | jq -r '.count'
   ) || {
     echo "::error::Cannot check the stable repository $stable_repository content to guard $name $version-$release ($arch); refusing to deliver. Retry once the api is reachable."
     return 1
@@ -63,16 +59,14 @@ assert_not_in_stable() {
   fi
 }
 
-# Wait for a repository-less upload task and emit
-# the created content href. A task that did not produce one (content already
-# existing on a job re-run) is resolved by the package sha256 instead of
-# failing the delivery.
+# wait for the upload task and emit its content href; fall back to a sha256
+# lookup if the task produced none (content already existing on a job re-run)
 resolve_uploaded_content() {
   local task_href=$1 sha256=$2
   local body state content attempt
   for ((attempt = 0; attempt < 200; attempt++)); do
     refresh_pulp_token
-    body=$(curl -fsSL -H "Authorization: Github $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null) || body=""
+    body=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null) || body=""
     state=$(echo "$body" | jq -r '.state' 2>/dev/null) || state=""
     case "$state" in
       completed)
@@ -92,10 +86,10 @@ resolve_uploaded_content() {
     esac
   done
   content=$(
-    curl -fsSL -H "Authorization: Github $PULP_TOKEN" -G \
+    curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" -G \
       --data-urlencode "sha256=$sha256" \
       --data-urlencode "limit=1" \
-      "$PULP_URL/api/v3/content/rpm/packages/" | jq -r '.results[0].pulp_href // empty'
+      "$PULP_URL/$PULP_DOMAIN/api/v3/content/rpm/packages/" | jq -r '.results[0].pulp_href // empty'
   )
   if [[ -z "$content" ]]; then
     echo "::error::Cannot resolve the uploaded content for task $task_href (sha256 $sha256)" >&2
@@ -137,6 +131,8 @@ for ARCH in noarch x86_64; do
 
   REPOSITORY_NAME="$REPOSITORY_PREFIX-$ARCH"
   BASE_PATH="$BASE_PATH_PREFIX/$ARCH"
+  LEGACY_BASE_PATH=""
+  [[ -n "$LEGACY_BASE_PATH_PREFIX" ]] && LEGACY_BASE_PATH="$LEGACY_BASE_PATH_PREFIX/$ARCH"
 
   if ! pulp_resource_exists "repositories/rpm/rpm" "$REPOSITORY_NAME"; then
     echo "::error::rpm repository $REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before delivering."
@@ -150,21 +146,12 @@ for ARCH in noarch x86_64; do
 
   REPOSITORY_HREF=$(pulp rpm repository show --name "$REPOSITORY_NAME" | jq -r '.pulp_href')
 
-  # Batched delivery: packages are
-  # uploaded as unassociated content (repository-less, so the create tasks
-  # parallelize across the pulp workers instead of serializing on the
-  # repository lock), then the whole batch is added to the repository with a
-  # single modify task. Requires the reconciled rpm/packages access policy
-  # (delivery-tooling#209). Packages are labeled with their module so that
-  # promote-to-stable can identify them.
+  # upload as unassociated (repository-less) content so creates parallelize
+  # across pulp workers, then add the whole batch in one modify task
   TASK_HREFS=()
   SHA256S=()
-  # The uploads are parallelized client-side (the
-  # repository-less create tasks already parallelize server-side). A bounded
-  # pool of background subshells posts the files, each writing its task href
-  # to a marker file; the parent refreshes the OIDC token between spawn
-  # chunks so the workers always inherit a fresh token. Worker failures are
-  # detected through missing/empty marker files after the wait.
+  # bounded pool of background subshells upload in parallel, each writing its
+  # task href to a marker file; a missing/empty marker means that worker failed
   UPLOAD_DIR=$(mktemp -d)
   MAX_PARALLEL_UPLOADS=8
   for i in "${!ARCH_FILES[@]}"; do
@@ -173,15 +160,14 @@ for ARCH in noarch x86_64; do
       refresh_pulp_token
     fi
     (
-      # subshell-local refresh: under server slowdowns the inherited token can
-      # outlive its validity between two parent refreshes
+      # subshell-local: the inherited token can go stale between parent refreshes
       refresh_pulp_token
       assert_not_in_stable "$FILE" "$ARCH"
       echo "[INFO] Uploading $(basename "$FILE") (module $MODULE_NAME)"
       pulp_upload \
         -F "file=@\"$FILE\"" \
         -F "pulp_labels=$PULP_LABELS" \
-        "$PULP_URL/api/v3/content/rpm/packages/" > "$UPLOAD_DIR/$i.task"
+        "$PULP_URL/$PULP_DOMAIN/api/v3/content/rpm/packages/" > "$UPLOAD_DIR/$i.task"
     ) &
     while (($(jobs -rp | wc -l) >= MAX_PARALLEL_UPLOADS)); do
       wait -n || true
@@ -199,8 +185,7 @@ for ARCH in noarch x86_64; do
     sha256=$(sha256sum "$FILE" | cut -d' ' -f1)
     SHA256S+=("$sha256")
 
-    # record the uploaded package in the manifest (name-version-release parsed
-    # the same way as assert_not_in_stable) for the verification step
+    # name/version/release parsed the same way as assert_not_in_stable
     FILENAME=$(basename "$FILE")
     base=${FILENAME%.rpm}
     base=${base%."$ARCH"}
@@ -211,14 +196,13 @@ for ARCH in noarch x86_64; do
     manifest_add "$(jq -cn \
       --arg filename "$FILENAME" --arg name "$name" --arg version "$version" \
       --arg release "$release" --arg arch "$ARCH" --arg sha256 "$sha256" \
-      --arg repository "$REPOSITORY_NAME" --arg base_path "$BASE_PATH" \
+      --arg repository "$REPOSITORY_NAME" --arg base_path "${LEGACY_BASE_PATH:-$PULP_DOMAIN/$BASE_PATH}" \
       '{filename:$filename,name:$name,version:$version,release:$release,arch:$arch,sha256:$sha256,repository:$repository,base_path:$base_path}')"
   done
   rm -rf "$UPLOAD_DIR"
 
   echo "[INFO] Waiting for ${#TASK_HREFS[@]} upload task(s) and resolving the content"
-  # The resolutions are parallelized like the
-  # uploads - sequential, they paid one task GET per package (~6 min at 675)
+  # parallelized like the uploads: sequential took one task GET per package (~6 min at 675)
   RESOLVE_DIR=$(mktemp -d)
   for i in "${!TASK_HREFS[@]}"; do
     if ((i % 40 == 0)); then
@@ -244,14 +228,12 @@ for ARCH in noarch x86_64; do
   rm -rf "$RESOLVE_DIR"
 
   echo "[INFO] Adding ${#CONTENT_HREFS[@]} package(s) to $REPOSITORY_NAME in a single task"
-  # refresh from the parent shell: the resolutions above ran in subshells, so
-  # their refreshes never updated this shell's token (the 401 trap, again)
+  # the subshell refreshes above never updated this shell's token
   refresh_pulp_token
   # body through a file: thousands of hrefs exceed the argv limit
   ADD_BODY_FILE=$(mktemp)
   printf '%s\n' "${CONTENT_HREFS[@]}" | jq -R . | jq -cs '{add_content_units: .}' > "$ADD_BODY_FILE"
-  # retried like the deb path: several modules deliver into the same rpm
-  # repository (version race), and any task can lose its worker
+  # several modules deliver into the same repository (version race)
   for modify_attempt in 1 2 3; do
     MODIFY_TASK=$(start_modify_task "$PULP_URL${REPOSITORY_HREF}modify/" "$ADD_BODY_FILE")
     wait_task_race "$MODIFY_TASK" && rc=0 || rc=$?
@@ -269,7 +251,7 @@ for ARCH in noarch x86_64; do
   echo "[INFO] Publishing repository $REPOSITORY_NAME"
   create_publication rpm "$REPOSITORY_NAME"
 
-  echo "::notice::Packages are available at $PULP_CONTENT_URL/$BASE_PATH/"
+  echo "::notice::Packages are available at $PULP_CONTENT_URL/${LEGACY_BASE_PATH:-$PULP_DOMAIN/$BASE_PATH}/"
 done
 
 manifest_write "$MODULE_NAME" "${DISTRIB:-}" "rpm" "${STABILITY:-}" "delivery" "$PULP_CONTENT_URL"

--- a/.github/actions/promote-to-stable-pulp/action.yml
+++ b/.github/actions/promote-to-stable-pulp/action.yml
@@ -30,16 +30,13 @@ inputs:
     default: "true"
   pulp_url:
     description: "The pulp server api url"
-    required: false
-    default: "https://pulp-api.apps.centreon.com"
+    required: true
   pulp_content_url:
     description: "The pulp server content url"
-    required: false
-    default: "https://packages.apps.centreon.com"
+    required: true
   audience:
     description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
-    required: false
-    default: "https://pulp.dev.centreon.io"
+    required: true
 
 runs:
   using: "composite"
@@ -73,6 +70,7 @@ runs:
       with:
         pulp_url: ${{ inputs.pulp_url }}
         audience: ${{ inputs.audience }}
+        domain: ${{ steps.pulp-properties.outputs.domain }}
 
     - name: Promote RPM packages to stable
       id: promote-rpm
@@ -82,12 +80,17 @@ runs:
         MODULE_NAME: ${{ inputs.module_name }}
         DISTRIB: ${{ inputs.distrib }}
         TESTING_REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.testing_repository_prefix }}
+        TESTING_BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.testing_base_path_prefix }}
         STABLE_REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.stable_repository_prefix }}
         STABLE_BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.stable_base_path_prefix }}
+        LEGACY_STABLE_BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.legacy_stable_base_path_prefix }}
         STABILITY: ${{ inputs.stability }}
         PULP_URL: ${{ inputs.pulp_url }}
         PULP_TOKEN: ${{ env.PULP_TOKEN }}
         PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+        # stable shares the domain since the domain merge; kept distinct for the scripts that address the stable tier
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
+        PULP_STABLE_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
       run: ${{ github.action_path }}/promote-rpm.sh
 
     - name: Promote DEB packages to stable
@@ -97,11 +100,17 @@ runs:
       env:
         MODULE_NAME: ${{ inputs.module_name }}
         DISTRIB: ${{ inputs.distrib }}
-        REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.repository_name }}
-        BASE_PATH: ${{ steps.pulp-properties.outputs.base_path }}
+        # the promotion source is the testing repository (one deb repository per
+        # stability), not the repository matching the requested stability
+        REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.testing_repository_name }}
+        BASE_PATH: ${{ steps.pulp-properties.outputs.testing_base_path }}
+        LEGACY_TESTING_BASE_PATH: ${{ steps.pulp-properties.outputs.legacy_testing_base_path }}
+        LEGACY_STABLE_BASE_PATH: ${{ steps.pulp-properties.outputs.legacy_stable_base_path }}
         TESTING_POOL_PATH: ${{ steps.pulp-properties.outputs.testing_pool_path }}
         TESTING_SUITE: ${{ steps.pulp-properties.outputs.testing_suite }}
         STABLE_SUITE: ${{ steps.pulp-properties.outputs.stable_suite }}
+        STABLE_LEGACY_SUITE: ${{ steps.pulp-properties.outputs.stable_legacy_suite }}
+        STABLE_LEGACY_REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.stable_legacy_repository_name }}
         STABLE_REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.stable_repository_name }}
         STABLE_BASE_PATH: ${{ steps.pulp-properties.outputs.stable_base_path }}
         PACKAGE_DISTRIB_NAME: ${{ steps.pulp-properties.outputs.package_distrib_name }}
@@ -109,6 +118,9 @@ runs:
         PULP_URL: ${{ inputs.pulp_url }}
         PULP_TOKEN: ${{ env.PULP_TOKEN }}
         PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+        # stable shares the domain since the domain merge; kept distinct for the scripts that address the stable tier
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
+        PULP_STABLE_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
       run: ${{ github.action_path }}/promote-deb.sh
 
     - name: Verify RPM promotion
@@ -125,6 +137,8 @@ runs:
         PULP_URL: ${{ inputs.pulp_url }}
         PULP_TOKEN: ${{ env.PULP_TOKEN }}
         PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+        # verifying the just-promoted content, which now lives in the stable domain
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
       run: |
         ${{ github.action_path }}/../../scripts/pulp/check-rpm.sh ||
           echo "::warning::Pulp promotion verification failed for ${MODULE_NAME} on ${DISTRIB} (non-blocking during the Artifactory-to-Pulp migration, see the run summary table)"
@@ -143,6 +157,8 @@ runs:
         PULP_URL: ${{ inputs.pulp_url }}
         PULP_TOKEN: ${{ env.PULP_TOKEN }}
         PULP_CONTENT_URL: ${{ inputs.pulp_content_url }}
+        # verifying the just-promoted content, which now lives in the stable domain
+        PULP_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
       run: |
         ${{ github.action_path }}/../../scripts/pulp/check-deb.sh ||
           echo "::warning::Pulp promotion verification failed for ${MODULE_NAME} on ${DISTRIB} (non-blocking during the Artifactory-to-Pulp migration, see the run summary table)"

--- a/.github/actions/promote-to-stable-pulp/promote-deb.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-deb.sh
@@ -6,25 +6,20 @@ source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
 # shellcheck source=.github/scripts/pulp/api.sh
 source "$(dirname "$0")/../../scripts/pulp/api.sh"
 
-# use the org-variable values, falling back to the defaults when passed empty
-# (an unset org variable is forwarded as an empty string, overriding the default)
-PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
-PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
-
-# the stable packages may live in a DEDICATED repository (deb plugins:
-# apt-plugins-stable/ubuntu-plugins-stable with plain-codename suites, the
-# artifactory-compatible client layout); default to the source repository
-# for the families whose stable suite it hosts.
-STABLE_REPOSITORY_NAME="${STABLE_REPOSITORY_NAME:-$REPOSITORY_NAME}"
-STABLE_BASE_PATH="${STABLE_BASE_PATH:-$BASE_PATH}"
+# an unset org variable is forwarded as an empty string, overriding the default
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
+# stable shares its Domain with testing since the domain merge (PULP_STABLE_DOMAIN
+# now equals PULP_DOMAIN); the read/write phase switch is kept as a no-op
+PULP_DOMAIN="${PULP_DOMAIN:-default}"
+PULP_STABLE_DOMAIN="${PULP_STABLE_DOMAIN:-default}"
+# switch_pulp_domain overwrites PULP_DOMAIN itself once the write phase
+# starts; download_testing_package always needs the original (testing-tier)
+# domain, including after the switch, so keep our own copy
+TESTING_DOMAIN="$PULP_DOMAIN"
 
 if ! pulp_resource_exists "repositories/deb/apt" "$REPOSITORY_NAME"; then
   echo "::error::Nothing to promote, repository $REPOSITORY_NAME does not exist"
-  exit 1
-fi
-
-if ! pulp_resource_exists "repositories/deb/apt" "$STABLE_REPOSITORY_NAME"; then
-  echo "::error::Stable repository $STABLE_REPOSITORY_NAME does not exist. Pulp repositories are provisioned centrally by delivery-tooling create-repos; run create-repos before promoting."
   exit 1
 fi
 
@@ -39,12 +34,10 @@ fetch_index() {
   return 1
 }
 
-# collect the sha256 set of every package published in a suite. The served
-# dists/ indexes are the source of truth for suite membership: the packages'
-# relative_path cannot be trusted for that (content reused across suites
-# keeps its original upload path) and the release_components api is not
-# listable by the OIDC ci-user. A missing Release (404) is an empty suite;
-# any other fetch failure aborts, a partial set must not drive a promotion.
+# collect the sha256 set of every package published in a suite: the served
+# dists/ indexes are the source of truth for suite membership (relative_path
+# and the release_components api can't be trusted/used here, see deliver-deb.sh).
+# A missing Release (404) is an empty suite; any other fetch failure aborts.
 suite_sha_file() {
   local base_path=$1 suite=$2 out release_file arches arch pkg_file rc
   out=$(mktemp)
@@ -72,53 +65,41 @@ suite_sha_file() {
   echo "$out"
 }
 
-TESTING_SHAS_FILE=$(suite_sha_file "$BASE_PATH" "$TESTING_SUITE")
+# resolve the served filename from the testing suite's Packages file by
+# sha256 (the published pool layout doesn't match the upload relative_path)
+download_testing_package() {
+  local sha256=$1 arch=$2 dest=$3 filename
+  filename=$(
+    content_curl -fsSL --retry 3 --retry-delay 5 "$PULP_CONTENT_URL/${LEGACY_TESTING_BASE_PATH:-$TESTING_DOMAIN/$BASE_PATH}/dists/$TESTING_SUITE/main/binary-$arch/Packages" |
+      awk -v sha="$sha256" 'BEGIN { RS = ""; FS = "\n" } index($0, "SHA256: " sha) { for (i = 1; i <= NF; i++) if ($i ~ /^Filename: /) { sub(/^Filename: /, "", $i); print $i; exit } }'
+  )
+  if [[ -z "$filename" ]]; then
+    echo "::error::Cannot locate the published file for sha256 $sha256 in $TESTING_SUITE ($arch)" >&2
+    return 1
+  fi
+  content_curl -fsSL --retry 3 --retry-delay 5 -o "$dest" "$PULP_CONTENT_URL/${LEGACY_TESTING_BASE_PATH:-$TESTING_DOMAIN/$BASE_PATH}/$filename"
+}
 
-# "already promoted" is decided against the stable repository VERSION when a
-# dedicated stable repository is used (it only ever receives stable content):
-# a promotion whose publication failed then reruns as a plain republish. With
-# a shared repository the version cannot discriminate suites, so membership
-# stays based on the published stable index.
-if [[ "$STABLE_REPOSITORY_NAME" != "$REPOSITORY_NAME" ]]; then
-  STABLE_SHAS_FILE=$(mktemp)
-  STABLE_VERSION_HREF=$(pulp deb repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.latest_version_href')
-  url="$PULP_URL/api/v3/content/deb/packages/?$(
-    printf 'repository_version=%s&fields=sha256&limit=1000' \
-      "$(jq -rn --arg v "$STABLE_VERSION_HREF" '$v | @uri')"
-  )"
-  while [[ -n "$url" ]]; do
-    refresh_pulp_token
-    page=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Github $PULP_TOKEN" "$url")
-    echo "$page" | jq -r '.results[].sha256' >> "$STABLE_SHAS_FILE"
-    url=$(echo "$page" | jq -r '.next // empty')
-  done
-  sort -u "$STABLE_SHAS_FILE" -o "$STABLE_SHAS_FILE"
-else
-  STABLE_SHAS_FILE=$(suite_sha_file "$STABLE_BASE_PATH" "$STABLE_SUITE")
-fi
+TESTING_SHAS_FILE=$(suite_sha_file "${LEGACY_TESTING_BASE_PATH:-$TESTING_DOMAIN/$BASE_PATH}" "$TESTING_SUITE")
 
-# packages of the module are identified by the label set at delivery time.
-# Paginated: the shared repository keeps every delivered version across all
-# suites, so the module listing exceeds a single page.
+# paginated: the repository keeps every delivered version across all suites,
+# so the module listing can exceed a single page
 RESULTS_FILE=$(mktemp)
-url="$PULP_URL/api/v3/content/deb/packages/?$(
+url="$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/packages/?$(
   printf 'repository_version=%s&pulp_label_select=%s&limit=1000' \
     "$(jq -rn --arg v "$VERSION_HREF" '$v | @uri')" \
     "$(jq -rn --arg v "module=$MODULE_NAME" '$v | @uri')"
 )"
 while [[ -n "$url" ]]; do
   refresh_pulp_token
-  page=$(curl -fsSL -H "Authorization: Github $PULP_TOKEN" "$url")
+  page=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$url")
   echo "$page" | jq -c '.results[]' >> "$RESULTS_FILE"
   url=$(echo "$page" | jq -r '.next // empty')
 done
 
-# only the LATEST version of each package is promoted: the testing suite
-# accumulates every delivered build (deb has no retention mechanism).
-# Versions are compared segment by segment (numeric segments as numbers): a
-# plain string max would rank "0.9" above "0.10", which bites the
-# semver-like versions of some modules. Pipeline-built versions carry no
-# epoch or tilde.
+# only the LATEST version of each package is promoted (deb has no retention
+# mechanism, testing accumulates every build); compare segment by segment
+# (numeric as numbers) since a plain string max ranks "0.9" above "0.10"
 TESTING_SET_FILE=$(mktemp)
 jq -R . "$TESTING_SHAS_FILE" | jq -s 'map({key: ., value: true}) | from_entries' > "$TESTING_SET_FILE"
 PACKAGES=$(
@@ -143,20 +124,142 @@ if [[ "$STABILITY" != "stable" ]]; then
   exit 0
 fi
 
+# everything from here on targets the stable-tier domain
+refresh_pulp_token
+switch_pulp_domain "$PULP_STABLE_DOMAIN"
+
+if ! pulp_resource_exists "repositories/deb/apt" "$STABLE_REPOSITORY_NAME"; then
+  echo "::error::Stable repository $STABLE_REPOSITORY_NAME does not exist. Pulp repositories are provisioned centrally by delivery-tooling create-repos; run create-repos before promoting."
+  exit 1
+fi
 STABLE_REPOSITORY_HREF=$(pulp deb repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.pulp_href')
+
+# 24.x standard clients use the dedicated legacy repository form
+# (apt-standard-24.10-stable/ with a plain-codename suite, provisioned by
+# create-repos): mirror every candidate package association into that suite so
+# both suites always list the same stable content. Idempotent (rerun safe).
+ensure_legacy_suite_associations() {
+  [[ -z "${STABLE_LEGACY_REPOSITORY_NAME:-}" ]] && return 0
+  refresh_pulp_token
+  if ! pulp_resource_exists "repositories/deb/apt" "$STABLE_LEGACY_REPOSITORY_NAME"; then
+    echo "::error::Dedicated legacy repository $STABLE_LEGACY_REPOSITORY_NAME does not exist. Pulp repositories are provisioned centrally by delivery-tooling create-repos; run create-repos before promoting."
+    return 1
+  fi
+  local legacy_repo_href latest legacy_rc
+  legacy_repo_href=$(pulp deb repository show --name "$STABLE_LEGACY_REPOSITORY_NAME" | jq -r '.pulp_href')
+  latest=$(pulp deb repository show --name "$STABLE_LEGACY_REPOSITORY_NAME" | jq -r '.latest_version_href')
+  legacy_rc=$(
+    curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" \
+      "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/release_components/?$(
+        printf 'repository_version=%s&distribution=%s&component=main&limit=1' \
+          "$(jq -rn --arg v "$latest" '$v | @uri')" "$(jq -rn --arg v "$STABLE_LEGACY_SUITE" '$v | @uri')"
+      )" | jq -r '.results[0].pulp_href // empty'
+  )
+  if [[ -z "$legacy_rc" ]]; then
+    echo "::error::Cannot resolve the $STABLE_LEGACY_SUITE/main release component of $STABLE_LEGACY_REPOSITORY_NAME (provisioned by create-repos)"
+    return 1
+  fi
+  echo "[INFO] Mirroring $PACKAGES_COUNT package association(s) into $STABLE_LEGACY_REPOSITORY_NAME $STABLE_LEGACY_SUITE/main"
+  local units_file body_file sha href out code body prc n=0
+  units_file=$(mktemp)
+  while read -r sha; do
+    if ((n % 40 == 0)); then refresh_pulp_token; fi
+    n=$((n + 1))
+    href=$(lookup_deb_content "packages" "--data-urlencode sha256=$sha")
+    if [[ -z "$href" ]]; then
+      echo "::error::Cannot resolve the promoted package (sha256 $sha) for the $STABLE_LEGACY_SUITE mirror"
+      return 1
+    fi
+    out=$(post_json "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/package_release_components/" \
+      "{\"package\": \"$href\", \"release_component\": \"$legacy_rc\"}") || out=$'\n000'
+    code="${out##*$'\n'}"
+    body="${out%$'\n'*}"
+    prc=""
+    if [[ "$code" == 2* ]]; then
+      prc=$(echo "$body" | jq -r '.pulp_href // empty' 2>/dev/null) || prc=""
+    fi
+    if [[ -z "$prc" ]]; then
+      # the api answers 500 on a duplicate synchronous create; expected on a rerun
+      prc=$(lookup_deb_content "package_release_components" \
+        "--data-urlencode package=$href --data-urlencode release_component=$legacy_rc")
+    fi
+    if [[ -z "$prc" ]]; then
+      echo "::error::Legacy suite association failed for sha256 $sha (HTTP $code)"
+      return 1
+    fi
+    printf '%s\n%s\n' "$href" "$prc" >> "$units_file"
+  done < <(echo "$PACKAGES" | jq -r '.[].sha256')
+  body_file=$(mktemp)
+  jq -R . "$units_file" | jq -cs '{add_content_units: ([.[] | select(. != "")] | unique)}' > "$body_file"
+  rm -f "$units_file"
+  local task rc
+  for _ in 1 2 3; do
+    task=$(start_modify_task "$PULP_URL${legacy_repo_href}modify/" "$body_file")
+    wait_task_race "$task" && rc=0 || rc=$?
+    if [[ $rc -eq 0 ]]; then
+      rm -f "$body_file"
+      create_publication deb "$STABLE_LEGACY_REPOSITORY_NAME" --structured
+      return 0
+    fi
+  done
+  echo "::error::Cannot add the $STABLE_LEGACY_SUITE mirror associations to $STABLE_LEGACY_REPOSITORY_NAME"
+  return 1
+}
+
+# "already promoted" is decided against the stable repository's OWN version
+# (it's always dedicated, never shared, so it only ever receives stable content)
+STABLE_SHAS_FILE=$(mktemp)
+STABLE_VERSION_HREF=$(pulp deb repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.latest_version_href')
+url="$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/packages/?$(
+  printf 'repository_version=%s&fields=sha256&limit=1000' \
+    "$(jq -rn --arg v "$STABLE_VERSION_HREF" '$v | @uri')"
+)"
+while [[ -n "$url" ]]; do
+  refresh_pulp_token
+  page=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" "$url")
+  echo "$page" | jq -r '.results[].sha256' >> "$STABLE_SHAS_FILE"
+  url=$(echo "$page" | jq -r '.next // empty')
+done
+sort -u "$STABLE_SHAS_FILE" -o "$STABLE_SHAS_FILE"
 
 mkdir -p promoted-packages
 
-# module label, built with jq (safe escaping) — consistent with the delivery scripts
-PULP_LABELS=$(jq -cn --arg mod "$MODULE_NAME" '{"module": $mod}')
+# mirrors deliver-deb.sh's own PULP_LABELS, but this run's own git context
+PULP_LABELS=$(jq -cn \
+  --arg mod        "$MODULE_NAME" \
+  --arg git_commit "${GITHUB_SHA:-}" \
+  --arg git_ref    "${GITHUB_REF:-}" \
+  --arg run_id     "${GITHUB_RUN_ID:-}" \
+  --arg actor      "${GITHUB_ACTOR:-}" \
+  --arg workflow   "${GITHUB_WORKFLOW:-}" \
+  '{"module": $mod, "git_commit": $git_commit, "git_ref": $git_ref, "github_run_id": $run_id, "github_actor": $actor, "github_workflow": $workflow}')
+
+# emit the href of a matching stable-domain deb content unit, empty if absent.
+# Retried: the api has been observed answering an empty page for content
+# committed seconds earlier (stale read)
+lookup_deb_content() {
+  local endpoint=$1 query=$2 out attempt
+  for attempt in 1 2 3 4 5; do
+    out=$(curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" -G \
+      --data-urlencode "limit=1" \
+      $query \
+      "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/$endpoint/" | jq -r '.results[0].pulp_href // empty') || out=""
+    if [[ -n "$out" ]]; then
+      echo "$out"
+      return 0
+    fi
+    sleep $((attempt * 3))
+    refresh_pulp_token
+  done
+}
 
 # emit the release-component hrefs a package is associated with
 lookup_prcs() {
   local package_href=$1
-  curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Github $PULP_TOKEN" -G \
+  curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" -G \
     --data-urlencode "package=$package_href" \
     --data-urlencode "limit=100" \
-    "$PULP_URL/api/v3/content/deb/package_release_components/" \
+    "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/package_release_components/" \
     | jq -r '.results[].release_component'
 }
 
@@ -175,24 +278,23 @@ if ((${#UNPROMOTED_HREFS[@]} == 0)); then
   echo "[INFO] All $PACKAGES_COUNT package(s) are already promoted to $STABLE_SUITE; republishing only"
   while read -r PACKAGE; do
     manifest_add "$(echo "$PACKAGE" | jq -c \
-      --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "$STABLE_BASE_PATH" \
+      --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" \
       --arg suite "$STABLE_SUITE" \
       '{filename: (.relative_path | sub(".*/"; "")), name: .package, version, arch: .architecture, sha256, repository: $repository, base_path: $base_path, suite: $suite, relative_path}')"
   done < <(echo "$PACKAGES" | jq -c '.[]')
+  ensure_legacy_suite_associations
   create_publication deb "$STABLE_REPOSITORY_NAME" --structured
-  echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/$STABLE_BASE_PATH/ $STABLE_SUITE main"
+  echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}/ $STABLE_SUITE main"
   manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "$STABILITY" "promote" "$PULP_CONTENT_URL"
   exit 0
 fi
 
-# batched promote, mirroring the batched delivery: the packages already exist
-# as content units in the repository (testing suite), so promoting is only a
-# matter of stable suite associations. The FIRST package of each architecture
-# is promoted through the legacy re-upload path - it get_or_creates the stable
-# ReleaseComponent and ReleaseArchitecture, which the ci user cannot create
-# nor list directly - then the stable release-component href is deduced from
-# its associations, every other association is created synchronously, and one
-# modify adds the whole batch to the repository.
+# batched promote, mirroring the batched delivery. Testing and stable share
+# their domain (and content) since the domain merge: the batch below associates
+# the testing package hrefs directly, no re-download/re-upload. Only the FIRST
+# package of each arch goes through the legacy upload path, to establish the
+# release component and deduce its href (see deliver-deb.sh; listing release
+# components requires admin rights).
 declare -A ARCH_SEEN=()
 LEGACY_PACKAGES=()
 BATCH_PACKAGES=()
@@ -206,12 +308,13 @@ while read -r PACKAGE; do
   fi
 done < <(echo "$PACKAGES" | jq -c '.[]')
 
-# the stable release component is deduced from the association the legacy
-# re-upload of the FIRST reference creates: capture its association set
-# before the upload so the new one stands out as the difference.
+# capture the reference package's pre-upload stable associations (if it
+# already exists there, e.g. a rerun) so the new one stands out as the diff
 refresh_pulp_token
-LEGACY_REF_HREF=$(echo "${LEGACY_PACKAGES[0]}" | jq -r '.pulp_href')
-LEGACY_REF_BEFORE=$(lookup_prcs "$LEGACY_REF_HREF" | sort)
+LEGACY_REF_SHA256=$(echo "${LEGACY_PACKAGES[0]}" | jq -r '.sha256')
+LEGACY_REF_BEFORE_HREF=$(lookup_deb_content "packages" "--data-urlencode sha256=$LEGACY_REF_SHA256")
+LEGACY_REF_BEFORE=""
+[[ -n "$LEGACY_REF_BEFORE_HREF" ]] && LEGACY_REF_BEFORE=$(lookup_prcs "$LEGACY_REF_BEFORE_HREF" | sort)
 
 for PACKAGE in "${LEGACY_PACKAGES[@]}"; do
   RELATIVE_PATH=$(echo "$PACKAGE" | jq -r '.relative_path')
@@ -220,27 +323,12 @@ for PACKAGE in "${LEGACY_PACKAGES[@]}"; do
   FILE_NAME=$(basename "$RELATIVE_PATH")
   FILE="promoted-packages/$FILE_NAME"
 
-  # the structured publication serves packages under the canonical debian pool
-  # layout, not their upload relative_path, so resolve the published location
-  # from the testing suite Packages indexed by checksum to download the file
-  FILENAME=$(
-    content_curl -fsSL --retry 3 --retry-delay 5 "$PULP_CONTENT_URL/$BASE_PATH/dists/$TESTING_SUITE/main/binary-$ARCH/Packages" |
-      awk -v sha="$SHA256" 'BEGIN { RS = ""; FS = "\n" } index($0, "SHA256: " sha) { for (i = 1; i <= NF; i++) if ($i ~ /^Filename: /) { sub(/^Filename: /, "", $i); print $i } }'
-  )
-  if [[ -z "$FILENAME" ]]; then
-    echo "::error::Cannot locate the published file of $FILE_NAME (sha256 $SHA256) in $TESTING_SUITE"
-    exit 1
-  fi
+  echo "[INFO] Downloading $FILE_NAME from $TESTING_SUITE"
+  download_testing_package "$SHA256" "$ARCH" "$FILE"
 
-  echo "[INFO] Downloading $PULP_CONTENT_URL/$BASE_PATH/$FILENAME"
-  content_curl -fsSL --retry 3 --retry-delay 5 -o "$FILE" "$PULP_CONTENT_URL/$BASE_PATH/$FILENAME"
-
-  # re-upload the same bytes with the SAME relative_path: pulp reuses the
-  # existing content unit and only adds the stable suite association,
-  # creating the stable ReleaseComponent/ReleaseArchitecture on the way
-  # retried: the legacy path creates a repository version and can lose the
-  # version race against a concurrent promotion or delivery (wait_task_race
-  # rc 2); re-uploading converges, content and structure are get_or_created
+  # same relative_path into stable: pulp reuses existing content and adds the
+  # stable suite association, creating the ReleaseComponent/ReleaseArchitecture
+  # retried: the legacy path creates a repository version and can lose the race
   for legacy_attempt in 1 2 3; do
     echo "[INFO] Promoting $FILE_NAME to $STABLE_SUITE/main [legacy path, attempt $legacy_attempt]"
     TASK_HREF=$(
@@ -251,7 +339,7 @@ for PACKAGE in "${LEGACY_PACKAGES[@]}"; do
         -F "component=main" \
         -F "repository=$STABLE_REPOSITORY_HREF" \
         -F "pulp_labels=$PULP_LABELS" \
-        "$PULP_URL/api/v3/content/deb/packages/"
+        "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/packages/"
     )
     wait_task_race "$TASK_HREF" && rc=0 || rc=$?
     if [[ $rc -eq 0 ]]; then
@@ -267,47 +355,35 @@ for PACKAGE in "${LEGACY_PACKAGES[@]}"; do
 done
 
 if ((${#BATCH_PACKAGES[@]} > 0)); then
-  # the stable release component is the association the legacy re-upload just
-  # added to the reference package. On a rerun the association pre-exists and
-  # the difference is empty: the reference then carries every suite it belongs
-  # to (stable, testing, possibly unstable for reused content), and the
-  # stable one is isolated by subtracting the associations of not-yet-promoted
-  # candidates - those belong to every suite of the reference EXCEPT stable.
+  # the release component is the association the legacy re-upload just added
+  # to the reference package (diffed against its pre-upload set captured above)
   refresh_pulp_token
-  LEGACY_REF_AFTER=$(lookup_prcs "$LEGACY_REF_HREF" | sort)
+  LEGACY_REF_STABLE_HREF=$(lookup_deb_content "packages" "--data-urlencode sha256=$LEGACY_REF_SHA256")
+  if [[ -z "$LEGACY_REF_STABLE_HREF" ]]; then
+    echo "::error::Cannot resolve the promoted reference package (sha256 $LEGACY_REF_SHA256) in the stable domain"
+    exit 1
+  fi
+  LEGACY_REF_AFTER=$(lookup_prcs "$LEGACY_REF_STABLE_HREF" | sort)
   STABLE_RC_SET=$(comm -13 <(echo "$LEGACY_REF_BEFORE") <(echo "$LEGACY_REF_AFTER") | grep . || true)
   if [[ $(echo "$STABLE_RC_SET" | grep -c .) -ne 1 ]]; then
-    STABLE_RC_SET=$(echo "$LEGACY_REF_AFTER" | grep . || true)
-    for u_href in "${UNPROMOTED_HREFS[@]}"; do
-      [[ "$u_href" == "$LEGACY_REF_HREF" ]] && continue
-      [[ $(echo "$STABLE_RC_SET" | grep -c .) -le 1 ]] && break
-      u_prcs=$(lookup_prcs "$u_href" | sort)
-      STABLE_RC_SET=$(comm -23 <(echo "$STABLE_RC_SET") <(echo "$u_prcs") | grep . || true)
-    done
-  fi
-  STABLE_RC=$(echo "$STABLE_RC_SET" | grep . | head -1)
-  if [[ (-z "$STABLE_RC" || $(echo "$STABLE_RC_SET" | grep -c .) -ne 1) && "$STABLE_REPOSITORY_NAME" != "$REPOSITORY_NAME" ]]; then
-    # dedicated stable repository: it only ever receives stable suite
-    # associations, so any association it already holds points to the stable
-    # release component. Covers reruns of a promotion interrupted between the
-    # association creation and the repository modify, where every
-    # before/after diff above is empty.
     refresh_pulp_token
     STABLE_LATEST=$(pulp deb repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.latest_version_href')
-    STABLE_RC=$(
-      curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Github $PULP_TOKEN" \
-        "$PULP_URL/api/v3/content/deb/package_release_components/?$(
-          printf 'repository_version=%s&limit=1' "$(jq -rn --arg v "$STABLE_LATEST" '$v | @uri')"
-        )" | jq -r '.results[0].release_component // empty'
+    STABLE_RC_SET=$(
+      curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Bearer $PULP_TOKEN" \
+        "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/release_components/?$(
+          printf 'repository_version=%s&distribution=%s&component=main&limit=1' \
+            "$(jq -rn --arg v "$STABLE_LATEST" '$v | @uri')" "$(jq -rn --arg v "$STABLE_SUITE" '$v | @uri')"
+        )" | jq -r '.results[0].pulp_href // empty'
     )
-    [[ -n "$STABLE_RC" ]] && STABLE_RC_SET="$STABLE_RC"
   fi
-  if [[ -z "$STABLE_RC" || $(echo "$STABLE_RC_SET" | grep -c .) -ne 1 ]]; then
+  STABLE_RC=$(echo "$STABLE_RC_SET" | grep . | head -1)
+  if [[ -z "$STABLE_RC" ]]; then
     # a promotion interrupted after its repository modify only misses the
     # publication: republish and re-check every candidate before giving up
     echo "[WARN] Cannot deduce the $STABLE_SUITE/main release component (got: ${STABLE_RC_SET:-none}); republishing to check for an interrupted promotion"
+    ensure_legacy_suite_associations
     create_publication deb "$STABLE_REPOSITORY_NAME" --structured
-    RECHECK_SHAS_FILE=$(suite_sha_file "$STABLE_BASE_PATH" "$STABLE_SUITE")
+    RECHECK_SHAS_FILE=$(suite_sha_file "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" "$STABLE_SUITE")
     MISSING_COUNT=0
     while read -r sha; do
       grep -qxF "$sha" "$RECHECK_SHAS_FILE" || MISSING_COUNT=$((MISSING_COUNT + 1))
@@ -317,11 +393,11 @@ if ((${#BATCH_PACKAGES[@]} > 0)); then
       echo "[INFO] Every candidate package is published in $STABLE_SUITE; the interrupted promotion only missed the publication"
       while read -r PACKAGE; do
         manifest_add "$(echo "$PACKAGE" | jq -c \
-          --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "$STABLE_BASE_PATH" \
+          --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" \
           --arg suite "$STABLE_SUITE" \
           '{filename: (.relative_path | sub(".*/"; "")), name: .package, version, arch: .architecture, sha256, repository: $repository, base_path: $base_path, suite: $suite, relative_path}')"
       done < <(echo "$PACKAGES" | jq -c '.[]')
-      echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/$STABLE_BASE_PATH/ $STABLE_SUITE main"
+      echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}/ $STABLE_SUITE main"
       manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "$STABILITY" "promote" "$PULP_CONTENT_URL"
       exit 0
     fi
@@ -330,49 +406,40 @@ if ((${#BATCH_PACKAGES[@]} > 0)); then
   fi
   echo "[INFO] Release component of $STABLE_SUITE/main: $STABLE_RC"
 
-  # create the stable suite associations: synchronous creates (201 with the
-  # unit, no task), parallelized; a failed create (existing association on a
-  # re-run) falls back to a lookup
-  echo "[INFO] Associating ${#BATCH_PACKAGES[@]} package(s) with $STABLE_SUITE/main"
-  PRC_DIR=$(mktemp -d)
+  # remaining packages: the testing content hrefs are associated with the
+  # stable release component directly (same domain, shared content); the
+  # packages keep their delivery-time labels
+  PACKAGE_HREFS=()
+  for PACKAGE in "${BATCH_PACKAGES[@]}"; do
+    PACKAGE_HREFS+=("$(echo "$PACKAGE" | jq -r '.pulp_href')")
+  done
+
+  # package_release_components create is synchronous (201 with the unit, no
+  # task); a failed create (already existing on a job re-run) falls back to a lookup
+  echo "[INFO] Associating ${#PACKAGE_HREFS[@]} package(s) with $STABLE_SUITE/main"
   MAX_PARALLEL=8
-  for i in "${!BATCH_PACKAGES[@]}"; do
+  PRC_DIR=$(mktemp -d)
+  for i in "${!PACKAGE_HREFS[@]}"; do
     if ((i % 40 == 0)); then
       refresh_pulp_token
     fi
     (
       refresh_pulp_token
-      package_href=$(echo "${BATCH_PACKAGES[$i]}" | jq -r '.pulp_href')
-      out=$(post_json "$PULP_URL/api/v3/content/deb/package_release_components/" \
+      package_href="${PACKAGE_HREFS[$i]}"
+      out=$(post_json "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/package_release_components/" \
         "{\"package\": \"$package_href\", \"release_component\": \"$STABLE_RC\"}") || out=$'\n000'
       code="${out##*$'\n'}"
       body="${out%$'\n'*}"
       href=""
       if [[ "$code" == 2* ]]; then
-        # tolerate a non-json body (gateway error page behind a 2xx): a jq
-        # failure inside the substitution would silently kill this subshell
+        # tolerate a non-json body (gateway error page behind a 2xx)
         href=$(echo "$body" | jq -r '.pulp_href // empty' 2>/dev/null) || href=""
       fi
       if [[ -z "$href" ]]; then
-        # the api answers 500 on a duplicate synchronous content create; on a
-        # rerun the stable association simply pre-exists (see the lookup below)
+        # api answers 500 on a duplicate synchronous create; expected on a rerun
         echo "[INFO] $(echo "${BATCH_PACKAGES[$i]}" | jq -r '.package'): stable association create answered HTTP $code, falling back to the lookup (expected on a rerun)"
-        # the association exists (the create just hit its unique constraint):
-        # empty pages are retried, the api has been observed answering stale
-        # reads for content committed seconds earlier
-        for lookup_attempt in 1 2 3 4 5; do
-          href=$(
-            curl -fsSL --retry 3 --retry-delay 5 -H "Authorization: Github $PULP_TOKEN" -G \
-              --data-urlencode "package=$package_href" \
-              --data-urlencode "release_component=$STABLE_RC" \
-              --data-urlencode "limit=1" \
-              "$PULP_URL/api/v3/content/deb/package_release_components/" \
-              | jq -r '.results[0].pulp_href // empty'
-          ) || href=""
-          [[ -n "$href" ]] && break
-          sleep $((lookup_attempt * 3))
-          refresh_pulp_token
-        done
+        href=$(lookup_deb_content "package_release_components" \
+          "--data-urlencode package=$package_href --data-urlencode release_component=$STABLE_RC")
       fi
       printf '%s\n%s' "$package_href" "$href" > "$PRC_DIR/$i.pair"
     ) &
@@ -399,8 +466,7 @@ if ((${#BATCH_PACKAGES[@]} > 0)); then
   ADD_BODY_FILE=$(mktemp)
   jq -R . "$ADD_UNITS_FILE" | jq -cs '{add_content_units: [.[] | select(. != "")]}' > "$ADD_BODY_FILE"
   rm -f "$ADD_UNITS_FILE"
-  # retried like the legacy uploads: the modify also creates a repository
-  # version and can lose the same race
+  # retried like the legacy uploads: same repository-version race
   for modify_attempt in 1 2 3; do
     MODIFY_TASK=$(start_modify_task "$PULP_URL${STABLE_REPOSITORY_HREF}modify/" "$ADD_BODY_FILE")
     wait_task_race "$MODIFY_TASK" && rc=0 || rc=$?
@@ -420,14 +486,15 @@ fi
 # verification step verifies exactly this set against the stable suite
 while read -r PACKAGE; do
   manifest_add "$(echo "$PACKAGE" | jq -c \
-    --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "$STABLE_BASE_PATH" \
+    --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" \
     --arg suite "$STABLE_SUITE" \
     '{filename: (.relative_path | sub(".*/"; "")), name: .package, version, arch: .architecture, sha256, repository: $repository, base_path: $base_path, suite: $suite, relative_path}')"
 done < <(echo "$PACKAGES" | jq -c '.[]')
 
+ensure_legacy_suite_associations
 echo "[INFO] Publishing repository $STABLE_REPOSITORY_NAME"
 create_publication deb "$STABLE_REPOSITORY_NAME" --structured
 
-echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/$STABLE_BASE_PATH/ $STABLE_SUITE main"
+echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}/ $STABLE_SUITE main"
 
 manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "$STABILITY" "promote" "$PULP_CONTENT_URL"

--- a/.github/actions/promote-to-stable-pulp/promote-rpm.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-rpm.sh
@@ -6,11 +6,13 @@ source "$(dirname "$0")/../../scripts/pulp/manifest.sh"
 # shellcheck source=.github/scripts/pulp/api.sh
 source "$(dirname "$0")/../../scripts/pulp/api.sh"
 
-# use the org-variable values, falling back to the defaults when passed empty
-# (an unset org variable is forwarded as an empty string, overriding the default)
-PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
-PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
-
+# an unset org variable is forwarded as an empty string, overriding the default
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
+# stable shares its Domain with testing since the domain merge (PULP_STABLE_DOMAIN
+# now equals PULP_DOMAIN); the read/write phase switch is kept as a no-op
+PULP_DOMAIN="${PULP_DOMAIN:-default}"
+PULP_STABLE_DOMAIN="${PULP_STABLE_DOMAIN:-default}"
 declare -A ARCH_CONTENT
 declare -A ARCH_RESULTS
 TOTAL_PACKAGES_COUNT=0
@@ -25,28 +27,23 @@ for ARCH in noarch x86_64; do
 
   VERSION_HREF=$(pulp rpm repository show --name "$TESTING_REPOSITORY_NAME" | jq -r '.latest_version_href')
 
-  # packages of the module are identified by the label set at delivery time;
-  # keep both the href list (for the content modify call) and the package
-  # identity (name/version/release/arch/filename) to feed the promotion manifest
   # paginate: the testing repository keeps every delivered version, so the
   # module listing can exceed a single page
   RESULTS_FILE=$(mktemp)
-  url="$PULP_URL/api/v3/content/rpm/packages/?$(
+  url="$PULP_URL/$PULP_DOMAIN/api/v3/content/rpm/packages/?$(
     printf 'repository_version=%s&pulp_label_select=%s&limit=1000' \
       "$(jq -rn --arg v "$VERSION_HREF" '$v | @uri')" \
       "$(jq -rn --arg v "module=$MODULE_NAME" '$v | @uri')"
   )"
   while [[ -n "$url" ]]; do
     refresh_pulp_token
-    page=$(curl -fsSL -H "Authorization: Github $PULP_TOKEN" "$url")
+    page=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$url")
     echo "$page" | jq -c '.results[]' >> "$RESULTS_FILE"
     url=$(echo "$page" | jq -r '.next // empty')
   done
 
-  # only the LATEST build of each package is promoted. Versions are compared
-  # segment by segment (numeric segments as numbers): a plain string max
-  # would rank "0.9" above "0.10", which bites the semver-like versions of
-  # some modules. Pipeline-built versions carry no epoch or tilde.
+  # only the LATEST build of each package is promoted; compare version/release
+  # segment by segment (numeric as numbers) since a plain string max ranks "0.9" above "0.10"
   RESULTS=$(jq -s 'def vkey: [scan("[0-9]+|[^0-9]+") | (tonumber? // .)];
     [.[] | {pulp_href, name, version, release, arch, location_href, sha256}]
     | group_by(.name, .arch) | map(max_by([(.version | vkey), (.release | vkey)]))' "$RESULTS_FILE")
@@ -70,8 +67,13 @@ if [[ "$STABILITY" != "stable" ]]; then
   exit 0
 fi
 
+# everything from here on targets the stable-tier domain
+refresh_pulp_token
+switch_pulp_domain "$PULP_STABLE_DOMAIN"
+
 for ARCH in noarch x86_64; do
   CONTENT="${ARCH_CONTENT[$ARCH]:-[]}"
+  RESULTS="${ARCH_RESULTS[$ARCH]:-[]}"
   ARCH_PACKAGES_COUNT=$(echo "$CONTENT" | jq 'length')
 
   if [[ "$ARCH_PACKAGES_COUNT" -eq 0 ]]; then
@@ -81,6 +83,8 @@ for ARCH in noarch x86_64; do
 
   STABLE_REPOSITORY_NAME="$STABLE_REPOSITORY_PREFIX-$ARCH"
   STABLE_BASE_PATH="$STABLE_BASE_PATH_PREFIX/$ARCH"
+  LEGACY_STABLE_BASE_PATH=""
+  [[ -n "$LEGACY_STABLE_BASE_PATH_PREFIX" ]] && LEGACY_STABLE_BASE_PATH="$LEGACY_STABLE_BASE_PATH_PREFIX/$ARCH"
 
   if ! pulp_resource_exists "repositories/rpm/rpm" "$STABLE_REPOSITORY_NAME"; then
     echo "::error::stable rpm repository $STABLE_REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before promoting."
@@ -94,12 +98,15 @@ for ARCH in noarch x86_64; do
 
   STABLE_REPOSITORY_HREF=$(pulp rpm repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.pulp_href')
 
+  # Same-domain promotion: testing and stable share their domain, so the
+  # testing content hrefs (already collected above) are associated with the
+  # stable repository directly — no re-download/re-upload, the packages keep
+  # their delivery-time labels (check-rpm.sh only needs "module").
   echo "[INFO] Promoting $ARCH_PACKAGES_COUNT packages to $STABLE_REPOSITORY_NAME"
   # pulp-cli repository content modify does not resolve content by pulp_href, use the api directly
   ADD_BODY_FILE=$(mktemp)
   echo "$CONTENT" | jq -c '{add_content_units: .}' > "$ADD_BODY_FILE"
-  # retried like the deb path: any task can lose its worker, and concurrent
-  # promotions can race on the stable repository version
+  # retried like the deb path: concurrent promotions can race on the repository version
   for modify_attempt in 1 2 3; do
     TASK_HREF=$(start_modify_task "$PULP_URL${STABLE_REPOSITORY_HREF}modify/" "$ADD_BODY_FILE")
     wait_task_race "$TASK_HREF" && rc=0 || rc=$?
@@ -121,11 +128,11 @@ for ARCH in noarch x86_64; do
   # verification step verifies exactly this set against the stable repo
   while read -r PKG; do
     manifest_add "$(echo "$PKG" | jq -c \
-      --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "$STABLE_BASE_PATH" \
+      --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" \
       '{filename: (.location_href | sub(".*/"; "")), name, version, release, arch, sha256, repository: $repository, base_path: $base_path}')"
   done < <(echo "${ARCH_RESULTS[$ARCH]}" | jq -c '.[]')
 
-  echo "::notice::Packages are available at $PULP_CONTENT_URL/$STABLE_BASE_PATH/"
+  echo "::notice::Packages are available at $PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}/"
 done
 
 manifest_write "$MODULE_NAME" "${DISTRIB:-}" "rpm" "$STABILITY" "promote" "$PULP_CONTENT_URL"

--- a/.github/actions/promote-to-stable/action.yml
+++ b/.github/actions/promote-to-stable/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
 
     - name: Parse distrib name

--- a/.github/actions/pulp-repository-properties/action.yml
+++ b/.github/actions/pulp-repository-properties/action.yml
@@ -48,32 +48,65 @@ outputs:
   base_path_prefix:
     description: "Base path prefix of rpm distributions (one distribution per architecture)"
     value: ${{ steps.properties.outputs.base_path_prefix }}
+  legacy_base_path_prefix:
+    description: "Legacy (front) rpm base path prefix, used by the content verifications"
+    value: ${{ steps.properties.outputs.legacy_base_path_prefix }}
+  legacy_testing_base_path_prefix:
+    description: "Legacy (front) testing rpm base path prefix"
+    value: ${{ steps.properties.outputs.legacy_testing_base_path_prefix }}
+  legacy_stable_base_path_prefix:
+    description: "Legacy (front) stable rpm base path prefix"
+    value: ${{ steps.properties.outputs.legacy_stable_base_path_prefix }}
   repository_name:
     description: "Repository name of the deb repository"
     value: ${{ steps.properties.outputs.repository_name }}
   base_path:
     description: "Base path of the deb distribution"
     value: ${{ steps.properties.outputs.base_path }}
+  legacy_base_path:
+    description: "Legacy (front) deb base path, used by the content verifications"
+    value: ${{ steps.properties.outputs.legacy_base_path }}
+  legacy_testing_base_path:
+    description: "Legacy (front) testing deb base path"
+    value: ${{ steps.properties.outputs.legacy_testing_base_path }}
+  legacy_stable_base_path:
+    description: "Legacy (front) stable deb base path"
+    value: ${{ steps.properties.outputs.legacy_stable_base_path }}
   suite:
     description: "Apt suite of the deb delivery"
     value: ${{ steps.properties.outputs.suite }}
   testing_repository_prefix:
     description: "Repository name prefix of testing rpm repositories, used as promotion source"
     value: ${{ steps.properties.outputs.testing_repository_prefix }}
+  testing_base_path_prefix:
+    description: "Base path prefix of testing rpm distributions, used to download promotion source content"
+    value: ${{ steps.properties.outputs.testing_base_path_prefix }}
   stable_repository_prefix:
     description: "Repository name prefix of stable rpm repositories"
     value: ${{ steps.properties.outputs.stable_repository_prefix }}
   stable_base_path_prefix:
     description: "Base path prefix of stable rpm distributions"
     value: ${{ steps.properties.outputs.stable_base_path_prefix }}
+  testing_repository_name:
+    description: "Repository name of the testing deb repository, used as promotion source"
+    value: ${{ steps.properties.outputs.testing_repository_name }}
+  testing_base_path:
+    description: "Base path of the testing deb distribution, used to download promotion source content"
+    value: ${{ steps.properties.outputs.testing_base_path }}
   testing_suite:
     description: "Apt suite of testing deb packages"
     value: ${{ steps.properties.outputs.testing_suite }}
   stable_suite:
     description: "Apt suite of stable deb packages"
     value: ${{ steps.properties.outputs.stable_suite }}
+  stable_legacy_suite:
+    description: "Plain-codename suite of the dedicated 24.x stable legacy repositories (empty otherwise)"
+    value: ${{ steps.properties.outputs.stable_legacy_suite }}
+  stable_legacy_repository_name:
+    description: "Dedicated 24.x stable legacy repository fed by the promote mirror (empty otherwise)"
+    value: ${{ steps.properties.outputs.stable_legacy_repository_name }}
   stable_repository_name:
-    description: "Repository holding the stable packages (dedicated for deb plugins, the delivery repository otherwise)"
+    description: "Repository holding the stable deb packages (one deb repository per stability)"
     value: ${{ steps.properties.outputs.stable_repository_name }}
   stable_base_path:
     description: "Base path serving the stable packages"
@@ -87,6 +120,12 @@ outputs:
   stable_pool_path:
     description: "Module scoped pool path of stable deb packages"
     value: ${{ steps.properties.outputs.stable_pool_path }}
+  domain:
+    description: "Pulp Domain of the delivery (testing/unstable tier) repository"
+    value: ${{ steps.properties.outputs.domain }}
+  stable_domain:
+    description: "Pulp Domain of the stable-tier repository"
+    value: ${{ steps.properties.outputs.stable_domain }}
 
 runs:
   using: "composite"

--- a/.github/actions/pulp-repository-properties/properties.sh
+++ b/.github/actions/pulp-repository-properties/properties.sh
@@ -30,29 +30,21 @@ fi
 # parse-distrib emits the el family either generically ("el") or per version
 # ("el7"/"el8"/"el9"/"el10" on centreon-collect); normalize it to "el" so the
 # family checks below are portable across both conventions.
+DEB_PREFIX=""
 case "$DISTRIB_FAMILY" in
   el | el[0-9]*)
-    FAMILY_PREFIX="rpm-"
     DISTRIB_FAMILY="el"
     ;;
-  debian) FAMILY_PREFIX="apt-" ;;
-  ubuntu) FAMILY_PREFIX="ubuntu-" ;;
+  debian) DEB_PREFIX="apt-" ;;
+  ubuntu) DEB_PREFIX="ubuntu-" ;;
   *)
     echo "::error::Unsupported distribution family: $DISTRIB_FAMILY"
     exit 1
     ;;
 esac
 
-ROOT_REPO="${FAMILY_PREFIX}${REPO_BASE}"
-
-# business (paid) rpm content is served under an opaque path segment, mirroring
-# the Artifactory layout; only rpm business repos use it (deb business does not).
-BUSINESS_HASH="1a97ff9985262bf3daf7a0919f9c59a6"
-HASH_SEGMENT=""
-if [[ "$REPO_BASE" == "business" && "$DISTRIB_FAMILY" == "el" ]]; then
-  HASH_SEGMENT="/$BUSINESS_HASH"
-fi
-
+# uniform stability segments across every edition (plugins included):
+# unstable, testing-release, testing-hotfix, stable
 TESTING_SEGMENT="testing"
 TESTING_POOL_SEGMENT="testing"
 if [[ "$RELEASE_TYPE" == "release" || "$RELEASE_TYPE" == "hotfix" ]]; then
@@ -69,61 +61,75 @@ fi
 
 REPOSITORY_PREFIX=""
 BASE_PATH_PREFIX=""
+LEGACY_BASE_PATH_PREFIX=""
+LEGACY_TESTING_BASE_PATH_PREFIX=""
+LEGACY_STABLE_BASE_PATH_PREFIX=""
+LEGACY_BASE_PATH=""
+LEGACY_TESTING_BASE_PATH=""
+LEGACY_STABLE_BASE_PATH=""
 TESTING_REPOSITORY_PREFIX=""
+TESTING_BASE_PATH_PREFIX=""
 STABLE_REPOSITORY_PREFIX=""
 STABLE_BASE_PATH_PREFIX=""
 REPOSITORY_NAME=""
 BASE_PATH=""
 SUITE=""
+TESTING_REPOSITORY_NAME=""
+TESTING_BASE_PATH=""
 TESTING_SUITE=""
 STABLE_SUITE=""
+STABLE_LEGACY_SUITE=""
+STABLE_LEGACY_REPOSITORY_NAME=""
 POOL_PATH=""
 TESTING_POOL_PATH=""
 STABLE_POOL_PATH=""
 
 if [[ "$REPO_BASE" == "plugins" ]]; then
-  # plugins repositories are not versioned and use their own testing layout: a
-  # bare "testing" segment for releases and "testing-hotfix" for hotfixes,
-  # mirroring the artifactory rpm-plugins/<distrib>/<stability> layout. deb
-  # plugins share one apt-plugins/ubuntu-plugins repo with <distrib>-<stability>
-  # suites.
+  # plugins repositories are not versioned: rpm paths carry no version segment
+  # and deb suites are the plain distribution codename.
   if [[ "$DELIVERY_TYPE" == "feature" ]]; then
     echo "::notice::Feature delivery is not supported for plugins packages, skipping delivery."
     echo "skip_delivery=true" >> "$GITHUB_OUTPUT"
     exit 0
   fi
 
-  TESTING_SEGMENT="testing"
-  TESTING_POOL_SEGMENT="testing"
-  if [[ "$RELEASE_TYPE" == "hotfix" ]]; then
-    TESTING_SEGMENT="testing-hotfix"
-    TESTING_POOL_SEGMENT="testing/hotfix"
-  fi
-
-  STABILITY_SEGMENT="$STABILITY"
-  POOL_SEGMENT="$STABILITY"
-  if [[ "$STABILITY" == "testing" ]]; then
-    STABILITY_SEGMENT="$TESTING_SEGMENT"
-    POOL_SEGMENT="$TESTING_POOL_SEGMENT"
-  fi
-
   if [[ "$DISTRIB_FAMILY" == "el" ]]; then
-    REPOSITORY_PREFIX="$ROOT_REPO-$DISTRIB-$STABILITY_SEGMENT"
-    BASE_PATH_PREFIX="$ROOT_REPO/$DISTRIB/$STABILITY_SEGMENT"
-    TESTING_REPOSITORY_PREFIX="$ROOT_REPO-$DISTRIB-$TESTING_SEGMENT"
-    STABLE_REPOSITORY_PREFIX="$ROOT_REPO-$DISTRIB-stable"
-    STABLE_BASE_PATH_PREFIX="$ROOT_REPO/$DISTRIB/stable"
+    REPOSITORY_PREFIX="rpm-$DISTRIB-$STABILITY_SEGMENT"
+    BASE_PATH_PREFIX="rpm/$DISTRIB/$STABILITY_SEGMENT"
+    TESTING_REPOSITORY_PREFIX="rpm-$DISTRIB-$TESTING_SEGMENT"
+    TESTING_BASE_PATH_PREFIX="rpm/$DISTRIB/$TESTING_SEGMENT"
+    STABLE_REPOSITORY_PREFIX="rpm-$DISTRIB-stable"
+    STABLE_BASE_PATH_PREFIX="rpm/$DISTRIB/stable"
+    LEGACY_SEGMENT_RPM="$STABILITY_SEGMENT"
+    [[ "$STABILITY_SEGMENT" == "testing-release" ]] && LEGACY_SEGMENT_RPM="testing"
+    LEGACY_TESTING_SEGMENT_RPM="$TESTING_SEGMENT"
+    [[ "$TESTING_SEGMENT" == "testing-release" ]] && LEGACY_TESTING_SEGMENT_RPM="testing"
+    LEGACY_BASE_PATH_PREFIX="rpm-$REPO_BASE/$DISTRIB/$LEGACY_SEGMENT_RPM"
+    LEGACY_TESTING_BASE_PATH_PREFIX="rpm-$REPO_BASE/$DISTRIB/$LEGACY_TESTING_SEGMENT_RPM"
+    LEGACY_STABLE_BASE_PATH_PREFIX="rpm-$REPO_BASE/$DISTRIB/stable"
   else
-    REPOSITORY_NAME="$ROOT_REPO"
-    BASE_PATH="$ROOT_REPO"
-    SUITE="$DISTRIB-$STABILITY_SEGMENT"
-    TESTING_SUITE="$DISTRIB-$TESTING_SEGMENT"
-    # stable lives in a DEDICATED repository with plain-codename suites, so
-    # the client apt configuration stays identical to the artifactory one
-    # (deb .../apt-plugins-stable <codename> main)
-    STABLE_REPOSITORY_NAME="$ROOT_REPO-stable"
-    STABLE_BASE_PATH="$ROOT_REPO-stable"
+    # one deb repository per stability (base path = repository name), suites
+    # carry the plain codename only
+    REPOSITORY_NAME="${DEB_PREFIX}${STABILITY_SEGMENT}"
+    BASE_PATH="$REPOSITORY_NAME"
+    # historical layout: one repository per stability with plain-codename
+    # suites; the legacy stability (bare "testing") lives in the front prefix
+    LEGACY_SEGMENT="$STABILITY_SEGMENT"
+    [[ "$STABILITY_SEGMENT" == "testing-release" ]] && LEGACY_SEGMENT="testing"
+    LEGACY_TESTING_SEGMENT="$TESTING_SEGMENT"
+    [[ "$TESTING_SEGMENT" == "testing-release" ]] && LEGACY_TESTING_SEGMENT="testing"
+    SUITE="$DISTRIB"
+    TESTING_REPOSITORY_NAME="${DEB_PREFIX}${TESTING_SEGMENT}"
+    TESTING_BASE_PATH="$TESTING_REPOSITORY_NAME"
+    TESTING_SUITE="$DISTRIB"
+    STABLE_REPOSITORY_NAME="${DEB_PREFIX}stable"
+    STABLE_BASE_PATH="$STABLE_REPOSITORY_NAME"
     STABLE_SUITE="$DISTRIB"
+    # legacy (front) paths used by the content verifications: the CI exercises
+    # the compatibility rewrites on every delivery
+    LEGACY_BASE_PATH="${DEB_PREFIX}${REPO_BASE}-${LEGACY_SEGMENT}"
+    LEGACY_TESTING_BASE_PATH="${DEB_PREFIX}${REPO_BASE}-${LEGACY_TESTING_SEGMENT}"
+    LEGACY_STABLE_BASE_PATH="${DEB_PREFIX}${REPO_BASE}-stable"
     POOL_PATH="pool/$POOL_SEGMENT/$MODULE_NAME"
     TESTING_POOL_PATH="pool/$TESTING_POOL_SEGMENT/$MODULE_NAME"
     STABLE_POOL_PATH="pool/stable/$MODULE_NAME"
@@ -141,25 +147,65 @@ elif [[ "$DELIVERY_TYPE" == "feature" ]]; then
     exit 1
   fi
 
-  REPOSITORY_PREFIX="$ROOT_REPO-feature-$FEATURE_TICKET-$VERSION-$DISTRIB-$STABILITY"
-  BASE_PATH_PREFIX="$ROOT_REPO-feature$HASH_SEGMENT/$FEATURE_TICKET/$VERSION/$DISTRIB/$STABILITY"
+  REPOSITORY_PREFIX="rpm-feature-$FEATURE_TICKET-$VERSION-$DISTRIB-$STABILITY"
+  BASE_PATH_PREFIX="rpm-feature/$FEATURE_TICKET/$VERSION/$DISTRIB/$STABILITY"
+  LEGACY_BASE_PATH_PREFIX="rpm-$REPO_BASE-feature/$FEATURE_TICKET/$VERSION/$DISTRIB/$STABILITY"
 else
+  RPM_ROOT="rpm"
+  DEB_INFIX=""
   if [[ "$IS_CLOUD" == "true" || "$REPOSITORY_TYPE" == *-internal ]]; then
-    ROOT_REPO="$ROOT_REPO-internal"
+    RPM_ROOT="rpm-internal"
+    DEB_INFIX="internal-"
   fi
 
   if [[ "$DISTRIB_FAMILY" == "el" ]]; then
-    REPOSITORY_PREFIX="$ROOT_REPO-$VERSION-$DISTRIB-$STABILITY_SEGMENT"
-    BASE_PATH_PREFIX="$ROOT_REPO$HASH_SEGMENT/$VERSION/$DISTRIB/$STABILITY_SEGMENT"
-    TESTING_REPOSITORY_PREFIX="$ROOT_REPO-$VERSION-$DISTRIB-$TESTING_SEGMENT"
-    STABLE_REPOSITORY_PREFIX="$ROOT_REPO-$VERSION-$DISTRIB-stable"
-    STABLE_BASE_PATH_PREFIX="$ROOT_REPO$HASH_SEGMENT/$VERSION/$DISTRIB/stable"
+    REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-$STABILITY_SEGMENT"
+    BASE_PATH_PREFIX="$RPM_ROOT/$VERSION/$DISTRIB/$STABILITY_SEGMENT"
+    TESTING_REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-$TESTING_SEGMENT"
+    TESTING_BASE_PATH_PREFIX="$RPM_ROOT/$VERSION/$DISTRIB/$TESTING_SEGMENT"
+    STABLE_REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-stable"
+    STABLE_BASE_PATH_PREFIX="$RPM_ROOT/$VERSION/$DISTRIB/stable"
+    # legacy (front) paths used by the content verifications (the front also
+    # accepts the historical token'd business form)
+    LEGACY_RPM_ROOT="rpm-$REPO_BASE"
+    [[ "$RPM_ROOT" == "rpm-internal" ]] && LEGACY_RPM_ROOT="rpm-$REPO_BASE-internal"
+    LEGACY_BASE_PATH_PREFIX="$LEGACY_RPM_ROOT/$VERSION/$DISTRIB/$STABILITY_SEGMENT"
+    LEGACY_TESTING_BASE_PATH_PREFIX="$LEGACY_RPM_ROOT/$VERSION/$DISTRIB/$TESTING_SEGMENT"
+    LEGACY_STABLE_BASE_PATH_PREFIX="$LEGACY_RPM_ROOT/$VERSION/$DISTRIB/stable"
   else
-    REPOSITORY_NAME="$ROOT_REPO"
-    BASE_PATH="$ROOT_REPO"
+    # one deb repository per stability (base path = repository name), shared by
+    # every major version: the version lives in the suite name only
+    # (e.g. "trixie-26.09")
+    REPOSITORY_NAME="${DEB_PREFIX}${DEB_INFIX}${STABILITY_SEGMENT}"
+    BASE_PATH="$REPOSITORY_NAME"
+    # suites keep their historical stability-suffixed names so the legacy
+    # client lines (deb .../apt-standard/ trixie-26.10-stable main) work
+    # through the content-front rewrites; each suite lives in its own
+    # per-stability repository regardless
     SUITE="$DISTRIB-$VERSION-$STABILITY_SEGMENT"
+    TESTING_REPOSITORY_NAME="${DEB_PREFIX}${DEB_INFIX}${TESTING_SEGMENT}"
+    TESTING_BASE_PATH="$TESTING_REPOSITORY_NAME"
     TESTING_SUITE="$DISTRIB-$VERSION-$TESTING_SEGMENT"
+    STABLE_REPOSITORY_NAME="${DEB_PREFIX}${DEB_INFIX}stable"
+    STABLE_BASE_PATH="$STABLE_REPOSITORY_NAME"
     STABLE_SUITE="$DISTRIB-$VERSION-stable"
+    # 24.x clients use dedicated legacy stable repositories with plain-codename
+    # suites (apt|ubuntu-standard-<major>-stable, apt-<major>-business-stable):
+    # the promote mirrors its package associations into them
+    if [[ -z "$DEB_INFIX" && ( "$VERSION" == "24.04" || "$VERSION" == "24.10" ) ]]; then
+      if [[ "$REPO_BASE" == "standard" ]]; then
+        STABLE_LEGACY_REPOSITORY_NAME="${DEB_PREFIX}standard-$VERSION-stable"
+        STABLE_LEGACY_SUITE="$DISTRIB"
+      elif [[ "$REPO_BASE" == "business" && "$DEB_PREFIX" == "apt-" ]]; then
+        STABLE_LEGACY_REPOSITORY_NAME="apt-$VERSION-business-stable"
+        STABLE_LEGACY_SUITE="$DISTRIB"
+      fi
+    fi
+    LEGACY_DEB_ROOT="${DEB_PREFIX}${REPO_BASE}"
+    [[ -n "$DEB_INFIX" ]] && LEGACY_DEB_ROOT="${DEB_PREFIX}${REPO_BASE}-internal"
+    LEGACY_BASE_PATH="$LEGACY_DEB_ROOT"
+    LEGACY_TESTING_BASE_PATH="$LEGACY_DEB_ROOT"
+    LEGACY_STABLE_BASE_PATH="$LEGACY_DEB_ROOT"
     POOL_PATH="pool/$VERSION/$POOL_SEGMENT/$MODULE_NAME"
     TESTING_POOL_PATH="pool/$VERSION/$TESTING_POOL_SEGMENT/$MODULE_NAME"
     STABLE_POOL_PATH="pool/$VERSION/stable/$MODULE_NAME"
@@ -167,41 +213,66 @@ else
 fi
 
 # unless a dedicated stable repository was selected above, stable shares the
-# delivery repository
+# delivery repository (rpm resolves stable through the *_PREFIX variables)
 STABLE_REPOSITORY_NAME="${STABLE_REPOSITORY_NAME:-$REPOSITORY_NAME}"
 STABLE_BASE_PATH="${STABLE_BASE_PATH:-$BASE_PATH}"
 
+# one Pulp Domain per edition; stable and non-stable repositories share it
+# ("-internal"/cloud repos too). The stable/non-stable write boundary is the
+# repository name, enforced server-side by name-scoped grants. stable_domain
+# is kept as a distinct output for the scripts that address the stable tier,
+# even though it now always equals domain.
+DOMAIN="$REPO_BASE"
+STABLE_DOMAIN="$DOMAIN"
+
 echo "[DEBUG] - repository_type: $REPOSITORY_TYPE"
-echo "[DEBUG] - root_repo: $ROOT_REPO"
 echo "[DEBUG] - repository_prefix: $REPOSITORY_PREFIX"
 echo "[DEBUG] - base_path_prefix: $BASE_PATH_PREFIX"
 echo "[DEBUG] - testing_repository_prefix: $TESTING_REPOSITORY_PREFIX"
+echo "[DEBUG] - testing_base_path_prefix: $TESTING_BASE_PATH_PREFIX"
 echo "[DEBUG] - stable_repository_prefix: $STABLE_REPOSITORY_PREFIX"
 echo "[DEBUG] - stable_base_path_prefix: $STABLE_BASE_PATH_PREFIX"
 echo "[DEBUG] - repository_name: $REPOSITORY_NAME"
 echo "[DEBUG] - base_path: $BASE_PATH"
 echo "[DEBUG] - suite: $SUITE"
+echo "[DEBUG] - testing_repository_name: $TESTING_REPOSITORY_NAME"
+echo "[DEBUG] - testing_base_path: $TESTING_BASE_PATH"
 echo "[DEBUG] - testing_suite: $TESTING_SUITE"
 echo "[DEBUG] - stable_suite: $STABLE_SUITE"
 echo "[DEBUG] - pool_path: $POOL_PATH"
 echo "[DEBUG] - testing_pool_path: $TESTING_POOL_PATH"
 echo "[DEBUG] - stable_pool_path: $STABLE_POOL_PATH"
+echo "[DEBUG] - domain: $DOMAIN"
+echo "[DEBUG] - stable_domain: $STABLE_DOMAIN"
 
 {
   echo "skip_delivery=false"
   echo "repository_prefix=$REPOSITORY_PREFIX"
   echo "base_path_prefix=$BASE_PATH_PREFIX"
+  echo "legacy_base_path_prefix=$LEGACY_BASE_PATH_PREFIX"
+  echo "legacy_testing_base_path_prefix=$LEGACY_TESTING_BASE_PATH_PREFIX"
+  echo "legacy_stable_base_path_prefix=$LEGACY_STABLE_BASE_PATH_PREFIX"
   echo "testing_repository_prefix=$TESTING_REPOSITORY_PREFIX"
+  echo "testing_base_path_prefix=$TESTING_BASE_PATH_PREFIX"
   echo "stable_repository_prefix=$STABLE_REPOSITORY_PREFIX"
   echo "stable_base_path_prefix=$STABLE_BASE_PATH_PREFIX"
   echo "repository_name=$REPOSITORY_NAME"
   echo "base_path=$BASE_PATH"
+  echo "legacy_base_path=$LEGACY_BASE_PATH"
+  echo "legacy_testing_base_path=$LEGACY_TESTING_BASE_PATH"
+  echo "legacy_stable_base_path=$LEGACY_STABLE_BASE_PATH"
   echo "suite=$SUITE"
+  echo "testing_repository_name=$TESTING_REPOSITORY_NAME"
+  echo "testing_base_path=$TESTING_BASE_PATH"
   echo "testing_suite=$TESTING_SUITE"
   echo "stable_suite=$STABLE_SUITE"
+  echo "stable_legacy_suite=$STABLE_LEGACY_SUITE"
+  echo "stable_legacy_repository_name=$STABLE_LEGACY_REPOSITORY_NAME"
   echo "stable_repository_name=$STABLE_REPOSITORY_NAME"
   echo "stable_base_path=$STABLE_BASE_PATH"
   echo "pool_path=$POOL_PATH"
   echo "testing_pool_path=$TESTING_POOL_PATH"
   echo "stable_pool_path=$STABLE_POOL_PATH"
+  echo "domain=$DOMAIN"
+  echo "stable_domain=$STABLE_DOMAIN"
 } >> "$GITHUB_OUTPUT"

--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -44,14 +44,14 @@ runs:
 
     - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
 
     - if: inputs.delivery_type == 'feature'
       name: Create a rpm feature repository
       shell: bash
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
         GH_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         CENTREON_TECHNIQUE_PAT: ${{ inputs.centreon_technique_pat }}
@@ -70,21 +70,23 @@ runs:
               --arg major_version "$major_version" \
               --arg repo_type "feature" \
               --arg feature_ticket "$feature_ticket" \
+              --arg target "jfrog" \
               '{
                 event_type: "create-feature-repositories",
                 client_payload: {
                   major_version: $major_version,
                   repo_type: $repo_type,
-                  feature_ticket: $feature_ticket
+                  feature_ticket: $feature_ticket,
+                  target: $target
                 }
               }'
             )"
 
         attempt=0
         count=$(jf rt search rpm-standard-feature/$feature_ticket/$major_version/*.repo 2>/dev/null | jq '. | length' 2>/dev/null || echo "0")
-        until [[ $count -eq 2 || $attempt -ge 40 ]]; do
+        until [[ $count -eq 3 || $attempt -ge 40 ]]; do
           attempt=$((attempt+1))
-          echo "[INFO] Checking is the feature repository has been created... [ATTEMPT $attempt]"
+          echo "[INFO] Checking if the feature repository has been created... [ATTEMPT $attempt]"
           sleep 15
           count=$(jf rt search rpm-standard-feature/$feature_ticket/$major_version/*.repo 2>/dev/null | jq '. | length' 2>/dev/null || echo "0")
         done
@@ -97,7 +99,7 @@ runs:
     - name: Publish RPMs
       shell: bash
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
         GH_HEAD_REF: ${{ github.head_ref || github.ref_name }}
         MODULE_NAME: ${{ inputs.module_name }}

--- a/.github/actions/setup-pulp-cli/action.yml
+++ b/.github/actions/setup-pulp-cli/action.yml
@@ -3,12 +3,14 @@ description: "Install pulp-cli and authenticate to pulp with a GitHub OIDC token
 inputs:
   pulp_url:
     description: "The pulp server api url"
-    required: false
-    default: "https://pulp-api.apps.centreon.com"
+    required: true
   audience:
     description: "OIDC audience, must match the pulp server GITHUB_OIDC.audience"
+    required: true
+  domain:
+    description: "Pulp Domain to operate in (DOMAIN_ENABLED). Pre-Domains repositories live in \"default\"."
     required: false
-    default: "https://pulp.dev.centreon.io"
+    default: "default"
 
 runs:
   using: "composite"
@@ -78,12 +80,14 @@ runs:
       shell: bash
       env:
         PULP_URL: ${{ inputs.pulp_url }}
+        DOMAIN: ${{ inputs.domain }}
       run: |
         set -euo pipefail
 
         # fall back to the default when the caller passes an empty value (unset
         # org variable forwarded as "" would otherwise override the default).
-        PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
+        PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+        DOMAIN="${DOMAIN:-default}"
 
         # keep the pulp-cli config (which stores the OIDC token) under the per-job
         # RUNNER_TEMP rather than the runner's persistent ~/.config, and share the
@@ -93,16 +97,14 @@ runs:
         mkdir -p "$XDG_CONFIG_HOME"
         echo "XDG_CONFIG_HOME=$XDG_CONFIG_HOME" >> "$GITHUB_ENV"
 
-        # the GitHub OIDC plugin authenticates requests carrying this header,
-        # there is no username/password, the token grants are derived from the
-        # token claims by the pulp server rules
+        # WorkloadIdentityAuthentication reads a Bearer token, no username/password
         # pulp-cli splits --header on the first colon and keeps the value
-        # verbatim, so no space after the colon (it would be rejected as
-        # leading whitespace); the sent header is still "Authorization: Github …"
+        # verbatim, so no space after the colon (rejected as leading whitespace)
         pulp config create --overwrite \
           --base-url "$PULP_URL" \
           --api-root "/" \
-          --header "Authorization:Github $PULP_TOKEN" \
+          --domain "$DOMAIN" \
+          --header "Authorization:Bearer $PULP_TOKEN" \
           --timeout 0
 
         # fail fast on connectivity issues, scripts cannot distinguish

--- a/.github/scripts/pulp/api.sh
+++ b/.github/scripts/pulp/api.sh
@@ -1,6 +1,25 @@
 #!/usr/bin/env bash
 # Shared pulp api helpers for the delivery/promotion scripts. Source this file
 # like manifest.sh; PULP_URL and PULP_TOKEN must be set by the caller.
+#
+# DOMAIN_ENABLED requires every viewset URL to carry a domain segment, no
+# unprefixed fallback; every domain-scoped REST call in this file is prefixed with "/$PULP_DOMAIN"
+PULP_DOMAIN="${PULP_DOMAIN:-default}"
+
+# forces pulp-cli's config to update immediately, unlike a plain PULP_DOMAIN
+# reassignment: refresh_pulp_token only re-runs "pulp config create" once the
+# token itself goes stale (>240s), which could leave pulp-cli on the old domain that long
+switch_pulp_domain() {
+  PULP_DOMAIN="$1"
+  if command -v pulp >/dev/null 2>&1; then
+    if ! pulp config create --overwrite --base-url "$PULP_URL" --api-root "/" \
+      --domain "$PULP_DOMAIN" \
+      --header "Authorization:Bearer $PULP_TOKEN" --timeout 0 >/dev/null 2>&1; then
+      echo "::error::Cannot switch the pulp-cli profile to domain $PULP_DOMAIN" >&2
+      return 1
+    fi
+  fi
+}
 
 # the github actions oidc token expires ~5 minutes after issuance, which is
 # shorter than a large delivery: refresh it before it goes stale whenever the
@@ -38,7 +57,8 @@ refresh_pulp_token() {
   fi
   if command -v pulp >/dev/null 2>&1; then
     pulp config create --overwrite --base-url "$PULP_URL" --api-root "/" \
-      --header "Authorization:Github $token" --timeout 0 >/dev/null 2>&1 || true
+      --domain "$PULP_DOMAIN" \
+      --header "Authorization:Bearer $token" --timeout 0 >/dev/null 2>&1 || true
   fi
 }
 
@@ -52,13 +72,13 @@ wait_task() {
   local state attempt
   for ((attempt = 0; attempt < 600; attempt++)); do
     refresh_pulp_token
-    state=$(curl -fsSL -H "Authorization: Github $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null | jq -r '.state' 2>/dev/null) || state=""
+    state=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null | jq -r '.state' 2>/dev/null) || state=""
     case "$state" in
       completed)
         return 0
         ;;
       failed|canceled)
-        echo "::error::Task $task_href $state: $(curl -fsSL -H "Authorization: Github $PULP_TOKEN" "$PULP_URL$task_href" | jq -c '.error')"
+        echo "::error::Task $task_href $state: $(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$PULP_URL$task_href" | jq -c '.error')"
         return 1
         ;;
       *)
@@ -76,7 +96,7 @@ pulp_upload() {
   local attempt response http_code body
   for attempt in 1 2 3 4 5; do
     refresh_pulp_token
-    response=$(curl -sS -H "Authorization: Github $PULP_TOKEN" -w $'\n%{http_code}' "$@" 2>/dev/null) || response=""
+    response=$(curl -sS -H "Authorization: Bearer $PULP_TOKEN" -w $'\n%{http_code}' "$@" 2>/dev/null) || response=""
     http_code=${response##*$'\n'}
     body=${response%$'\n'*}
     if [[ "$http_code" == "202" ]]; then
@@ -103,7 +123,7 @@ wait_task_race() {
   local task_href=$1 body state error attempt
   for ((attempt = 0; attempt < 600; attempt++)); do
     refresh_pulp_token
-    body=$(curl -fsSL -H "Authorization: Github $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null) || body=""
+    body=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null) || body=""
     state=$(echo "$body" | jq -r '.state' 2>/dev/null) || state=""
     case "$state" in
       completed)
@@ -140,9 +160,9 @@ pulp_resource_exists() {
   local type_path=$1 name=$2 attempt response http_code count
   for attempt in 1 2 3 4; do
     refresh_pulp_token
-    response=$(curl -sS -H "Authorization: Github $PULP_TOKEN" -w $'\n%{http_code}' -G \
+    response=$(curl -sS -H "Authorization: Bearer $PULP_TOKEN" -w $'\n%{http_code}' -G \
       --data-urlencode "name=$name" --data-urlencode "limit=1" \
-      "$PULP_URL/api/v3/$type_path/" 2>/dev/null) || response=$'\n000'
+      "$PULP_URL/$PULP_DOMAIN/api/v3/$type_path/" 2>/dev/null) || response=$'\n000'
     http_code="${response##*$'\n'}"
     if [[ "$http_code" == "200" ]]; then
       count=$(printf '%s' "${response%$'\n'*}" | jq -r '.count' 2>/dev/null) || count=""
@@ -169,7 +189,7 @@ post_json() {
   response=$'\n000'
   for attempt in 1 2 3 4; do
     refresh_pulp_token
-    response=$(curl -sS -H "Authorization: Github $PULP_TOKEN" -w $'\n%{http_code}' \
+    response=$(curl -sS -H "Authorization: Bearer $PULP_TOKEN" -w $'\n%{http_code}' \
       -X POST -H "Content-Type: application/json" -d "$json" "$url" 2>/dev/null) || response=$'\n000'
     code="${response##*$'\n'}"
     case "$code" in
@@ -188,7 +208,7 @@ start_modify_task() {
   local url=$1 body_file=$2 attempt response http_code body
   for attempt in 1 2 3 4 5; do
     refresh_pulp_token
-    response=$(curl -sS -H "Authorization: Github $PULP_TOKEN" -w $'\n%{http_code}' \
+    response=$(curl -sS -H "Authorization: Bearer $PULP_TOKEN" -w $'\n%{http_code}' \
       -X POST -H "Content-Type: application/json" \
       -d @"$body_file" "$url" 2>/dev/null) || response=""
     http_code=${response##*$'\n'}
@@ -214,24 +234,42 @@ start_modify_task() {
 # downloader role); unguarded distributions ignore the header.
 content_curl() {
   refresh_pulp_token
-  curl -H "Authorization: Github $PULP_TOKEN" "$@"
+  curl -H "Authorization: Bearer $PULP_TOKEN" "$@"
 }
 
 create_publication() {
   local plugin=$1 repository=$2
   shift 2
-  local out task attempt outer rc
+  # pulp-cli's own task re-poll is domain-unaware and 404s under Domains ("No
+  # Task matches the given query"), so this goes straight through
+  # post_json/wait_task_race instead, both already domain-aware
+  local publication_path
+  case "$plugin" in
+    rpm) publication_path="rpm/rpm" ;;
+    deb) publication_path="deb/apt" ;;
+    *) echo "::error::create_publication: unsupported plugin $plugin" >&2; return 1 ;;
+  esac
+  local repo_href body_json response code body task attempt outer rc
   # outer retry: the publication task itself can die server-side for
   # retryable reasons (task worker terminated mid-task, version race)
   for outer in 1 2 3; do
     task=""
     for attempt in 1 2 3; do
       refresh_pulp_token
-      if out=$(pulp --background "$plugin" publication create --repository "$repository" "$@" 2>&1); then
-        # an output without a task href (gateway error page relayed by the
-        # cli) is a start failure too, retried like a non-zero exit
-        task=$(grep -oPm1 '/api/v3/tasks/[0-9a-f-]+/' <<< "$out" || true)
-        [[ -n "$task" ]] && break
+      repo_href=$(pulp "$plugin" repository show --name "$repository" 2>/dev/null | jq -r '.pulp_href // empty') || repo_href=""
+      if [[ -n "$repo_href" ]]; then
+        if [[ "$*" == *"--structured"* ]]; then
+          body_json=$(jq -nc --arg repo "$repo_href" '{repository: $repo, structured: true, simple: false}')
+        else
+          body_json=$(jq -nc --arg repo "$repo_href" '{repository: $repo}')
+        fi
+        response=$(post_json "$PULP_URL/$PULP_DOMAIN/api/v3/publications/$publication_path/" "$body_json")
+        code="${response##*$'\n'}"
+        body="${response%$'\n'*}"
+        if [[ "$code" == "202" ]]; then
+          task=$(echo "$body" | jq -r '.task // empty')
+          [[ -n "$task" ]] && break
+        fi
       fi
       echo "[WARN] publication start attempt $attempt/3 failed for $repository, retrying..." >&2
       sleep $((attempt * 10))

--- a/.github/scripts/pulp/check-common.sh
+++ b/.github/scripts/pulp/check-common.sh
@@ -11,8 +11,10 @@
 # shellcheck source=.github/scripts/pulp/api.sh
 source "$(dirname "${BASH_SOURCE[0]}")/api.sh"
 
-PULP_URL="${PULP_URL:-https://pulp-api.apps.centreon.com}"
-PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.apps.centreon.com}"
+PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
+PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
+
+switch_pulp_domain "$PULP_DOMAIN" || exit 1
 # 900s: the published indexes can lag a finished publication by up to the
 # content-app cache TTL (600s), the window must survive that worst case
 METADATA_TIMEOUT="${METADATA_TIMEOUT:-900}"

--- a/.github/scripts/pulp/check-deb.sh
+++ b/.github/scripts/pulp/check-deb.sh
@@ -43,14 +43,14 @@ for repo in $(printf '%s\n' "${E_REPOSITORY[@]}" | sort -u); do
     echo "[WARN] Repository $repo does not exist or has no version"
     continue
   fi
-  url="$PULP_URL/api/v3/content/deb/packages/?$(
+  url="$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/packages/?$(
     printf 'repository_version=%s&pulp_label_select=%s&ordering=-pulp_created&limit=1000' \
       "$(jq -rn --arg v "$version_href" '$v | @uri')" \
       "$(jq -rn --arg v "module=$MODULE_NAME" '$v | @uri')"
   )"
   pages=0
   while [[ -n "$url" ]] && ((pages < 20)); do
-    page=$(curl -fsSL -H "Authorization: Github $PULP_TOKEN" "$url") || {
+    page=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$url") || {
       echo "[WARN] presence page fetch failed for $repo ($url)" >&2
       break
     }

--- a/.github/scripts/pulp/check-rpm.sh
+++ b/.github/scripts/pulp/check-rpm.sh
@@ -38,14 +38,14 @@ for repo in $(printf '%s\n' "${E_REPOSITORY[@]}" | sort -u); do
     echo "[WARN] Repository $repo does not exist or has no version"
     continue
   fi
-  url="$PULP_URL/api/v3/content/rpm/packages/?$(
+  url="$PULP_URL/$PULP_DOMAIN/api/v3/content/rpm/packages/?$(
     printf 'repository_version=%s&pulp_label_select=%s&ordering=-pulp_created&limit=1000' \
       "$(jq -rn --arg v "$version_href" '$v | @uri')" \
       "$(jq -rn --arg v "module=$MODULE_NAME" '$v | @uri')"
   )"
   pages=0
   while [[ -n "$url" ]] && ((pages < 20)); do
-    page=$(curl -fsSL -H "Authorization: Github $PULP_TOKEN" "$url") || {
+    page=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$url") || {
       echo "[WARN] presence page fetch failed for $repo ($url)" >&2
       break
     }

--- a/.github/workflows/monitoring-agent.yml
+++ b/.github/workflows/monitoring-agent.yml
@@ -700,7 +700,7 @@ jobs:
     steps:
       - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
         env:
-          JF_URL: https://packages.centreon.com
+          JF_URL: https://centreon.jfrog.io
           JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
 
       - name: Restore cache monitoring agent
@@ -841,7 +841,7 @@ jobs:
 
       - uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
         env:
-          JF_URL: https://packages.centreon.com
+          JF_URL: https://centreon.jfrog.io
           JF_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
 
       - name: Promote testing to stable


### PR DESCRIPTION
## Description

Ports the `develop` state of the package delivery and promotion actions to `release-26.10-next`, so the dual delivery (Artifactory and Pulp) on this branch behaves exactly like on `develop`:

- `.github/actions/package-delivery-pulp`, `promote-to-stable-pulp`, `pulp-repository-properties`, `setup-pulp-cli` and `.github/scripts/pulp/*`: WorkloadIdentity authentication and Pulp domains, merged domains with deb repositories split per stability, promotion by content href (no re-upload), opaque path tokens dropped, stability-suffixed deb suites (plain codename for plugins/connectors), 24.x legacy stable suite mirroring, required Pulp environment inputs, front-verified deliveries.
- `.github/actions/rpm-delivery` and `promote-to-stable` (Artifactory): native `centreon.jfrog.io` hostname, `target: jfrog` in the delivery-tooling dispatch payload, feature repository readiness check expecting 3 files.
- `.github/workflows/monitoring-agent.yml`: the Windows agent `deliver-windows` / `promote-windows` jobs use `JF_URL: https://centreon.jfrog.io` as on `develop`.

The caller workflows of `release-26.10-next` already carry the matching `deliver-*-pulp` / `promote-pulp` jobs and pass every required input (checked by parsing all workflows); `deb-delivery` was already identical to `develop`. The ported files are byte-identical to `develop`. Same change as the `dev-26.10.x` backport ([#3688](https://github.com/centreon/centreon-collect/pull/3688)).

Backport of [#3620](https://github.com/centreon/centreon-collect/pull/3620), [#3621](https://github.com/centreon/centreon-collect/pull/3621), [#3627](https://github.com/centreon/centreon-collect/pull/3627), [#3638](https://github.com/centreon/centreon-collect/pull/3638), [#3641](https://github.com/centreon/centreon-collect/pull/3641), [#3643](https://github.com/centreon/centreon-collect/pull/3643), [#3645](https://github.com/centreon/centreon-collect/pull/3645), [#3646](https://github.com/centreon/centreon-collect/pull/3646), [#3648](https://github.com/centreon/centreon-collect/pull/3648), [#3656](https://github.com/centreon/centreon-collect/pull/3656), [#3679](https://github.com/centreon/centreon-collect/pull/3679).

Fixes: [MON-208847](https://centreon.atlassian.net/browse/MON-208847)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] 26.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Run a component workflow on this branch (push, or a pull request with the `delivery-feature` label) and check that the `deliver-*-pulp` jobs upload the packages to Pulp next to the Artifactory delivery, with the post-delivery checks green. On a stable event, the `promote-pulp` job must promote the content by href. A Pulp failure only produces a warning, as on `develop`.

Static checks done: `bash -n` on the shell scripts, yamllint on the changed YAML files, every required action input provided by the callers, no referenced `.github/` path missing on the branch.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-208847]: https://centreon.atlassian.net/browse/MON-208847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ