### PR TITLE
feat(docker): wire email notifications into the centreon-engine image

### DIFF
--- a/.github/docker/centreon-engine/fixtures/minimal-config/engine/commands.cfg
+++ b/.github/docker/centreon-engine/fixtures/minimal-config/engine/commands.cfg
@@ -7,3 +7,23 @@ define command {
     command_name                   base_dummy
     command_line                   /bin/true
 }
+
+# Option 1: native SMTP command (mailutils' `mail`, relayed via msmtp).
+define command {
+    command_name                   notify-host-by-email
+    command_line                   /usr/bin/printf "%b" "***** Centreon *****\n\nNotification Type: $NOTIFICATIONTYPE$\n\nHost: $HOSTALIAS$\nState: $HOSTSTATE$\nAddress: $HOSTADDRESS$\nInfo: $HOSTOUTPUT$\n\nDate/Time: $LONGDATETIME$\n" | /usr/bin/mail -s "Host $HOSTSTATE$ alert for $HOSTALIAS$" $CONTACTEMAIL$
+}
+define command {
+    command_name                   notify-service-by-email
+    command_line                   /usr/bin/printf "%b" "***** Centreon *****\n\nNotification Type: $NOTIFICATIONTYPE$\n\nService: $SERVICEDESC$\nHost: $HOSTALIAS$\nAddress: $HOSTADDRESS$\nState: $SERVICESTATE$\n\nDate/Time: $LONGDATETIME$\nAdditional Info: $SERVICEOUTPUT$\n" | /usr/bin/mail -s "** $NOTIFICATIONTYPE$ alert - $HOSTALIAS$/$SERVICEDESC$ is $SERVICESTATE$ **" $CONTACTEMAIL$
+}
+
+# Option 2: centreon-plugin-notification-email connector.
+define command {
+    command_name                   notify-host-by-email-plugin
+    command_line                   $CENTREONPLUGINS$centreon_notification_email.pl --plugin=notification::email::plugin --mode=alert --to-address='$CONTACTEMAIL$' --host-address='$HOSTADDRESS$' --host-name='$HOSTNAME$' --host-alias='$HOSTALIAS$' --host-state='$HOSTSTATE$' --host-output='$HOSTOUTPUT$' --host-attempts='$HOSTATTEMPT$' --max-host-attempts='$MAXHOSTATTEMPTS$' --host-duration='$HOSTDURATION$' --date='$SHORTDATETIME$' --type='$NOTIFICATIONTYPE$' --host-id='$HOSTID$' --notif-author='$NOTIFICATIONAUTHOR$' --notif-comment='$NOTIFICATIONCOMMENT$' --smtp-nossl --smtp-address='$SMTPADDRESS$' --smtp-port='$SMTPPORT$' --from-address='$SMTPFROMADDRESS$'
+}
+define command {
+    command_name                   notify-service-by-email-plugin
+    command_line                   $CENTREONPLUGINS$centreon_notification_email.pl --plugin=notification::email::plugin --mode=alert --to-address='$CONTACTEMAIL$' --host-address='$HOSTADDRESS$' --host-name='$HOSTNAME$' --host-alias='$HOSTALIAS$' --host-state='$HOSTSTATE$' --host-output='$HOSTOUTPUT$' --date='$SHORTDATETIME$' --type='$NOTIFICATIONTYPE$' --service-description='$SERVICEDESC$' --service-displayname='$SERVICEDISPLAYNAME$' --service-state='$SERVICESTATE$' --service-output='$SERVICEOUTPUT$' --service-longoutput='$LONGSERVICEOUTPUT$' --service-attempts='$SERVICEATTEMPT$' --max-service-attempts='$MAXSERVICEATTEMPTS$' --service-duration='$SERVICEDURATION$' --host-id='$HOSTID$' --service-id='$SERVICEID$' --notif-author='$NOTIFICATIONAUTHOR$' --notif-comment='$NOTIFICATIONCOMMENT$' --smtp-nossl --smtp-address='$SMTPADDRESS$' --smtp-port='$SMTPPORT$' --from-address='$SMTPFROMADDRESS$'
+}

--- a/.github/docker/centreon-engine/fixtures/minimal-config/engine/contactgroups.cfg
+++ b/.github/docker/centreon-engine/fixtures/minimal-config/engine/contactgroups.cfg
@@ -1,1 +1,5 @@
-# Intentionally empty - referenced by centengine.cfg cfg_file list but not needed by this fixture.
+define contactgroup {
+    contactgroup_name              admins
+    alias                          Administrators
+    members                        admin-smtp,admin-plugin
+}

--- a/.github/docker/centreon-engine/fixtures/minimal-config/engine/contacts.cfg
+++ b/.github/docker/centreon-engine/fixtures/minimal-config/engine/contacts.cfg
@@ -1,1 +1,27 @@
-# Intentionally empty - referenced by centengine.cfg cfg_file list but not needed by this fixture.
+define contact {
+    contact_name                   admin-smtp
+    alias                          Admin (native SMTP)
+    email                          admin-smtp@example.test
+    host_notifications_enabled     1
+    service_notifications_enabled  1
+    host_notification_period       24x7
+    service_notification_period    24x7
+    host_notification_options      d,u,r
+    service_notification_options   w,u,c,r
+    host_notification_commands     notify-host-by-email
+    service_notification_commands  notify-service-by-email
+}
+
+define contact {
+    contact_name                   admin-plugin
+    alias                          Admin (notification-email connector)
+    email                          admin-plugin@example.test
+    host_notifications_enabled     1
+    service_notifications_enabled  1
+    host_notification_period       24x7
+    service_notification_period    24x7
+    host_notification_options      d,u,r
+    service_notification_options   w,u,c,r
+    host_notification_commands     notify-host-by-email-plugin
+    service_notification_commands  notify-service-by-email-plugin
+}

--- a/.github/docker/centreon-engine/fixtures/minimal-config/engine/hostTemplates.cfg
+++ b/.github/docker/centreon-engine/fixtures/minimal-config/engine/hostTemplates.cfg
@@ -9,4 +9,7 @@ define host {
     register                       0
     active_checks_enabled          1
     passive_checks_enabled         0
+    notifications_enabled          1
+    notification_options           d,u,r
+    contact_groups                 admins
 }

--- a/.github/docker/centreon-engine/fixtures/minimal-config/engine/resource.cfg
+++ b/.github/docker/centreon-engine/fixtures/minimal-config/engine/resource.cfg
@@ -1,2 +1,5 @@
 $USER1$=/usr/lib64/nagios/plugins
 $CENTREONPLUGINS$=/usr/lib/centreon/plugins/
+$SMTPADDRESS$=
+$SMTPPORT$=25
+$SMTPFROMADDRESS$=centreon-engine@localhost

--- a/.github/docker/centreon-engine/fixtures/minimal-config/engine/serviceTemplates.cfg
+++ b/.github/docker/centreon-engine/fixtures/minimal-config/engine/serviceTemplates.cfg
@@ -9,4 +9,7 @@ define service {
     is_volatile                    0
     active_checks_enabled          1
     passive_checks_enabled         0
+    notifications_enabled          1
+    notification_options           w,u,c,r
+    contact_groups                 admins
 }

--- a/.github/docker/centreon-engine/trixie/Dockerfile
+++ b/.github/docker/centreon-engine/trixie/Dockerfile
@@ -52,7 +52,12 @@ ENV DEBIAN_FRONTEND=noninteractive \
     GORGONE_TOKEN= \
     CENTRAL_HOST= \
     APP_SECRET= \
-    SALT=
+    SALT= \
+    SMTP_HOST= \
+    SMTP_PORT=25 \
+    SMTP_FROM=centreon-engine@localhost \
+    SMTP_TLS=off \
+    MSMTPRC=/var/lib/centreon-engine/.msmtprc
 
 # Create users and groups (must match current setup for compatibility)
 RUN bash -e <<EOF
@@ -117,7 +122,11 @@ apt-get install -y --no-install-recommends \
     ca-certificates \
     wget \
     gnupg \
-    centreon-plugin-applications-monitoring-centreon-poller
+    mailutils \
+    msmtp \
+    msmtp-mta \
+    centreon-plugin-applications-monitoring-centreon-poller \
+    centreon-plugin-notification-email
 setcap cap_net_raw+ep /usr/lib/nagios/plugins/check_icmp
 apt-get remove -y --purge libcap2-bin
 apt-get autoremove -y

--- a/.github/docker/centreon-engine/trixie/entrypoint/container.d/06-mail-config.sh
+++ b/.github/docker/centreon-engine/trixie/entrypoint/container.d/06-mail-config.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Wire the email notification path (both options: native msmtp/mail command
+# and the centreon-plugin-notification-email connector) from SMTP_* env vars.
+# If SMTP_HOST is empty, notifications simply won't have anywhere to send
+# mail to (consistent with the previous no-op state) but boot never fails.
+
+if [ -n "$SMTP_HOST" ]; then
+    TLS_LINE="tls off"
+    if [ "$SMTP_TLS" = "on" ] || [ "$SMTP_TLS" = "1" ]; then
+        TLS_LINE="tls on"
+    fi
+
+    # container.sh runs as the unprivileged centreon-engine user (USER
+    # centreon-engine in the Dockerfile), so /etc/msmtprc is not writable.
+    # MSMTPRC (set in the Dockerfile ENV) points msmtp at a writable path
+    # instead - and since it's an exported env var rather than $HOME, it's
+    # inherited the same way by centengine itself and by every notification
+    # command it forks, regardless of how each child's environment is built.
+    cat > "$MSMTPRC" <<EOF
+defaults
+$TLS_LINE
+tls_starttls on
+
+account relay
+host $SMTP_HOST
+port $SMTP_PORT
+from $SMTP_FROM
+
+account default : relay
+EOF
+    chmod 600 "$MSMTPRC"
+fi
+
+RESOURCE_CFG="/etc/centreon-engine/resource.cfg"
+
+if [ -f "$RESOURCE_CFG" ]; then
+    sed -i "s|^\$SMTPADDRESS\$=.*|\$SMTPADDRESS\$=$SMTP_HOST|" "$RESOURCE_CFG"
+    sed -i "s|^\$SMTPPORT\$=.*|\$SMTPPORT\$=$SMTP_PORT|" "$RESOURCE_CFG"
+    sed -i "s|^\$SMTPFROMADDRESS\$=.*|\$SMTPFROMADDRESS\$=$SMTP_FROM|" "$RESOURCE_CFG"
+fi

--- a/.github/scripts/centreon-engine-docker-config-wiring-test.sh
+++ b/.github/scripts/centreon-engine-docker-config-wiring-test.sh
@@ -232,4 +232,69 @@ if ! echo "$grpc_output" | grep -q '"major"'; then
 fi
 echo "OK: engine gRPC management API answered GetVersion on port 50155."
 
+summary_step_start "Email notifications reach an SMTP relay (native mail command + connector plugin)"
+echo "=== [wiring:mail-notifications] both notify-*-by-email (native msmtp/mail) and notify-*-by-email-plugin (centreon-plugin-notification-email) actually deliver mail ==="
+MAIL_NET="engine-mail-wiring-net-$$"
+docker network create "$MAIL_NET" > /dev/null
+NETWORKS+=("$MAIL_NET")
+
+MAILPIT="mailpit-$$"
+docker run -d --name "$MAILPIT" --network "$MAIL_NET" -p 127.0.0.1::8025 axllent/mailpit:v1.31.1 > /dev/null
+CONTAINERS+=("$MAILPIT")
+
+MAILPIT_HTTP_PORT=$(docker port "$MAILPIT" 8025/tcp | head -1 | cut -d: -f2)
+mailpit_up=false
+for _ in $(seq 1 30); do
+  if curl -sf "http://127.0.0.1:$MAILPIT_HTTP_PORT/api/v1/messages" > /dev/null 2>&1; then
+    mailpit_up=true
+    break
+  fi
+  sleep 1
+done
+if [ "$mailpit_up" != "true" ]; then
+  echo "::error::mailpit stub never came up on http://127.0.0.1:$MAILPIT_HTTP_PORT"
+  exit 1
+fi
+
+MAIL_TEST_CONTAINER="centreon-engine-wiring-mail-$$"
+CREATE_EXTRA_ARGS="--network $MAIL_NET -e SMTP_HOST=$MAILPIT -e SMTP_PORT=1025 -e SMTP_FROM=centreon-engine@example.test" \
+  create_with_configs "$MAIL_TEST_CONTAINER"
+wait_ready "$MAIL_TEST_CONTAINER" || exit 1
+
+# Go through the real external-command pipe (SEND_CUSTOM_HOST/SVC_NOTIFICATION)
+# rather than invoking mail/the connector by hand: this is what actually
+# exercises commands.cfg's notify-*-by-email(-plugin) command_line as centengine
+# resolves it (macros like $CONTACTEMAIL$/$SMTPADDRESS$/$HOSTID$ included), and
+# the contacts.cfg/contactgroups.cfg wiring that fans a single notification out
+# to both the admin-smtp and admin-plugin contacts. Option 3 = broadcast|forced,
+# so it bypasses the notification_period/state filtering that a synthetic
+# CUSTOM-type event would otherwise never satisfy.
+docker exec "$MAIL_TEST_CONTAINER" sh -c \
+  'echo "[$(date +%s)] SEND_CUSTOM_HOST_NOTIFICATION;test;3;e2e-test;wiring test host notification" > /var/lib/centreon-engine/rw/centengine.cmd'
+docker exec "$MAIL_TEST_CONTAINER" sh -c \
+  'echo "[$(date +%s)] SEND_CUSTOM_SVC_NOTIFICATION;test;dummy;3;e2e-test;wiring test service notification" > /var/lib/centreon-engine/rw/centengine.cmd'
+
+messages_json=""
+for _ in $(seq 1 30); do
+  messages_json=$(curl -sf "http://127.0.0.1:$MAILPIT_HTTP_PORT/api/v1/messages")
+  if echo "$messages_json" | grep -q "admin-smtp@example.test" && echo "$messages_json" | grep -q "admin-plugin@example.test"; then
+    break
+  fi
+  sleep 1
+done
+if ! echo "$messages_json" | grep -q "admin-smtp@example.test"; then
+  echo "::error::no mail received by mailpit for the admin-smtp contact (notify-host/service-by-email, native mailutils/msmtp path)"
+  echo "$messages_json"
+  docker logs "$MAIL_TEST_CONTAINER" || true
+  exit 1
+fi
+if ! echo "$messages_json" | grep -q "admin-plugin@example.test"; then
+  echo "::error::no mail received by mailpit for the admin-plugin contact (notify-host/service-by-email-plugin, centreon-plugin-notification-email connector)"
+  echo "$messages_json"
+  docker logs "$MAIL_TEST_CONTAINER" || true
+  exit 1
+fi
+echo "OK: a real custom notification, resolved and dispatched by centengine itself, delivered mail via both the native SMTP command and the notification-email connector."
+summary_step_pass
+
 echo "=== [config/wiring] PASSED ==="


### PR DESCRIPTION
## Description
Backport of #3687 to `release-26.10-next` (cherry-picked from the dev-26.10.x backport #3690).

The centreon-engine Docker e2e image had no notification path wired: no mailer installed, empty `contacts.cfg`/`contactgroups.cfg`, no `notify-*` commands. Adds both a native SMTP option (`mailutils`/`msmtp`/`msmtp-mta`, `notify-host-by-email`/`notify-service-by-email` commands, `06-mail-config.sh` wiring `SMTP_HOST`/`SMTP_PORT`/`SMTP_FROM` into `/etc/msmtprc`) and a connector option (`centreon-plugin-notification-email`, baked into the Dockerfile like the existing poller plugin), wired via two contacts (`admin-smtp`, `admin-plugin`) in one `admins` contactgroup on `hostTemplates.cfg`/`serviceTemplates.cfg`.

Ref: MON-208849

**Fixes** MON-208849

## Type of change
- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

## How this pull request can be tested ?
Same testing procedure as #3687: new e2e scenario in `centreon-engine-docker-config-wiring-test.sh` (`docker-config-wiring-test` job) spins up a mailpit stub on a dedicated docker network, submits `SEND_CUSTOM_HOST_NOTIFICATION`/`SEND_CUSTOM_SVC_NOTIFICATION` through centengine's real external-command pipe, and asserts both contacts actually received mail.

## Checklist
#### Community contributors & Centreon team
- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).